### PR TITLE
fix(build): parse ripgrep .sha256 in both sha256sum and CertUtil formats

### DIFF
--- a/scripts/ripgrep.test.ts
+++ b/scripts/ripgrep.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { test } from "vitest"
-import { resolveRipgrepTarget, ripgrepExecutableName } from "./ripgrep.ts"
+import { parseSha256, resolveRipgrepTarget, ripgrepExecutableName } from "./ripgrep.ts"
 
 test("ripgrep executable name follows platform conventions", () => {
   assert.equal(ripgrepExecutableName("win32"), "rg.exe")
@@ -33,4 +33,28 @@ test("resolveRipgrepTarget maps Linux x64 to the static musl tarball", () => {
     assetName: "ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz",
     executableFileName: "rg",
   })
+})
+
+test("parseSha256 reads the sha256sum format (Unix assets)", () => {
+  const hash = "4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e"
+  assert.equal(parseSha256(`${hash}  ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz\n`), hash)
+})
+
+test("parseSha256 reads the CertUtil format (Windows assets)", () => {
+  // GitHub 上 Windows zip 的 .sha256 是 CertUtil 输出：字面量 "SHA256" 在首行，
+  // 真实哈希在第二行。旧实现按 split()[0] 取 token 会误把 "SHA256" 当哈希。
+  const hash = "d0f534024c42afd6cb4d38907c25cd2b249b79bbe6cc1dbee8e3e37c2b6e25a1"
+  const certUtil =
+    "SHA256 hash of ripgrep-14.1.1-x86_64-pc-windows-msvc.zip:\n" +
+    `${hash}\n` +
+    "CertUtil: -hashfile command completed successfully.\n"
+  assert.equal(parseSha256(certUtil), hash)
+})
+
+test("parseSha256 lowercases and returns null when no digest is present", () => {
+  assert.equal(
+    parseSha256("D0F534024C42AFD6CB4D38907C25CD2B249B79BBE6CC1DBEE8E3E37C2B6E25A1"),
+    "d0f534024c42afd6cb4d38907c25cd2b249b79bbe6cc1dbee8e3e37c2b6e25a1",
+  )
+  assert.equal(parseSha256("Not Found"), null)
 })

--- a/scripts/ripgrep.ts
+++ b/scripts/ripgrep.ts
@@ -104,11 +104,19 @@ async function fetchBytes(url: string): Promise<Buffer> {
   return Buffer.from(await response.arrayBuffer())
 }
 
+// 从 .sha256 文件内容里抽取 64 位十六进制摘要。ripgrep 各平台格式不同：
+// Unix 是 sha256sum 风格（`<hash>  <file>`，哈希在首列），Windows 是 CertUtil
+// 风格（首行 `SHA256 hash of <file>:`，哈希独占第二行）。统一按内容匹配 64-hex
+// 串，不按 token 位置取——否则 Windows 会把字面量 "SHA256" 当成期望哈希。
+export function parseSha256(shaFile: string): string | null {
+  return shaFile.match(/[0-9a-f]{64}/i)?.[0]?.toLowerCase() ?? null
+}
+
 function verifySha256(data: Buffer, shaFile: string, source: string): void {
-  const expected = shaFile.trim().split(/\s+/)[0]
+  const expected = parseSha256(shaFile)
   const actual = createHash("sha256").update(data).digest("hex")
   if (!expected || actual !== expected) {
-    throw new Error(`sha256 mismatch for ${source}: expected ${expected || "<missing>"}, got ${actual}`)
+    throw new Error(`sha256 mismatch for ${source}: expected ${expected ?? "<missing>"}, got ${actual}`)
   }
 }
 


### PR DESCRIPTION
## Problem

The **Release Build** (`release.yml`, Windows job) fails during `npm ci` postinstall while downloading ripgrep:

```
Error: sha256 mismatch for https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-pc-windows-msvc.zip: expected SHA256, got d0f534024c42afd6cb4d38907c25cd2b249b79bbe6cc1dbee8e3e37c2b6e25a1
```

Note the expected value is the literal string `SHA256`, and the "got" value (`d0f534…`) is in fact the **correct** hash of the downloaded zip — the download is fine, the checksum **parsing** is wrong.

## Root cause

GitHub's ripgrep release ships a per-asset `.sha256` file whose layout is **platform-dependent**:

| Asset | `.sha256` format | First whitespace token |
|---|---|---|
| Linux / macOS (`tar.gz`) | `sha256sum` style — `<hash>  <file>` | the hash ✅ |
| Windows (`zip`, x64 & ia32) | **CertUtil** output — first line `SHA256 hash of <file>:`, hash on line 2 | the literal `SHA256` ❌ |

The old `verifySha256` did `shaFile.trim().split(/\s+/)[0]`, assuming the digest is always the first token. That holds for Unix but not for the Windows CertUtil format, so every Windows release build aborted.

## Fix

Extract the 64-hex digest from the file content regardless of layout (new pure helper `parseSha256`), instead of taking it positionally. Robust to both `sha256sum` and CertUtil formats.

## Verification

- Added unit tests covering both `.sha256` formats (real release content), lowercase normalization, and the no-digest case.
- End-to-end: downloaded the real `ripgrep-14.1.1-x86_64-pc-windows-msvc.zip` + its `.sha256` and confirmed the fixed parser yields `expected == actual == d0f534…`.
- Full gate green: `ts-check`, `lint`, `format`, `test` (510 passed).

After merge, re-dispatch the Release Build.