### PR TITLE
Fix Windows title bar overlay theme

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,6 +34,11 @@ import { SettingsServiceImpl } from "./settings/node.ts"
 import { SettingsStore } from "./settings/store.ts"
 import { SkillServiceImpl } from "./skills/node.ts"
 import { UpdateServiceImpl } from "./update/node.ts"
+import {
+  buildWindowsTitleBarOverlay,
+  resolveWindowsTitleBarTheme,
+  windowBackgroundColorForTheme,
+} from "./window/title-bar-overlay.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const appRoot = path.join(dirname, "..")
@@ -42,10 +47,7 @@ process.env.APP_ROOT = appRoot
 const viteDevServerUrl = process.env["VITE_DEV_SERVER_URL"]
 const rendererDist = path.join(appRoot, "dist")
 const preloadPath = path.join(dirname, "preload.js")
-const titleBarHeight = 48
 const macTrafficLightPosition = { x: 15, y: 17 }
-const darkWindowColor = "#171717"
-const lightWindowColor = "#ffffff"
 const skillRuntimeRefreshDelayMs = 1_500
 const skillRuntimeRefreshBusyRetryMs = 2_000
 const skillRuntimeRefreshMaxBusyRetries = 10
@@ -419,7 +421,8 @@ function openExternalUrl(url: string): void {
 function createMainWindow(): void {
   installPermissionRequestHandler()
   const isMac = process.platform === "darwin"
-  const backgroundColor = nativeTheme.shouldUseDarkColors ? darkWindowColor : lightWindowColor
+  const titleBarTheme = resolveWindowsTitleBarTheme(nativeTheme.shouldUseDarkColors)
+  const backgroundColor = windowBackgroundColorForTheme(titleBarTheme)
 
   mainWindow = new BrowserWindow({
     width: 1080,
@@ -436,11 +439,7 @@ function createMainWindow(): void {
       ? {}
       : {
           frame: false,
-          titleBarOverlay: {
-            color: backgroundColor,
-            symbolColor: nativeTheme.shouldUseDarkColors ? "#e5e5e5" : "#404040",
-            height: titleBarHeight,
-          },
+          titleBarOverlay: buildWindowsTitleBarOverlay(titleBarTheme),
         }),
     webPreferences: {
       preload: preloadPath,

--- a/electron/settings/node.ts
+++ b/electron/settings/node.ts
@@ -1,9 +1,16 @@
+import type { WindowsTitleBarTheme } from "../window/title-bar-overlay.ts"
 import type { AppSettings, SettingsService, ThemeSource } from "./common.ts"
 import type { SettingsStore } from "./store.ts"
 import type { IConnectionService } from "@oomol/connection"
 
 import { ConnectionService } from "@oomol/connection"
-import { nativeTheme } from "electron"
+import { BrowserWindow, nativeTheme } from "electron"
+import {
+  buildWindowsTitleBarOverlay,
+  resolveWindowsTitleBarTheme,
+  shouldApplyWindowsTitleBarTheme,
+  windowBackgroundColorForTheme,
+} from "../window/title-bar-overlay.ts"
 import { SettingsService as SettingsServiceName } from "./common.ts"
 
 export interface SettingsServiceDeps {
@@ -15,10 +22,16 @@ export class SettingsServiceImpl
   implements IConnectionService<SettingsService>
 {
   private readonly deps: SettingsServiceDeps
+  private lastAppliedWindowsTitleBarTheme: WindowsTitleBarTheme | null = null
+  private nativeThemeListenerInstalled = false
 
   public constructor(deps: SettingsServiceDeps) {
     super(SettingsServiceName)
     this.deps = deps
+  }
+
+  private readonly handleNativeThemeUpdated = (): void => {
+    this.applyWindowsTitleBarOverlay()
   }
 
   /** 从持久化读取当前设置（含默认值兜底）。 */
@@ -32,11 +45,53 @@ export class SettingsServiceImpl
   /** 启动时把持久化的 themeSource 应用到 nativeTheme（窗口背景一致）。 */
   public applyStartupTheme(): void {
     nativeTheme.themeSource = this.current().themeSource
+    this.installNativeThemeListener()
+    this.applyWindowsTitleBarOverlay()
   }
 
   public setThemeSource(source: ThemeSource): Promise<void> {
     nativeTheme.themeSource = source
+    this.applyWindowsTitleBarOverlay()
     this.deps.store.write({ ...this.deps.store.read(), themeSource: source })
     return Promise.resolve()
+  }
+
+  public override dispose(): void {
+    nativeTheme.off("updated", this.handleNativeThemeUpdated)
+    this.nativeThemeListenerInstalled = false
+    super.dispose()
+  }
+
+  private installNativeThemeListener(): void {
+    if (this.nativeThemeListenerInstalled) {
+      return
+    }
+
+    nativeTheme.on("updated", this.handleNativeThemeUpdated)
+    this.nativeThemeListenerInstalled = true
+  }
+
+  private applyWindowsTitleBarOverlay(): void {
+    if (process.platform !== "win32") {
+      return
+    }
+
+    const windows = BrowserWindow.getAllWindows().filter((window) => !window.isDestroyed())
+    if (windows.length === 0) {
+      return
+    }
+
+    const nextTheme = resolveWindowsTitleBarTheme(nativeTheme.shouldUseDarkColors)
+    if (!shouldApplyWindowsTitleBarTheme(this.lastAppliedWindowsTitleBarTheme, nextTheme)) {
+      return
+    }
+
+    const overlay = buildWindowsTitleBarOverlay(nextTheme)
+    const backgroundColor = windowBackgroundColorForTheme(nextTheme)
+    for (const window of windows) {
+      window.setBackgroundColor(backgroundColor)
+      window.setTitleBarOverlay(overlay)
+    }
+    this.lastAppliedWindowsTitleBarTheme = nextTheme
   }
 }

--- a/electron/window/title-bar-overlay.test.ts
+++ b/electron/window/title-bar-overlay.test.ts
@@ -11,15 +11,15 @@ describe("buildWindowsTitleBarOverlay", () => {
   it("uses the light title bar colors", () => {
     expect(buildWindowsTitleBarOverlay("light")).toEqual({
       color: "#ffffff",
-      symbolColor: "#1c2024",
+      symbolColor: "#252a2e",
       height: windowsTitleBarOverlayHeight,
     })
   })
 
   it("uses the dark title bar colors", () => {
     expect(buildWindowsTitleBarOverlay("dark")).toEqual({
-      color: "#111113",
-      symbolColor: "#edeef0",
+      color: "#111213",
+      symbolColor: "#f0f6fc",
       height: windowsTitleBarOverlayHeight,
     })
   })
@@ -28,7 +28,7 @@ describe("buildWindowsTitleBarOverlay", () => {
 describe("windowBackgroundColorForTheme", () => {
   it("matches the overlay background color", () => {
     expect(windowBackgroundColorForTheme("light")).toBe("#ffffff")
-    expect(windowBackgroundColorForTheme("dark")).toBe("#111113")
+    expect(windowBackgroundColorForTheme("dark")).toBe("#111213")
   })
 })
 

--- a/electron/window/title-bar-overlay.test.ts
+++ b/electron/window/title-bar-overlay.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildWindowsTitleBarOverlay,
+  resolveWindowsTitleBarTheme,
+  shouldApplyWindowsTitleBarTheme,
+  windowBackgroundColorForTheme,
+  windowsTitleBarOverlayHeight,
+} from "./title-bar-overlay.ts"
+
+describe("buildWindowsTitleBarOverlay", () => {
+  it("uses the light title bar colors", () => {
+    expect(buildWindowsTitleBarOverlay("light")).toEqual({
+      color: "#ffffff",
+      symbolColor: "#1c2024",
+      height: windowsTitleBarOverlayHeight,
+    })
+  })
+
+  it("uses the dark title bar colors", () => {
+    expect(buildWindowsTitleBarOverlay("dark")).toEqual({
+      color: "#111113",
+      symbolColor: "#edeef0",
+      height: windowsTitleBarOverlayHeight,
+    })
+  })
+})
+
+describe("windowBackgroundColorForTheme", () => {
+  it("matches the overlay background color", () => {
+    expect(windowBackgroundColorForTheme("light")).toBe("#ffffff")
+    expect(windowBackgroundColorForTheme("dark")).toBe("#111113")
+  })
+})
+
+describe("resolveWindowsTitleBarTheme", () => {
+  it("maps nativeTheme dark state to a title bar theme", () => {
+    expect(resolveWindowsTitleBarTheme(false)).toBe("light")
+    expect(resolveWindowsTitleBarTheme(true)).toBe("dark")
+  })
+})
+
+describe("shouldApplyWindowsTitleBarTheme", () => {
+  it("returns true when the next theme differs from the last applied theme", () => {
+    expect(shouldApplyWindowsTitleBarTheme(null, "light")).toBe(true)
+    expect(shouldApplyWindowsTitleBarTheme("light", "dark")).toBe(true)
+  })
+
+  it("returns false when the theme is unchanged", () => {
+    expect(shouldApplyWindowsTitleBarTheme("light", "light")).toBe(false)
+    expect(shouldApplyWindowsTitleBarTheme("dark", "dark")).toBe(false)
+  })
+})

--- a/electron/window/title-bar-overlay.ts
+++ b/electron/window/title-bar-overlay.ts
@@ -2,17 +2,17 @@ import type { TitleBarOverlayOptions } from "electron"
 
 export type WindowsTitleBarTheme = "light" | "dark"
 
-export const windowsTitleBarOverlayHeight = 48
+export const windowsTitleBarOverlayHeight = 47
 
 const windowsTitleBarOverlayColors: Record<WindowsTitleBarTheme, { color: string; symbolColor: string }> = {
-  // 与 src/index.css 里的顶栏背景/前景保持同步。
+  // 与 Chat desktop 的 Windows 顶栏叠层基线保持同步；高度少 1px 以露出顶栏底部分隔线。
   light: {
     color: "#ffffff",
-    symbolColor: "#1c2024",
+    symbolColor: "#252a2e",
   },
   dark: {
-    color: "#111113",
-    symbolColor: "#edeef0",
+    color: "#111213",
+    symbolColor: "#f0f6fc",
   },
 }
 

--- a/electron/window/title-bar-overlay.ts
+++ b/electron/window/title-bar-overlay.ts
@@ -1,0 +1,39 @@
+import type { TitleBarOverlayOptions } from "electron"
+
+export type WindowsTitleBarTheme = "light" | "dark"
+
+export const windowsTitleBarOverlayHeight = 48
+
+const windowsTitleBarOverlayColors: Record<WindowsTitleBarTheme, { color: string; symbolColor: string }> = {
+  // 与 src/index.css 里的顶栏背景/前景保持同步。
+  light: {
+    color: "#ffffff",
+    symbolColor: "#1c2024",
+  },
+  dark: {
+    color: "#111113",
+    symbolColor: "#edeef0",
+  },
+}
+
+export function resolveWindowsTitleBarTheme(shouldUseDarkColors: boolean): WindowsTitleBarTheme {
+  return shouldUseDarkColors ? "dark" : "light"
+}
+
+export function buildWindowsTitleBarOverlay(theme: WindowsTitleBarTheme): TitleBarOverlayOptions {
+  return {
+    ...windowsTitleBarOverlayColors[theme],
+    height: windowsTitleBarOverlayHeight,
+  }
+}
+
+export function windowBackgroundColorForTheme(theme: WindowsTitleBarTheme): string {
+  return windowsTitleBarOverlayColors[theme].color
+}
+
+export function shouldApplyWindowsTitleBarTheme(
+  lastAppliedTheme: WindowsTitleBarTheme | null,
+  nextTheme: WindowsTitleBarTheme,
+): boolean {
+  return lastAppliedTheme !== nextTheme
+}


### PR DESCRIPTION
## Summary

This PR fixes the Windows title bar overlay colors so the native minimize, maximize, and close controls visually match Lumo's top navigation bar in both light and dark themes.

The issue was that the Electron `titleBarOverlay` colors were only set once during `BrowserWindow` creation. When Lumo switched themes, or when the system theme changed while using the system theme preference, the renderer updated the visible navigation bar but the native Windows control overlay could keep a mismatched background.

## Root Cause

Lumo configured `titleBarOverlay` inline in `electron/main.ts` using startup-time `nativeTheme.shouldUseDarkColors` values. There was no shared helper for the overlay colors and no follow-up call to `BrowserWindow.setTitleBarOverlay()` from the theme settings path.

## Changes

- Added a shared Windows title bar overlay helper that centralizes the overlay height, background color, symbol color, and theme resolution.
- Updated `BrowserWindow` creation to use the shared overlay helper and the same background color used by the overlay.
- Updated the settings service to sync existing Windows windows with `setBackgroundColor()` and `setTitleBarOverlay()` when the app theme changes.
- Added a `nativeTheme.updated` listener so the overlay also follows system theme changes when the theme preference is set to system.
- Added unit tests for the overlay helper behavior.

## Verification

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
- `npm run dev` started successfully on macOS and reached the agent sidecar ready state.

I could not visually inspect the native Windows caption buttons from this macOS environment, but the implementation uses Electron's Windows-specific `setTitleBarOverlay()` path and mirrors the existing Chat desktop approach from OOMOL Studio Core.
