### PR TITLE
Harden chat event rendering

### DIFF
--- a/electron/agent/event-translator.test.ts
+++ b/electron/agent/event-translator.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict"
-import { test } from "vitest"
-import { normalizeMessage, parseAuthorization, translateOpencodeEvent } from "./event-translator.ts"
+import { test, vi } from "vitest"
+import {
+  normalizeMessage,
+  normalizeSyncMessage,
+  parseAuthorization,
+  translateOpencodeEvent,
+} from "./event-translator.ts"
 
 test("message.updated → messageStarted with role", () => {
   const out = translateOpencodeEvent({
@@ -46,6 +51,40 @@ test("message.updated with assistant abort skips agentError", () => {
   })
 
   assert.deepEqual(out, [{ event: "messageStarted", data: { sessionId: "s1", messageId: "m1", role: "assistant" } }])
+})
+
+test("known ignored event types do not warn in development", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = "development"
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+  try {
+    assert.deepEqual(translateOpencodeEvent({ type: "installation.update-available", properties: {} }), [])
+    assert.equal(warn.mock.calls.length, 0)
+  } finally {
+    warn.mockRestore()
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  }
+})
+
+test("unknown event types warn in development", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = "development"
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+  try {
+    assert.deepEqual(translateOpencodeEvent({ type: "new.event", properties: {} }), [])
+    assert.equal(warn.mock.calls[0]?.[0], "[wanta] unhandled OpenCode event type: new.event")
+  } finally {
+    warn.mockRestore()
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  }
 })
 
 test("text part.updated → messageDelta carrying cumulative text", () => {
@@ -114,6 +153,15 @@ test("session.next.text.ended strips Wanta hidden turn context", () => {
   ])
 })
 
+test("ignored text part.updated is not shown", () => {
+  const out = translateOpencodeEvent({
+    type: "message.part.updated",
+    properties: { part: { id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "hidden", ignored: true } },
+  })
+
+  assert.deepEqual(out, [])
+})
+
 test("reasoning part.updated → messageReasoningDelta", () => {
   const out = translateOpencodeEvent({
     type: "message.part.updated",
@@ -169,6 +217,25 @@ test("retry signals update assistant activity", () => {
       data: { sessionId: "s1", messageId: "m1", phase: "retrying", message: "upstream timeout", attempt: 2 },
     },
   ])
+})
+
+test("known non-chat part types are explicitly ignored", () => {
+  assert.deepEqual(
+    translateOpencodeEvent({
+      type: "message.part.updated",
+      properties: {
+        part: { id: "snapshot-1", sessionID: "s1", messageID: "m1", type: "snapshot", snapshot: "abc" },
+      },
+    }),
+    [],
+  )
+  assert.deepEqual(
+    translateOpencodeEvent({
+      type: "message.part.updated",
+      properties: { part: { id: "agent-1", sessionID: "s1", messageID: "m1", type: "agent", name: "build" } },
+    }),
+    [],
+  )
 })
 
 test("file part.updated → messageAttachment", () => {
@@ -276,7 +343,17 @@ test("tool events preserve title, metadata and timing for renderer summaries", (
           title: "Run tests",
           metadata: { exit: 0 },
           time: { start: 100, end: 250 },
-          attachments: [{}],
+          attachments: [
+            {
+              id: "file-1",
+              sessionID: "s1",
+              messageID: "m1",
+              type: "file",
+              filename: "result.txt",
+              mime: "text/plain",
+              source: { path: "/tmp/result.txt" },
+            },
+          ],
         },
       },
     },
@@ -296,6 +373,16 @@ test("tool events preserve title, metadata and timing for renderer summaries", (
     metadata: { exit: 0 },
     timing: { start: 100, end: 250 },
     attachmentsCount: 1,
+    attachments: [
+      {
+        id: "file-1",
+        name: "result.txt",
+        mime: "text/plain",
+        size: 0,
+        path: "/tmp/result.txt",
+        kind: "file",
+      },
+    ],
   })
 })
 
@@ -411,6 +498,31 @@ test("session.error skips message aborts", () => {
   })
 
   assert.deepEqual(out, [])
+})
+
+test("permission.updated reports an unexpected permission request", () => {
+  const out = translateOpencodeEvent({
+    type: "permission.updated",
+    properties: {
+      id: "perm-1",
+      sessionID: "s1",
+      messageID: "m1",
+      title: "Run bash",
+      type: "tool",
+    },
+  })
+
+  assert.deepEqual(out, [
+    {
+      event: "unexpectedPermission",
+      data: {
+        sessionId: "s1",
+        messageId: "m1",
+        message:
+          "OpenCode requested permission approval (Run bash · tool), but Wanta does not support ask permissions. The generation was stopped.",
+      },
+    },
+  ])
 })
 
 test("parseAuthorization accepts auth json, rejects plain results", () => {
@@ -570,6 +682,18 @@ test("normalizeMessage ignores V2 history entries with no visible parts", () => 
   assert.equal(assistant, null)
 })
 
+test("normalizeSyncMessage skips ignored text parts", () => {
+  const message = normalizeSyncMessage({
+    info: { id: "m1", role: "assistant", time: { created: 1 } },
+    parts: [
+      { id: "p1", type: "text", text: "hidden", ignored: true },
+      { id: "p2", type: "text", text: "visible" },
+    ],
+  })
+
+  assert.deepEqual(message?.parts, [{ kind: "text", partId: "p2", text: "visible" }])
+})
+
 test("normalizeMessage builds ChatMessage with text + reasoning + tool parts in order", () => {
   const msg = normalizeMessage({
     id: "m1",
@@ -596,6 +720,59 @@ test("normalizeMessage builds ChatMessage with text + reasoning + tool parts in 
   assert.equal(msg.parts[0].kind, "text")
   assert.equal(msg.parts[1].kind, "reasoning")
   assert.equal(msg.parts[2].kind, "tool")
+})
+
+test("normalizeSyncMessage preserves structured tool attachments", () => {
+  const msg = normalizeSyncMessage({
+    info: { id: "m1", role: "assistant", time: { created: 123 } },
+    parts: [
+      {
+        id: "tool-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: "cat result.txt" },
+          output: "ok",
+          attachments: [
+            {
+              id: "file-1",
+              type: "file",
+              filename: "result.txt",
+              mime: "text/plain",
+              source: { path: "/tmp/result.txt" },
+            },
+          ],
+        },
+      },
+    ],
+  })
+
+  assert.deepEqual(msg?.parts[0], {
+    kind: "tool",
+    partId: "tool-1",
+    callId: "call-1",
+    tool: "bash",
+    status: "completed",
+    input: { command: "cat result.txt" },
+    output: "ok",
+    error: undefined,
+    title: undefined,
+    metadata: undefined,
+    timing: undefined,
+    attachmentsCount: 1,
+    attachments: [
+      {
+        id: "file-1",
+        name: "result.txt",
+        mime: "text/plain",
+        size: 0,
+        path: "/tmp/result.txt",
+        kind: "file",
+      },
+    ],
+  })
 })
 
 test("normalizeMessage preserves assistant token usage", () => {

--- a/electron/agent/event-translator.ts
+++ b/electron/agent/event-translator.ts
@@ -38,6 +38,7 @@ export type ChatEmit =
   | { event: "messageCompleted"; data: MessageCompletedEvent }
   | { event: "messagePartRemoved"; data: MessagePartRemovedEvent }
   | { event: "agentError"; data: { sessionId?: string; message: string } }
+  | { event: "unexpectedPermission"; data: { sessionId: string; messageId: string; message: string } }
 
 interface OpencodeEvent {
   type: string
@@ -154,6 +155,43 @@ function messageErrorPart(error: unknown): ChatMessagePart | undefined {
     partId: `message-error-${name}`,
     errorText: errorMessage(error),
   }
+}
+
+const ignoredOpencodeEventTypes = new Set([
+  "command.executed",
+  "file.edited",
+  "file.watcher.updated",
+  "installation.update-available",
+  "installation.updated",
+  "lsp.client.diagnostics",
+  "lsp.updated",
+  "message.removed",
+  "permission.replied",
+  "pty.created",
+  "pty.deleted",
+  "pty.exited",
+  "pty.updated",
+  "server.connected",
+  "server.instance.disposed",
+  "session.compacted",
+  "session.created",
+  "session.deleted",
+  "session.diff",
+  "session.updated",
+  "todo.updated",
+  "tui.command.execute",
+  "tui.prompt.append",
+  "tui.toast.show",
+  "vcs.branch.updated",
+])
+
+const ignoredOpencodePartTypes = new Set(["agent", "compaction", "patch", "snapshot", "subtask"])
+
+function warnUnhandledOpencode(kind: "event" | "part", type: string): void {
+  if (process.env.NODE_ENV === "test") {
+    return
+  }
+  console.warn(`[wanta] unhandled OpenCode ${kind} type: ${type}`)
 }
 
 export function translateOpencodeEvent(event: OpencodeEvent): ChatEmit[] {
@@ -298,7 +336,29 @@ export function translateOpencodeEvent(event: OpencodeEvent): ChatEmit[] {
         { event: "agentError", data: { sessionId: asString(props.sessionID), message: errorMessage(props.error) } },
       ]
     }
+    case "permission.updated": {
+      const p = props as { sessionID?: string; messageID?: string; title?: string; type?: string }
+      if (!p.sessionID || !p.messageID) {
+        return []
+      }
+      const detail = [p.title, p.type].filter(Boolean).join(" · ")
+      return [
+        {
+          event: "unexpectedPermission",
+          data: {
+            sessionId: p.sessionID,
+            messageId: p.messageID,
+            message: detail
+              ? `OpenCode requested permission approval (${detail}), but Wanta does not support ask permissions. The generation was stopped.`
+              : "OpenCode requested permission approval, but Wanta does not support ask permissions. The generation was stopped.",
+          },
+        },
+      ]
+    }
     default:
+      if (!ignoredOpencodeEventTypes.has(event.type)) {
+        warnUnhandledOpencode("event", event.type)
+      }
       return []
   }
 }
@@ -510,6 +570,8 @@ interface OpencodePart {
   }
   callID?: string
   tool?: string
+  ignored?: boolean
+  synthetic?: boolean
   state?: {
     status: ToolStatus
     input?: Record<string, unknown>
@@ -523,7 +585,7 @@ interface OpencodePart {
       end?: number
       compacted?: number
     }
-    attachments?: unknown[]
+    attachments?: OpencodePart[]
   }
   attempt?: number
   error?: unknown
@@ -535,12 +597,15 @@ interface OpencodePart {
 function toolContext(state: NonNullable<OpencodePart["state"]>) {
   const description = typeof state.input?.description === "string" ? state.input.description : undefined
   const title = state.title ?? description
+  const attachments = toolAttachments(state.attachments)
+  const attachmentsCount = attachments.length > 0 ? attachments.length : (state.attachments?.length ?? 0)
   return {
     input: state.input ?? {},
     ...(title ? { title } : {}),
     ...(state.metadata ? { metadata: state.metadata } : {}),
     ...(state.time ? { timing: { start: state.time.start, end: state.time.end } } : {}),
-    ...(Array.isArray(state.attachments) ? { attachmentsCount: state.attachments.length } : {}),
+    ...(attachmentsCount > 0 ? { attachmentsCount } : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
   }
 }
 
@@ -573,6 +638,9 @@ function translatePart(part: OpencodePart, delta?: string): ChatEmit[] {
     ]
   }
   if (part.type === "text") {
+    if (part.ignored === true) {
+      return []
+    }
     const rawText = part.text ?? ""
     const text = visibleText(rawText)
     const cleanedDelta = delta === undefined ? undefined : visibleText(delta)
@@ -657,6 +725,9 @@ function translatePart(part: OpencodePart, delta?: string): ChatEmit[] {
       return [{ event: "toolCallResult", data: { ...base, ...context, status: "error", error: state.error } }]
     }
   }
+  if (!ignoredOpencodePartTypes.has(part.type)) {
+    warnUnhandledOpencode("part", part.type)
+  }
   return []
 }
 
@@ -692,6 +763,15 @@ function attachmentPart(part: OpencodePart): ChatMessagePart {
       kind: mime === "inode/directory" ? "directory" : "file",
     },
   }
+}
+
+function toolAttachments(value: OpencodePart[] | undefined): NonNullable<ToolCallResultEvent["attachments"]> {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value
+    .map((part) => attachmentPart(part).attachment)
+    .filter((attachment): attachment is NonNullable<ChatMessagePart["attachment"]> => Boolean(attachment))
 }
 
 function numberOrZero(value: unknown): number {
@@ -735,6 +815,9 @@ export function normalizeSyncMessage(message: { info?: unknown; parts?: unknown 
   const parts: ChatMessagePart[] = []
   for (const part of rawParts) {
     if (part.type === "text") {
+      if (part.ignored === true) {
+        continue
+      }
       const text = visibleText(part.text ?? "")
       if (text.length > 0) {
         parts.push({ kind: "text", partId: part.id, text })
@@ -751,6 +834,8 @@ export function normalizeSyncMessage(message: { info?: unknown; parts?: unknown 
       }
     } else if (part.type === "tool" && part.state && part.callID && part.tool) {
       const state = part.state
+      const attachments = toolAttachments(state.attachments)
+      const attachmentsCount = attachments.length > 0 ? attachments.length : (state.attachments?.length ?? 0)
       const tool: ChatMessagePart = {
         kind: "tool",
         partId: part.id,
@@ -763,7 +848,8 @@ export function normalizeSyncMessage(message: { info?: unknown; parts?: unknown 
         title: state.title ?? (typeof state.input?.description === "string" ? state.input.description : undefined),
         metadata: state.metadata,
         timing: state.time ? { start: state.time.start, end: state.time.end } : undefined,
-        attachmentsCount: Array.isArray(state.attachments) ? state.attachments.length : undefined,
+        attachmentsCount: attachmentsCount > 0 ? attachmentsCount : undefined,
+        attachments: attachments.length > 0 ? attachments : undefined,
       }
       if (state.status === "completed") {
         const auth = parseToolAuthorization(part.tool, state.output)

--- a/electron/chat/common.ts
+++ b/electron/chat/common.ts
@@ -101,6 +101,7 @@ export interface ToolCallResultEvent {
   metadata?: Record<string, unknown>
   timing?: ToolTiming
   attachmentsCount?: number
+  attachments?: ChatAttachment[]
   authorization?: AuthorizationInfo
 }
 export interface MessageCompletedEvent {
@@ -155,6 +156,7 @@ export interface ChatMessagePart {
   metadata?: Record<string, unknown>
   timing?: ToolTiming
   attachmentsCount?: number
+  attachments?: ChatAttachment[]
   authorization?: AuthorizationInfo
   cancelled?: boolean
 }

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -178,6 +178,130 @@ test("stopGeneration suppresses delayed streaming events until the next send", a
   assert.equal(events.at(-1)?.event, "messageStarted")
 })
 
+test("unexpected OpenCode permission request is aborted and surfaced as a message error", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+  })
+  bridge.emit({
+    type: "permission.updated",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      messageID: "assistant-1",
+      title: "Run bash",
+      type: "tool",
+    },
+  })
+  await waitForEventCount(events, 2)
+
+  assert.equal(bridge.abort.mock.calls.length, 1)
+  const messageError = events.find((event) => event.event === "messageError") as
+    | { data: { message?: string; messageId?: string } }
+    | undefined
+  assert.equal(messageError?.data.messageId, "assistant-1")
+  assert.match(messageError?.data.message ?? "", /does not support ask permissions/)
+})
+
+test("stale OpenCode permission request does not abort a newer generation before its message starts", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({ sessionId: "session-1", text: "first" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+  })
+  await service.sendMessage({ sessionId: "session-1", text: "second" })
+
+  bridge.emit({
+    type: "permission.updated",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      messageID: "assistant-1",
+      title: "Run bash",
+      type: "tool",
+    },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(bridge.abort.mock.calls.length, 0)
+  assert.equal(service.hasActiveGeneration(), true)
+  assert.equal(
+    events.some((event) => event.event === "messageError"),
+    false,
+  )
+
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-2", sessionID: "session-1", role: "assistant" } },
+  })
+  assert.deepEqual(events.at(-1)?.data, { sessionId: "session-1", messageId: "assistant-2", role: "assistant" })
+})
+
+test("unexpected OpenCode permission request does not clear a newer generation", async () => {
+  const bridge = createBridgeAgent()
+  let resolveAbort: (() => void) | undefined
+  bridge.abort.mockImplementationOnce(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveAbort = resolve
+      }),
+  )
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({ sessionId: "session-1", text: "first" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+  })
+  bridge.emit({
+    type: "permission.updated",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      messageID: "assistant-1",
+      title: "Run bash",
+      type: "tool",
+    },
+  })
+  await vi.waitFor(() => {
+    assert.equal(bridge.abort.mock.calls.length, 1)
+  })
+
+  await service.sendMessage({ sessionId: "session-1", text: "second" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-2", sessionID: "session-1", role: "assistant" } },
+  })
+  resolveAbort?.()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(service.hasActiveGeneration(), true)
+  assert.equal(
+    events.some((event) => event.event === "messageError"),
+    false,
+  )
+  assert.equal(events.at(-1)?.event, "messageStarted")
+  assert.deepEqual(
+    events.filter((event) => event.event === "messageStarted").map((event) => event.data),
+    [
+      { sessionId: "session-1", messageId: "assistant-1", role: "assistant" },
+      { sessionId: "session-1", messageId: "assistant-2", role: "assistant" },
+    ],
+  )
+})
+
 test("stopGeneration finalizes process files produced before cancellation", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-chat-stop-turn-output-"))
   try {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -761,6 +761,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private pendingProcessDirs = new Map<string, string[]>()
   private activeTurnOutputs = new Map<string, ActiveTurnOutput>()
   private activeAssistantMessages = new Map<string, string>()
+  private activeAssistantMessageGenerations = new Map<string, string>()
   private activeToolParts = new Map<string, Set<string>>()
   private readonly deps: ChatServiceDeps
   private agentStatus: AgentRuntimeStatus = { status: "signed_out" }
@@ -797,6 +798,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.pendingProcessDirs.clear()
     this.activeTurnOutputs.clear()
     this.activeAssistantMessages.clear()
+    this.activeAssistantMessageGenerations.clear()
     this.activeToolParts.clear()
     this.artifactRoots.clear()
     this.artifactRootsLoaded = false
@@ -826,6 +828,21 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     )
   }
 
+  private setActiveAssistantMessage(sessionId: string, messageId: string): void {
+    this.activeAssistantMessages.set(sessionId, messageId)
+    const generationId = this.sessionGenerations.get(sessionId)?.id
+    if (generationId) {
+      this.activeAssistantMessageGenerations.set(sessionId, generationId)
+    } else {
+      this.activeAssistantMessageGenerations.delete(sessionId)
+    }
+  }
+
+  private clearActiveAssistantMessage(sessionId: string): void {
+    this.activeAssistantMessages.delete(sessionId)
+    this.activeAssistantMessageGenerations.delete(sessionId)
+  }
+
   /** agent 就绪后调用：订阅 OpenCode SSE，转译为 ServerEvents 广播给渲染层。 */
   public startEventBridge(): void {
     if (!this.agent || this.bridged) {
@@ -835,6 +852,45 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     const emit = this.send.bind(this) as (event: string, data: unknown) => Promise<void>
     this.agent.subscribe((event) => {
       for (const translated of translateOpencodeEvent(event)) {
+        if (translated.event === "unexpectedPermission") {
+          const { sessionId, messageId, message } = translated.data
+          const isCurrentPermissionTurn = (): boolean => {
+            const currentGenerationId = this.sessionGenerations.get(sessionId)?.id
+            const messageGenerationId = this.activeAssistantMessageGenerations.get(sessionId)
+            const sameMessage = this.activeAssistantMessages.get(sessionId) === messageId
+            if (currentGenerationId || messageGenerationId) {
+              return sameMessage && Boolean(currentGenerationId && messageGenerationId === currentGenerationId)
+            }
+            return sameMessage
+          }
+          void (async () => {
+            if (!isCurrentPermissionTurn()) {
+              return
+            }
+            try {
+              await this.agent?.abort(sessionId)
+            } catch (error) {
+              console.warn("[wanta] failed to abort unexpected permission request", error)
+            }
+            if (!isCurrentPermissionTurn()) {
+              return
+            }
+            await this.finalizeTurnOutput(sessionId, messageId).catch((error: unknown) => {
+              console.warn("[wanta] failed to finalize permission-blocked turn output", error)
+            })
+            if (!isCurrentPermissionTurn()) {
+              return
+            }
+            this.clearSessionGeneration(sessionId, this.activeAssistantMessageGenerations.get(sessionId))
+            this.clearActiveAssistantMessage(sessionId)
+            this.activeToolParts.delete(sessionId)
+            this.emitSessionActivity(sessionId)
+            this.emitMessageError(emit, sessionId, message, messageId)
+          })().catch((error: unknown) => {
+            console.warn("[wanta] failed to handle unexpected permission request", error)
+          })
+          continue
+        }
         if (
           translated.event === "agentError" &&
           translated.data.sessionId &&
@@ -848,7 +904,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             })
             .finally(() => {
               this.clearSessionGeneration(sessionId)
-              this.activeAssistantMessages.delete(sessionId)
+              this.clearActiveAssistantMessage(sessionId)
               this.activeToolParts.delete(sessionId)
               this.emitSessionActivity(sessionId)
               void emit("generationStopped", { sessionId })
@@ -862,7 +918,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           this.emitSessionActivity(translated.data.sessionId)
         }
         if (translated.event === "messageStarted" && translated.data.role === "assistant") {
-          this.activeAssistantMessages.set(translated.data.sessionId, translated.data.messageId)
+          this.setActiveAssistantMessage(translated.data.sessionId, translated.data.messageId)
           this.activeToolParts.set(translated.data.sessionId, new Set())
           const artifactRoot = this.consumePendingArtifactDir(translated.data.sessionId)
           const processRoot = this.consumePendingProcessDir(translated.data.sessionId)
@@ -886,7 +942,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           }
         }
         if (translated.event === "toolCallStarted") {
-          this.activeAssistantMessages.set(translated.data.sessionId, translated.data.messageId)
+          this.setActiveAssistantMessage(translated.data.sessionId, translated.data.messageId)
           const partIds = this.activeToolParts.get(translated.data.sessionId) ?? new Set<string>()
           partIds.add(translated.data.partId)
           this.activeToolParts.set(translated.data.sessionId, partIds)
@@ -917,7 +973,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             })
             .finally(() => {
               this.clearSessionGeneration(sessionId)
-              this.activeAssistantMessages.delete(sessionId)
+              this.clearActiveAssistantMessage(sessionId)
               this.activeToolParts.delete(sessionId)
               this.emitSessionActivity(sessionId)
               this.emitMessageError(emit, sessionId, translated.data.message, messageId)
@@ -933,7 +989,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             })
             .finally(() => {
               this.clearSessionGeneration(sessionId)
-              this.activeAssistantMessages.delete(sessionId)
+              this.clearActiveAssistantMessage(sessionId)
               this.activeToolParts.delete(sessionId)
               this.emitSessionActivity(sessionId)
               void emit(translated.event, translated.data)
@@ -1166,7 +1222,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         }
         const messageId = this.activeAssistantMessages.get(req.sessionId)
         this.clearSessionGeneration(req.sessionId, generation.id)
-        this.activeAssistantMessages.delete(req.sessionId)
+        this.clearActiveAssistantMessage(req.sessionId)
         this.emitMessageError(
           this.send.bind(this) as (event: string, data: unknown) => Promise<void>,
           req.sessionId,
@@ -1637,7 +1693,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.pendingArtifactDirs.delete(sessionId)
     this.pendingProcessDirs.delete(sessionId)
     this.activeTurnOutputs.delete(sessionId)
-    this.activeAssistantMessages.delete(sessionId)
+    this.clearActiveAssistantMessage(sessionId)
     this.activeToolParts.delete(sessionId)
     await this.send("generationStopped", { sessionId }).catch(() => undefined)
   }

--- a/src/hooks/chat-message-state.test.ts
+++ b/src/hooks/chat-message-state.test.ts
@@ -1,0 +1,47 @@
+import type { ChatAttachment, ChatMessage } from "../../electron/chat/common.ts"
+
+import { describe, expect, it } from "vitest"
+import { setAttachmentPart } from "./chat-message-state.ts"
+
+const attachment: ChatAttachment = {
+  id: "file-1",
+  name: "report.pdf",
+  mime: "application/pdf",
+  size: 12,
+  path: "/tmp/report.pdf",
+  kind: "file",
+}
+
+describe("chat message state", () => {
+  it("keeps assistant role when an attachment arrives for an existing assistant message", () => {
+    const messages: ChatMessage[] = [{ id: "assistant-1", role: "assistant", parts: [], createdAt: 1 }]
+
+    const next = setAttachmentPart(messages, {
+      sessionId: "session-1",
+      messageId: "assistant-1",
+      partId: "file-1",
+      attachment,
+    })
+
+    expect(next[0]).toMatchObject({
+      id: "assistant-1",
+      role: "assistant",
+      parts: [{ kind: "attachment", partId: "file-1", attachment }],
+    })
+  })
+
+  it("keeps the historical user fallback when attachment arrives before messageStarted", () => {
+    const next = setAttachmentPart([], {
+      sessionId: "session-1",
+      messageId: "user-1",
+      partId: "file-1",
+      attachment,
+    })
+
+    expect(next[0]).toMatchObject({
+      id: "user-1",
+      role: "user",
+      parts: [{ kind: "attachment", partId: "file-1", attachment }],
+    })
+  })
+})

--- a/src/hooks/chat-message-state.ts
+++ b/src/hooks/chat-message-state.ts
@@ -244,7 +244,8 @@ export function hasVisibleMessageDelta(event: MessageDeltaEvent): boolean {
 }
 
 export function setAttachmentPart(msgs: ChatMessage[], event: MessageAttachmentEvent): ChatMessage[] {
-  const ensured = ensureMessage(msgs, event.messageId, "user")
+  const existingRole = msgs.find((message) => message.id === event.messageId)?.role
+  const ensured = ensureMessage(msgs, event.messageId, existingRole ?? "user")
   return ensured.map((message) =>
     message.id === event.messageId
       ? {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -325,6 +325,7 @@ export function useChat(activeSessionId: string | null, visibleSessionId: string
         metadata: e.metadata,
         timing: e.timing,
         attachmentsCount: e.attachmentsCount,
+        attachments: e.attachments,
         authorization: e.authorization,
         ...(cancelled ? { cancelled: true } : {}),
       })

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest"
 import { I18nContext, translate } from "../../i18n/i18n.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
 
-function renderToolActivityStep(part: ChatMessagePart, options: { shimmer?: boolean } = {}): string {
+function renderToolActivityStep(part: ChatMessagePart): string {
   return renderToStaticMarkup(
     React.createElement(
       I18nContext.Provider,
@@ -17,7 +17,7 @@ function renderToolActivityStep(part: ChatMessagePart, options: { shimmer?: bool
           t: (key, vars) => translate("zh-CN", key, vars),
         },
       },
-      React.createElement(ToolActivityStep, { part, shimmer: options.shimmer, onAuthorize: () => undefined }),
+      React.createElement(ToolActivityStep, { part, onAuthorize: () => undefined }),
     ),
   )
 }
@@ -128,21 +128,18 @@ describe("ToolActivityStep", () => {
     expect(html).not.toContain("text-transparent")
   })
 
-  it("can shimmer a completed tool row while the turn is still transitioning", () => {
-    const html = renderToolActivityStep(
-      {
-        kind: "tool",
-        partId: "tool-1",
-        callId: "call-1",
-        tool: "todo_write",
-        status: "completed",
-        input: {},
-        title: "4 todos",
-      },
-      { shimmer: true },
-    )
+  it("keeps completed tool rows static while the turn is still transitioning", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-1",
+      callId: "call-1",
+      tool: "todo_write",
+      status: "completed",
+      input: {},
+      title: "4 todos",
+    })
 
-    expect(html).toMatch(/class="[^"]*text-transparent[^"]*"[^>]*>使用工具<\/span>/)
+    expect(html).not.toContain("text-transparent")
     expect(html).toContain("4 todos")
     expect(html).toContain("已完成")
   })

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -25,6 +25,8 @@ import {
   Wrench,
 } from "lucide-react"
 import * as React from "react"
+import { attachmentWithPreview } from "./chat-attachment-utils.ts"
+import { AttachmentList } from "./ChatAttachments.tsx"
 import { LoadingShimmerText } from "./LoadingShimmerText.tsx"
 import { shouldShowRunningNoOutput } from "./tool-activity.ts"
 import { parseToolAuthorization, toolDisplayLine } from "./tool-display.ts"
@@ -183,6 +185,7 @@ function hasToolDetails(part: ChatMessagePart, auth: AuthorizationInfo | null): 
     Boolean(part.error && !stopped) ||
     Boolean(auth?.message) ||
     shouldShowRunningNoOutput(part) ||
+    Boolean(part.attachments?.length) ||
     Boolean(part.attachmentsCount)
   )
 }
@@ -190,12 +193,10 @@ function hasToolDetails(part: ChatMessagePart, auth: AuthorizationInfo | null): 
 export function ToolActivityStep({
   part,
   provider,
-  shimmer = false,
   onAuthorize,
 }: {
   part: ChatMessagePart
   provider?: ConnectionProvider
-  shimmer?: boolean
   onAuthorize: (auth: AuthorizationInfo) => void
 }) {
   const t = useT()
@@ -205,10 +206,11 @@ export function ToolActivityStep({
   const [open, setOpen] = React.useState(false)
   const statusText = toolPartStatusLabel(t, part)
   const active = isActiveToolPart(part)
-  const showShimmer = active || shimmer
+  const showShimmer = active
   const displayLine = toolDisplayLine(t, part)
   const metaItems = [provider?.displayName, statusText].filter(Boolean)
   const completedMeta = part.status === "completed" && !auth
+  const toolAttachments = part.attachments ?? []
 
   const row = (
     <div className="group/tool-step flex min-h-6 min-w-0 flex-1 items-center gap-2">
@@ -321,7 +323,11 @@ export function ToolActivityStep({
                 <ToolPre>{formatJson(part.metadata ?? {})}</ToolPre>
               </ToolDetailSection>
             )}
-            {open && part.attachmentsCount ? (
+            {open && toolAttachments.length > 0 ? (
+              <ToolDetailSection label={t("chat.toolAttachments", { count: toolAttachments.length })}>
+                <AttachmentList attachments={toolAttachments.map(attachmentWithPreview)} />
+              </ToolDetailSection>
+            ) : open && part.attachmentsCount ? (
               <div className="oo-text-caption text-muted-foreground">
                 {t("chat.toolAttachments", { count: part.attachmentsCount })}
               </div>

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -289,13 +289,8 @@ function TurnProcessActivity({
   const duration = formatProcessDuration(process, now, live)
   const title = processTitle(t, status, duration)
   const renderBlocks = blocks.map((item) => item.block)
-  const showLiveStatus = renderBlocks.length === 0 && shouldShowLiveStatus(process, status)
+  const showLiveStatus = shouldShowLiveStatus(process, status)
   const titleText = processStatusText(t, status)
-  const activeTool = latestActiveTool(process)
-  const shimmerToolPartId =
-    !activeTool && status === "running" && process.activity && process.tools.length > 0
-      ? process.tools.at(-1)?.partId
-      : undefined
   const forceOpen = status === "needsAction" || (status === "error" && !process.hasFinalAnswer)
   const userChangedOpenRef = React.useRef(false)
 
@@ -351,7 +346,6 @@ function TurnProcessActivity({
               billingCacheScope={billingCacheScope}
               smoothText={false}
               providerByService={providerByService}
-              shimmerToolPartId={shimmerToolPartId}
               onAuthorize={onAuthorize}
               onViewBilling={onViewBilling}
             />
@@ -378,8 +372,11 @@ function shouldShowLiveStatus(
   status = processStatus(process),
 ): boolean {
   const activeTool = latestActiveTool(process)
+  if (activeTool) {
+    return false
+  }
   return (
-    (status === "running" && !activeTool) ||
+    status === "running" ||
     status === "retrying" ||
     Boolean(process.activity && status !== "completed" && status !== "stopped")
   )
@@ -629,7 +626,6 @@ function AssistantBlock({
   billingCacheScope,
   smoothText,
   providerByService,
-  shimmerToolPartId,
   onAuthorize,
   onViewBilling,
 }: {
@@ -638,7 +634,6 @@ function AssistantBlock({
   billingCacheScope: string
   smoothText: boolean
   providerByService: Map<string, ConnectionProvider>
-  shimmerToolPartId?: string
   onAuthorize: (auth: AuthorizationInfo, source?: ChatTurnRetrySource) => void
   onViewBilling?: () => void
 }) {
@@ -658,6 +653,10 @@ function AssistantBlock({
           message={block.part.errorText ?? block.part.error ?? t("chatError.failed.description")}
           onViewBilling={onViewBilling}
         />
+      ) : block.kind === "attachment" ? (
+        block.part.attachment ? (
+          <AttachmentList attachments={[attachmentWithPreview(block.part.attachment)]} />
+        ) : null
       ) : (
         <div className="space-y-0.5">
           {block.parts.map((part) => {
@@ -667,7 +666,6 @@ function AssistantBlock({
                 key={part.partId}
                 part={part}
                 provider={service ? providerByService.get(service) : undefined}
-                shimmer={part.partId === shimmerToolPartId}
                 onAuthorize={onAuthorize}
               />
             )

--- a/src/routes/Chat/render-blocks.test.ts
+++ b/src/routes/Chat/render-blocks.test.ts
@@ -26,6 +26,21 @@ function reasoningPart(partId: string, text: string): ChatMessagePart {
   return { kind: "reasoning", partId, text }
 }
 
+function attachmentPart(partId: string): ChatMessagePart {
+  return {
+    kind: "attachment",
+    partId,
+    attachment: {
+      id: partId,
+      name: "report.pdf",
+      mime: "application/pdf",
+      size: 12,
+      path: "/tmp/report.pdf",
+      kind: "file",
+    },
+  }
+}
+
 describe("renderBlocks", () => {
   it("ignores whitespace-only text parts so adjacent tools stay grouped", () => {
     const firstTool = toolPart("tool-1")
@@ -80,5 +95,17 @@ describe("renderBlocks", () => {
     const blocks = renderBlocks([reasoning, answer])
 
     expect(blocks).toEqual([{ kind: "text", part: answer }])
+  })
+
+  it("renders assistant attachments as standalone blocks", () => {
+    const attachment = attachmentPart("attachment-1")
+    const answer = textPart("text-1", "Done")
+
+    const blocks = renderBlocks([attachment, answer])
+
+    expect(blocks).toEqual([
+      { kind: "attachment", part: attachment },
+      { kind: "text", part: answer },
+    ])
   })
 })

--- a/src/routes/Chat/render-blocks.ts
+++ b/src/routes/Chat/render-blocks.ts
@@ -3,10 +3,16 @@ import type { ChatMessagePart } from "../../../electron/chat/common.ts"
 export type RenderBlock =
   | { kind: "text"; part: ChatMessagePart }
   | { kind: "error"; part: ChatMessagePart }
+  | { kind: "attachment"; part: ChatMessagePart }
   | { kind: "tools"; key: string; parts: ChatMessagePart[] }
 
 export function isRenderablePart(part: ChatMessagePart): boolean {
-  return part.kind === "tool" || part.kind === "error" || (part.kind === "text" && Boolean(part.text?.trim()))
+  return (
+    part.kind === "tool" ||
+    part.kind === "error" ||
+    (part.kind === "attachment" && Boolean(part.attachment)) ||
+    (part.kind === "text" && Boolean(part.text?.trim()))
+  )
 }
 
 export function renderBlocks(parts: ChatMessagePart[]): RenderBlock[] {
@@ -30,6 +36,8 @@ export function renderBlocks(parts: ChatMessagePart[]): RenderBlock[] {
     flushTools()
     if (part.kind === "error") {
       blocks.push({ kind: "error", part })
+    } else if (part.kind === "attachment") {
+      blocks.push({ kind: "attachment", part })
     } else if (part.kind === "text") {
       blocks.push({ kind: "text", part })
     }


### PR DESCRIPTION
## Summary

- Preserve and render structured attachments from OpenCode assistant/tool parts instead of reducing everything to attachment counts.
- Make known ignored OpenCode events/parts explicit and warn on genuinely unknown payloads during development.
- Abort and surface an error if OpenCode emits permission.updated, because Wanta does not implement the ask-permission confirmation flow.
- Preserve existing assistant/user roles when late attachment parts are merged into message state.

## Root cause

The previous translation/display path treated several OpenCode payload shapes as either implicit no-ops or reduced metadata. That worked for common chat flows, but it could hide useful attachments, silently discard newly introduced part/event types, and keep a session hanging if OpenCode ever produced an ask-style permission update.

## Validation

- npm run lint
- npm run format
- npm run ts-check
- npm test
