### PR TITLE
[codex] Add keyboard shortcuts and menu commands

### DIFF
--- a/electron/app-command.ts
+++ b/electron/app-command.ts
@@ -1,0 +1,18 @@
+export const APP_COMMAND_CHANNEL = "lumo:app-command"
+
+export const APP_COMMANDS = {
+  focusComposer: "chat.focusComposer",
+  newChat: "chat.new",
+  openSearch: "sessions.search",
+  openSettings: "settings.open",
+  stopGeneration: "chat.stopGeneration",
+  toggleSidebar: "sidebar.toggle",
+} as const
+
+export type AppCommand = (typeof APP_COMMANDS)[keyof typeof APP_COMMANDS]
+
+const appCommandValues = new Set<string>(Object.values(APP_COMMANDS))
+
+export function isAppCommand(value: unknown): value is AppCommand {
+  return typeof value === "string" && appCommandValues.has(value)
+}

--- a/electron/app-locale.ts
+++ b/electron/app-locale.ts
@@ -1,0 +1,11 @@
+export const APP_LOCALE_CHANNEL = "lumo:app-locale"
+
+export type AppLocale = "zh-CN" | "en"
+
+export function isAppLocale(value: unknown): value is AppLocale {
+  return value === "zh-CN" || value === "en"
+}
+
+export function normalizeAppLocale(locale: string | null | undefined): AppLocale {
+  return typeof locale === "string" && locale.toLowerCase().startsWith("zh") ? "zh-CN" : "en"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,8 +1,9 @@
+import type { AppCommand } from "./app-command.ts"
 import type { AuthRuntimeAccount } from "./auth/store.ts"
 
 import { ConnectionServer } from "@oomol/connection"
 import { ElectronServerAdapter } from "@oomol/connection-electron-adapter/server"
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme, session, shell } from "electron"
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, session, shell } from "electron"
 import { stat } from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -16,6 +17,7 @@ import {
   resolveDevOpencodeBin,
 } from "./agent/binaries.ts"
 import { AgentManager } from "./agent/manager.ts"
+import { APP_COMMAND_CHANNEL } from "./app-command.ts"
 import { AuthManager, AuthServiceImpl } from "./auth/node.ts"
 import { AuthStore } from "./auth/store.ts"
 import { branding } from "./branding.ts"
@@ -36,6 +38,7 @@ import { SettingsServiceImpl } from "./settings/node.ts"
 import { SettingsStore } from "./settings/store.ts"
 import { SkillServiceImpl } from "./skills/node.ts"
 import { UpdateServiceImpl } from "./update/node.ts"
+import { buildApplicationMenuTemplate } from "./window/application-menu.ts"
 import {
   buildWindowsTitleBarOverlay,
   resolveWindowsTitleBarTheme,
@@ -183,6 +186,7 @@ if (isLocked) {
   app.whenReady().then(() => {
     // 放行渲染进程对 *.<endpoint> 的已鉴权直连请求（凭证经会话 cookie 自动附带，token 不进渲染层）。
     installOomolCorsShim(session.defaultSession)
+    installApplicationMenu()
     createMainWindow()
     // 启动静默检查（autoDownload=false，下载/安装由设置页 UI 显式触发）；dev 内部短路。
     void updateService.checkForAppUpdate().catch((error: unknown) => {
@@ -446,6 +450,32 @@ function openExternalUrl(url: string): void {
   if (/^(https?|mailto|tel):/i.test(url)) {
     void shell.openExternal(url)
   }
+}
+
+function sendAppCommand(command: AppCommand): void {
+  showMainWindow()
+  const target = mainWindow
+  if (!target) {
+    return
+  }
+  const send = (): void => target.webContents.send(APP_COMMAND_CHANNEL, command)
+  if (target.webContents.isLoading()) {
+    target.webContents.once("did-finish-load", send)
+    return
+  }
+  send()
+}
+
+function installApplicationMenu(): void {
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate(
+      buildApplicationMenuTemplate({
+        locale: app.getLocale(),
+        onCommand: sendAppCommand,
+        platform: process.platform,
+      }),
+    ),
+  )
 }
 
 function createMainWindow(): void {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
 import type { AppCommand } from "./app-command.ts"
+import type { AppLocale } from "./app-locale.ts"
 import type { AuthRuntimeAccount } from "./auth/store.ts"
 
 import { ConnectionServer } from "@oomol/connection"
@@ -18,6 +19,7 @@ import {
 } from "./agent/binaries.ts"
 import { AgentManager } from "./agent/manager.ts"
 import { APP_COMMAND_CHANNEL } from "./app-command.ts"
+import { APP_LOCALE_CHANNEL, isAppLocale, normalizeAppLocale } from "./app-locale.ts"
 import { AuthManager, AuthServiceImpl } from "./auth/node.ts"
 import { AuthStore } from "./auth/store.ts"
 import { branding } from "./branding.ts"
@@ -77,6 +79,7 @@ interface SaveClipboardAttachmentRequest {
 const protocolScheme = viteDevServerUrl ? branding.devProtocolScheme : branding.protocolScheme
 
 let mainWindow: BrowserWindow | null = null
+let currentLocale: AppLocale | null = null
 let isQuitting = false
 let windowsTrayLifecycle: {
   dispose: () => void
@@ -168,6 +171,7 @@ server.registerService(authService)
 server.registerService(updateService)
 settingsService.applyStartupTheme()
 registerAttachmentDialogHandler()
+registerAppLocaleHandler()
 
 if (isLocked) {
   server.start()
@@ -470,12 +474,34 @@ function installApplicationMenu(): void {
   Menu.setApplicationMenu(
     Menu.buildFromTemplate(
       buildApplicationMenuTemplate({
-        locale: app.getLocale(),
+        developmentMode: shouldShowDevelopmentMenu(),
+        locale: activeLocale(),
         onCommand: sendAppCommand,
         platform: process.platform,
       }),
     ),
   )
+}
+
+function activeLocale(): AppLocale {
+  return currentLocale ?? normalizeAppLocale(app.getLocale())
+}
+
+function shouldShowDevelopmentMenu(): boolean {
+  return !app.isPackaged || process.env["LUMO_ENABLE_DEV_MENU"] === "1"
+}
+
+function registerAppLocaleHandler(): void {
+  ipcMain.on(APP_LOCALE_CHANNEL, (_event, locale: unknown) => {
+    if (!isAppLocale(locale) || currentLocale === locale) {
+      return
+    }
+    currentLocale = locale
+    if (app.isReady()) {
+      installApplicationMenu()
+    }
+    windowsTrayLifecycle?.setLocale(locale)
+  })
 }
 
 function createMainWindow(): void {
@@ -521,7 +547,7 @@ function createMainWindow(): void {
       try {
         windowsTrayLifecycle = createWindowsTrayLifecycle({
           iconPath: getBrandingResourcePath("icon.ico"),
-          locale: app.getLocale(),
+          locale: activeLocale(),
           onExit: () => {
             isQuitting = true
             app.quit()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,9 @@
+import type { AppCommand } from "./app-command.ts"
+
 import { electronAPI } from "@electron-toolkit/preload"
 import { setupConnectionPreload } from "@oomol/connection-electron-adapter/preload"
-import { contextBridge, webUtils } from "electron"
+import { contextBridge, ipcRenderer, webUtils } from "electron"
+import { APP_COMMAND_CHANNEL, isAppCommand } from "./app-command.ts"
 import { branding } from "./branding.ts"
 
 declare const __APP_COMMIT__: string | undefined
@@ -23,6 +26,7 @@ export interface SaveClipboardAttachmentInput {
 export interface LumoBridge {
   appCommit: string
   getPathForFile(file: File): string
+  onAppCommand(callback: (command: AppCommand) => void): () => void
   platform: NodeJS.Platform
   saveClipboardAttachment(input: SaveClipboardAttachmentInput): Promise<SelectedAttachmentPath>
   selectAttachmentPaths(kind: "file" | "directory"): Promise<SelectedAttachmentPath[]>
@@ -41,6 +45,15 @@ setupConnectionPreload()
 const lumo: LumoBridge = {
   appCommit: typeof __APP_COMMIT__ === "string" ? __APP_COMMIT__ : "unknown",
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
+  onAppCommand: (callback: (command: AppCommand) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, command: unknown): void => {
+      if (isAppCommand(command)) {
+        callback(command)
+      }
+    }
+    ipcRenderer.on(APP_COMMAND_CHANNEL, listener)
+    return () => ipcRenderer.removeListener(APP_COMMAND_CHANNEL, listener)
+  },
   platform: process.platform,
   saveClipboardAttachment: (input: SaveClipboardAttachmentInput) =>
     electronAPI.ipcRenderer.invoke("lumo:save-clipboard-attachment", input) as Promise<SelectedAttachmentPath>,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,10 +1,11 @@
 import type { AppCommand } from "./app-command.ts"
+import type { AppLocale } from "./app-locale.ts"
 
 import { electronAPI } from "@electron-toolkit/preload"
 import { setupConnectionPreload } from "@oomol/connection-electron-adapter/preload"
 import { contextBridge, ipcRenderer, webUtils } from "electron"
 import { APP_COMMAND_CHANNEL, isAppCommand } from "./app-command.ts"
-import { APP_LOCALE_CHANNEL, isAppLocale } from "./app-locale.ts"
+import { APP_LOCALE_CHANNEL } from "./app-locale.ts"
 import { branding } from "./branding.ts"
 
 declare const __APP_COMMIT__: string | undefined
@@ -31,7 +32,7 @@ export interface LumoBridge {
   platform: NodeJS.Platform
   saveClipboardAttachment(input: SaveClipboardAttachmentInput): Promise<SelectedAttachmentPath>
   selectAttachmentPaths(kind: "file" | "directory"): Promise<SelectedAttachmentPath[]>
-  setAppLocale(locale: string): void
+  setAppLocale(locale: AppLocale): void
   version: string
 }
 
@@ -61,11 +62,7 @@ const lumo: LumoBridge = {
     electronAPI.ipcRenderer.invoke("lumo:save-clipboard-attachment", input) as Promise<SelectedAttachmentPath>,
   selectAttachmentPaths: (kind: "file" | "directory") =>
     electronAPI.ipcRenderer.invoke("lumo:select-attachment-paths", kind) as Promise<SelectedAttachmentPath[]>,
-  setAppLocale: (locale: string) => {
-    if (isAppLocale(locale)) {
-      ipcRenderer.send(APP_LOCALE_CHANNEL, locale)
-    }
-  },
+  setAppLocale: (locale: AppLocale) => ipcRenderer.send(APP_LOCALE_CHANNEL, locale),
   version: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "0.0.0",
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,7 @@ import { electronAPI } from "@electron-toolkit/preload"
 import { setupConnectionPreload } from "@oomol/connection-electron-adapter/preload"
 import { contextBridge, ipcRenderer, webUtils } from "electron"
 import { APP_COMMAND_CHANNEL, isAppCommand } from "./app-command.ts"
+import { APP_LOCALE_CHANNEL, isAppLocale } from "./app-locale.ts"
 import { branding } from "./branding.ts"
 
 declare const __APP_COMMIT__: string | undefined
@@ -30,6 +31,7 @@ export interface LumoBridge {
   platform: NodeJS.Platform
   saveClipboardAttachment(input: SaveClipboardAttachmentInput): Promise<SelectedAttachmentPath>
   selectAttachmentPaths(kind: "file" | "directory"): Promise<SelectedAttachmentPath[]>
+  setAppLocale(locale: string): void
   version: string
 }
 
@@ -59,6 +61,11 @@ const lumo: LumoBridge = {
     electronAPI.ipcRenderer.invoke("lumo:save-clipboard-attachment", input) as Promise<SelectedAttachmentPath>,
   selectAttachmentPaths: (kind: "file" | "directory") =>
     electronAPI.ipcRenderer.invoke("lumo:select-attachment-paths", kind) as Promise<SelectedAttachmentPath[]>,
+  setAppLocale: (locale: string) => {
+    if (isAppLocale(locale)) {
+      ipcRenderer.send(APP_LOCALE_CHANNEL, locale)
+    }
+  },
   version: typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "0.0.0",
 }
 

--- a/electron/window/application-menu-messages.ts
+++ b/electron/window/application-menu-messages.ts
@@ -1,0 +1,131 @@
+import type { AppLocale } from "../app-locale.ts"
+
+import { branding } from "../branding.ts"
+
+export interface ApplicationMenuLabels {
+  about: string
+  closeWindow: string
+  copy: string
+  cut: string
+  delete: string
+  developer: string
+  edit: string
+  exit: string
+  file: string
+  focusComposer: string
+  forceReload: string
+  front: string
+  help: string
+  hide: string
+  hideOthers: string
+  minimize: string
+  newChat: string
+  paste: string
+  pasteAndMatchStyle: string
+  quit: string
+  redo: string
+  reload: string
+  resetZoom: string
+  searchTasks: string
+  selectAll: string
+  services: string
+  settings: string
+  showAll: string
+  stopGeneration: string
+  toggleDevTools: string
+  toggleFullScreen: string
+  toggleSidebar: string
+  undo: string
+  view: string
+  window: string
+  zoom: string
+  zoomIn: string
+  zoomOut: string
+}
+
+export const applicationMenuMessages: Record<AppLocale, ApplicationMenuLabels> = {
+  "zh-CN": {
+    about: `关于 ${branding.appName}`,
+    closeWindow: "关闭窗口",
+    copy: "复制",
+    cut: "剪切",
+    delete: "删除",
+    developer: "开发",
+    edit: "编辑",
+    exit: "退出",
+    file: "文件",
+    focusComposer: "聚焦输入框",
+    forceReload: "强制重新加载",
+    front: "前置所有窗口",
+    help: "帮助",
+    hide: `隐藏 ${branding.appName}`,
+    hideOthers: "隐藏其他",
+    minimize: "最小化",
+    newChat: "新对话",
+    paste: "粘贴",
+    pasteAndMatchStyle: "粘贴并匹配样式",
+    quit: `退出 ${branding.appName}`,
+    redo: "重做",
+    reload: "重新加载窗口",
+    resetZoom: "实际大小",
+    searchTasks: "搜索任务",
+    selectAll: "全选",
+    services: "服务",
+    settings: "设置…",
+    showAll: "全部显示",
+    stopGeneration: "停止生成",
+    toggleDevTools: "切换开发者工具",
+    toggleFullScreen: "切换全屏",
+    toggleSidebar: "切换侧边栏",
+    undo: "撤销",
+    view: "视图",
+    window: "窗口",
+    zoom: "缩放",
+    zoomIn: "放大",
+    zoomOut: "缩小",
+  },
+  en: {
+    about: `About ${branding.appName}`,
+    closeWindow: "Close Window",
+    copy: "Copy",
+    cut: "Cut",
+    delete: "Delete",
+    developer: "Developer",
+    edit: "Edit",
+    exit: "Exit",
+    file: "File",
+    focusComposer: "Focus Composer",
+    forceReload: "Force Reload",
+    front: "Bring All to Front",
+    help: "Help",
+    hide: `Hide ${branding.appName}`,
+    hideOthers: "Hide Others",
+    minimize: "Minimize",
+    newChat: "New Chat",
+    paste: "Paste",
+    pasteAndMatchStyle: "Paste and Match Style",
+    quit: `Quit ${branding.appName}`,
+    redo: "Redo",
+    reload: "Reload Window",
+    resetZoom: "Actual Size",
+    searchTasks: "Search Tasks",
+    selectAll: "Select All",
+    services: "Services",
+    settings: "Settings…",
+    showAll: "Show All",
+    stopGeneration: "Stop Generation",
+    toggleDevTools: "Toggle Developer Tools",
+    toggleFullScreen: "Toggle Full Screen",
+    toggleSidebar: "Toggle Sidebar",
+    undo: "Undo",
+    view: "View",
+    window: "Window",
+    zoom: "Zoom",
+    zoomIn: "Zoom In",
+    zoomOut: "Zoom Out",
+  },
+}
+
+export function applicationMenuLabels(locale: AppLocale): ApplicationMenuLabels {
+  return applicationMenuMessages[locale]
+}

--- a/electron/window/application-menu.test.ts
+++ b/electron/window/application-menu.test.ts
@@ -3,6 +3,7 @@ import type { MenuItemConstructorOptions } from "electron"
 import { describe, expect, it, vi } from "vitest"
 import { APP_COMMANDS } from "../app-command.ts"
 import { normalizeAppLocale } from "../app-locale.ts"
+import { branding } from "../branding.ts"
 import { applicationMenuMessages } from "./application-menu-messages.ts"
 import { buildApplicationMenuTemplate } from "./application-menu.ts"
 
@@ -66,7 +67,7 @@ describe("buildApplicationMenuTemplate", () => {
     const template = menuTemplate({ developmentMode: false, locale: "zh-CN", platform: "darwin" })
     const labels = collectLabels(template)
 
-    expect(topLabels(template)).toEqual(["Lumo", "文件", "编辑", "视图", "窗口", "帮助"])
+    expect(topLabels(template)).toEqual([branding.appName, "文件", "编辑", "视图", "窗口", "帮助"])
     expect(labels).not.toContain("开发")
     expect(labels).not.toContain("重新加载窗口")
     expect(labels).not.toContain("强制重新加载")
@@ -77,7 +78,7 @@ describe("buildApplicationMenuTemplate", () => {
     const template = menuTemplate({ developmentMode: true, locale: "zh-CN", platform: "darwin" })
     const labels = collectLabels(template)
 
-    expect(topLabels(template)).toEqual(["Lumo", "文件", "编辑", "视图", "开发", "窗口", "帮助"])
+    expect(topLabels(template)).toEqual([branding.appName, "文件", "编辑", "视图", "开发", "窗口", "帮助"])
     expect(labels).toContain("重新加载窗口")
     expect(labels).toContain("强制重新加载")
     expect(labels).toContain("切换开发者工具")

--- a/electron/window/application-menu.test.ts
+++ b/electron/window/application-menu.test.ts
@@ -1,0 +1,111 @@
+import type { MenuItemConstructorOptions } from "electron"
+
+import { describe, expect, it, vi } from "vitest"
+import { APP_COMMANDS } from "../app-command.ts"
+import { normalizeAppLocale } from "../app-locale.ts"
+import { applicationMenuMessages } from "./application-menu-messages.ts"
+import { buildApplicationMenuTemplate } from "./application-menu.ts"
+
+type MenuClick = () => void
+
+function menuTemplate(input: Partial<Parameters<typeof buildApplicationMenuTemplate>[0]> = {}) {
+  return buildApplicationMenuTemplate({
+    developmentMode: false,
+    locale: "en",
+    onCommand: () => undefined,
+    platform: "darwin",
+    ...input,
+  })
+}
+
+function collectLabels(items: MenuItemConstructorOptions[]): string[] {
+  return items.flatMap((item) => {
+    const labels = typeof item.label === "string" ? [item.label] : []
+    const submenuLabels = Array.isArray(item.submenu) ? collectLabels(item.submenu) : []
+    return [...labels, ...submenuLabels]
+  })
+}
+
+function topLabels(items: MenuItemConstructorOptions[]): string[] {
+  return items.map((item) => item.label).filter((label): label is string => typeof label === "string")
+}
+
+function findItem(items: MenuItemConstructorOptions[], label: string): MenuItemConstructorOptions {
+  const item = items.find((entry) => entry.label === label)
+  expect(item).toBeTruthy()
+  return item as MenuItemConstructorOptions
+}
+
+describe("application menu locale helpers", () => {
+  it("normalizes supported app locales", () => {
+    expect(normalizeAppLocale("zh-CN")).toBe("zh-CN")
+    expect(normalizeAppLocale("zh-Hans")).toBe("zh-CN")
+    expect(normalizeAppLocale("en-US")).toBe("en")
+    expect(normalizeAppLocale(undefined)).toBe("en")
+  })
+
+  it("keeps menu message keys in parity", () => {
+    expect(Object.keys(applicationMenuMessages["zh-CN"]).sort()).toEqual(Object.keys(applicationMenuMessages.en).sort())
+  })
+})
+
+describe("buildApplicationMenuTemplate", () => {
+  it("localizes standard macOS menu role labels in Chinese", () => {
+    const template = menuTemplate({ locale: "zh-CN", platform: "darwin" })
+    const labels = collectLabels(template)
+
+    expect(labels).toContain("撤销")
+    expect(labels).toContain("剪切")
+    expect(labels).toContain("粘贴并匹配样式")
+    expect(labels).toContain("前置所有窗口")
+    expect(labels).not.toContain("Undo")
+    expect(labels).not.toContain("Paste and Match Style")
+  })
+
+  it("hides developer-only commands in production menus", () => {
+    const template = menuTemplate({ developmentMode: false, locale: "zh-CN", platform: "darwin" })
+    const labels = collectLabels(template)
+
+    expect(topLabels(template)).toEqual(["Lumo", "文件", "编辑", "视图", "窗口", "帮助"])
+    expect(labels).not.toContain("开发")
+    expect(labels).not.toContain("重新加载窗口")
+    expect(labels).not.toContain("强制重新加载")
+    expect(labels).not.toContain("切换开发者工具")
+  })
+
+  it("places developer commands in a dedicated development menu", () => {
+    const template = menuTemplate({ developmentMode: true, locale: "zh-CN", platform: "darwin" })
+    const labels = collectLabels(template)
+
+    expect(topLabels(template)).toEqual(["Lumo", "文件", "编辑", "视图", "开发", "窗口", "帮助"])
+    expect(labels).toContain("重新加载窗口")
+    expect(labels).toContain("强制重新加载")
+    expect(labels).toContain("切换开发者工具")
+  })
+
+  it("uses Windows-friendly File menu labels", () => {
+    const template = menuTemplate({ developmentMode: false, locale: "en", platform: "win32" })
+    const fileMenu = findItem(template, "File")
+    const fileLabels = Array.isArray(fileMenu.submenu) ? collectLabels(fileMenu.submenu) : []
+
+    expect(topLabels(template)).toEqual(["File", "Edit", "View", "Window", "Help"])
+    expect(fileLabels).toContain("New Chat")
+    expect(fileLabels).toContain("Settings…")
+    expect(fileLabels).toContain("Exit")
+  })
+
+  it("dispatches app command menu items", () => {
+    const onCommand = vi.fn()
+    const template = menuTemplate({ locale: "zh-CN", onCommand, platform: "darwin" })
+    const fileMenu = findItem(template, "文件")
+    const newChatItem = Array.isArray(fileMenu.submenu) ? findItem(fileMenu.submenu, "新对话") : undefined
+
+    if (!newChatItem) {
+      throw new Error("New chat menu item was not found.")
+    }
+    expect(newChatItem.click).toBeTypeOf("function")
+    ;(newChatItem.click as MenuClick)()
+
+    expect(onCommand).toHaveBeenCalledExactlyOnceWith(APP_COMMANDS.newChat)
+  })
+})

--- a/electron/window/application-menu.ts
+++ b/electron/window/application-menu.ts
@@ -2,59 +2,15 @@ import type { AppCommand } from "../app-command.ts"
 import type { MenuItemConstructorOptions } from "electron"
 
 import { APP_COMMANDS } from "../app-command.ts"
+import { normalizeAppLocale } from "../app-locale.ts"
 import { branding } from "../branding.ts"
+import { applicationMenuLabels } from "./application-menu-messages.ts"
 
 interface ApplicationMenuOptions {
+  developmentMode: boolean
   locale?: string
   onCommand: (command: AppCommand) => void
   platform: NodeJS.Platform
-}
-
-function labels(locale: string | undefined): {
-  about: string
-  edit: string
-  file: string
-  focusComposer: string
-  help: string
-  newChat: string
-  searchTasks: string
-  settings: string
-  stopGeneration: string
-  toggleSidebar: string
-  view: string
-  window: string
-} {
-  const useChinese = locale?.toLowerCase().startsWith("zh") ?? false
-  if (useChinese) {
-    return {
-      about: `关于 ${branding.appName}`,
-      edit: "编辑",
-      file: "文件",
-      focusComposer: "聚焦输入框",
-      help: "帮助",
-      newChat: "新对话",
-      searchTasks: "搜索任务",
-      settings: "设置",
-      stopGeneration: "停止生成",
-      toggleSidebar: "切换侧边栏",
-      view: "视图",
-      window: "窗口",
-    }
-  }
-  return {
-    about: `About ${branding.appName}`,
-    edit: "Edit",
-    file: "File",
-    focusComposer: "Focus Composer",
-    help: "Help",
-    newChat: "New Chat",
-    searchTasks: "Search Tasks",
-    settings: "Settings",
-    stopGeneration: "Stop Generation",
-    toggleSidebar: "Toggle Sidebar",
-    view: "View",
-    window: "Window",
-  }
 }
 
 function settingsMenuItem(input: ApplicationMenuOptions, label: string): MenuItemConstructorOptions {
@@ -65,8 +21,15 @@ function settingsMenuItem(input: ApplicationMenuOptions, label: string): MenuIte
   }
 }
 
+function roleMenuItem(
+  role: NonNullable<MenuItemConstructorOptions["role"]>,
+  label: string,
+): MenuItemConstructorOptions {
+  return { label, role }
+}
+
 export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): MenuItemConstructorOptions[] {
-  const label = labels(input.locale)
+  const label = applicationMenuLabels(normalizeAppLocale(input.locale))
   const isMac = input.platform === "darwin"
 
   const template: MenuItemConstructorOptions[] = []
@@ -75,17 +38,17 @@ export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): Men
     template.push({
       label: branding.appName,
       submenu: [
-        { label: label.about, role: "about" },
+        roleMenuItem("about", label.about),
         { type: "separator" },
         settingsMenuItem(input, label.settings),
         { type: "separator" },
-        { role: "services" },
+        roleMenuItem("services", label.services),
         { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
+        roleMenuItem("hide", label.hide),
+        roleMenuItem("hideOthers", label.hideOthers),
+        roleMenuItem("unhide", label.showAll),
         { type: "separator" },
-        { role: "quit" },
+        roleMenuItem("quit", label.quit),
       ],
     })
   }
@@ -101,22 +64,22 @@ export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): Men
         },
         ...(isMac ? [] : [{ type: "separator" } as const, settingsMenuItem(input, label.settings)]),
         { type: "separator" },
-        isMac ? { role: "close" } : { role: "quit" },
+        isMac ? roleMenuItem("close", label.closeWindow) : roleMenuItem("quit", label.exit),
       ],
     },
     {
       label: label.edit,
       submenu: [
-        { role: "undo" },
-        { role: "redo" },
+        roleMenuItem("undo", label.undo),
+        roleMenuItem("redo", label.redo),
         { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "pasteAndMatchStyle" },
-        { role: "delete" },
+        roleMenuItem("cut", label.cut),
+        roleMenuItem("copy", label.copy),
+        roleMenuItem("paste", label.paste),
+        roleMenuItem("pasteAndMatchStyle", label.pasteAndMatchStyle),
+        roleMenuItem("delete", label.delete),
         { type: "separator" },
-        { role: "selectAll" },
+        roleMenuItem("selectAll", label.selectAll),
       ],
     },
     {
@@ -144,26 +107,42 @@ export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): Men
           label: label.toggleSidebar,
         },
         { type: "separator" },
-        { role: "reload" },
-        { role: "forceReload" },
-        { role: "toggleDevTools" },
+        roleMenuItem("resetZoom", label.resetZoom),
+        roleMenuItem("zoomIn", label.zoomIn),
+        roleMenuItem("zoomOut", label.zoomOut),
         { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { type: "separator" },
-        { role: "togglefullscreen" },
+        roleMenuItem("togglefullscreen", label.toggleFullScreen),
       ],
     },
+  )
+
+  if (input.developmentMode) {
+    template.push({
+      label: label.developer,
+      submenu: [
+        roleMenuItem("reload", label.reload),
+        roleMenuItem("forceReload", label.forceReload),
+        roleMenuItem("toggleDevTools", label.toggleDevTools),
+      ],
+    })
+  }
+
+  template.push(
     {
       label: label.window,
       submenu: isMac
-        ? [{ role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }]
-        : [{ role: "minimize" }, { role: "close" }],
+        ? [
+            roleMenuItem("minimize", label.minimize),
+            roleMenuItem("zoom", label.zoom),
+            { type: "separator" },
+            roleMenuItem("front", label.front),
+          ]
+        : [roleMenuItem("minimize", label.minimize), roleMenuItem("close", label.closeWindow)],
     },
     {
+      role: "help",
       label: label.help,
-      submenu: [],
+      submenu: [roleMenuItem("about", label.about)],
     },
   )
 

--- a/electron/window/application-menu.ts
+++ b/electron/window/application-menu.ts
@@ -1,0 +1,171 @@
+import type { AppCommand } from "../app-command.ts"
+import type { MenuItemConstructorOptions } from "electron"
+
+import { APP_COMMANDS } from "../app-command.ts"
+import { branding } from "../branding.ts"
+
+interface ApplicationMenuOptions {
+  locale?: string
+  onCommand: (command: AppCommand) => void
+  platform: NodeJS.Platform
+}
+
+function labels(locale: string | undefined): {
+  about: string
+  edit: string
+  file: string
+  focusComposer: string
+  help: string
+  newChat: string
+  searchTasks: string
+  settings: string
+  stopGeneration: string
+  toggleSidebar: string
+  view: string
+  window: string
+} {
+  const useChinese = locale?.toLowerCase().startsWith("zh") ?? false
+  if (useChinese) {
+    return {
+      about: `关于 ${branding.appName}`,
+      edit: "编辑",
+      file: "文件",
+      focusComposer: "聚焦输入框",
+      help: "帮助",
+      newChat: "新对话",
+      searchTasks: "搜索任务",
+      settings: "设置",
+      stopGeneration: "停止生成",
+      toggleSidebar: "切换侧边栏",
+      view: "视图",
+      window: "窗口",
+    }
+  }
+  return {
+    about: `About ${branding.appName}`,
+    edit: "Edit",
+    file: "File",
+    focusComposer: "Focus Composer",
+    help: "Help",
+    newChat: "New Chat",
+    searchTasks: "Search Tasks",
+    settings: "Settings",
+    stopGeneration: "Stop Generation",
+    toggleSidebar: "Toggle Sidebar",
+    view: "View",
+    window: "Window",
+  }
+}
+
+function settingsMenuItem(input: ApplicationMenuOptions, label: string): MenuItemConstructorOptions {
+  return {
+    accelerator: "CommandOrControl+,",
+    click: () => input.onCommand(APP_COMMANDS.openSettings),
+    label,
+  }
+}
+
+export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): MenuItemConstructorOptions[] {
+  const label = labels(input.locale)
+  const isMac = input.platform === "darwin"
+
+  const template: MenuItemConstructorOptions[] = []
+
+  if (isMac) {
+    template.push({
+      label: branding.appName,
+      submenu: [
+        { label: label.about, role: "about" },
+        { type: "separator" },
+        settingsMenuItem(input, label.settings),
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    })
+  }
+
+  template.push(
+    {
+      label: label.file,
+      submenu: [
+        {
+          accelerator: "CommandOrControl+N",
+          click: () => input.onCommand(APP_COMMANDS.newChat),
+          label: label.newChat,
+        },
+        ...(isMac ? [] : [{ type: "separator" } as const, settingsMenuItem(input, label.settings)]),
+        { type: "separator" },
+        isMac ? { role: "close" } : { role: "quit" },
+      ],
+    },
+    {
+      label: label.edit,
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "pasteAndMatchStyle" },
+        { role: "delete" },
+        { type: "separator" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: label.view,
+      submenu: [
+        {
+          accelerator: "CommandOrControl+K",
+          click: () => input.onCommand(APP_COMMANDS.openSearch),
+          label: label.searchTasks,
+        },
+        {
+          accelerator: "CommandOrControl+L",
+          click: () => input.onCommand(APP_COMMANDS.focusComposer),
+          label: label.focusComposer,
+        },
+        {
+          accelerator: "CommandOrControl+.",
+          click: () => input.onCommand(APP_COMMANDS.stopGeneration),
+          label: label.stopGeneration,
+        },
+        { type: "separator" },
+        {
+          accelerator: "CommandOrControl+B",
+          click: () => input.onCommand(APP_COMMANDS.toggleSidebar),
+          label: label.toggleSidebar,
+        },
+        { type: "separator" },
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    {
+      label: label.window,
+      submenu: isMac
+        ? [{ role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }]
+        : [{ role: "minimize" }, { role: "close" }],
+    },
+    {
+      label: label.help,
+      submenu: [],
+    },
+  )
+
+  return template
+}

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -195,6 +195,17 @@ function normalizeSearchText(value: string): string {
   return value.trim().toLocaleLowerCase()
 }
 
+function encodedDomIdSegment(value: string): string {
+  return Array.from(value, (char) => {
+    const codePoint = char.codePointAt(0)
+    return codePoint === undefined ? "0" : codePoint.toString(16)
+  }).join("-")
+}
+
+function sessionSearchResultId(sessionId: string): string {
+  return `session-search-result-${encodedDomIdSegment(sessionId)}`
+}
+
 function accountInitial(name?: string): string {
   const trimmed = name?.trim()
   return trimmed ? trimmed.charAt(0).toLocaleUpperCase() : "L"
@@ -830,6 +841,8 @@ function SessionSearchOverlay({
   const filteredSessions = normalizedQuery
     ? sessions.filter((session) => normalizeSearchText(session.title).includes(normalizedQuery))
     : sessions
+  const activeSession = filteredSessions[activeIndex]
+  const activeResultId = activeSession ? sessionSearchResultId(activeSession.id) : undefined
 
   React.useEffect(() => {
     if (open) {
@@ -848,12 +861,11 @@ function SessionSearchOverlay({
   }, [filteredSessions.length])
 
   React.useEffect(() => {
-    const activeSession = filteredSessions[activeIndex]
     if (!activeSession) {
       return
     }
     resultRefs.current.get(activeSession.id)?.scrollIntoView({ block: "nearest" })
-  }, [activeIndex, filteredSessions])
+  }, [activeSession])
 
   const selectSession = (session: SessionInfo | undefined): void => {
     if (!session) {
@@ -921,7 +933,11 @@ function SessionSearchOverlay({
             onChange={(event) => setQuery(event.target.value)}
             placeholder={t("sidebar.searchPlaceholder")}
             aria-label={t("sidebar.searchPlaceholder")}
+            aria-activedescendant={activeResultId}
+            aria-controls="session-search-results"
+            aria-expanded="true"
             className="h-8 min-w-0 flex-1 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+            role="combobox"
           />
         </div>
 
@@ -929,6 +945,7 @@ function SessionSearchOverlay({
           {t("sidebar.searchResults", { count: filteredSessions.length })}
         </p>
         <div
+          id="session-search-results"
           className="mt-3 max-h-[min(46vh,420px)] overflow-y-auto pr-1"
           role="listbox"
           aria-label={t("sidebar.searchResults", { count: filteredSessions.length })}
@@ -937,6 +954,7 @@ function SessionSearchOverlay({
             {filteredSessions.map((session, index) => (
               <button
                 key={session.id}
+                id={sessionSearchResultId(session.id)}
                 ref={(node) => {
                   if (node) {
                     resultRefs.current.set(session.id, node)

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1,3 +1,4 @@
+import type { AppCommand } from "../../../electron/app-command.ts"
 import type {
   AgentRuntimeStatus,
   AuthorizationInfo,
@@ -41,6 +42,7 @@ import {
 } from "lucide-react"
 import * as React from "react"
 import { toast } from "sonner"
+import { APP_COMMANDS } from "../../../electron/app-command.ts"
 import {
   buildFallbackSessionTitle,
   shouldAutoRefreshSessionTitle,
@@ -71,6 +73,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import { useAppCommandEvents, useAppCommandShortcuts } from "@/hooks/useAppCommandShortcuts"
 import { useAppUpdate } from "@/hooks/useAppUpdate"
 import { useAuth } from "@/hooks/useAuth"
 import { useChat } from "@/hooks/useChat"
@@ -82,6 +85,7 @@ import {
 } from "@/hooks/useOrganizationWorkspace"
 import { useSessions } from "@/hooks/useSessions"
 import { useI18n, useT } from "@/i18n/i18n"
+import { appCommandAriaShortcut, appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 import { chatTurnInputKey } from "@/routes/Chat/chat-turns"
@@ -819,7 +823,9 @@ function SessionSearchOverlay({
 }) {
   const t = useT()
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const resultRefs = React.useRef(new Map<string, HTMLButtonElement>())
   const [query, setQuery] = React.useState("")
+  const [activeIndex, setActiveIndex] = React.useState(0)
   const normalizedQuery = normalizeSearchText(query)
   const filteredSessions = normalizedQuery
     ? sessions.filter((session) => normalizeSearchText(session.title).includes(normalizedQuery))
@@ -828,9 +834,33 @@ function SessionSearchOverlay({
   React.useEffect(() => {
     if (open) {
       setQuery("")
+      setActiveIndex(0)
       window.setTimeout(() => inputRef.current?.focus(), 0)
     }
   }, [open])
+
+  React.useEffect(() => {
+    setActiveIndex(0)
+  }, [normalizedQuery])
+
+  React.useEffect(() => {
+    setActiveIndex((index) => Math.min(index, Math.max(0, filteredSessions.length - 1)))
+  }, [filteredSessions.length])
+
+  React.useEffect(() => {
+    const activeSession = filteredSessions[activeIndex]
+    if (!activeSession) {
+      return
+    }
+    resultRefs.current.get(activeSession.id)?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex, filteredSessions])
+
+  const selectSession = (session: SessionInfo | undefined): void => {
+    if (!session) {
+      return
+    }
+    onSelect(session)
+  }
 
   if (!open) {
     return null
@@ -849,7 +879,36 @@ function SessionSearchOverlay({
       }}
       onKeyDown={(event) => {
         if (event.key === "Escape") {
+          event.preventDefault()
           onClose()
+          return
+        }
+        if (filteredSessions.length === 0) {
+          return
+        }
+        if (event.key === "ArrowDown") {
+          event.preventDefault()
+          setActiveIndex((index) => (index + 1) % filteredSessions.length)
+          return
+        }
+        if (event.key === "ArrowUp") {
+          event.preventDefault()
+          setActiveIndex((index) => (index - 1 + filteredSessions.length) % filteredSessions.length)
+          return
+        }
+        if (event.key === "Home") {
+          event.preventDefault()
+          setActiveIndex(0)
+          return
+        }
+        if (event.key === "End") {
+          event.preventDefault()
+          setActiveIndex(filteredSessions.length - 1)
+          return
+        }
+        if (event.key === "Enter") {
+          event.preventDefault()
+          selectSession(filteredSessions[activeIndex])
         }
       }}
     >
@@ -869,15 +928,32 @@ function SessionSearchOverlay({
         <p className="oo-text-control mt-4 px-3 text-muted-foreground">
           {t("sidebar.searchResults", { count: filteredSessions.length })}
         </p>
-        <div className="mt-3 max-h-[min(46vh,420px)] overflow-y-auto pr-1">
+        <div
+          className="mt-3 max-h-[min(46vh,420px)] overflow-y-auto pr-1"
+          role="listbox"
+          aria-label={t("sidebar.searchResults", { count: filteredSessions.length })}
+        >
           <div className="grid gap-1">
-            {filteredSessions.map((session) => (
+            {filteredSessions.map((session, index) => (
               <button
                 key={session.id}
+                ref={(node) => {
+                  if (node) {
+                    resultRefs.current.set(session.id, node)
+                  } else {
+                    resultRefs.current.delete(session.id)
+                  }
+                }}
                 type="button"
-                onClick={() => onSelect(session)}
+                role="option"
+                aria-selected={index === activeIndex}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => selectSession(session)}
                 title={session.title}
-                className="oo-session-search-result oo-text-value flex h-10 min-w-0 items-center rounded-lg px-3 text-left"
+                className={cn(
+                  "oo-session-search-result oo-text-value flex h-10 min-w-0 items-center rounded-lg px-3 text-left",
+                  index === activeIndex && "bg-accent text-accent-foreground",
+                )}
               >
                 <span className="truncate">{session.title}</span>
               </button>
@@ -918,13 +994,17 @@ function SidebarTitlebarActions({
   onSearch: () => void
 }) {
   const t = useT()
+  const sidebarLabel = collapsed ? t("aria.expandSidebar") : t("aria.collapseSidebar")
+  const sidebarTitle = labelWithShortcut(sidebarLabel, appCommandShortcutLabel(APP_COMMANDS.toggleSidebar))
+  const searchTitle = labelWithShortcut(t("sidebar.search"), appCommandShortcutLabel(APP_COMMANDS.openSearch))
 
   return (
     <div className="oo-sidebar-titlebar-actions flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
       <button
         type="button"
-        title={collapsed ? t("aria.expandSidebar") : t("aria.collapseSidebar")}
-        aria-label={collapsed ? t("aria.expandSidebar") : t("aria.collapseSidebar")}
+        title={sidebarTitle}
+        aria-label={sidebarTitle}
+        aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.toggleSidebar)}
         aria-pressed={collapsed}
         onClick={onToggleCollapsed}
         className="oo-sidebar-titlebar-button flex size-7 shrink-0 items-center justify-center rounded-md"
@@ -933,8 +1013,9 @@ function SidebarTitlebarActions({
       </button>
       <button
         type="button"
-        title={t("sidebar.search")}
-        aria-label={t("sidebar.search")}
+        title={searchTitle}
+        aria-label={searchTitle}
+        aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.openSearch)}
         onClick={onSearch}
         className="oo-sidebar-titlebar-button flex size-7 shrink-0 items-center justify-center rounded-md"
       >
@@ -1189,6 +1270,7 @@ export function AppShell() {
   const [sidebarWidth, setSidebarWidth] = React.useState(readStoredSidebarWidth)
   const [isSidebarResizing, setIsSidebarResizing] = React.useState(false)
   const [searchOpen, setSearchOpen] = React.useState(false)
+  const [composerFocusRequest, setComposerFocusRequest] = React.useState(0)
   const [renameSessionId, setRenameSessionId] = React.useState<string | null>(null)
   const [archiveSessionId, setArchiveSessionId] = React.useState<string | null>(null)
   const [archiveConfirming, setArchiveConfirming] = React.useState(false)
@@ -1489,12 +1571,20 @@ export function AppShell() {
     composerDraftsByKey.current.delete(draftKey)
   }, [])
 
-  const handleNewSession = (): void => {
+  const requestComposerFocus = React.useCallback((): void => {
+    setRoute("chat")
+    setSearchOpen(false)
+    setComposerFocusRequest((request) => request + 1)
+  }, [])
+
+  const handleNewSession = React.useCallback((): void => {
     setActiveSessionId(null)
     setIsDraftSession(true)
     setPendingChatTransition(null)
     setRoute("chat")
-  }
+    setSearchOpen(false)
+    setComposerFocusRequest((request) => request + 1)
+  }, [])
 
   const refreshGeneratedTitle = React.useCallback(
     async (
@@ -1835,12 +1925,14 @@ export function AppShell() {
     },
     [activeSessionId],
   )
-  const handleToggleSidebar = (): void => {
-    if (sidebarCollapsed) {
-      setIsSidebarRestoring(true)
-    }
-    setSidebarCollapsed((collapsed) => !collapsed)
-  }
+  const handleToggleSidebar = React.useCallback((): void => {
+    setSidebarCollapsed((collapsed) => {
+      if (collapsed) {
+        setIsSidebarRestoring(true)
+      }
+      return !collapsed
+    })
+  }, [])
   const handleSidebarResizeStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (sidebarCollapsed) {
       return
@@ -1897,7 +1989,7 @@ export function AppShell() {
       setArtifactsPanelWidth(ARTIFACTS_PANEL_MAX_WIDTH_PX)
     }
   }
-  const handleOpenSearch = (): void => setSearchOpen(true)
+  const handleOpenSearch = React.useCallback((): void => setSearchOpen(true), [])
   const handleRenameSession = (sessionId: string, title: string): void => {
     autoFallbackTitleBySession.current.delete(sessionId)
     void rename(sessionId, title).catch((cause: unknown) => {
@@ -1921,6 +2013,35 @@ export function AppShell() {
       void stop(activeSessionId)
     }
   }, [activeSessionId, stop])
+  const runAppCommand = React.useCallback(
+    (command: AppCommand): void => {
+      switch (command) {
+        case APP_COMMANDS.focusComposer:
+          requestComposerFocus()
+          return
+        case APP_COMMANDS.newChat:
+          handleNewSession()
+          return
+        case APP_COMMANDS.openSearch:
+          handleOpenSearch()
+          return
+        case APP_COMMANDS.openSettings:
+          setSearchOpen(false)
+          setRoute("settings")
+          return
+        case APP_COMMANDS.stopGeneration:
+          handleChatStop()
+          return
+        case APP_COMMANDS.toggleSidebar:
+          handleToggleSidebar()
+          return
+      }
+    },
+    [handleChatStop, handleNewSession, handleOpenSearch, handleToggleSidebar, requestComposerFocus],
+  )
+  useAppCommandEvents(runAppCommand)
+  useAppCommandShortcuts(runAppCommand)
+
   const handleQueuedMessageRemove = React.useCallback(
     (messageId: string) => {
       if (!activeSessionId) {
@@ -1939,6 +2060,8 @@ export function AppShell() {
   const ArtifactsToggleIcon = artifactsPanelOpen ? PanelRightClose : PanelRightOpen
   const artifactsToggleLabel = artifactsPanelOpen ? t("artifacts.collapse") : t("artifacts.expand")
   const billingCacheScope = auth.state?.account?.id ?? "authenticated"
+  const newChatShortcut = appCommandShortcutLabel(APP_COMMANDS.newChat)
+  const newChatLabel = labelWithShortcut(t("sidebar.newSession"), newChatShortcut)
 
   if (route === "settings") {
     return (
@@ -2011,6 +2134,9 @@ export function AppShell() {
             <button
               type="button"
               onClick={handleNewSession}
+              title={newChatLabel}
+              aria-label={newChatLabel}
+              aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.newChat)}
               className={cn(
                 "oo-sidebar-nav-item oo-text-control flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
                 route === "chat" && !activeSessionId && "bg-sidebar-accent text-sidebar-accent-foreground",
@@ -2212,6 +2338,7 @@ export function AppShell() {
                     submitDisabled={!ready || chatBootstrapping}
                     initialComposerState={initialComposerState}
                     initialSendPending={initialSendPending}
+                    composerFocusRequest={composerFocusRequest}
                     providers={activeProviders}
                     queuedMessages={activeQueuedMessages}
                     placeholder={

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -14,7 +14,33 @@ export interface DialogProps {
   className?: string
 }
 
-/** 轻量模态：portal + 遮罩 + Esc 关闭 + 挂载聚焦。无 Radix 依赖。 */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const selector = [
+    "a[href]",
+    "button:not([disabled])",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(",")
+
+  return Array.from(container.querySelectorAll<HTMLElement>(selector)).filter((element) => {
+    return (
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      element.getClientRects().length > 0
+    )
+  })
+}
+
+function isPortalKeyboardOwner(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    Boolean(target.closest('[data-slot="select-content"], [data-slot="dropdown-menu-content"]'))
+  )
+}
+
+/** 轻量模态：portal + 遮罩 + Esc 关闭 + 焦点循环 / 恢复。无 Radix 依赖。 */
 export function Dialog({ open, onClose, title, description, children, footer, closeLabel, className }: DialogProps) {
   const panelRef = React.useRef<HTMLDivElement>(null)
   const onCloseRef = React.useRef(onClose)
@@ -27,15 +53,66 @@ export function Dialog({ open, onClose, title, description, children, footer, cl
     if (!open) {
       return
     }
+    const previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
     const onKey = (e: KeyboardEvent): void => {
+      if (isPortalKeyboardOwner(e.target)) {
+        return
+      }
+
       if (e.key === "Escape") {
+        e.preventDefault()
+        e.stopPropagation()
         onCloseRef.current()
+        return
+      }
+
+      if (e.key !== "Tab") {
+        return
+      }
+
+      const panel = panelRef.current
+      if (!panel) {
+        return
+      }
+      const focusableElements = getFocusableElements(panel)
+      if (focusableElements.length === 0) {
+        e.preventDefault()
+        panel.focus()
+        return
+      }
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+      const activeElement = document.activeElement
+      if (e.shiftKey) {
+        if (activeElement === firstElement || activeElement === panel || !panel.contains(activeElement)) {
+          e.preventDefault()
+          lastElement.focus()
+        }
+        return
+      }
+
+      if (activeElement === lastElement || activeElement === panel || !panel.contains(activeElement)) {
+        e.preventDefault()
+        firstElement.focus()
       }
     }
     document.addEventListener("keydown", onKey)
-    // 挂载后聚焦面板，便于 Esc / 表单内首个输入接管。
-    panelRef.current?.focus()
-    return () => document.removeEventListener("keydown", onKey)
+    // 挂载后优先聚焦第一个控件；没有控件时聚焦面板本身。
+    const frame = window.requestAnimationFrame(() => {
+      const panel = panelRef.current
+      if (!panel) {
+        return
+      }
+      ;(getFocusableElements(panel)[0] ?? panel).focus()
+    })
+    return () => {
+      window.cancelAnimationFrame(frame)
+      document.removeEventListener("keydown", onKey)
+      if (previousActiveElement?.isConnected) {
+        previousActiveElement.focus()
+      }
+    }
   }, [open])
 
   if (!open) {

--- a/src/hooks/useAppCommandShortcuts.ts
+++ b/src/hooks/useAppCommandShortcuts.ts
@@ -1,0 +1,41 @@
+import type { AppCommand } from "../../electron/app-command.ts"
+
+import * as React from "react"
+import { appCommandForKeyboardShortcut } from "@/lib/app-shortcuts"
+
+const blockingOverlaySelector = [
+  '[role="dialog"][aria-modal="true"]',
+  '[role="menu"]',
+  '[data-slot="dropdown-menu-content"]',
+  '[data-slot="select-content"]',
+].join(",")
+
+function hasBlockingOverlay(): boolean {
+  return Boolean(document.querySelector(blockingOverlaySelector))
+}
+
+export function useAppCommandEvents(runCommand: (command: AppCommand) => void): void {
+  React.useEffect(() => {
+    const bridge = globalThis.lumo
+    if (!bridge?.onAppCommand) {
+      return undefined
+    }
+    return bridge.onAppCommand(runCommand)
+  }, [runCommand])
+}
+
+export function useAppCommandShortcuts(runCommand: (command: AppCommand) => void): void {
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      const command = appCommandForKeyboardShortcut(event)
+      if (!command || hasBlockingOverlay()) {
+        return
+      }
+      event.preventDefault()
+      runCommand(command)
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [runCommand])
+}

--- a/src/hooks/useAppCommandShortcuts.ts
+++ b/src/hooks/useAppCommandShortcuts.ts
@@ -14,6 +14,18 @@ function hasBlockingOverlay(): boolean {
   return Boolean(document.querySelector(blockingOverlaySelector))
 }
 
+function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false
+  }
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    Boolean(target.closest('[contenteditable="true"]'))
+  )
+}
+
 export function useAppCommandEvents(runCommand: (command: AppCommand) => void): void {
   React.useEffect(() => {
     const bridge = globalThis.lumo
@@ -27,6 +39,9 @@ export function useAppCommandEvents(runCommand: (command: AppCommand) => void): 
 export function useAppCommandShortcuts(runCommand: (command: AppCommand) => void): void {
   React.useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (isEditableShortcutTarget(event.target)) {
+        return
+      }
       const command = appCommandForKeyboardShortcut(event)
       if (!command || hasBlockingOverlay()) {
         return

--- a/src/i18n/I18nProvider.tsx
+++ b/src/i18n/I18nProvider.tsx
@@ -8,6 +8,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     document.documentElement.lang = locale
+    globalThis.lumo?.setAppLocale(locale)
   }, [locale])
 
   const setLocale = React.useCallback((next: Locale) => {

--- a/src/lib/app-shortcuts.test.ts
+++ b/src/lib/app-shortcuts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { APP_COMMANDS } from "../../electron/app-command.ts"
+import { appCommandAriaShortcut, appCommandForKeyboardShortcut, appCommandShortcutLabel } from "./app-shortcuts.ts"
+
+describe("app shortcuts", () => {
+  it("maps command modifier shortcuts on macOS", () => {
+    expect(appCommandForKeyboardShortcut({ key: "n", metaKey: true }, "darwin")).toBe(APP_COMMANDS.newChat)
+    expect(appCommandForKeyboardShortcut({ key: "K", metaKey: true }, "darwin")).toBe(APP_COMMANDS.openSearch)
+    expect(appCommandForKeyboardShortcut({ key: ",", metaKey: true }, "darwin")).toBe(APP_COMMANDS.openSettings)
+    expect(appCommandForKeyboardShortcut({ key: "b", metaKey: true }, "darwin")).toBe(APP_COMMANDS.toggleSidebar)
+    expect(appCommandForKeyboardShortcut({ key: "l", metaKey: true }, "darwin")).toBe(APP_COMMANDS.focusComposer)
+    expect(appCommandForKeyboardShortcut({ key: ".", metaKey: true }, "darwin")).toBe(APP_COMMANDS.stopGeneration)
+  })
+
+  it("maps control shortcuts off macOS", () => {
+    expect(appCommandForKeyboardShortcut({ key: "n", ctrlKey: true }, "win32")).toBe(APP_COMMANDS.newChat)
+    expect(appCommandForKeyboardShortcut({ key: "k", ctrlKey: true }, "linux")).toBe(APP_COMMANDS.openSearch)
+  })
+
+  it("does not steal text-editing or repeated variants", () => {
+    expect(appCommandForKeyboardShortcut({ key: "k", ctrlKey: true }, "darwin")).toBeNull()
+    expect(appCommandForKeyboardShortcut({ key: "k", metaKey: true, shiftKey: true }, "darwin")).toBeNull()
+    expect(appCommandForKeyboardShortcut({ key: "k", metaKey: true, repeat: true }, "darwin")).toBeNull()
+    expect(appCommandForKeyboardShortcut({ key: "k" }, "darwin")).toBeNull()
+  })
+
+  it("formats visible and aria shortcut labels", () => {
+    expect(appCommandShortcutLabel(APP_COMMANDS.openSearch, "darwin")).toBe("⌘K")
+    expect(appCommandShortcutLabel(APP_COMMANDS.openSearch, "win32")).toBe("Ctrl+K")
+    expect(appCommandAriaShortcut(APP_COMMANDS.openSearch, "darwin")).toBe("Meta+K")
+    expect(appCommandAriaShortcut(APP_COMMANDS.openSearch, "win32")).toBe("Control+K")
+  })
+})

--- a/src/lib/app-shortcuts.ts
+++ b/src/lib/app-shortcuts.ts
@@ -1,0 +1,94 @@
+import type { AppCommand } from "../../electron/app-command.ts"
+
+import { APP_COMMANDS } from "../../electron/app-command.ts"
+
+export interface KeyboardShortcutEvent {
+  altKey?: boolean
+  ctrlKey?: boolean
+  key: string
+  metaKey?: boolean
+  repeat?: boolean
+  shiftKey?: boolean
+}
+
+export function isMacPlatform(platform: NodeJS.Platform | undefined = globalThis.lumo?.platform): boolean {
+  return platform === "darwin"
+}
+
+export function appCommandForKeyboardShortcut(
+  event: KeyboardShortcutEvent,
+  platform: NodeJS.Platform | undefined = globalThis.lumo?.platform,
+): AppCommand | null {
+  if (event.repeat || event.altKey || event.shiftKey) {
+    return null
+  }
+
+  const isMac = isMacPlatform(platform)
+  const commandModifier = isMac ? Boolean(event.metaKey) && !event.ctrlKey : Boolean(event.ctrlKey) && !event.metaKey
+  if (!commandModifier) {
+    return null
+  }
+
+  switch (event.key.toLowerCase()) {
+    case "b":
+      return APP_COMMANDS.toggleSidebar
+    case "k":
+      return APP_COMMANDS.openSearch
+    case "l":
+      return APP_COMMANDS.focusComposer
+    case "n":
+      return APP_COMMANDS.newChat
+    case ",":
+      return APP_COMMANDS.openSettings
+    case ".":
+      return APP_COMMANDS.stopGeneration
+    default:
+      return null
+  }
+}
+
+export function appCommandShortcutLabel(
+  command: AppCommand,
+  platform: NodeJS.Platform | undefined = globalThis.lumo?.platform,
+): string {
+  const modifier = isMacPlatform(platform) ? "⌘" : "Ctrl+"
+  switch (command) {
+    case APP_COMMANDS.focusComposer:
+      return `${modifier}L`
+    case APP_COMMANDS.newChat:
+      return `${modifier}N`
+    case APP_COMMANDS.openSearch:
+      return `${modifier}K`
+    case APP_COMMANDS.openSettings:
+      return `${modifier},`
+    case APP_COMMANDS.stopGeneration:
+      return `${modifier}.`
+    case APP_COMMANDS.toggleSidebar:
+      return `${modifier}B`
+  }
+}
+
+export function appCommandAriaShortcut(
+  command: AppCommand,
+  platform: NodeJS.Platform | undefined = globalThis.lumo?.platform,
+): string {
+  const modifier = isMacPlatform(platform) ? "Meta" : "Control"
+  switch (command) {
+    case APP_COMMANDS.focusComposer:
+      return `${modifier}+L`
+    case APP_COMMANDS.newChat:
+      return `${modifier}+N`
+    case APP_COMMANDS.openSearch:
+      return `${modifier}+K`
+    case APP_COMMANDS.openSettings:
+      return `${modifier}+,`
+    case APP_COMMANDS.stopGeneration:
+      return `${modifier}+.`
+    case APP_COMMANDS.toggleSidebar:
+      return `${modifier}+B`
+  }
+}
+
+export function labelWithShortcut(label: string, shortcut: string): string {
+  return `${label} (${shortcut})`
+}

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -39,6 +39,7 @@ import { cn } from "@/lib/utils"
 
 interface ChatComposerProps {
   error: string | null
+  focusRequest: number
   hasMessages: boolean
   initialComposerState?: ComposerState
   initialSendPending: boolean
@@ -85,6 +86,7 @@ function paletteLabels({
 
 export function ChatComposer({
   error,
+  focusRequest,
   hasMessages,
   initialComposerState: initialComposerStateProp,
   initialSendPending,
@@ -141,6 +143,14 @@ export function ChatComposer({
     () => buildConnectionPaletteItems(providers, (service) => t("chat.connectionFallbackDescription", { service })),
     [providers, t],
   )
+
+  React.useEffect(() => {
+    if (focusRequest <= 0) {
+      return
+    }
+    const frame = window.requestAnimationFrame(() => textareaRef.current?.focus())
+    return () => window.cancelAnimationFrame(frame)
+  }, [focusRequest])
 
   React.useEffect(() => {
     onComposerStateChange?.(composer)

--- a/src/routes/Chat/ComposerTrailingControls.tsx
+++ b/src/routes/Chat/ComposerTrailingControls.tsx
@@ -3,11 +3,13 @@ import type { ChatStatus } from "ai"
 
 import { Loader2, Mic, RotateCcw, Square, X } from "lucide-react"
 import * as React from "react"
+import { APP_COMMANDS } from "../../../electron/app-command.ts"
 import { composerSubmitState, composerVoiceControlMode } from "./composer-controls.ts"
 import { ModelPicker } from "./ModelControls.tsx"
 import { PromptInputSubmit } from "@/components/ai-elements/prompt-input"
 import { Button } from "@/components/ui/button"
 import { useT } from "@/i18n/i18n"
+import { appCommandAriaShortcut, appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
 import { cn } from "@/lib/utils"
 
 interface ComposerTrailingControlsProps {
@@ -159,6 +161,7 @@ export function ComposerTrailingControls({
   const voiceMode = composerVoiceControlMode({ voiceActive, voiceTranscribing, visibleVoiceError })
   const submit = composerSubmitState({ canSubmit, initialSendPending, isGenerating, status })
   const retryDisabled = !voiceRetryBlob || voiceTranscribing
+  const stopLabel = labelWithShortcut(t("aria.stop"), appCommandShortcutLabel(APP_COMMANDS.stopGeneration))
 
   return (
     <>
@@ -268,6 +271,10 @@ export function ComposerTrailingControls({
               aria-label={
                 submit.aria === "sending" ? t("aria.sending") : submit.aria === "stop" ? t("aria.stop") : t("aria.send")
               }
+              aria-keyshortcuts={
+                submit.stopsGeneration ? appCommandAriaShortcut(APP_COMMANDS.stopGeneration) : undefined
+              }
+              title={submit.stopsGeneration ? stopLabel : undefined}
               onClick={
                 submit.stopsGeneration
                   ? (event) => {

--- a/src/routes/Chat/ModelControls.tsx
+++ b/src/routes/Chat/ModelControls.tsx
@@ -60,35 +60,88 @@ function clampNumber(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
-function ModelRow({
-  active,
-  icon,
-  title,
-  supportsImages,
-  visionLabel,
-  deleteLabel,
-  onSelect,
-  onDelete,
-}: {
+type ModelMenuItem =
+  | {
+      active: boolean
+      choice: ModelChoice
+      id: string
+      kind: "builtin"
+      supportsImages?: boolean
+      title: string
+    }
+  | {
+      active: boolean
+      choice: ModelChoice
+      id: string
+      kind: "custom"
+      modelId: string
+      providerName: string
+      supportsImages?: boolean
+      title: string
+    }
+  | {
+      active: false
+      id: string
+      kind: "add"
+      title: string
+    }
+
+function nextModelMenuIndex(currentIndex: number, itemCount: number, direction: -1 | 1): number {
+  return itemCount === 0 ? 0 : (currentIndex + direction + itemCount) % itemCount
+}
+
+function modelMenuItemElementId(itemId: string): string {
+  return `model-menu-item-${itemId.replace(/[^a-zA-Z0-9_-]/g, "-")}`
+}
+
+interface ModelRowProps {
   active: boolean
-  icon: React.ReactNode
-  title: string
-  supportsImages?: boolean
-  visionLabel: string
   deleteLabel?: string
-  onSelect: () => void
+  highlighted: boolean
+  icon: React.ReactNode
+  id: string
   onDelete?: () => void
-}) {
+  onHighlight: () => void
+  onSelect: () => void
+  role: "menuitem" | "menuitemradio"
+  supportsImages?: boolean
+  title: string
+  visionLabel: string
+}
+
+const ModelRow = React.forwardRef<HTMLButtonElement, ModelRowProps>(function ModelRow(
+  {
+    active,
+    highlighted,
+    icon,
+    id,
+    role,
+    title,
+    supportsImages,
+    visionLabel,
+    deleteLabel,
+    onHighlight,
+    onSelect,
+    onDelete,
+  },
+  ref,
+) {
   return (
     <div className="group flex min-w-0 items-center gap-1">
       <button
+        ref={ref}
+        id={id}
         type="button"
-        aria-current={active ? "true" : undefined}
+        role={role}
+        aria-checked={role === "menuitemradio" ? active : undefined}
         className={cn(
           "flex min-h-10 min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent hover:text-accent-foreground",
           active && "bg-accent font-medium text-accent-foreground",
+          highlighted && "bg-accent text-accent-foreground",
         )}
+        tabIndex={-1}
         title={title}
+        onMouseEnter={onHighlight}
         onClick={onSelect}
       >
         {icon}
@@ -112,6 +165,7 @@ function ModelRow({
       {onDelete ? (
         <button
           type="button"
+          tabIndex={-1}
           className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100"
           aria-label={deleteLabel}
           onClick={(event) => {
@@ -124,7 +178,7 @@ function ModelRow({
       ) : null}
     </div>
   )
-}
+})
 
 export function ModelPicker({
   catalog,
@@ -141,11 +195,59 @@ export function ModelPicker({
 }) {
   const t = useT()
   const [open, setOpen] = React.useState(false)
+  const [activeIndex, setActiveIndex] = React.useState(0)
   const [menuStyle, setMenuStyle] = React.useState<React.CSSProperties>({})
   const rootRef = React.useRef<HTMLDivElement | null>(null)
   const menuRef = React.useRef<HTMLDivElement | null>(null)
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+  const itemRefs = React.useRef(new Map<string, HTMLButtonElement>())
   const selected = selectedModelSummary(catalog)
   const selectedTitle = selected.supportsImages ? `${selected.label} · ${t("chat.modelVision")}` : selected.label
+  const items = React.useMemo<ModelMenuItem[]>(() => {
+    if (!catalog) {
+      return [
+        {
+          active: true,
+          choice: { kind: "builtin", id: DEFAULT_BUILTIN_MODEL_ID },
+          id: `builtin:${DEFAULT_BUILTIN_MODEL_ID}`,
+          kind: "builtin",
+          supportsImages: selected.supportsImages,
+          title: selected.label,
+        },
+        { active: false, id: "action:add", kind: "add", title: t("chat.modelAdd") },
+      ]
+    }
+
+    return [
+      ...catalog.builtins.map((model): ModelMenuItem => {
+        const choice: ModelChoice = { kind: "builtin", id: model.id }
+        return {
+          active: sameModelChoice(catalog.selected, choice),
+          choice,
+          id: `builtin:${model.id}`,
+          kind: "builtin",
+          supportsImages: model.supportsImages,
+          title: model.displayName,
+        }
+      }),
+      ...catalog.customModels.map((model): ModelMenuItem => {
+        const choice: ModelChoice = { kind: "custom", id: model.id }
+        return {
+          active: sameModelChoice(catalog.selected, choice),
+          choice,
+          id: `custom:${model.id}`,
+          kind: "custom",
+          modelId: model.id,
+          providerName: model.providerName,
+          supportsImages: model.supportsImages,
+          title: model.displayName,
+        }
+      }),
+      { active: false, id: "action:add", kind: "add", title: t("chat.modelAdd") },
+    ]
+  }, [catalog, selected.label, selected.supportsImages, t])
+  const activeItem = items[activeIndex]
+  const activeItemElementId = activeItem ? modelMenuItemElementId(activeItem.id) : undefined
 
   const updateMenuPosition = React.useCallback(() => {
     const anchor = rootRef.current
@@ -168,6 +270,50 @@ export function ModelPicker({
     }
   }, [open, updateMenuPosition])
 
+  const closeMenu = React.useCallback((restoreFocus = true): void => {
+    setOpen(false)
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => triggerRef.current?.focus())
+    }
+  }, [])
+
+  const activateItem = React.useCallback(
+    (item: ModelMenuItem | undefined): void => {
+      if (!item) {
+        return
+      }
+      if (item.kind === "add") {
+        closeMenu(false)
+        onAdd()
+        return
+      }
+      onSelect(item.choice)
+      closeMenu()
+    },
+    [closeMenu, onAdd, onSelect],
+  )
+
+  const focusItem = React.useCallback((item: ModelMenuItem | undefined): void => {
+    if (!item) {
+      return
+    }
+    itemRefs.current.get(item.id)?.focus()
+  }, [])
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+    const selectedIndex = items.findIndex((item) => item.active)
+    const nextIndex = selectedIndex >= 0 ? selectedIndex : 0
+    setActiveIndex(nextIndex)
+    window.requestAnimationFrame(() => focusItem(items[nextIndex]))
+  }, [focusItem, items, open])
+
+  React.useEffect(() => {
+    setActiveIndex((index) => Math.min(index, Math.max(0, items.length - 1)))
+  }, [items.length])
+
   React.useEffect(() => {
     if (!open) {
       return
@@ -175,12 +321,12 @@ export function ModelPicker({
     const onMouseDown = (event: MouseEvent): void => {
       const target = event.target as Node
       if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
-        setOpen(false)
+        closeMenu(false)
       }
     }
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
-        setOpen(false)
+        closeMenu()
       }
     }
     const onReposition = (): void => updateMenuPosition()
@@ -194,61 +340,129 @@ export function ModelPicker({
       window.removeEventListener("resize", onReposition)
       window.removeEventListener("scroll", onReposition, true)
     }
-  }, [open, updateMenuPosition])
+  }, [closeMenu, open, updateMenuPosition])
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (items.length === 0) {
+      return
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault()
+      closeMenu()
+      return
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      const nextIndex = nextModelMenuIndex(activeIndex, items.length, 1)
+      setActiveIndex(nextIndex)
+      focusItem(items[nextIndex])
+      return
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      const nextIndex = nextModelMenuIndex(activeIndex, items.length, -1)
+      setActiveIndex(nextIndex)
+      focusItem(items[nextIndex])
+      return
+    }
+    if (event.key === "Home") {
+      event.preventDefault()
+      setActiveIndex(0)
+      focusItem(items[0])
+      return
+    }
+    if (event.key === "End") {
+      event.preventDefault()
+      const nextIndex = items.length - 1
+      setActiveIndex(nextIndex)
+      focusItem(items[nextIndex])
+      return
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      activateItem(items[activeIndex])
+      return
+    }
+    if (event.key === "Delete" || event.key === "Backspace") {
+      const item = items[activeIndex]
+      if (item?.kind === "custom") {
+        event.preventDefault()
+        onDelete(item.modelId)
+      }
+    }
+  }
 
   const menu = open
     ? createPortal(
         <div
           ref={menuRef}
           style={menuStyle}
+          role="menu"
+          tabIndex={-1}
+          aria-activedescendant={activeItemElementId}
+          aria-label={t("chat.modelPicker")}
           className="oo-border-divider fixed z-50 overflow-y-auto rounded-lg border bg-popover p-1.5 text-popover-foreground shadow-xl"
+          onKeyDown={handleMenuKeyDown}
         >
           <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">{t("chat.modelBuiltIn")}</div>
-          {catalog?.builtins.map((model) => {
-            const choice: ModelChoice = { kind: "builtin", id: model.id }
+          {items.map((item, index) => {
+            if (item.kind !== "builtin") {
+              return null
+            }
             return (
               <ModelRow
-                key={model.id}
-                active={sameModelChoice(catalog.selected, choice)}
-                icon={<Brain className="size-4 shrink-0 text-muted-foreground" />}
-                title={model.displayName}
-                supportsImages={model.supportsImages}
-                visionLabel={t("chat.modelVision")}
-                onSelect={() => {
-                  onSelect(choice)
-                  setOpen(false)
+                key={item.id}
+                id={modelMenuItemElementId(item.id)}
+                ref={(node) => {
+                  if (node) {
+                    itemRefs.current.set(item.id, node)
+                  } else {
+                    itemRefs.current.delete(item.id)
+                  }
                 }}
+                active={item.active}
+                highlighted={index === activeIndex}
+                icon={<Brain className="size-4 shrink-0 text-muted-foreground" />}
+                role="menuitemradio"
+                title={item.title}
+                supportsImages={item.supportsImages}
+                visionLabel={t("chat.modelVision")}
+                onHighlight={() => setActiveIndex(index)}
+                onSelect={() => activateItem(item)}
               />
             )
-          }) ?? (
-            <ModelRow
-              active
-              icon={<Brain className="size-4 shrink-0 text-muted-foreground" />}
-              title="Auto"
-              visionLabel={t("chat.modelVision")}
-              onSelect={() => setOpen(false)}
-            />
-          )}
+          })}
 
-          {catalog && catalog.customModels.length > 0 ? (
+          {items.some((item) => item.kind === "custom") ? (
             <div className="oo-border-divider mt-1 border-t pt-1">
               <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">{t("chat.modelCustom")}</div>
-              {catalog.customModels.map((model) => {
-                const choice: ModelChoice = { kind: "custom", id: model.id }
+              {items.map((item, index) => {
+                if (item.kind !== "custom") {
+                  return null
+                }
                 return (
                   <ModelRow
-                    key={model.id}
-                    active={sameModelChoice(catalog.selected, choice)}
-                    icon={<ProviderMark name={model.providerName} />}
-                    title={model.displayName}
-                    supportsImages={model.supportsImages}
+                    key={item.id}
+                    id={modelMenuItemElementId(item.id)}
+                    ref={(node) => {
+                      if (node) {
+                        itemRefs.current.set(item.id, node)
+                      } else {
+                        itemRefs.current.delete(item.id)
+                      }
+                    }}
+                    active={item.active}
+                    highlighted={index === activeIndex}
+                    icon={<ProviderMark name={item.providerName} />}
+                    role="menuitemradio"
+                    title={item.title}
+                    supportsImages={item.supportsImages}
                     visionLabel={t("chat.modelVision")}
                     deleteLabel={t("chat.modelDelete")}
-                    onSelect={() => {
-                      onSelect(choice)
-                      setOpen(false)
-                    }}
-                    onDelete={() => onDelete(model.id)}
+                    onHighlight={() => setActiveIndex(index)}
+                    onSelect={() => activateItem(item)}
+                    onDelete={() => onDelete(item.modelId)}
                   />
                 )
               })}
@@ -256,17 +470,36 @@ export function ModelPicker({
           ) : null}
 
           <div className="oo-border-divider mt-1 border-t pt-1">
-            <button
-              type="button"
-              className="flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-              onClick={() => {
-                setOpen(false)
-                onAdd()
-              }}
-            >
-              <Settings2 className="size-4 text-muted-foreground" />
-              <span>{t("chat.modelAdd")}</span>
-            </button>
+            {items.map((item, index) => {
+              if (item.kind !== "add") {
+                return null
+              }
+              return (
+                <button
+                  key={item.id}
+                  id={modelMenuItemElementId(item.id)}
+                  ref={(node) => {
+                    if (node) {
+                      itemRefs.current.set(item.id, node)
+                    } else {
+                      itemRefs.current.delete(item.id)
+                    }
+                  }}
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
+                  className={cn(
+                    "flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm hover:bg-accent hover:text-accent-foreground",
+                    index === activeIndex && "bg-accent text-accent-foreground",
+                  )}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => activateItem(item)}
+                >
+                  <Settings2 className="size-4 text-muted-foreground" />
+                  <span>{item.title}</span>
+                </button>
+              )
+            })}
           </div>
         </div>,
         document.body,
@@ -276,15 +509,23 @@ export function ModelPicker({
   return (
     <div ref={rootRef} className="min-w-0">
       <Button
+        ref={triggerRef}
         type="button"
         variant="ghost"
         size="sm"
         title={selectedTitle}
         aria-label={t("chat.modelPicker")}
         aria-expanded={open}
+        aria-haspopup="menu"
         disabled={disabled}
         className="h-8 max-w-[min(14rem,100%)] min-w-0 shrink rounded-full px-2"
         onClick={() => setOpen((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
+            setOpen(true)
+          }
+        }}
       >
         <Brain className="size-4" />
         <span className="min-w-0 truncate">{selected.label}</span>

--- a/src/routes/Chat/ModelControls.tsx
+++ b/src/routes/Chat/ModelControls.tsx
@@ -91,7 +91,11 @@ function nextModelMenuIndex(currentIndex: number, itemCount: number, direction: 
 }
 
 function modelMenuItemElementId(itemId: string): string {
-  return `model-menu-item-${itemId.replace(/[^a-zA-Z0-9_-]/g, "-")}`
+  const encoded = Array.from(itemId, (char) => {
+    const codePoint = char.codePointAt(0)
+    return codePoint === undefined ? "0" : codePoint.toString(16)
+  }).join("-")
+  return `model-menu-item-${encoded}`
 }
 
 interface ModelRowProps {

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -71,6 +71,7 @@ const GeneratedArtifacts = React.lazy(() =>
 interface ChatAreaProps {
   billingCacheScope: string
   composerDraftKey: string
+  composerFocusRequest: number
   messages: ChatMessage[]
   status: ChatStatus
   activity: AssistantActivityEvent | null
@@ -1022,6 +1023,7 @@ const ChatTimeline = React.memo(function ChatTimeline({
 export const ChatArea = React.memo(function ChatArea({
   billingCacheScope,
   composerDraftKey,
+  composerFocusRequest,
   messages,
   status,
   activity,
@@ -1062,6 +1064,7 @@ export const ChatArea = React.memo(function ChatArea({
     <ChatComposer
       key={composerDraftKey}
       error={error}
+      focusRequest={composerFocusRequest}
       hasMessages={hasMessages}
       initialComposerState={initialComposerState}
       initialSendPending={initialSendPending}


### PR DESCRIPTION
## Summary

- Add a shared app-command registry, native menu accelerators, and renderer shortcut handling for common chat actions.
- Improve keyboard accessibility for search, dialogs, composer focus, stop generation, and the model picker.
- Localize the native application menu with explicit Chinese and English labels, sync renderer locale changes back to the main process, and move reload/devtools commands into a dev-only menu.

## User Impact

- Users can discover and use standard desktop shortcuts from the native menu.
- Chinese and English application menus stay consistent with the selected app language.
- Production builds no longer expose developer-only reload and DevTools commands in the normal View menu.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
- `git diff --check`
- `npm run dev -- --port 5274`