### PR TITLE
Fix local markdown image previews

### DIFF
--- a/src/components/ai-elements/message-image.tsx
+++ b/src/components/ai-elements/message-image.tsx
@@ -79,7 +79,23 @@ function imageFileName(value: string | null | undefined): string {
   }
 }
 
-function localImagePathFromSrc(src: string | undefined): string | null {
+function decodeLocalImagePathSegment(value: string): string {
+  try {
+    const decoded = decodeURIComponent(value)
+    return /[\\/]/.test(decoded) ? value : decoded
+  } catch {
+    return value
+  }
+}
+
+function decodeLocalImagePath(value: string): string {
+  return value
+    .split(/([\\/])/)
+    .map((segment) => (segment === "/" || segment === "\\" ? segment : decodeLocalImagePathSegment(segment)))
+    .join("")
+}
+
+export function localImagePathFromSrc(src: string | undefined): string | null {
   const value = src?.trim()
   if (!value || /^(?:https?:|data:|blob:|wanta:|wanta-local:)/i.test(value)) {
     return null
@@ -94,7 +110,7 @@ function localImagePathFromSrc(src: string | undefined): string | null {
     }
   }
   if (/^(?:~?[\\/]|[A-Za-z]:[\\/])/.test(value)) {
-    return value
+    return decodeLocalImagePath(value)
   }
   return null
 }

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -7,6 +7,7 @@ import {
   clampImageViewerOffset,
   imageViewerFitScale,
   imageViewerWheelAction,
+  localImagePathFromSrc,
   MarkdownImage,
   panImageViewerState,
   zoomImageViewerState,
@@ -131,6 +132,20 @@ describe("MarkdownTable", () => {
 })
 
 describe("MarkdownImage", () => {
+  it("decodes percent-encoded local paths from markdown image URLs", () => {
+    expect(localImagePathFromSrc("/Users/me/Library/Application%20Support/wanta/agent/artifacts/turn/001.png")).toBe(
+      "/Users/me/Library/Application Support/wanta/agent/artifacts/turn/001.png",
+    )
+  })
+
+  it("keeps malformed percent escapes readable instead of rejecting local paths", () => {
+    expect(localImagePathFromSrc("/tmp/100% legit/image.png")).toBe("/tmp/100% legit/image.png")
+  })
+
+  it("does not decode escaped path separators inside local path segments", () => {
+    expect(localImagePathFromSrc("/tmp/output%23final/a%2Fb.png")).toBe("/tmp/output#final/a%2Fb.png")
+  })
+
   it("renders image previews as clickable buttons with a download action", () => {
     const html = renderToStaticMarkup(
       React.createElement(


### PR DESCRIPTION
## Summary

Fix local Markdown image previews when generated artifact paths contain spaces or other percent-encoded filename characters.

## Issue

Wanta already asks the agent to include Markdown image references for small generated image sets, and the assistant output can contain a valid local image reference such as `![title](</Users/.../Application Support/.../001.png>)`. Streamdown normalizes that Markdown image URL before it reaches Wanta's custom image renderer, so the renderer receives `Application%20Support` instead of `Application Support`.

The previous local path handling only decoded `file://` URLs. Plain absolute local paths were passed through unchanged, so the main-process preview request tried to `stat()` a path containing `%20`. That file does not exist on disk, causing `getAttachmentPreview` to return no data URL and the inline image preview to disappear even though the generated artifact itself existed and appeared in the artifact panel.

## Fix

Decode percent-encoded segments for local absolute and home-relative image paths before requesting the preview from the main process. The decoding is done per path segment so useful filename characters like spaces and `#` are restored while escaped path separators such as `%2F` are not converted into real directory separators.

The local image path parser is exported for focused unit coverage.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
