### PR TITLE
fix(window): align dark title bar overlay background

### DIFF
--- a/electron/window/title-bar-overlay.test.ts
+++ b/electron/window/title-bar-overlay.test.ts
@@ -18,7 +18,7 @@ describe("buildWindowsTitleBarOverlay", () => {
 
   it("uses the dark title bar colors", () => {
     expect(buildWindowsTitleBarOverlay("dark")).toEqual({
-      color: "#111213",
+      color: "#111113",
       symbolColor: "#f0f6fc",
       height: windowsTitleBarOverlayHeight,
     })
@@ -28,7 +28,7 @@ describe("buildWindowsTitleBarOverlay", () => {
 describe("windowBackgroundColorForTheme", () => {
   it("matches the overlay background color", () => {
     expect(windowBackgroundColorForTheme("light")).toBe("#ffffff")
-    expect(windowBackgroundColorForTheme("dark")).toBe("#111213")
+    expect(windowBackgroundColorForTheme("dark")).toBe("#111113")
   })
 })
 

--- a/electron/window/title-bar-overlay.ts
+++ b/electron/window/title-bar-overlay.ts
@@ -5,13 +5,13 @@ export type WindowsTitleBarTheme = "light" | "dark"
 export const windowsTitleBarOverlayHeight = 47
 
 const windowsTitleBarOverlayColors: Record<WindowsTitleBarTheme, { color: string; symbolColor: string }> = {
-  // 与 Chat desktop 的 Windows 顶栏叠层基线保持同步；高度少 1px 以露出顶栏底部分隔线。
+  // 背景色需与 src/index.css 的 --background 保持一致；高度少 1px 以露出顶栏底部分隔线。
   light: {
     color: "#ffffff",
     symbolColor: "#252a2e",
   },
   dark: {
-    color: "#111213",
+    color: "#111113",
     symbolColor: "#f0f6fc",
   },
 }


### PR DESCRIPTION
The Windows title bar overlay background must match the renderer dark
surface so native window controls do not appear on a separate strip from
the app chrome.