### PR TITLE
Add default registry skill auto install

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -350,6 +350,9 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   chatService.startEventBridge()
   chatService.setAgentStatus({ status: "ready" })
   console.log("[lumo] agent sidecar ready at", nextAgent.url)
+  void skillService.ensureDefaultRegistrySkillsInstalled().catch((error: unknown) => {
+    console.warn("[lumo] default registry skill installation failed:", error)
+  })
 }
 
 function handleConnectionWorkspaceChanged(workspace: ConnectionWorkspace): void {

--- a/electron/skills/default-install-store.test.ts
+++ b/electron/skills/default-install-store.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readdir, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { test } from "vitest"
+import {
+  DefaultSkillInstallStore,
+  createDefaultSkillKey,
+  defaultSkillInstallSchemaVersion,
+  emptyDefaultSkillInstallStore,
+  readDefaultSkillInstallRecord,
+  readDefaultSkillInstallStore,
+  upsertDefaultSkillInstallRecord,
+} from "./default-install-store.ts"
+import { defaultRegistrySkillSetVersion } from "./default-registry-skills.ts"
+
+test("DefaultSkillInstallStore round-trips records atomically", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "lumo-default-skills-"))
+  const store = new DefaultSkillInstallStore(dir)
+  const now = "2026-06-21T00:00:00.000Z"
+
+  await store.write(
+    upsertDefaultSkillInstallRecord(emptyDefaultSkillInstallStore(), {
+      packageName: "@oomol/example",
+      skillId: "example",
+      status: "installed",
+      updatedAt: now,
+    }),
+  )
+
+  assert.deepEqual(await store.read(), {
+    records: [
+      {
+        packageName: "@oomol/example",
+        skillId: "example",
+        status: "installed",
+        updatedAt: now,
+      },
+    ],
+    schemaVersion: defaultSkillInstallSchemaVersion,
+    skillSetVersion: defaultRegistrySkillSetVersion,
+  })
+  assert.deepEqual(await readdir(path.join(dir, "skills")), ["default-install.json"])
+})
+
+test("upsertDefaultSkillInstallRecord replaces matching package and skill", () => {
+  const initial = upsertDefaultSkillInstallRecord(emptyDefaultSkillInstallStore(), {
+    packageName: "@oomol/example",
+    skillId: "example",
+    status: "failed",
+    updatedAt: "first",
+  })
+  const next = upsertDefaultSkillInstallRecord(initial, {
+    packageName: "@oomol/example",
+    skillId: "example",
+    status: "removed-by-user",
+    updatedAt: "second",
+  })
+
+  assert.equal(next.records.length, 1)
+  assert.equal(next.records[0]?.status, "removed-by-user")
+  assert.equal(
+    readDefaultSkillInstallRecord(next, { packageName: "@oomol/example", skillId: "example" })?.updatedAt,
+    "second",
+  )
+})
+
+test("readDefaultSkillInstallStore ignores unsupported records", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "lumo-default-skills-"))
+  const file = path.join(dir, "default-install.json")
+  await writeFile(
+    file,
+    JSON.stringify({
+      schemaVersion: defaultSkillInstallSchemaVersion,
+      skillSetVersion: defaultRegistrySkillSetVersion,
+      records: [
+        {
+          packageName: "@oomol/example",
+          skillId: "example",
+          status: "installed",
+          updatedAt: "now",
+        },
+        {
+          packageName: "",
+          skillId: "broken",
+          status: "installed",
+          updatedAt: "now",
+        },
+      ],
+    }),
+    "utf8",
+  )
+
+  const store = await readDefaultSkillInstallStore(file)
+
+  assert.deepEqual(
+    store.records.map((record) => createDefaultSkillKey(record)),
+    ["@oomol/example\u0000example"],
+  )
+})
+
+test("readDefaultSkillInstallStore returns empty store for missing file", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "lumo-default-skills-"))
+
+  assert.deepEqual(await readDefaultSkillInstallStore(path.join(dir, "missing.json")), emptyDefaultSkillInstallStore())
+})

--- a/electron/skills/default-install-store.ts
+++ b/electron/skills/default-install-store.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { defaultRegistrySkillSetVersion } from "./default-registry-skills.ts"
+
+export const defaultSkillInstallSchemaVersion = 1
+
+export type DefaultSkillInstallStatus = "failed" | "installed" | "removed-by-user" | "skipped"
+
+export interface DefaultSkillInstallRecord {
+  installedAt?: string
+  lastAttemptAt?: string
+  lastError?: string
+  packageName: string
+  skillId: string
+  status: DefaultSkillInstallStatus
+  updatedAt: string
+}
+
+export interface DefaultSkillInstallStoreData {
+  records: DefaultSkillInstallRecord[]
+  schemaVersion: typeof defaultSkillInstallSchemaVersion
+  skillSetVersion: number
+}
+
+export class DefaultSkillInstallStore {
+  private readonly file: string
+
+  public constructor(userDataPath: string) {
+    this.file = path.join(userDataPath, "skills", "default-install.json")
+  }
+
+  public async read(): Promise<DefaultSkillInstallStoreData> {
+    return readDefaultSkillInstallStore(this.file)
+  }
+
+  public async write(store: DefaultSkillInstallStoreData): Promise<void> {
+    await writeDefaultSkillInstallStore(this.file, store)
+  }
+}
+
+export async function readDefaultSkillInstallStore(file: string): Promise<DefaultSkillInstallStoreData> {
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf8")) as Partial<DefaultSkillInstallStoreData>
+
+    if (parsed.schemaVersion !== defaultSkillInstallSchemaVersion || !Array.isArray(parsed.records)) {
+      return emptyDefaultSkillInstallStore()
+    }
+
+    return {
+      records: parsed.records.filter(isDefaultSkillInstallRecord).map((record) => ({ ...record })),
+      schemaVersion: defaultSkillInstallSchemaVersion,
+      skillSetVersion:
+        typeof parsed.skillSetVersion === "number" && Number.isFinite(parsed.skillSetVersion)
+          ? parsed.skillSetVersion
+          : defaultRegistrySkillSetVersion,
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error
+    }
+    return emptyDefaultSkillInstallStore()
+  }
+}
+
+export async function writeDefaultSkillInstallStore(file: string, store: DefaultSkillInstallStoreData): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true })
+  const tmp = `${file}.tmp-${process.pid}-${randomUUID()}`
+  try {
+    await writeFile(tmp, `${JSON.stringify(normalizeDefaultSkillInstallStore(store), null, 2)}\n`, "utf8")
+    await rename(tmp, file)
+  } catch (error) {
+    await rm(tmp, { force: true })
+    throw error
+  }
+}
+
+export function emptyDefaultSkillInstallStore(): DefaultSkillInstallStoreData {
+  return {
+    records: [],
+    schemaVersion: defaultSkillInstallSchemaVersion,
+    skillSetVersion: defaultRegistrySkillSetVersion,
+  }
+}
+
+export function createDefaultSkillKey(request: { packageName: string; skillId: string }): string {
+  return `${request.packageName.trim()}\u0000${request.skillId.trim()}`
+}
+
+export function readDefaultSkillInstallRecord(
+  store: DefaultSkillInstallStoreData,
+  request: { packageName: string; skillId: string },
+): DefaultSkillInstallRecord | undefined {
+  const key = createDefaultSkillKey(request)
+  return store.records.find((record) => createDefaultSkillKey(record) === key)
+}
+
+export function upsertDefaultSkillInstallRecord(
+  store: DefaultSkillInstallStoreData,
+  record: DefaultSkillInstallRecord,
+): DefaultSkillInstallStoreData {
+  const records = [...store.records]
+  const key = createDefaultSkillKey(record)
+  const index = records.findIndex((item) => createDefaultSkillKey(item) === key)
+
+  if (index === -1) {
+    records.push(record)
+  } else {
+    records[index] = record
+  }
+
+  return normalizeDefaultSkillInstallStore({
+    records,
+    schemaVersion: defaultSkillInstallSchemaVersion,
+    skillSetVersion: defaultRegistrySkillSetVersion,
+  })
+}
+
+function normalizeDefaultSkillInstallStore(store: DefaultSkillInstallStoreData): DefaultSkillInstallStoreData {
+  return {
+    records: store.records
+      .filter(isDefaultSkillInstallRecord)
+      .map((record) => ({ ...record }))
+      .sort((left, right) => createDefaultSkillKey(left).localeCompare(createDefaultSkillKey(right))),
+    schemaVersion: defaultSkillInstallSchemaVersion,
+    skillSetVersion: defaultRegistrySkillSetVersion,
+  }
+}
+
+function isDefaultSkillInstallRecord(value: unknown): value is DefaultSkillInstallRecord {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const record = value as DefaultSkillInstallRecord
+  return (
+    typeof record.packageName === "string" &&
+    record.packageName.trim().length > 0 &&
+    typeof record.skillId === "string" &&
+    record.skillId.trim().length > 0 &&
+    isDefaultSkillInstallStatus(record.status) &&
+    typeof record.updatedAt === "string" &&
+    (record.installedAt === undefined || typeof record.installedAt === "string") &&
+    (record.lastAttemptAt === undefined || typeof record.lastAttemptAt === "string") &&
+    (record.lastError === undefined || typeof record.lastError === "string")
+  )
+}
+
+function isDefaultSkillInstallStatus(value: unknown): value is DefaultSkillInstallStatus {
+  return value === "failed" || value === "installed" || value === "removed-by-user" || value === "skipped"
+}

--- a/electron/skills/default-registry-skills.ts
+++ b/electron/skills/default-registry-skills.ts
@@ -1,0 +1,24 @@
+export interface DefaultRegistrySkillSpec {
+  category?: "ecommerce" | "image-generation" | "document" | "productivity" | "other"
+  enabled: boolean
+  packageName: string
+  skillId: string
+}
+
+export const defaultRegistrySkillSetVersion = 1
+
+// 默认安装清单：登录后后台补装，必须使用 registry 中稳定的 packageName + skillId。
+export const defaultRegistrySkills: readonly DefaultRegistrySkillSpec[] = [
+  {
+    category: "image-generation",
+    enabled: true,
+    packageName: "@zjxuyunshi/gpt-image-2",
+    skillId: "gpt-image-2",
+  },
+  {
+    category: "ecommerce",
+    enabled: true,
+    packageName: "@zjxuyunshi/ecommerce-image-studio",
+    skillId: "ecommerce-image-studio",
+  },
+]

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -24,6 +24,7 @@ import type {
   SkillVersionReport,
   UpdateRegistrySkillRequest,
 } from "./common.ts"
+import type { DefaultRegistrySkillSpec } from "./default-registry-skills.ts"
 import type { InstalledSkill } from "./types.ts"
 import type { IConnectionService } from "@oomol/connection"
 import type { FSWatcher } from "node:fs"
@@ -61,6 +62,12 @@ import {
 } from "./actions.ts"
 import { SkillService as SkillServiceName } from "./common.ts"
 import { metadataFileName } from "./constants.ts"
+import {
+  DefaultSkillInstallStore,
+  readDefaultSkillInstallRecord,
+  upsertDefaultSkillInstallRecord,
+} from "./default-install-store.ts"
+import { defaultRegistrySkills } from "./default-registry-skills.ts"
 import { buildSummary, groupInstalledSkills } from "./inventory.ts"
 import {
   areManifestStoresEqual,
@@ -127,6 +134,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   private versionReportInFlight: { generation: number; key: string; promise: Promise<SkillVersionReport> } | undefined
   private versionReportCacheGeneration = 0
   private inventoryInFlight: { promise: Promise<SkillInventory>; writeManifest: boolean } | undefined
+  private defaultRegistrySkillInstallInFlight: Promise<void> | undefined
   private inventoryChangeTimer: NodeJS.Timeout | undefined
   private readonly options: SkillServiceOptions
   private readonly unsubscribeAuthStateChanged: () => void
@@ -155,6 +163,10 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
 
   private getManifestPath(): string {
     return path.join(app.getPath("userData"), "skills", "manifest.json")
+  }
+
+  private getDefaultSkillInstallStore(): DefaultSkillInstallStore {
+    return new DefaultSkillInstallStore(app.getPath("userData"))
   }
 
   private getLumoSkillStoreRoot(): string {
@@ -198,6 +210,25 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
 
   public async getSkillSummary(): Promise<SkillSummary> {
     return (await this.getSkillInventory()).summary
+  }
+
+  public async ensureDefaultRegistrySkillsInstalled(
+    specs: readonly DefaultRegistrySkillSpec[] = defaultRegistrySkills,
+  ): Promise<void> {
+    if (this.defaultRegistrySkillInstallInFlight) {
+      return this.defaultRegistrySkillInstallInFlight
+    }
+
+    const promise = this.installDefaultRegistrySkills(specs)
+    this.defaultRegistrySkillInstallInFlight = promise
+
+    try {
+      await promise
+    } finally {
+      if (this.defaultRegistrySkillInstallInFlight === promise) {
+        this.defaultRegistrySkillInstallInFlight = undefined
+      }
+    }
   }
 
   public async searchRegistrySkills(request: { query: string }) {
@@ -397,6 +428,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
     })
     assertOoSkillOperationResult(result, "skills.uninstall")
     await this.deleteSharedSkillTarget(request.skillId)
+    await this.rememberDefaultRegistrySkillRemovedByUser(request.skillId)
     this.notifyRuntimeSkillsChanged("delete-skill")
 
     return this.readAndPublishSkillInventory()
@@ -549,6 +581,86 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
     this.cliChanged.emit({
       updatedAt: new Date().toISOString(),
     })
+  }
+
+  private async installDefaultRegistrySkills(specs: readonly DefaultRegistrySkillSpec[]): Promise<void> {
+    const enabledSpecs = specs.filter((spec) => spec.enabled)
+    if (enabledSpecs.length === 0) {
+      return
+    }
+
+    const store = this.getDefaultSkillInstallStore()
+    let installStore = await store.read()
+    let inventory = await this.readSharedSkillInventory({ writeManifest: true })
+
+    for (const spec of enabledSpecs) {
+      const request = normalizeDefaultRegistrySkillRequest(spec)
+      const existingRecord = readDefaultSkillInstallRecord(installStore, request)
+      const now = new Date().toISOString()
+
+      if (isRuntimeSkillInstalled(inventory, request.skillId)) {
+        installStore = upsertDefaultSkillInstallRecord(installStore, {
+          ...request,
+          installedAt: existingRecord?.installedAt ?? now,
+          status: "installed",
+          updatedAt: now,
+        })
+        await store.write(installStore)
+        continue
+      }
+
+      if (existingRecord?.status === "removed-by-user") {
+        continue
+      }
+
+      try {
+        inventory = await this.installRegistrySkill(request)
+        installStore = upsertDefaultSkillInstallRecord(installStore, {
+          ...request,
+          installedAt: now,
+          lastAttemptAt: now,
+          status: "installed",
+          updatedAt: now,
+        })
+      } catch (error) {
+        const message = runtimeErrorMessage(error)
+        console.warn("[lumo] failed to install default registry skill:", {
+          error: message,
+          packageName: request.packageName,
+          skillId: request.skillId,
+        })
+        installStore = upsertDefaultSkillInstallRecord(installStore, {
+          ...request,
+          lastAttemptAt: now,
+          lastError: message,
+          status: "failed",
+          updatedAt: now,
+        })
+      }
+
+      await store.write(installStore)
+    }
+  }
+
+  private async rememberDefaultRegistrySkillRemovedByUser(skillId: string): Promise<void> {
+    const normalizedSkillId = normalizeSkillId(skillId)
+    const spec = defaultRegistrySkills.find((item) => item.skillId.trim() === normalizedSkillId)
+    if (!spec) {
+      return
+    }
+
+    const request = normalizeDefaultRegistrySkillRequest(spec)
+    const store = this.getDefaultSkillInstallStore()
+    const current = await store.read()
+    const now = new Date().toISOString()
+
+    await store.write(
+      upsertDefaultSkillInstallRecord(current, {
+        ...request,
+        status: "removed-by-user",
+        updatedAt: now,
+      }),
+    )
   }
 
   private async refreshManifestRecordsForTargets(targetPaths: string[]): Promise<void> {
@@ -1194,6 +1306,28 @@ function assertOoSkillOperationResult(
 
     throw cause
   }
+}
+
+function normalizeDefaultRegistrySkillRequest(spec: DefaultRegistrySkillSpec): InstallRegistrySkillRequest {
+  const packageName = spec.packageName.trim()
+  if (!packageName) {
+    throw new Error("Default registry Skill packageName is empty.")
+  }
+
+  return {
+    packageName,
+    skillId: normalizeSkillId(spec.skillId),
+  }
+}
+
+function isRuntimeSkillInstalled(inventory: SkillInventory, skillId: string): boolean {
+  const normalizedSkillId = normalizeSkillId(skillId)
+  const group = inventory.groups.find((item) => item.id === normalizedSkillId)
+  return group?.runtimeHosts.some((host) => host.status === "installed") ?? false
+}
+
+function runtimeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function createVersionReportCacheKey(inventory: SkillInventory): string {


### PR DESCRIPTION
## Summary

This PR adds a default registry Skill auto-install path for Lumo. After a signed-in runtime account starts the agent successfully, Lumo now kicks off a background reconciliation that installs enabled default registry Skills without blocking login, agent readiness, or chat usage.

The immediate default list includes the image generation and ecommerce Skills requested for first-run support:

- `@zjxuyunshi/gpt-image-2` / `gpt-image-2`
- `@zjxuyunshi/ecommerce-image-studio` / `ecommerce-image-studio`

## Problem

Users in image generation and ecommerce workflows should not need to manually discover and install baseline Skills before using the product. The app already has a registry Skill installation path, but there was no startup-time mechanism to reconcile a product-owned default Skill list into the local Lumo runtime.

## Root Cause

Skill installation currently only happens through explicit user actions in the Skills UI. Lumo starts the OpenCode sidecar and scans installed Skills, but it does not compare that inventory against a product default manifest after login.

## Fix

- Add `default-registry-skills.ts` as the product-owned default registry Skill manifest.
- Add `DefaultSkillInstallStore`, persisted under `userData/skills/default-install.json`, to record installation outcomes and user removal state.
- Add `SkillServiceImpl.ensureDefaultRegistrySkillsInstalled()` to install missing enabled defaults through the existing `installRegistrySkill()` path.
- Trigger the default install reconciliation after the agent reaches ready state, fire-and-forget, so startup remains responsive.
- Preserve user intent by marking manually deleted default Skills as `removed-by-user`, preventing automatic reinstall on later starts.
- Add focused tests for the default install store.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
- `npm run build`
