### PR TITLE
Hide project paths and improve skill removal

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -529,6 +529,8 @@ function buildArtifactSystem(artifactDir: string | undefined): string | undefine
     "- Manifest item paths must be relative paths inside the artifact directory. Mark each main user-facing deliverable with role primary. Use summary only for a separate short summary file, never for the main report itself. Do not mark temporary scripts, caches, raw connector JSON, or intermediate files as primary.",
     "- Treat HTML reports, images, PDFs, charts, spreadsheets, presentations, archives, and documents as user-facing deliverables. For a single HTML report, use kind web_page or document, display single or document, and include the HTML file as a primary item.",
     "- For image sets, put the primary images in display order, use stable padded names such as 001.jpg and 002.jpg, set kind to image_set, set display to gallery, and include only user-facing images as primary items.",
+    "- When the final deliverable is one to four image files and inline viewing helps the user, include Markdown image references in the final response using their absolute local paths, for example ![short title](</absolute/path/image.png>).",
+    "- When there are many images, such as crawled or downloaded image sets, do not inline every image in the final response. Summarize the set and rely on the artifact pack for browsing.",
     "- Do not reuse output folders from earlier turns or other chats.",
     "- Do not write deliverables to Desktop, Downloads, the OpenCode workspace, or prior output directories unless the user explicitly requested that exact destination.",
     "- When you finish, summarize the deliverable contents and report generated file paths in prose or inline code, not fenced code blocks; fenced blocks are only for code or multi-line text.",

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -6,6 +6,7 @@ import type {
   DeleteSkillRequest,
   ExecuteSkillUpdateRequest,
   InstallRegistrySkillRequest,
+  ManagedSkillGroup,
   OpenSkillPathRequest,
   PublishSkillRequest,
   PublishSkillResult,
@@ -284,13 +285,36 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       throw new Error("Skill deletion requires confirmation.")
     }
 
-    const result = await this.runOoCommand(createDeleteSkillArgs(request), {
-      owner: "skill-service",
-      rejectOnFailure: false,
-    })
-    assertOoSkillOperationResult(result, "skills.uninstall")
-    await this.deleteSharedSkillTarget(request.skillId)
-    await this.rememberDefaultRegistrySkillRemovedByUser(request.skillId)
+    const skillId = normalizeSkillId(request.skillId)
+    const inventory = await this.readSkillInventory({ writeManifest: false })
+    const group = inventory.groups.find((item) => item.id === skillId)
+
+    if (!group) {
+      throw new Error(`Skill not found: ${skillId}`)
+    }
+
+    let registryUninstallError: unknown
+    if (group.kind === "registry" && group.packageName?.trim()) {
+      try {
+        const result = await this.runOoCommand(createDeleteSkillArgs({ skillId }), {
+          owner: "skill-service",
+          rejectOnFailure: false,
+        })
+        assertOoSkillOperationResult(result, "skills.uninstall")
+      } catch (cause) {
+        registryUninstallError = cause
+      }
+    }
+
+    const deletedTargets = await this.deleteInstalledSkillTargets(group)
+    if (deletedTargets === 0 && registryUninstallError) {
+      throw registryUninstallError
+    }
+    if (deletedTargets === 0) {
+      throw new Error(`No installed Skill target found: ${skillId}`)
+    }
+
+    await this.rememberDefaultRegistrySkillRemovedByUser(skillId)
     this.notifyRuntimeSkillsChanged("delete-skill")
 
     return this.readAndPublishSkillInventory()
@@ -591,8 +615,20 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
     return path.join(this.getSharedAgentSkillRoot(), normalizeSkillId(skillId))
   }
 
-  private async deleteSharedSkillTarget(skillId: string): Promise<void> {
-    await rm(this.resolveSharedSkillTargetPath(skillId), { force: true, recursive: true })
+  private async deleteInstalledSkillTargets(group: ManagedSkillGroup): Promise<number> {
+    const targetPaths = readDeletableSkillTargetPaths(group, this.readDeletableSkillRoots())
+    let deletedTargets = 0
+
+    for (const targetPath of targetPaths) {
+      await rm(targetPath, { force: true, recursive: true })
+      deletedTargets += 1
+    }
+
+    return deletedTargets
+  }
+
+  private readDeletableSkillRoots(): string[] {
+    return [this.getSharedAgentSkillRoot(), ...supportedAgents.map((agent) => resolveAgentSkillRoot(agent))]
   }
 
   private invalidateVersionReport(): void {
@@ -953,6 +989,36 @@ function normalizeSkillId(skillId: string): string {
   }
 
   return normalizedSkillId
+}
+
+function readDeletableSkillTargetPaths(group: ManagedSkillGroup, skillRoots: string[]): string[] {
+  const normalizedSkillId = normalizeSkillId(group.id)
+  const normalizedSkillRoots = skillRoots.map((skillRoot) => path.resolve(skillRoot))
+  const targetPaths = new Set<string>()
+
+  for (const host of group.hosts) {
+    const targetPath = host.path ? path.resolve(host.path) : undefined
+    if (!targetPath || host.status !== "installed") {
+      continue
+    }
+
+    if (path.basename(targetPath) !== normalizedSkillId) {
+      continue
+    }
+
+    if (!normalizedSkillRoots.some((skillRoot) => isPathInside(skillRoot, targetPath))) {
+      continue
+    }
+
+    targetPaths.add(targetPath)
+  }
+
+  return Array.from(targetPaths)
+}
+
+function isPathInside(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath)
+  return Boolean(relativePath) && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
 }
 
 async function localPathExists(pathname: string): Promise<boolean> {

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -83,7 +83,7 @@ import { ErrorNotice } from "@/components/ErrorNotice"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group"
 import { useAppCommandEvents, useAppCommandShortcuts } from "@/hooks/useAppCommandShortcuts"
 import { useAppUpdate } from "@/hooks/useAppUpdate"
 import { useAuth } from "@/hooks/useAuth"
@@ -1090,10 +1090,13 @@ function SessionSearchOverlay({
       }}
     >
       <section className="oo-modal-surface w-full max-w-[520px] rounded-lg border p-5">
-        <div className="oo-session-search-input oo-text-title flex h-10 min-w-0 items-center gap-2 rounded-lg border px-3">
-          <Search className="size-4 shrink-0 text-muted-foreground" />
-          <Input
+        <InputGroup className="oo-session-search-input h-10 rounded-lg shadow-none">
+          <InputGroupAddon align="inline-start">
+            <Search className="size-4" aria-hidden="true" />
+          </InputGroupAddon>
+          <InputGroupInput
             ref={inputRef}
+            type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={t("sidebar.searchPlaceholder")}
@@ -1101,10 +1104,14 @@ function SessionSearchOverlay({
             aria-activedescendant={activeResultId}
             aria-controls="session-search-results"
             aria-expanded="true"
-            className="h-8 min-w-0 flex-1 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            className="oo-text-title h-8 min-w-0"
             role="combobox"
+            spellCheck={false}
           />
-        </div>
+        </InputGroup>
 
         <p className="oo-text-control mt-4 px-3 text-muted-foreground">
           {t("sidebar.searchResults", { count: filteredSessions.length })}
@@ -1133,10 +1140,7 @@ function SessionSearchOverlay({
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => selectSession(session)}
                 title={session.title}
-                className={cn(
-                  "oo-session-search-result oo-text-value flex h-10 min-w-0 items-center rounded-lg px-3 text-left",
-                  index === activeIndex && "bg-accent text-accent-foreground",
-                )}
+                className="oo-session-search-result oo-text-label flex h-9 min-w-0 items-center rounded-md px-3 text-left"
               >
                 <span className="truncate">{session.title}</span>
               </button>
@@ -2971,10 +2975,7 @@ export function AppShell() {
               title={newChatLabel}
               aria-label={newChatLabel}
               aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.newChat)}
-              className={cn(
-                "oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2",
-                route === "chat" && !activeSessionId && "bg-sidebar-accent text-sidebar-accent-foreground",
-              )}
+              className="oo-sidebar-nav-item oo-text-body flex h-[var(--sidebar-item-height)] items-center gap-2 rounded-md px-2"
             >
               <SquarePen className="size-4 shrink-0" />
               <span className="oo-sidebar-nav-label truncate">{t("sidebar.newSession")}</span>

--- a/src/components/app-shell/ProjectContextBar.tsx
+++ b/src/components/app-shell/ProjectContextBar.tsx
@@ -128,9 +128,7 @@ export function ProjectContextBar({
     if (!query) {
       return projects
     }
-    return projects.filter(
-      (project) => normalizedQuery(project.name).includes(query) || normalizedQuery(project.path).includes(query),
-    )
+    return projects.filter((project) => normalizedQuery(project.name).includes(query))
   }, [projectQuery, projects])
   const visibleBranches = React.useMemo(() => {
     const query = normalizedQuery(branchQuery)
@@ -494,10 +492,7 @@ function ProjectMenu({
             onClick={() => void onSelectProject(project.id)}
           >
             <Folder className="size-4 text-muted-foreground" />
-            <span className="grid min-w-0 gap-0.5">
-              <span className="oo-text-value truncate">{project.name}</span>
-              <span className="oo-text-caption-compact truncate text-muted-foreground">{project.path}</span>
-            </span>
+            <span className="oo-text-body min-w-0 truncate">{project.name}</span>
             {project.id === activeProjectId ? <Check className="size-4" /> : <span aria-hidden="true" />}
           </button>
         ))}

--- a/src/components/app-shell/ProjectContextBar.tsx
+++ b/src/components/app-shell/ProjectContextBar.tsx
@@ -32,8 +32,36 @@ type ContextMenuPlacement = {
   width: number
 }
 
+type ProjectMenuEntry = {
+  disambiguator?: string
+  project: SessionProject
+  searchText: string
+}
+
 function normalizedQuery(value: string): string {
   return value.trim().toLocaleLowerCase()
+}
+
+function shortProjectId(projectId: string): string {
+  return projectId.replaceAll("-", "").slice(0, 8)
+}
+
+function buildProjectMenuEntries(projects: SessionProject[]): ProjectMenuEntry[] {
+  const nameCounts = new Map<string, number>()
+  for (const project of projects) {
+    const key = normalizedQuery(project.name)
+    nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1)
+  }
+
+  return projects.map((project) => {
+    const hasDuplicateName = (nameCounts.get(normalizedQuery(project.name)) ?? 0) > 1
+    const disambiguator = hasDuplicateName ? `#${shortProjectId(project.id)}` : undefined
+    return {
+      disambiguator,
+      project,
+      searchText: normalizedQuery([project.name, disambiguator].filter(Boolean).join(" ")),
+    }
+  })
 }
 
 function dirtyFileCount(state: GitRepositoryState): number {
@@ -123,13 +151,14 @@ export function ProjectContextBar({
   const [projectQuery, setProjectQuery] = React.useState("")
   const [branchQuery, setBranchQuery] = React.useState("")
   const [busyBranch, setBusyBranch] = React.useState<string | null>(null)
+  const projectMenuEntries = React.useMemo(() => buildProjectMenuEntries(projects), [projects])
   const filteredProjects = React.useMemo(() => {
     const query = normalizedQuery(projectQuery)
     if (!query) {
-      return projects
+      return projectMenuEntries
     }
-    return projects.filter((project) => normalizedQuery(project.name).includes(query))
-  }, [projectQuery, projects])
+    return projectMenuEntries.filter((entry) => entry.searchText.includes(query))
+  }, [projectMenuEntries, projectQuery])
   const visibleBranches = React.useMemo(() => {
     const query = normalizedQuery(branchQuery)
     const branches = gitState?.available
@@ -459,7 +488,7 @@ function ProjectMenu({
   disabled: boolean
   menuRef: React.RefObject<HTMLDivElement | null>
   placement: ContextMenuPlacement | null
-  projects: SessionProject[]
+  projects: ProjectMenuEntry[]
   query: string
   onCreateProject: () => void
   onQueryChange: (query: string) => void
@@ -483,7 +512,7 @@ function ProjectMenu({
     >
       <MenuSearch label={t("project.searchPlaceholder")} query={query} onQueryChange={onQueryChange} />
       <div className="min-h-0 flex-1 overflow-y-auto p-1">
-        {projects.map((project) => (
+        {projects.map(({ disambiguator, project }) => (
           <button
             key={project.id}
             type="button"
@@ -492,7 +521,12 @@ function ProjectMenu({
             onClick={() => void onSelectProject(project.id)}
           >
             <Folder className="size-4 text-muted-foreground" />
-            <span className="oo-text-body min-w-0 truncate">{project.name}</span>
+            <span className="grid min-w-0 gap-0.5">
+              <span className="oo-text-body min-w-0 truncate">{project.name}</span>
+              {disambiguator ? (
+                <span className="oo-text-caption-compact truncate text-muted-foreground">{disambiguator}</span>
+              ) : null}
+            </span>
             {project.id === activeProjectId ? <Check className="size-4" /> : <span aria-hidden="true" />}
           </button>
         ))}

--- a/src/components/useSkillObjectActions.ts
+++ b/src/components/useSkillObjectActions.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner"
 import { useAppI18n } from "../i18n/index.ts"
 import { resolveUserFacingError, userFacingErrorDescription } from "../lib/user-facing-error.ts"
 import { useSkillService } from "./AppContext.ts"
-import { useSkillInventoryResource, useSkillVersionReportResource } from "./AppDataHooks.ts"
+import { useHomeSummaryResource, useSkillInventoryResource, useSkillVersionReportResource } from "./AppDataHooks.ts"
 
 interface UseSkillObjectActionsOptions {
   onDeleted?: (inventory: SkillInventory) => void
@@ -24,6 +24,7 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
   const { onDeleted } = options
   const { t } = useAppI18n()
   const skillService = useSkillService()
+  const homeSummaryResource = useHomeSummaryResource()
   const inventoryResource = useSkillInventoryResource()
   const versionResource = useSkillVersionReportResource()
   const [removeTarget, setRemoveTarget] = React.useState<SkillRemoveTarget | null>(null)
@@ -74,6 +75,7 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
       })
       inventoryResource.setData(nextInventory)
       versionResource.invalidate()
+      homeSummaryResource.invalidate()
       await refreshSkillResources()
       if (!nextInventory.groups.some((group) => group.id === target.skill.id)) {
         onDeleted?.(nextInventory)
@@ -86,7 +88,16 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
       isRemovingSkillRef.current = false
       setIsRemovingSkill(false)
     }
-  }, [inventoryResource, onDeleted, refreshSkillResources, removeTarget, skillService, t, versionResource])
+  }, [
+    homeSummaryResource,
+    inventoryResource,
+    onDeleted,
+    refreshSkillResources,
+    removeTarget,
+    skillService,
+    t,
+    versionResource,
+  ])
 
   return {
     copySkillPath,

--- a/src/index.css
+++ b/src/index.css
@@ -875,14 +875,23 @@
   }
 
   .oo-session-search-input {
-    border-color: color-mix(in oklab, var(--input-focus-ring) 36%, var(--border));
+    border-color: var(--input);
     background: var(--oo-search-surface);
-    box-shadow: 0 0 0 3px color-mix(in oklab, var(--input-focus-ring) 18%, transparent);
     color: var(--foreground);
   }
 
+  .oo-session-search-input:has([data-slot="input-group-control"]:focus-visible) {
+    border-color: var(--ring);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 24%, transparent);
+  }
+
+  .oo-session-search-input [data-slot="input-group-control"]:focus-visible {
+    border-color: transparent;
+    box-shadow: none;
+  }
+
   .oo-session-search-result {
-    color: var(--foreground);
+    color: var(--popover-foreground);
     outline: none;
     transition:
       background-color 120ms ease-out,
@@ -893,6 +902,11 @@
   .oo-session-search-result:hover,
   .oo-session-search-result:focus-visible {
     background: var(--oo-row-hover);
+  }
+
+  .oo-session-search-result[aria-selected="true"] {
+    background: var(--selection-soft);
+    box-shadow: inset 0 0 0 1px var(--selection-ring);
   }
 
   .oo-session-search-result:focus-visible {

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -63,6 +63,7 @@ import {
   useSkillVersionReportResource,
 } from "@/components/AppDataHooks"
 import { AppIcons } from "@/components/AppIcons"
+import { DeleteSkillConfirmDialog } from "@/components/DeleteSkillConfirmDialog"
 import { ErrorNotice } from "@/components/ErrorNotice"
 import { InspectorCard, InspectorInsetCard } from "@/components/InspectorPanel"
 import { ObjectRowSkeletonGroup, SkeletonText } from "@/components/LoadingSkeletons"
@@ -246,7 +247,14 @@ export function SkillsRoute({
   const requestedVersionCheckRef = React.useRef(false)
   const publicPackageRequestIdRef = React.useRef(0)
   const myPublishedPackageRequestIdRef = React.useRef(0)
-  const { openSkillFolder } = useSkillObjectActions()
+  const { isRemovingSkill, openSkillFolder, removeSkill, removeTarget, setRemoveTarget } = useSkillObjectActions({
+    onDeleted: (nextInventory) => {
+      const nextSelectedSkill = nextInventory.groups.find(isInstalledSkillGroup)
+      setSelectedSkillId(nextSelectedSkill?.id ?? null)
+      setNarrowPane("list")
+      homeSummaryResource.invalidate()
+    },
+  })
 
   React.useEffect(() => {
     if (!selectedSkillId && inventory?.groups[0]) {
@@ -585,9 +593,11 @@ export function SkillsRoute({
     activePackageCatalog.status === "loading" || activePackageCatalog.status === "refreshing"
   const detailContentProps: SkillDetailContentProps = {
     inventoryInitialLoading: inventoryResource.isInitialLoading,
+    isRemovingSkill,
     openSkillFolder,
     publishSkill,
     publishingSkillId,
+    requestRemoveSkill: (skill) => setRemoveTarget({ skill }),
     selectedPlanError: visibleSkillOperationError(planError, selectedSkill?.id),
     selectedSkill,
     selectedStatus,
@@ -687,6 +697,16 @@ export function SkillsRoute({
         onClose={() => setOrganizationAddOpen(false)}
         onLoadMyPublishedPackages={loadMyPublishedSkillPackages}
         onLoadPublicPackages={loadPublicSkillPackages}
+      />
+      <DeleteSkillConfirmDialog
+        isRemoving={isRemovingSkill}
+        target={removeTarget}
+        onConfirm={removeSkill}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setRemoveTarget(null)
+          }
+        }}
       />
     </>
   )
@@ -1194,9 +1214,11 @@ function SkillDetailSkeleton() {
 
 interface SkillDetailContentProps {
   inventoryInitialLoading: boolean
+  isRemovingSkill: boolean
   openSkillFolder: (pathname: string) => void
   publishSkill: (skill: ManagedSkillGroup) => Promise<void>
   publishingSkillId: string | null
+  requestRemoveSkill: (skill: ManagedSkillGroup) => void
   selectedPlanError: string | null
   selectedSkill: ManagedSkillGroup | undefined
   selectedStatus: ReturnType<typeof getGroupStatus> | null
@@ -1207,9 +1229,11 @@ interface SkillDetailContentProps {
 
 function SkillDetailContent({
   inventoryInitialLoading,
+  isRemovingSkill,
   openSkillFolder,
   publishSkill,
   publishingSkillId,
+  requestRemoveSkill,
   selectedPlanError,
   selectedSkill,
   selectedStatus,
@@ -1230,6 +1254,8 @@ function SkillDetailContent({
         planError={selectedPlanError}
         publishSkill={publishSkill}
         publishingSkillId={publishingSkillId}
+        isRemovingSkill={isRemovingSkill}
+        requestRemoveSkill={requestRemoveSkill}
         selectedSkill={selectedSkill}
         selectedStatus={selectedStatus}
         selectedVersionCheck={selectedVersionCheck}
@@ -1895,7 +1921,7 @@ function SkillManagementSheet({
 
   return (
     <div
-      className="fixed inset-0 z-[120] bg-black/15 [-webkit-app-region:no-drag]"
+      className="oo-modal-backdrop fixed inset-0 z-[120] [-webkit-app-region:no-drag]"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) {
@@ -2055,7 +2081,7 @@ function PublicSkillPackageSheet({
 
   return (
     <div
-      className="fixed inset-0 z-[120] bg-black/15"
+      className="oo-modal-backdrop fixed inset-0 z-[120]"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) {
@@ -2237,10 +2263,12 @@ function PublicSkillPackageDetail({
 }
 
 interface SkillPeekProps {
+  isRemovingSkill: boolean
   openSkillFolder: (pathname: string) => void
   planError: string | null
   publishSkill: (skill: ManagedSkillGroup) => Promise<void>
   publishingSkillId: string | null
+  requestRemoveSkill: (skill: ManagedSkillGroup) => void
   selectedSkill: ManagedSkillGroup
   selectedStatus: ReturnType<typeof getGroupStatus>
   selectedVersionCheck?: SkillVersionReport["skills"][number]
@@ -2249,10 +2277,12 @@ interface SkillPeekProps {
 }
 
 function SkillPeek({
+  isRemovingSkill,
   openSkillFolder,
   planError,
   publishSkill,
   publishingSkillId,
+  requestRemoveSkill,
   selectedSkill,
   selectedStatus,
   selectedVersionCheck,
@@ -2476,6 +2506,17 @@ function SkillPeek({
                     : t("skills.publishToMarket")}
               </Button>
             ) : null}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="border-[var(--oo-danger-border)] text-destructive hover:bg-[var(--oo-danger-surface)] hover:text-destructive"
+              disabled={isRemovingSkill}
+              onClick={() => requestRemoveSkill(selectedSkill)}
+            >
+              {isRemovingSkill ? <AppIcons.status.loading className="animate-spin" /> : <AppIcons.action.delete />}
+              {isRemovingSkill ? t("skills.removing") : t("skills.removeConfirmAction")}
+            </Button>
           </div>
         </CardContent>
       </InspectorCard>


### PR DESCRIPTION
## Summary

This PR hides local project paths from the project picker and search, adds a Skills detail-page removal action, and makes skill deletion remove the installed targets that Wanta actually manages across supported agent skill roots.

## Issue

The UI was exposing local project paths in the project menu and using paths as searchable text. That leaks more local filesystem detail than the user needs for normal project switching. Separately, the Skills detail view did not offer the same removal path as the rest of the skill object actions, and the backend deletion flow only removed the shared skill target after attempting a registry uninstall.

## Cause and effect

Because project filtering and display both included the path, users could see or match against full local paths in the picker. For skills, deletion could fail or leave installed targets behind when a skill was installed in a supported agent root rather than only the shared Wanta skill directory. The Skills page also needed to refresh its home summary and selected skill state after a removal.

## Fix

Project search and display now use the project name only. The Skills detail panel now has a remove action wired through the shared confirmation dialog and invalidates the relevant skill and home-summary resources. The skill service now reads the inventory, validates the selected group, optionally runs registry uninstall for registry-backed skills, and removes installed skill target directories under the allowed skill roots only. The agent artifact prompt also clarifies when local image deliverables should be shown inline versus left for artifact browsing.

## Validation

- `npm run lint`
