### PR TITLE
Refresh pending authorization retries

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1414,8 +1414,8 @@ export function AppShell() {
       if (Date.now() - pendingRetryWatch.startedAt >= AUTH_RETRY_POLL_TIMEOUT_MS) {
         if (!cancelled && pendingRetry.current?.service === pendingRetryWatch.service) {
           pendingRetry.current = null
-          setPendingRetryWatch(null)
         }
+        setPendingRetryWatch(null)
         return
       }
       await connections.refresh({ forceRefresh: true })

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -124,6 +124,8 @@ const ARTIFACTS_PANEL_MIN_WIDTH_PX = 260
 const ARTIFACTS_PANEL_WIDTH_STORAGE_KEY = "wanta.artifactsPanelWidth"
 const TURN_RETRY_OPTIONS_LIMIT = 48
 const SESSION_TITLE_RETRY_DELAY_MS = 20_000
+const AUTH_RETRY_POLL_INTERVAL_MS = 2_000
+const AUTH_RETRY_POLL_TIMEOUT_MS = 5 * 60_000
 const EMPTY_CONNECTION_PROVIDERS: ConnectionProvider[] = []
 const NEW_SESSION_COMPOSER_DRAFT_KEY = "__new_session__"
 
@@ -1325,6 +1327,7 @@ export function AppShell() {
     contextMentions?: ChatContextMention[]
     model?: ModelChoice
   } | null>(null)
+  const [pendingRetryWatch, setPendingRetryWatch] = React.useState<{ service: string; startedAt: number } | null>(null)
   const sidebarResizeStart = React.useRef<{ pointerX: number; width: number } | null>(null)
   const artifactsPanelResizeStart = React.useRef<{ pointerX: number; width: number } | null>(null)
   const artifactsPanelResizeFrame = React.useRef<number | null>(null)
@@ -1402,6 +1405,33 @@ export function AppShell() {
 
   // R5 闭环：待重试的 provider 一旦连上，刷新已授权清单后自动重发原 action。
   React.useEffect(() => {
+    if (!pendingRetryWatch) {
+      return
+    }
+
+    let cancelled = false
+    const refreshUntilConnected = async (): Promise<void> => {
+      if (Date.now() - pendingRetryWatch.startedAt >= AUTH_RETRY_POLL_TIMEOUT_MS) {
+        if (!cancelled && pendingRetry.current?.service === pendingRetryWatch.service) {
+          pendingRetry.current = null
+          setPendingRetryWatch(null)
+        }
+        return
+      }
+      await connections.refresh({ forceRefresh: true })
+    }
+
+    void refreshUntilConnected()
+    const id = window.setInterval(() => {
+      void refreshUntilConnected()
+    }, AUTH_RETRY_POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [connections.refresh, pendingRetryWatch])
+
+  React.useEffect(() => {
     const pending = pendingRetry.current
     if (!pending) {
       return
@@ -1411,6 +1441,7 @@ export function AppShell() {
     )
     if (connected) {
       pendingRetry.current = null
+      setPendingRetryWatch(null)
       setSelectedService(null)
       setRoute("chat")
       void send(pending.sessionId, pending.text, pending.attachments, {
@@ -2049,9 +2080,11 @@ export function AppShell() {
           contextMentions: storedOptions?.contextMentions ?? lastContextMentionsBySession.current.get(activeSessionId),
           model: storedOptions?.model ?? lastModelBySession.current.get(activeSessionId),
         }
+        setPendingRetryWatch({ service: auth.service, startedAt: Date.now() })
+        void connections.refresh({ forceRefresh: true })
       }
     },
-    [activeSessionId],
+    [activeSessionId, connections.refresh],
   )
   const handleToggleSidebar = React.useCallback((): void => {
     setSidebarCollapsed((collapsed) => {


### PR DESCRIPTION
## Summary

This PR tightens the authorization retry loop after a chat tool reports that a connector provider needs authorization.

When a user clicks the authorization action from a chat turn, Wanta already stores the original request so it can retry after the provider becomes connected. The missing piece was that this retry depended on the Connections summary changing. If the user completed authorization in the external console, or if the renderer still held a cached summary, Wanta could remain on stale connection state and the original chat request would not be retried promptly.

The fix starts a short-lived watcher when an authorization retry is pending. It forces a Connections summary refresh immediately and then every two seconds for up to five minutes. Once the provider is reported as connected and active, the existing retry path clears the pending retry, returns to chat, and resends the original request.

## Changes

- Add a bounded pending-authorization watcher in `AppShell`.
- Force-refresh Connections summary immediately after recording a pending authorization retry.
- Poll Connections summary every two seconds while waiting for the provider to become active.
- Clear the watcher when the provider connects or when the five-minute wait window expires.

## User Impact

Users who authorize a provider after a chat tool reports `authorization_required` should see Wanta pick up the new connection state and retry the original request more reliably, including cases where the provider was authorized through the external console instead of an in-app refresh path.

This does not change connector execution, session token handling, or `oo` environment variables. The only expected extra work is a bounded set of forced Connections summary refreshes while Wanta is actively waiting for the user to finish authorization.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run dev` reached Vite ready and agent sidecar ready
