### PR TITLE
fix(release): 打 annotated tag 前配置 git committer 身份

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,6 +551,11 @@ jobs:
             PREV_TAG=$(git tag -l 'v*' --sort=-creatordate | head -1 || true)
           fi
 
+          # annotated tag 需要 committer 身份；GitHub runner 默认未配置，
+          # 用 github-actions[bot] 规范身份（不污染全局，仅本仓库）。
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git tag -a "$TAG" -m "$TAG"
           git push origin "$TAG"
 


### PR DESCRIPTION
## 问题

`Release Build` 工作流的 `create-release` job 在 **Create tag and release** 步骤以 exit code 128 失败（[run 27456998340](https://github.com/oomol/lumo/actions/runs/27456998340/job/81163516085)）：

```
Committer identity unknown
fatal: empty ident name (for <runner@...>) not allowed
```

## 根因

`git tag -a "$TAG"` 打 annotated tag 需要 committer 身份（`user.name` / `user.email`），但 GitHub runner 默认不配置。

workflow 注释特意说明"一律打 annotated tag"（为让 `creatordate` 排序对回溯发布正确），却漏了配套的身份配置。这是 `40e4dc6` 引入双渠道发布链路后**首次真正运行**——此前远端/本地都没有任何 tag，缺陷直到首发才暴露。

## 修复

在 `git tag -a` 之前配置 `github-actions[bot]` 规范身份（仅本仓库，不污染全局）。

## 验证

- YAML 合法（`yaml.safe_load`）
- `actionlint` 在改动处无报错
- 复核 job 内无其他需要 git 身份的操作：`git push` 用 checkout 持久化凭证、`gh` 命令用 `ACCESS_REPO` token，均不受影响

合并后重新 dispatch `Release Build` 即可验证 release 链路打通。