### PR TITLE
Reduce workspace refresh error noise

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -17,6 +17,7 @@ import type { ArtifactSelection } from "@/routes/Chat/GeneratedArtifacts"
 import type { ChatStatus } from "ai"
 
 import {
+  AlertTriangle,
   Archive,
   Building2,
   Check,
@@ -260,6 +261,7 @@ function WorkspaceMenuContent({
   onSelectPersonal,
   error,
   getOrganizationRole,
+  hasLoaded,
   organizations,
   side = "bottom",
   workspace,
@@ -269,6 +271,7 @@ function WorkspaceMenuContent({
   align?: "center" | "end" | "start"
   error: UseOrganizationWorkspace["error"]
   getOrganizationRole: UseOrganizationWorkspace["getOrganizationRole"]
+  hasLoaded: boolean
   loading: boolean
   onManageOrganizations: () => void
   onRefresh: () => void
@@ -283,6 +286,8 @@ function WorkspaceMenuContent({
   const personalLabel = accountName?.trim() || t("organizations.personal")
   const personalDescription =
     personalLabel === t("organizations.personal") ? t("organizations.workspace") : t("organizations.personal")
+  const showBlockingError = Boolean(error && !hasLoaded)
+  const showRefreshWarning = Boolean(error && hasLoaded)
 
   return (
     <DropdownMenuContent align={align} side={side} sideOffset={8} className="w-72">
@@ -309,9 +314,15 @@ function WorkspaceMenuContent({
           {t("organizations.loading")}
         </DropdownMenuItem>
       ) : null}
-      {error ? (
+      {showBlockingError && error ? (
         <div className="px-2 py-1.5">
           <ErrorNotice error={error} compact />
+        </div>
+      ) : null}
+      {showRefreshWarning ? (
+        <div className="mx-2 my-1.5 flex min-w-0 items-start gap-2 rounded-md border border-[var(--oo-warning-border)] bg-[var(--oo-warning-surface)] px-2.5 py-2 text-xs leading-5 text-muted-foreground">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-[var(--oo-warning-foreground)]" />
+          <span className="min-w-0">{t("organizations.refreshFailedDescription")}</span>
         </div>
       ) : null}
       {organizations.map((organization) => {
@@ -335,7 +346,7 @@ function WorkspaceMenuContent({
           </DropdownMenuItem>
         )
       })}
-      {!loading && organizations.length === 0 ? (
+      {!loading && organizations.length === 0 && !showBlockingError ? (
         <div className="oo-text-caption oo-text-muted px-2 py-1.5">{t("organizations.emptyOrganizations")}</div>
       ) : null}
       <DropdownMenuSeparator />
@@ -989,12 +1000,13 @@ function SidebarFooterControls({
           align="start"
           error={workspace.error}
           getOrganizationRole={workspace.getOrganizationRole}
+          hasLoaded={workspace.hasLoaded}
           loading={workspace.loading}
           organizations={workspace.organizations}
           side="top"
           workspace={workspace.activeWorkspace}
           onManageOrganizations={() => onNavigate("organizations")}
-          onRefresh={() => void workspace.refresh()}
+          onRefresh={() => void workspace.refresh({ forceRefresh: true })}
           onSelectOrganization={workspace.selectOrganization}
           onSelectPersonal={workspace.selectPersonal}
         />

--- a/src/hooks/useOrganizationWorkspace.ts
+++ b/src/hooks/useOrganizationWorkspace.ts
@@ -18,14 +18,33 @@ export interface UseOrganizationWorkspace {
   connectionWorkspace: ConnectionWorkspace | null
   error: UserFacingError | null
   getOrganizationRole: (organization: Organization) => OrganizationRole
+  hasLoaded: boolean
   loading: boolean
   organizations: Organization[]
-  refresh: () => Promise<void>
+  refresh: (options?: OrganizationWorkspaceRefreshOptions) => Promise<void>
   selectOrganization: (organizationId: string) => void
   selectPersonal: () => void
 }
 
+export interface OrganizationWorkspaceRefreshOptions {
+  forceRefresh?: boolean
+}
+
+interface WorkspaceOverviewCacheEntry {
+  accountId: string
+  fetchedAt: number
+  overview: OrganizationOverview
+}
+
+interface WorkspaceOverviewInFlightEntry {
+  accountId: string
+  promise: Promise<OrganizationOverview>
+}
+
 const selectedWorkspaceStorageKeyPrefix = "lumo:active-workspace:"
+const workspaceOverviewCacheMs = 30_000
+let workspaceOverviewCache: WorkspaceOverviewCacheEntry | null = null
+let workspaceOverviewInFlight: WorkspaceOverviewInFlightEntry | null = null
 
 function selectedWorkspaceStorageKey(accountId: string): string {
   return `${selectedWorkspaceStorageKeyPrefix}${accountId}`
@@ -96,6 +115,49 @@ function organizationRole(
     : "member"
 }
 
+function workspaceError(cause: unknown, hasLoaded: boolean): UserFacingError {
+  const error = resolveUserFacingError(cause, { area: "generic" })
+  return {
+    ...error,
+    descriptionKey: hasLoaded ? "organizations.refreshFailedDescription" : "organizations.loadFailedDescription",
+    titleKey: hasLoaded ? "organizations.refreshFailedTitle" : "organizations.loadFailed",
+  }
+}
+
+function readCachedWorkspaceOverview(
+  accountId: string,
+  options: OrganizationWorkspaceRefreshOptions,
+): Promise<OrganizationOverview> {
+  const now = Date.now()
+  if (
+    !options.forceRefresh &&
+    workspaceOverviewCache?.accountId === accountId &&
+    now - workspaceOverviewCache.fetchedAt < workspaceOverviewCacheMs
+  ) {
+    return Promise.resolve(workspaceOverviewCache.overview)
+  }
+
+  if (!options.forceRefresh && workspaceOverviewInFlight?.accountId === accountId) {
+    return workspaceOverviewInFlight.promise
+  }
+
+  const promise = getOrganizationOverview(accountId).then((overview) => {
+    if (workspaceOverviewInFlight?.promise === promise) {
+      workspaceOverviewCache = { accountId, fetchedAt: Date.now(), overview }
+    }
+    return overview
+  })
+  workspaceOverviewInFlight = { accountId, promise }
+  void promise
+    .finally(() => {
+      if (workspaceOverviewInFlight?.promise === promise) {
+        workspaceOverviewInFlight = null
+      }
+    })
+    .catch(() => undefined)
+  return promise
+}
+
 export function useOrganizationWorkspace(accountId: string | undefined): UseOrganizationWorkspace {
   const [overview, setOverview] = React.useState<OrganizationOverview | null>(null)
   const [selectedOrganizationId, setSelectedOrganizationId] = React.useState<string | null>(() =>
@@ -105,6 +167,7 @@ export function useOrganizationWorkspace(accountId: string | undefined): UseOrga
   const [error, setError] = React.useState<UserFacingError | null>(null)
   const requestIdRef = React.useRef(0)
   const loadedAccountIdRef = React.useRef<string | undefined>(undefined)
+  const overviewRef = React.useRef<OrganizationOverview | null>(null)
 
   React.useEffect(() => {
     if (loadedAccountIdRef.current === accountId) {
@@ -112,47 +175,54 @@ export function useOrganizationWorkspace(accountId: string | undefined): UseOrga
     }
     loadedAccountIdRef.current = accountId
     requestIdRef.current += 1
+    overviewRef.current = null
     setOverview(null)
     setError(null)
     setSelectedOrganizationId(readStoredOrganizationId(accountId))
   }, [accountId])
 
-  const refresh = React.useCallback(async (): Promise<void> => {
-    if (!accountId) {
-      setOverview(null)
-      setError(null)
-      setLoading(false)
-      return
-    }
-
-    const requestId = requestIdRef.current + 1
-    requestIdRef.current = requestId
-    setLoading(true)
-    try {
-      const next = await getOrganizationOverview(accountId)
-      if (requestIdRef.current !== requestId) {
+  const refresh = React.useCallback(
+    async (options: OrganizationWorkspaceRefreshOptions = {}): Promise<void> => {
+      if (!accountId) {
+        overviewRef.current = null
+        setOverview(null)
+        setError(null)
+        setLoading(false)
         return
       }
-      setOverview(next)
-      setError(null)
-      const organizations = uniqueOrganizations(next)
-      setSelectedOrganizationId((current) => {
-        if (!current || organizations.some((organization) => organization.id === current)) {
-          return current
+
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
+      const hadOverview = overviewRef.current !== null
+      setLoading(true)
+      try {
+        const next = await readCachedWorkspaceOverview(accountId, options)
+        if (requestIdRef.current !== requestId) {
+          return
         }
-        writeStoredWorkspace(accountId, null)
-        return null
-      })
-    } catch (err) {
-      if (requestIdRef.current === requestId) {
-        setError(resolveUserFacingError(err, { area: "connections" }))
+        overviewRef.current = next
+        setOverview(next)
+        setError(null)
+        const organizations = uniqueOrganizations(next)
+        setSelectedOrganizationId((current) => {
+          if (!current || organizations.some((organization) => organization.id === current)) {
+            return current
+          }
+          writeStoredWorkspace(accountId, null)
+          return null
+        })
+      } catch (err) {
+        if (requestIdRef.current === requestId) {
+          setError(workspaceError(err, hadOverview))
+        }
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setLoading(false)
+        }
       }
-    } finally {
-      if (requestIdRef.current === requestId) {
-        setLoading(false)
-      }
-    }
-  }, [accountId])
+    },
+    [accountId],
+  )
 
   React.useEffect(() => {
     void refresh()
@@ -160,7 +230,7 @@ export function useOrganizationWorkspace(accountId: string | undefined): UseOrga
 
   React.useEffect(() => {
     return onOrganizationChanged(() => {
-      void refresh()
+      void refresh({ forceRefresh: true })
     })
   }, [refresh])
 
@@ -209,6 +279,7 @@ export function useOrganizationWorkspace(accountId: string | undefined): UseOrga
     connectionWorkspace,
     error,
     getOrganizationRole,
+    hasLoaded: overview !== null,
     loading,
     organizations,
     refresh,

--- a/src/i18n/skills-messages.ts
+++ b/src/i18n/skills-messages.ts
@@ -23,6 +23,9 @@ export const skillsMessages = {
     "organizations.emptyOrganizations": "暂无组织",
     "organizations.emptyOrganizationsDescription": "创建组织后，可以添加成员并配置连接器权限。",
     "organizations.loadFailed": "组织加载失败",
+    "organizations.loadFailedDescription": "暂时无法读取工作区信息。请检查网络后重试。",
+    "organizations.refreshFailedTitle": "工作区暂时无法刷新",
+    "organizations.refreshFailedDescription": "正在显示已加载的工作区信息。请稍后重试。",
     "organizations.selectedOrganization": "当前组织",
     "organizations.selectedWorkspace": "当前工作区",
     "organizations.roleCreator": "创建者",
@@ -239,6 +242,10 @@ export const skillsMessages = {
     "organizations.emptyOrganizationsDescription":
       "Create an organization to add members and configure connector permissions.",
     "organizations.loadFailed": "Failed to load organizations",
+    "organizations.loadFailedDescription":
+      "Workspace information is unavailable right now. Check the network and retry.",
+    "organizations.refreshFailedTitle": "Workspace could not refresh",
+    "organizations.refreshFailedDescription": "Showing the workspace information already loaded. Try again later.",
     "organizations.selectedOrganization": "Selected organization",
     "organizations.selectedWorkspace": "Selected workspace",
     "organizations.roleCreator": "Creator",


### PR DESCRIPTION
## Summary

The workspace switcher could show a prominent network error whenever organization overview refreshes failed. This made transient organization-service failures look like a high-frequency global connection problem, even when connector data was still available.

This PR reduces that noise by adding a small workspace-overview cache and in-flight request coalescing in the sidebar workspace hook. Normal initial loads can reuse recently loaded workspace data, while explicit retries and organization-change events still force a fresh read.

The UI now distinguishes first-load failures from background refresh failures. If no workspace data has loaded yet, the menu still shows a blocking error with diagnostics. Once data has loaded, refresh failures are downgraded to a compact warning that keeps the existing workspace list visible.

## Changes

- Add a 30-second workspace overview cache and in-flight merge in `useOrganizationWorkspace`.
- Preserve loaded workspace data when a later refresh fails.
- Make manual retry and organization-change events force refreshes.
- Replace the generic network/connector copy with workspace-specific Chinese and English messages.
- Downgrade stale-data refresh failures in the workspace menu to a compact warning.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
