### PR TITLE
[codex] Fix Windows window control behavior

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -37,6 +37,10 @@
       to: "icon.png",
     },
     {
+      from: "resources/branding/icon.ico",
+      to: "icon.ico",
+    },
+    {
       from: "resources/bin",
       to: "bin",
     },

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -42,6 +42,8 @@ import {
   resolveWindowsTitleBarTheme,
   windowBackgroundColorForTheme,
 } from "./window/title-bar-overlay.ts"
+import { createWindowsCloseHandler, revealWindowFromTray } from "./window/windows-tray-close-behavior.ts"
+import { createWindowsTrayLifecycle } from "./window/windows-tray-lifecycle.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const appRoot = path.join(dirname, "..")
@@ -73,6 +75,11 @@ interface SaveClipboardAttachmentRequest {
 const protocolScheme = viteDevServerUrl ? branding.devProtocolScheme : branding.protocolScheme
 
 let mainWindow: BrowserWindow | null = null
+let isQuitting = false
+let windowsTrayLifecycle: {
+  dispose: () => void
+  setLocale: (locale: string) => void
+} | null = null
 
 const server = new ConnectionServer(new ElectronServerAdapter())
 
@@ -211,10 +218,13 @@ if (isLocked) {
   })
 
   app.on("before-quit", () => {
+    isQuitting = true
     if (pendingSkillRuntimeRefresh) {
       clearTimeout(pendingSkillRuntimeRefresh)
       pendingSkillRuntimeRefresh = undefined
     }
+    windowsTrayLifecycle?.dispose()
+    windowsTrayLifecycle = null
     agent?.dispose()
     server.dispose()
   })
@@ -470,6 +480,38 @@ function createMainWindow(): void {
 
   mainWindow.once("ready-to-show", () => mainWindow?.show())
 
+  if (process.platform === "win32") {
+    mainWindow.on(
+      "close",
+      createWindowsCloseHandler({
+        hide: () => mainWindow?.hide(),
+        isQuitting: () => isQuitting,
+      }),
+    )
+
+    if (!windowsTrayLifecycle) {
+      try {
+        windowsTrayLifecycle = createWindowsTrayLifecycle({
+          iconPath: getBrandingResourcePath("icon.ico"),
+          locale: app.getLocale(),
+          onExit: () => {
+            isQuitting = true
+            app.quit()
+          },
+          onOpen: () => {
+            if (mainWindow) {
+              revealWindowFromTray(mainWindow)
+            } else {
+              createMainWindow()
+            }
+          },
+        })
+      } catch (error) {
+        console.warn("[lumo] failed to initialize Windows tray lifecycle", error)
+      }
+    }
+  }
+
   // 渲染层里的外链（如 Markdown 里的链接、授权 URL）走系统浏览器，绝不在应用窗口内导航。
   // 仅放行安全的用户意图协议（http/https/mailto/tel），其余忽略，避免诱导触发 file:// 或自定义协议。
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -513,6 +555,9 @@ function showMainWindow(): void {
   }
   if (mainWindow.isMinimized()) {
     mainWindow.restore()
+  }
+  if (process.platform === "win32") {
+    mainWindow.show()
   }
   mainWindow.focus()
 }

--- a/electron/window/windows-tray-close-behavior.test.ts
+++ b/electron/window/windows-tray-close-behavior.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest"
+import { createWindowsCloseHandler, revealWindowFromTray } from "./windows-tray-close-behavior.ts"
+
+describe("createWindowsCloseHandler", () => {
+  it("prevents close and hides the window while the app keeps running", () => {
+    const preventDefault = vi.fn()
+    const hide = vi.fn()
+    const handler = createWindowsCloseHandler({
+      hide,
+      isQuitting: () => false,
+    })
+
+    handler({ preventDefault } as unknown as Electron.Event)
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(hide).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets the window close during a real app quit", () => {
+    const preventDefault = vi.fn()
+    const hide = vi.fn()
+    const handler = createWindowsCloseHandler({
+      hide,
+      isQuitting: () => true,
+    })
+
+    handler({ preventDefault } as unknown as Electron.Event)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(hide).not.toHaveBeenCalled()
+  })
+})
+
+describe("revealWindowFromTray", () => {
+  it("shows and focuses a hidden window", () => {
+    const focus = vi.fn()
+    const restore = vi.fn()
+    const show = vi.fn()
+
+    revealWindowFromTray({
+      focus,
+      isMinimized: () => false,
+      restore,
+      show,
+    })
+
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(restore).not.toHaveBeenCalled()
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it("restores minimized windows before focusing", () => {
+    const focus = vi.fn()
+    const restore = vi.fn()
+    const show = vi.fn()
+
+    revealWindowFromTray({
+      focus,
+      isMinimized: () => true,
+      restore,
+      show,
+    })
+
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(restore).toHaveBeenCalledTimes(1)
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/electron/window/windows-tray-close-behavior.ts
+++ b/electron/window/windows-tray-close-behavior.ts
@@ -1,0 +1,23 @@
+import type { BrowserWindow } from "electron"
+
+export function createWindowsCloseHandler(input: {
+  hide: () => void
+  isQuitting: () => boolean
+}): (event: Electron.Event) => void {
+  return (event) => {
+    if (input.isQuitting()) {
+      return
+    }
+
+    event.preventDefault()
+    input.hide()
+  }
+}
+
+export function revealWindowFromTray(window: Pick<BrowserWindow, "focus" | "isMinimized" | "restore" | "show">): void {
+  window.show()
+  if (window.isMinimized()) {
+    window.restore()
+  }
+  window.focus()
+}

--- a/electron/window/windows-tray-lifecycle.test.ts
+++ b/electron/window/windows-tray-lifecycle.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest"
+import { buildWindowsTrayMenuTemplate } from "./windows-tray-lifecycle.ts"
+
+type TrayMenuClick = () => void
+
+describe("buildWindowsTrayMenuTemplate", () => {
+  it("uses English tray labels by default", () => {
+    const onOpen = vi.fn()
+    const onExit = vi.fn()
+    const [openItem, exitItem] = buildWindowsTrayMenuTemplate({ onExit, onOpen })
+
+    expect(openItem?.label).toBe("Open Lumo")
+    expect(exitItem?.label).toBe("Exit")
+
+    expect(openItem?.click).toBeTypeOf("function")
+    expect(exitItem?.click).toBeTypeOf("function")
+
+    ;(openItem.click as TrayMenuClick)()
+    ;(exitItem.click as TrayMenuClick)()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onExit).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses Chinese tray labels for zh locales", () => {
+    const [openItem, exitItem] = buildWindowsTrayMenuTemplate({
+      locale: "zh-CN",
+      onExit: () => undefined,
+      onOpen: () => undefined,
+    })
+
+    expect(openItem?.label).toBe("打开 Lumo")
+    expect(exitItem?.label).toBe("退出")
+  })
+})

--- a/electron/window/windows-tray-lifecycle.ts
+++ b/electron/window/windows-tray-lifecycle.ts
@@ -1,0 +1,61 @@
+import type { MenuItemConstructorOptions } from "electron"
+
+import { Menu, Tray } from "electron"
+import { branding } from "../branding.ts"
+
+export function buildWindowsTrayMenuTemplate(input: {
+  locale?: string
+  onExit: () => void
+  onOpen: () => void
+}): MenuItemConstructorOptions[] {
+  const useChinese = input.locale?.toLowerCase().startsWith("zh") ?? false
+  const openLabel = useChinese ? `打开 ${branding.appName}` : `Open ${branding.appName}`
+  const exitLabel = useChinese ? "退出" : "Exit"
+
+  return [
+    {
+      label: openLabel,
+      click: () => input.onOpen(),
+    },
+    {
+      label: exitLabel,
+      click: () => input.onExit(),
+    },
+  ]
+}
+
+export function createWindowsTrayLifecycle(input: {
+  iconPath: string
+  locale?: string
+  onExit: () => void
+  onOpen: () => void
+}): {
+  dispose: () => void
+  setLocale: (locale: string) => void
+} {
+  const tray = new Tray(input.iconPath)
+  const onTrayClick = (): void => input.onOpen()
+
+  const updateTray = (locale = input.locale): void => {
+    tray.setToolTip(branding.appName)
+    tray.setContextMenu(
+      Menu.buildFromTemplate(
+        buildWindowsTrayMenuTemplate({
+          locale,
+          onExit: input.onExit,
+          onOpen: input.onOpen,
+        }),
+      ),
+    )
+  }
+  updateTray()
+  tray.on("click", onTrayClick)
+
+  return {
+    dispose: () => {
+      tray.removeListener("click", onTrayClick)
+      tray.destroy()
+    },
+    setLocale: (locale: string) => updateTray(locale),
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -351,6 +351,7 @@
 }
 
 :root[data-dev-window-controls="windows"] {
+  --traffic-light-space: 0px;
   --sidebar-titlebar-left-space: 20px;
   --window-control-right-space: 142px;
 }
@@ -667,7 +668,7 @@
   }
 
   .oo-sidebar-collapsed .oo-titlebar-control-spacer {
-    width: calc(var(--traffic-light-space) - 20px);
+    width: max(0px, calc(var(--traffic-light-space) - 20px));
   }
 
   .oo-main-titlebar-title {
@@ -1507,6 +1508,12 @@
     gap: 0.5rem;
     pointer-events: auto;
     -webkit-app-region: no-drag;
+  }
+
+  :root[data-platform="win32"] .oo-markdown-image-viewer-actions,
+  :root[data-platform="linux"] .oo-markdown-image-viewer-actions,
+  :root[data-dev-window-controls="windows"] .oo-markdown-image-viewer-actions {
+    right: calc(var(--window-control-right-space) + 1.25rem);
   }
 
   .oo-markdown-image-viewer-action {


### PR DESCRIPTION
## Summary

- Adjust Windows titlebar-safe spacing so image viewer actions avoid native window controls and collapsed sidebar controls align correctly.
- Add Windows tray lifecycle behavior so clicking the window close button hides Lumo to the system tray instead of quitting.
- Add focused tests for the Windows close interception, tray reveal behavior, and tray menu labels.

## Why

Windows frameless window controls can overlap app UI, and close should match Chat Desktop behavior by keeping the app alive in the tray unless the user explicitly exits.

## Validation

- `npm run lint`
- `npm run format`
- `npm run ts-check`
- `npm test`
- `npm run build`

## Notes

The tray behavior is gated to `process.platform === "win32"`. The implementation follows Chat Desktop's close/reveal pattern but avoids adding synchronous fs checks in Lumo's main process.