### PR TITLE
style(app-shell): refine workspace menu selection states

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -21,7 +21,6 @@ import {
   AlertTriangle,
   Archive,
   Building2,
-  Check,
   ChevronsUpDown,
   Download,
   LogOut,
@@ -303,14 +302,17 @@ function WorkspaceMenuContent({
     personalLabel === t("organizations.personal") ? t("organizations.workspace") : t("organizations.personal")
   const showBlockingError = Boolean(error && !hasLoaded)
   const showRefreshWarning = Boolean(error && hasLoaded)
+  const workspaceItemClassName =
+    "my-1 grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_3.5rem] items-center gap-2 rounded-md py-2 data-[active=true]:bg-accent data-[active=true]:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
 
   return (
     <DropdownMenuContent align={align} side={side} sideOffset={8} className="w-72">
       <DropdownMenuLabel>{t("organizations.workspaceGroup")}</DropdownMenuLabel>
       <DropdownMenuItem
-        className="min-w-0 items-center gap-2 py-2"
+        className={workspaceItemClassName}
         onSelect={onSelectPersonal}
         aria-checked={activeKey === "personal"}
+        data-active={activeKey === "personal"}
       >
         <WorkspaceAvatar
           accountAvatarUrl={accountAvatarUrl}
@@ -321,7 +323,6 @@ function WorkspaceMenuContent({
           <span className="truncate">{personalLabel}</span>
           <span className="truncate text-xs text-muted-foreground">{personalDescription}</span>
         </span>
-        {activeKey === "personal" ? <Check className="size-4" /> : null}
       </DropdownMenuItem>
       {loading ? (
         <DropdownMenuItem disabled>
@@ -346,18 +347,18 @@ function WorkspaceMenuContent({
         return (
           <DropdownMenuItem
             key={organization.id}
-            className="min-w-0 items-center gap-2 py-2"
+            className={workspaceItemClassName}
             onSelect={() => onSelectOrganization(organization.id)}
             aria-checked={selected}
+            data-active={selected}
           >
             <WorkspaceAvatar
               workspace={{ type: "organization", organization, organizationId: organization.id, role }}
             />
             <span className="min-w-0 flex-1 truncate">{organization.name}</span>
-            <Badge variant="outline" className="shrink-0 font-normal">
+            <Badge variant="outline" className="w-full justify-end text-right font-normal">
               {role === "creator" ? t("organizations.roleCreator") : t("organizations.roleMember")}
             </Badge>
-            {selected ? <Check className="size-4" /> : null}
           </DropdownMenuItem>
         )
       })}

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -311,7 +311,6 @@ function WorkspaceMenuContent({
       <DropdownMenuItem
         className={workspaceItemClassName}
         onSelect={onSelectPersonal}
-        aria-checked={activeKey === "personal"}
         data-active={activeKey === "personal"}
       >
         <WorkspaceAvatar
@@ -323,6 +322,7 @@ function WorkspaceMenuContent({
           <span className="truncate">{personalLabel}</span>
           <span className="truncate text-xs text-muted-foreground">{personalDescription}</span>
         </span>
+        <span aria-hidden="true" />
       </DropdownMenuItem>
       {loading ? (
         <DropdownMenuItem disabled>
@@ -349,14 +349,13 @@ function WorkspaceMenuContent({
             key={organization.id}
             className={workspaceItemClassName}
             onSelect={() => onSelectOrganization(organization.id)}
-            aria-checked={selected}
             data-active={selected}
           >
             <WorkspaceAvatar
               workspace={{ type: "organization", organization, organizationId: organization.id, role }}
             />
             <span className="min-w-0 flex-1 truncate">{organization.name}</span>
-            <Badge variant="outline" className="w-full justify-end text-right font-normal">
+            <Badge variant="outline" className="flex w-full justify-end text-right font-normal">
               {role === "creator" ? t("organizations.roleCreator") : t("organizations.roleMember")}
             </Badge>
           </DropdownMenuItem>


### PR DESCRIPTION
## Summary

- Remove the selected check icon from the workspace switcher menu.
- Use theme-aware active and focus backgrounds for workspace menu items.
- Align role labels to the right in a fixed column.
- Add vertical spacing so active and hovered rows stay visually separated.

## Why

The previous selected icon changed the row layout and made role labels look misaligned. When active and hover states overlapped, adjacent highlighted rows could visually merge. This update keeps the layout stable and uses theme tokens so light and dark modes stay consistent.

## Impact

Workspace switching remains functionally unchanged. The menu now presents selected and hovered organizations more clearly, with better alignment and spacing.

## Validation

- `npm run format`
- `npm run ts-check`
- `npm run lint`
- `npm test`
- `npm run dev -- --port 5274` during UI verification, with Electron main process and agent sidecar ready