### PR TITLE
[codex] Defer connector authorization suggestions and polish chat UI

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1293,28 +1293,30 @@ function ProjectSidebarGroupItem({
             {group.project.name}
           </span>
           <span className="relative flex size-3.5 shrink-0 items-center justify-center">
-            {showCollapsedRunning ? (
-              <LoaderCircle
-                className="absolute size-3.5 animate-spin text-sidebar-foreground/70 opacity-100 transition-opacity group-focus-within:opacity-0 group-hover:opacity-0"
-                aria-hidden="true"
-              />
-            ) : null}
             {expanded ? (
-              <ChevronDown className="absolute size-3.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100" />
+              <ChevronDown className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
             ) : (
-              <ChevronRight className="absolute size-3.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100" />
+              <ChevronRight className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
             )}
           </span>
         </button>
-        <button
-          type="button"
-          title={projectTitle}
-          aria-label={projectTitle}
-          className="pointer-events-none flex size-5 shrink-0 items-center justify-center rounded opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-          onClick={() => onNewSession(group.project)}
-        >
-          <SquarePen className="size-3.5" />
-        </button>
+        <span className="relative flex size-5 shrink-0 items-center justify-center">
+          {showCollapsedRunning ? (
+            <LoaderCircle
+              className="absolute size-3.5 animate-spin text-sidebar-foreground/70 opacity-100 transition-opacity group-hover:opacity-0"
+              aria-hidden="true"
+            />
+          ) : null}
+          <button
+            type="button"
+            title={projectTitle}
+            aria-label={projectTitle}
+            className="pointer-events-none absolute flex size-5 items-center justify-center rounded opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:pointer-events-auto focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground focus-visible:opacity-100"
+            onClick={() => onNewSession(group.project)}
+          >
+            <SquarePen className="size-3.5" />
+          </button>
+        </span>
       </div>
       {expanded ? (
         <div className="grid gap-0.5">

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1282,7 +1282,7 @@ function ProjectSidebarGroupItem({
       <div className="group oo-sidebar-nav-item oo-text-body flex h-8 items-center rounded-md px-3">
         <button
           type="button"
-          className="flex h-full min-w-0 flex-1 items-center gap-2 text-left"
+          className="group/toggle flex h-full min-w-0 flex-1 items-center gap-2 text-left"
           title={toggleTitle}
           aria-label={toggleTitle}
           aria-expanded={expanded}
@@ -1294,9 +1294,9 @@ function ProjectSidebarGroupItem({
           </span>
           <span className="relative flex size-3.5 shrink-0 items-center justify-center">
             {expanded ? (
-              <ChevronDown className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
+              <ChevronDown className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible/toggle:opacity-100" />
             ) : (
-              <ChevronRight className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
+              <ChevronRight className="absolute size-3.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible/toggle:opacity-100" />
             )}
           </span>
         </button>

--- a/src/routes/Chat/ModelControls.tsx
+++ b/src/routes/Chat/ModelControls.tsx
@@ -132,7 +132,6 @@ const ModelRow = React.forwardRef<HTMLButtonElement, ModelRowProps>(function Mod
               <span>{visionLabel}</span>
             </Badge>
           ) : null}
-          {active ? <Check className="size-4" /> : null}
         </span>
       </button>
       {onDelete ? (

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, it } from "vitest"
 import { I18nContext, translate } from "../../i18n/i18n.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
 
-function renderToolActivityStep(part: ChatMessagePart, options: { shimmer?: boolean } = {}): string {
+function renderToolActivityStep(
+  part: ChatMessagePart,
+  options: { shimmer?: boolean; showAuthorizationPrompt?: boolean } = {},
+): string {
   return renderToStaticMarkup(
     React.createElement(
       I18nContext.Provider,
@@ -17,7 +20,12 @@ function renderToolActivityStep(part: ChatMessagePart, options: { shimmer?: bool
           t: (key, vars) => translate("zh-CN", key, vars),
         },
       },
-      React.createElement(ToolActivityStep, { part, shimmer: options.shimmer, onAuthorize: () => undefined }),
+      React.createElement(ToolActivityStep, {
+        part,
+        shimmer: options.shimmer,
+        showAuthorizationPrompt: options.showAuthorizationPrompt,
+        onAuthorize: () => undefined,
+      }),
     ),
   )
 }
@@ -80,6 +88,26 @@ describe("ToolActivityStep", () => {
     expect(shimmerClassFor(html, "读取文件")).toContain("shrink-0")
     expect(html).toContain("/tmp/a.txt")
     expect(html).not.toMatch(/class="[^"]*text-transparent[^"]*"[^>]*>[^<]*\/tmp/)
+  })
+
+  it("can hide authorization prompts while the turn is still live", () => {
+    const part: ChatMessagePart = {
+      kind: "tool",
+      partId: "tool-1",
+      callId: "call-1",
+      tool: "call_action",
+      status: "completed",
+      input: { service: "gmail", action: "fetch_emails" },
+      output: JSON.stringify({
+        status: "authorization_required",
+        service: "gmail",
+        displayName: "Gmail",
+        errorCode: "connection_required",
+      }),
+    }
+
+    expect(renderToolActivityStep(part)).toContain("需要授权 Gmail 才能继续")
+    expect(renderToolActivityStep(part, { showAuthorizationPrompt: false })).not.toContain("需要授权 Gmail 才能继续")
   })
 
   it("shimmers only the active connector title when a connector target is shown inline", () => {

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -191,11 +191,13 @@ export function ToolActivityStep({
   part,
   provider,
   shimmer = false,
+  showAuthorizationPrompt = true,
   onAuthorize,
 }: {
   part: ChatMessagePart
   provider?: ConnectionProvider
   shimmer?: boolean
+  showAuthorizationPrompt?: boolean
   onAuthorize: (auth: AuthorizationInfo) => void
 }) {
   const t = useT()
@@ -264,15 +266,16 @@ export function ToolActivityStep({
       </div>
     </div>
   )
-  const authPrompt = auth ? (
-    <div className="mt-1 ml-7 flex flex-wrap items-center gap-2">
-      <span>{t("chat.authNeeded", { name: auth.displayName })}</span>
-      <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={() => onAuthorize(auth)}>
-        <Plug className="size-3.5" />
-        {t("chat.authorizeConnection")}
-      </Button>
-    </div>
-  ) : null
+  const authPrompt =
+    auth && showAuthorizationPrompt ? (
+      <div className="mt-1 ml-7 flex flex-wrap items-center gap-2">
+        <span>{t("chat.authNeeded", { name: auth.displayName })}</span>
+        <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={() => onAuthorize(auth)}>
+          <Plug className="size-3.5" />
+          {t("chat.authorizeConnection")}
+        </Button>
+      </div>
+    ) : null
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>

--- a/src/routes/Chat/chat-turns.test.ts
+++ b/src/routes/Chat/chat-turns.test.ts
@@ -10,6 +10,7 @@ import {
   retrySourceFromTurn,
   reuseStableChatTurns,
   shouldShowPlainTurnActivity,
+  shouldShowSuggestedAuthorization,
   shouldShowTurnProcess,
   summarizeTurnProcess,
 } from "./chat-turns.ts"
@@ -225,6 +226,36 @@ describe("summarizeTurnProcess", () => {
     expect(process.suggestedAuthorization).toBeUndefined()
   })
 
+  it("does not suggest connecting an unrelated unauthenticated provider after a connector call succeeds", () => {
+    const turn = groupChatTurns([
+      message("u1", "user", [text("u1-text", "帮我看一下近三天的 Gmail 邮件")]),
+      message("a1", "assistant", [
+        tool("tool-1", {
+          tool: "search_actions",
+          input: { keywords: "gmail", query: "recent emails" },
+          output: JSON.stringify([
+            { service: "gmail", name: "fetch_emails", authenticated: true },
+            { service: "mailtrap", name: "list_emails", authenticated: false },
+          ]),
+        }),
+      ]),
+      message("a2", "assistant", [
+        tool("tool-2", {
+          tool: "call_action",
+          input: { service: "gmail", action: "fetch_emails" },
+          output: JSON.stringify({ data: { emails: [{ subject: "Hello" }] } }),
+        }),
+      ]),
+      message("a3", "assistant", [text("a3-text", "Gmail 邮件已经整理好了。")]),
+    ])[0]
+
+    expect(turn).toBeDefined()
+    const process = summarizeTurnProcess(turn!, null)
+
+    expect(process.hasSuccessfulConnectorCall).toBe(true)
+    expect(process.suggestedAuthorization).toBeUndefined()
+  })
+
   it("normalizes service slugs when suppressing suggestions after successful calls", () => {
     const turn = groupChatTurns([
       message("u1", "user", [text("u1-text", "看一下 PostHog 数据")]),
@@ -259,6 +290,35 @@ describe("summarizeTurnProcess", () => {
 
     expect(process.activity?.phase).toBe("thinking")
     expect(process.hasFinalAnswer).toBe(false)
+  })
+
+  it("shows search-based authorization suggestions only after the turn is no longer active", () => {
+    const turn = groupChatTurns([
+      message("u1", "user", [text("u1-text", "有没有 Supabase 的连接可以用")]),
+      message("a1", "assistant", [
+        tool("tool-1", {
+          tool: "search_actions",
+          output: JSON.stringify([{ service: "supabase", name: "list_projects", authenticated: false }]),
+        }),
+      ]),
+      message("a2", "assistant", [text("a2-text", "有 Supabase 的连接器可用。")]),
+    ])[0]
+
+    expect(turn).toBeDefined()
+    const process = summarizeTurnProcess(turn!, null)
+
+    expect(process.suggestedAuthorization).toBeDefined()
+    expect(shouldShowSuggestedAuthorization(process, true)).toBe(false)
+    expect(shouldShowSuggestedAuthorization(process, false)).toBe(true)
+    expect(
+      shouldShowSuggestedAuthorization(
+        {
+          ...process,
+          activity: { sessionId: "s1", phase: "thinking" },
+        },
+        false,
+      ),
+    ).toBe(false)
   })
 
   it("keeps reasoning out of assistant answer text parts", () => {

--- a/src/routes/Chat/chat-turns.ts
+++ b/src/routes/Chat/chat-turns.ts
@@ -32,6 +32,7 @@ export interface ChatTurnProcess {
   hasBlockingError: boolean
   hasStoppedTool: boolean
   hasAuthorization: boolean
+  hasSuccessfulConnectorCall: boolean
   suggestedAuthorization?: AuthorizationInfo
   activity: AssistantActivityEvent | null
   startedAt?: number
@@ -190,19 +191,26 @@ function successfulCallActionServices(tools: ChatMessagePart[]): Set<string> {
 
 function suggestedAuthorizationFromTools(tools: ChatMessagePart[]): AuthorizationInfo | undefined {
   const successfulServices = successfulCallActionServices(tools)
+  if (successfulServices.size > 0) {
+    return undefined
+  }
   for (const part of tools) {
     if (part.tool !== "search_actions" || part.status !== "completed") {
       continue
     }
     const authorization = parseSearchAuthorizationSignal(part.output, part.input)
     if (authorization) {
-      if (successfulServices.has(normalizeServiceSlug(authorization.service))) {
-        continue
-      }
       return authorization
     }
   }
   return undefined
+}
+
+export function shouldShowSuggestedAuthorization(
+  process: Pick<ChatTurnProcess, "activity" | "hasActiveTool" | "suggestedAuthorization">,
+  turnIsActive: boolean,
+): boolean {
+  return Boolean(process.suggestedAuthorization && !turnIsActive && !process.hasActiveTool && !process.activity)
 }
 
 export function summarizeTurnProcess(
@@ -240,6 +248,7 @@ export function summarizeTurnProcess(
 
   const hasToolError = hasBlockingToolError(tools)
   const hasAuthorization = tools.some((part) => Boolean(parseToolAuthorization(part)))
+  const hasSuccessfulConnectorCall = successfulCallActionServices(tools).size > 0
 
   return {
     tools,
@@ -250,6 +259,7 @@ export function summarizeTurnProcess(
     hasBlockingError: errors.length > 0 || (hasToolError && !hasFinalAnswer),
     hasStoppedTool: hasStoppedTool(tools),
     hasAuthorization,
+    hasSuccessfulConnectorCall,
     ...(hasAuthorization ? {} : { suggestedAuthorization: suggestedAuthorizationFromTools(tools) }),
     activity: activeTurnActivity,
     startedAt,

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -44,6 +44,7 @@ import {
   retrySourceFromTurn,
   reuseStableChatTurns,
   shouldShowPlainTurnActivity,
+  shouldShowSuggestedAuthorization,
   shouldShowTurnProcess,
   summarizeTurnProcess,
 } from "./chat-turns.ts"
@@ -159,17 +160,17 @@ function isLiveProcess(process: ReturnType<typeof summarizeTurnProcess>, live = 
 }
 
 function processStatus(process: ReturnType<typeof summarizeTurnProcess>, live = false): TurnProcessStatus {
-  if (process.hasAuthorization) {
-    return "needsAction"
-  }
   if (process.activity?.phase === "retrying") {
     return "retrying"
   }
-  if (process.hasBlockingError) {
-    return "error"
-  }
   if (isLiveProcess(process, live)) {
     return "running"
+  }
+  if (process.hasAuthorization) {
+    return "needsAction"
+  }
+  if (process.hasBlockingError) {
+    return "error"
   }
   if (process.hasToolError) {
     return "completedWithIssues"
@@ -352,6 +353,7 @@ function TurnProcessActivity({
               smoothText={false}
               providerByService={providerByService}
               shimmerToolPartId={shimmerToolPartId}
+              showAuthorizationPrompt={!live}
               onAuthorize={onAuthorize}
               onViewBilling={onViewBilling}
             />
@@ -630,6 +632,7 @@ function AssistantBlock({
   smoothText,
   providerByService,
   shimmerToolPartId,
+  showAuthorizationPrompt = true,
   onAuthorize,
   onViewBilling,
 }: {
@@ -639,6 +642,7 @@ function AssistantBlock({
   smoothText: boolean
   providerByService: Map<string, ConnectionProvider>
   shimmerToolPartId?: string
+  showAuthorizationPrompt?: boolean
   onAuthorize: (auth: AuthorizationInfo, source?: ChatTurnRetrySource) => void
   onViewBilling?: () => void
 }) {
@@ -668,6 +672,7 @@ function AssistantBlock({
                 part={part}
                 provider={service ? providerByService.get(service) : undefined}
                 shimmer={part.partId === shimmerToolPartId}
+                showAuthorizationPrompt={showAuthorizationPrompt}
                 onAuthorize={onAuthorize}
               />
             )
@@ -938,8 +943,11 @@ const ChatTurnView = React.memo(function ChatTurnView({
   const responseActionsText =
     lastAssistant?.id === activeAssistantMessageId ? null : textFromTimelineBlocks(responseRenderBlocks) || null
   const processActionsText = responseRenderBlocks.length > 0 ? null : assistantActionsText
-  const responseSuggestedAuthorization = responseRenderBlocks.length > 0 ? process.suggestedAuthorization : undefined
-  const processSuggestedAuthorization = responseRenderBlocks.length > 0 ? undefined : process.suggestedAuthorization
+  const showSuggestedAuthorization = shouldShowSuggestedAuthorization(process, turnIsActive)
+  const responseSuggestedAuthorization =
+    showSuggestedAuthorization && responseRenderBlocks.length > 0 ? process.suggestedAuthorization : undefined
+  const processSuggestedAuthorization =
+    showSuggestedAuthorization && responseRenderBlocks.length === 0 ? process.suggestedAuthorization : undefined
   const retrySource = React.useMemo(() => retrySourceFromTurn(turn), [turn])
   const handleAuthorize = React.useCallback(
     (auth: AuthorizationInfo) => {


### PR DESCRIPTION
## Summary

- Defer connector authorization suggestions until the turn has finished instead of showing them during streaming.
- Suppress search-result connection suggestions when any connector call in the turn already succeeded, so unrelated unauthenticated providers do not distract from a completed task.
- Move collapsed project loading state to the project row action area and make chevrons/add actions appear only on hover.
- Remove the selected-model checkmark from the model menu so image capability badges align consistently.

## Why

The previous connection suggestion UI could surface while the assistant was still working, and search results could suggest connecting an unrelated provider even when another authorized provider had already solved the request. In the sidebar and model menu, focus and selected-state affordances were also creating persistent or misaligned UI states.

## Validation

- `npm run format`
- `npm run ts-check`
- `npm run lint`
- `npm test`
- `npm run dev -- --port 5274` smoke startup