### PR TITLE
[codex] Expand model picker label

### DIFF
--- a/src/routes/Chat/ComposerTrailingControls.tsx
+++ b/src/routes/Chat/ComposerTrailingControls.tsx
@@ -8,6 +8,7 @@ import { ModelPicker } from "./ModelControls.tsx"
 import { PromptInputSubmit } from "@/components/ai-elements/prompt-input"
 import { Button } from "@/components/ui/button"
 import { useT } from "@/i18n/i18n"
+import { cn } from "@/lib/utils"
 
 interface ComposerTrailingControlsProps {
   canSubmit: boolean
@@ -162,7 +163,7 @@ export function ComposerTrailingControls({
   return (
     <>
       {voiceActive ? <VoiceRecorderPanel bars={voiceBars} durationMs={voiceDurationMs} /> : null}
-      <div className="flex min-w-0 shrink-0 items-center justify-end gap-1">
+      <div className={cn("flex min-w-0 items-center justify-end gap-1", voiceActive ? "shrink-0" : "flex-1")}>
         {voiceActive ? (
           <>
             {voiceMode === "recording-error" ? (

--- a/src/routes/Chat/ModelControls.tsx
+++ b/src/routes/Chat/ModelControls.tsx
@@ -274,7 +274,7 @@ export function ModelPicker({
     : null
 
   return (
-    <div ref={rootRef}>
+    <div ref={rootRef} className="min-w-0">
       <Button
         type="button"
         variant="ghost"
@@ -283,7 +283,7 @@ export function ModelPicker({
         aria-label={t("chat.modelPicker")}
         aria-expanded={open}
         disabled={disabled}
-        className="h-8 max-w-44 rounded-full px-2"
+        className="h-8 max-w-[min(14rem,100%)] min-w-0 shrink rounded-full px-2"
         onClick={() => setOpen((value) => !value)}
       >
         <Brain className="size-4" />


### PR DESCRIPTION
## Summary

- Allow the chat model picker button to use more available toolbar width so common model names such as `DeepSeek V4 Flash` are shown in full on desktop layouts.
- Keep the picker constrained with `min(14rem, 100%)` so it still truncates only when space is genuinely tight.
- Let the idle composer trailing controls occupy remaining toolbar space while preserving the fixed control layout during voice recording.

## Validation

- `npm run lint`

## Notes

This keeps the existing ellipsis behavior as a fallback, but reduces premature truncation in the normal chat composer layout.