### PR TITLE
[codex] Adjust chat typography balance

### DIFF
--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -48,7 +48,7 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
   <div
     className={cn(
       "oo-text-chat flex max-w-full min-w-0 flex-col gap-2 overflow-hidden",
-      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:font-medium group-[.is-user]:text-foreground",
       "group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground",
       className,
     )}

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -507,7 +507,7 @@ function SessionItem({
   return (
     <div
       className={cn(
-        "oo-sidebar-nav-item group oo-text-control flex h-8 items-center rounded-md px-3",
+        "oo-sidebar-nav-item group oo-text-body flex h-8 items-center rounded-md px-3",
         active && "bg-sidebar-accent text-sidebar-accent-foreground",
       )}
     >
@@ -1096,7 +1096,7 @@ function SidebarFooterControls({
               workspace={workspace.activeWorkspace}
             />
             <div className="oo-sidebar-nav-label min-w-0 flex-1">
-              <div className="oo-text-control truncate text-sidebar-foreground" title={activeWorkspaceLabel}>
+              <div className="oo-text-body truncate text-sidebar-foreground" title={activeWorkspaceLabel}>
                 {activeWorkspaceLabel}
               </div>
             </div>
@@ -2254,7 +2254,7 @@ export function AppShell() {
               aria-label={newChatLabel}
               aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.newChat)}
               className={cn(
-                "oo-sidebar-nav-item oo-text-control flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
+                "oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
                 route === "chat" && !activeSessionId && "bg-sidebar-accent text-sidebar-accent-foreground",
               )}
             >
@@ -2265,7 +2265,7 @@ export function AppShell() {
               type="button"
               onClick={() => setRoute("connections")}
               className={cn(
-                "oo-sidebar-nav-item oo-text-control flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
+                "oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
                 route === "connections" && "bg-sidebar-accent text-sidebar-accent-foreground",
               )}
             >
@@ -2276,7 +2276,7 @@ export function AppShell() {
               type="button"
               onClick={() => setRoute("skills")}
               className={cn(
-                "oo-sidebar-nav-item oo-text-control flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
+                "oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
                 route === "skills" && "bg-sidebar-accent text-sidebar-accent-foreground",
               )}
             >
@@ -2287,7 +2287,7 @@ export function AppShell() {
               type="button"
               onClick={() => setRoute("organizations")}
               className={cn(
-                "oo-sidebar-nav-item oo-text-control flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
+                "oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
                 route === "organizations" && "bg-sidebar-accent text-sidebar-accent-foreground",
               )}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -107,8 +107,8 @@
   --oo-line-body: 1.25rem;
   --oo-font-chat: 0.875rem;
   --oo-line-chat: 1.375rem;
-  --oo-font-markdown: 0.9375rem;
-  --oo-line-markdown: 1.5rem;
+  --oo-font-markdown: var(--oo-font-chat);
+  --oo-line-markdown: var(--oo-line-chat);
   --oo-font-control: 0.8125rem;
   --oo-line-control: 1.25rem;
   --oo-font-value: 0.9375rem;
@@ -137,6 +137,7 @@
   --sidebar: var(--oo-sidebar);
   --sidebar-foreground: oklch(0.31 0.009 265);
   --sidebar-muted-foreground: oklch(0.61 0.01 265);
+  --oo-section-heading-foreground: color-mix(in oklab, var(--sidebar-muted-foreground) 68%, var(--sidebar));
   --sidebar-accent: oklch(0.936 0.004 287);
   --sidebar-accent-foreground: var(--sidebar-foreground);
   --sidebar-border: var(--oo-border-subtle);
@@ -235,6 +236,7 @@
   --sidebar: var(--oo-sidebar);
   --sidebar-foreground: oklch(0.84 0.006 265);
   --sidebar-muted-foreground: oklch(0.6 0.008 265);
+  --oo-section-heading-foreground: color-mix(in oklab, var(--sidebar-muted-foreground) 74%, var(--sidebar));
   --sidebar-accent: oklch(0.285 0.006 265);
   --sidebar-accent-foreground: var(--sidebar-foreground);
   --sidebar-border: var(--oo-border-subtle);
@@ -560,8 +562,10 @@
   }
 
   .oo-sidebar-section-heading.oo-text-caption {
-    color: var(--sidebar-muted-foreground);
+    color: var(--oo-section-heading-foreground);
+    font-size: var(--oo-font-body);
     font-weight: 500;
+    line-height: var(--oo-line-body);
   }
 
   .oo-sidebar-session-time {
@@ -1163,6 +1167,7 @@
   .oo-markdown,
   .oo-message-response {
     font-size: var(--oo-font-markdown);
+    font-weight: 500;
     line-height: var(--oo-line-markdown);
     overflow-wrap: anywhere;
   }

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -64,12 +64,12 @@ function ToolInlineDetail({ line }: { line: ToolDisplayLine }) {
   }
   if (line.detailKind === "code") {
     return (
-      <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[0.875em] text-muted-foreground">
+      <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[0.875em] font-medium text-muted-foreground">
         {line.detail}
       </code>
     )
   }
-  return <span className="min-w-0 flex-1 truncate text-muted-foreground">{line.detail}</span>
+  return <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground">{line.detail}</span>
 }
 
 function formatToolOutput(output: string | undefined): string {
@@ -228,10 +228,12 @@ export function ToolActivityStep({
       <div className="min-w-0 flex-1 overflow-hidden">
         {showShimmer ? (
           <div className="flex min-w-0 items-center gap-2">
-            <LoadingShimmerText className="min-w-0 shrink-0 truncate">{displayLine.title}</LoadingShimmerText>
+            <LoadingShimmerText className="min-w-0 shrink-0 truncate font-medium">
+              {displayLine.title}
+            </LoadingShimmerText>
             <ToolInlineDetail line={displayLine} />
             {displayLine.detail ? null : <span aria-hidden="true" className="min-w-0 flex-1" />}
-            <span className="flex min-w-0 shrink-0 items-center gap-1 text-muted-foreground">
+            <span className="flex min-w-0 shrink-0 items-center gap-1 font-medium text-muted-foreground">
               {metaItems.map((item, index) => (
                 <React.Fragment key={`${index}:${item}`}>
                   {index > 0 ? <span className="text-muted-foreground/70">·</span> : null}
@@ -242,13 +244,15 @@ export function ToolActivityStep({
           </div>
         ) : (
           <div className="flex min-w-0 items-center gap-2">
-            <span className={cn("min-w-0 truncate text-foreground", displayLine.detail ? "shrink-0" : "flex-1")}>
+            <span
+              className={cn("min-w-0 truncate font-medium text-foreground", displayLine.detail ? "shrink-0" : "flex-1")}
+            >
               {displayLine.title}
             </span>
             <ToolInlineDetail line={displayLine} />
             <span
               className={cn(
-                "flex min-w-0 shrink-0 items-center gap-1 text-muted-foreground transition-opacity",
+                "flex min-w-0 shrink-0 items-center gap-1 font-medium text-muted-foreground transition-opacity",
                 completedMeta && "opacity-0 group-hover/tool-step:opacity-100",
                 completedMeta &&
                   details &&

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -256,18 +256,20 @@ function TurnProcessActivity({
 
   return (
     <Task open={open} onOpenChange={handleOpenChange} className="not-prose my-0 w-full">
-      <TaskTrigger title={title}>
-        <button
-          type="button"
-          className="group flex w-full max-w-full items-center gap-1.5 border-b border-border/60 py-1.5 pr-1.5 text-left text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <span className="flex min-w-0 items-center gap-1">
-            <span className="min-w-0 truncate">{titleText}</span>
-            {duration ? <span className="shrink-0 text-muted-foreground/75 tabular-nums">{duration}</span> : null}
-          </span>
-          <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
-        </button>
-      </TaskTrigger>
+      <div className="border-b border-border/60 py-1.5 pr-1.5">
+        <TaskTrigger title={title}>
+          <button
+            type="button"
+            className="group inline-flex max-w-full items-center gap-1.5 text-left font-medium text-[var(--oo-section-heading-foreground)] transition-colors select-none"
+          >
+            <span className="flex min-w-0 items-center gap-1">
+              <span className="min-w-0 truncate">{titleText}</span>
+              {duration ? <span className="shrink-0 tabular-nums">{duration}</span> : null}
+            </span>
+            <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+          </button>
+        </TaskTrigger>
+      </div>
       <TaskContent className="[&>div]:mt-0">
         <div className="space-y-2 pt-2">
           {blocks.map(({ message, block }, index) => (


### PR DESCRIPTION
## Summary

- Adjust sidebar and chat typography for better visual hierarchy.
- Align process header color with sidebar section headings across light and dark themes.
- Narrow the process header collapse hit area to the label and chevron, and prevent text selection there.

## Validation

- npm run lint
- npm run format
- npm run ts-check
- npm test
- npm run dev -- --port 5274
