### PR TITLE
Fix chat composer popover layering

### DIFF
--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -84,7 +84,7 @@ export const PromptInputTextarea = ({
   return (
     <InputGroupTextarea
       className={cn(
-        "field-sizing-content max-h-52 min-h-14 min-w-0 px-4 pt-3 pb-1.5 [overflow-wrap:anywhere] [word-break:break-word]",
+        "field-sizing-content max-h-52 min-h-14 min-w-0 px-4 pt-3 pb-1.5 [overflow-wrap:anywhere] [word-break:break-word] placeholder:text-[var(--oo-prompt-input-placeholder)]",
         className,
       )}
       name="message"

--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,7 @@
   --oo-input-surface: oklch(0.991 0.002 289);
   --oo-prompt-input-surface: var(--background);
   --oo-prompt-input-border: color-mix(in oklab, var(--foreground) 12%, transparent);
+  --oo-prompt-input-placeholder: color-mix(in oklab, var(--foreground) 42%, transparent);
   --oo-prompt-input-shadow:
     0 1px 2px color-mix(in oklab, var(--foreground) 5%, transparent),
     0 8px 18px color-mix(in oklab, var(--foreground) 4%, transparent);
@@ -250,6 +251,7 @@
   --oo-input-surface: oklch(0.252 0.006 272);
   --oo-prompt-input-surface: var(--oo-input-surface);
   --oo-prompt-input-border: color-mix(in oklab, var(--foreground) 16%, transparent);
+  --oo-prompt-input-placeholder: color-mix(in oklab, var(--foreground) 48%, transparent);
   --oo-prompt-input-shadow: none;
   --oo-queue-dock-surface: color-mix(in oklab, var(--foreground) 5%, var(--oo-prompt-input-surface));
   --oo-queue-dock-hover: color-mix(in oklab, var(--foreground) 7%, var(--oo-queue-dock-surface));

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -16,6 +16,7 @@ import type { ChatStatus } from "ai"
 
 import { File as FileIcon, Folder, Plus } from "lucide-react"
 import * as React from "react"
+import { createPortal } from "react-dom"
 import { WANTA_AGENT_MODES, WANTA_DEFAULT_AGENT_MODE } from "../../../electron/agent/mode.ts"
 import { WANTA_DEFAULT_REASONING_LEVEL, WANTA_REASONING_LEVELS } from "../../../electron/agent/reasoning.ts"
 import { AttachmentList } from "./ChatAttachments.tsx"
@@ -183,12 +184,14 @@ export function ChatComposer({
   const skillInventory = useSkillInventoryResource()
   const modelCatalogState = useModelCatalog()
   const attachmentMenuRef = React.useRef<HTMLDivElement | null>(null)
+  const attachmentMenuPanelRef = React.useRef<HTMLDivElement | null>(null)
   const [composer, dispatchComposer] = React.useReducer(
     composerReducer,
     initialComposerStateProp ?? initialComposerState(),
   )
   const [inputError, setInputError] = React.useState<string | null>(null)
   const [attachmentMenuOpen, setAttachmentMenuOpen] = React.useState(false)
+  const [attachmentMenuStyle, setAttachmentMenuStyle] = React.useState<React.CSSProperties | undefined>()
   const [agentMode, setAgentModeState] = React.useState<AgentMode>(readStoredAgentMode)
   const [reasoningLevel, setReasoningLevelState] = React.useState<ReasoningLevel>(readStoredReasoningLevel)
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
@@ -247,8 +250,23 @@ export function ChatComposer({
     setAgentModeState(mode)
     writeStoredAgentMode(mode)
   }, [])
+  const updateAttachmentMenuPlacement = React.useCallback((): void => {
+    const trigger = attachmentMenuRef.current
+    if (!trigger) {
+      return
+    }
+    const rect = trigger.getBoundingClientRect()
+    const menuWidth = 160
+    const viewportPadding = 8
+    const maxLeft = Math.max(viewportPadding, window.innerWidth - menuWidth - viewportPadding)
+    setAttachmentMenuStyle({
+      bottom: Math.max(viewportPadding, window.innerHeight - rect.top + viewportPadding),
+      left: Math.min(Math.max(viewportPadding, rect.left), maxLeft),
+      minWidth: menuWidth,
+    })
+  }, [])
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (focusRequest <= 0) {
       return
     }
@@ -268,9 +286,13 @@ export function ChatComposer({
       setAttachmentMenuOpen(false)
       return
     }
+    updateAttachmentMenuPlacement()
     const handlePointerDown = (event: PointerEvent): void => {
       const target = event.target
       if (target instanceof Node && attachmentMenuRef.current?.contains(target)) {
+        return
+      }
+      if (target instanceof Node && attachmentMenuPanelRef.current?.contains(target)) {
         return
       }
       setAttachmentMenuOpen(false)
@@ -280,13 +302,18 @@ export function ChatComposer({
         setAttachmentMenuOpen(false)
       }
     }
+    const handleReposition = (): void => updateAttachmentMenuPlacement()
     document.addEventListener("pointerdown", handlePointerDown)
     document.addEventListener("keydown", handleKeyDown)
+    window.addEventListener("resize", handleReposition)
+    window.addEventListener("scroll", handleReposition, true)
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown)
       document.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener("resize", handleReposition)
+      window.removeEventListener("scroll", handleReposition, true)
     }
-  }, [attachmentMenuOpen, composerDisabled])
+  }, [attachmentMenuOpen, composerDisabled, updateAttachmentMenuPlacement])
 
   React.useLayoutEffect(() => {
     const textarea = textareaRef.current
@@ -483,36 +510,6 @@ export function ChatComposer({
             >
               <Plus className="size-4" />
             </Button>
-            {attachmentMenuOpen ? (
-              <div className="absolute bottom-full left-0 z-50 mb-2 min-w-40 rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
-                <AttachmentMenuButton
-                  disabled={composerDisabled}
-                  onClick={() => {
-                    if (composerDisabled) {
-                      return
-                    }
-                    setAttachmentMenuOpen(false)
-                    void composerAttachments.selectAttachments("file")
-                  }}
-                >
-                  <FileIcon className="size-4" />
-                  {t("chat.attachFileAction")}
-                </AttachmentMenuButton>
-                <AttachmentMenuButton
-                  disabled={composerDisabled}
-                  onClick={() => {
-                    if (composerDisabled) {
-                      return
-                    }
-                    setAttachmentMenuOpen(false)
-                    void composerAttachments.selectAttachments("directory")
-                  }}
-                >
-                  <Folder className="size-4" />
-                  {t("chat.attachFolderAction")}
-                </AttachmentMenuButton>
-              </div>
-            ) : null}
           </div>
         </PromptInputTools>
         <ComposerTrailingControls
@@ -599,6 +596,43 @@ export function ChatComposer({
         </div>
       </div>
       {modelDialog}
+      {attachmentMenuOpen
+        ? createPortal(
+            <div
+              ref={attachmentMenuPanelRef}
+              style={attachmentMenuStyle}
+              className="fixed z-[130] rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+            >
+              <AttachmentMenuButton
+                disabled={composerDisabled}
+                onClick={() => {
+                  if (composerDisabled) {
+                    return
+                  }
+                  setAttachmentMenuOpen(false)
+                  void composerAttachments.selectAttachments("file")
+                }}
+              >
+                <FileIcon className="size-4" />
+                {t("chat.attachFileAction")}
+              </AttachmentMenuButton>
+              <AttachmentMenuButton
+                disabled={composerDisabled}
+                onClick={() => {
+                  if (composerDisabled) {
+                    return
+                  }
+                  setAttachmentMenuOpen(false)
+                  void composerAttachments.selectAttachments("directory")
+                }}
+              >
+                <Folder className="size-4" />
+                {t("chat.attachFolderAction")}
+              </AttachmentMenuButton>
+            </div>,
+            document.body,
+          )
+        : null}
     </>
   )
 }


### PR DESCRIPTION
## Summary

This change fixes two chat composer UI polish issues.

The attachment menu opened from the composer `+` button was previously rendered inside the prompt input surface. Because that surface clips overflow and participates in its own stacking context, the menu could appear underneath or be visually cut by the chat box instead of floating above it. The attachment menu now renders through a body-level portal with fixed positioning and a higher overlay z-index, matching the behavior of the other composer popovers. Its placement is calculated from the trigger button and updated on resize or scroll, while outside-click and Escape handling continue to close the menu correctly.

This also adds a dedicated prompt input placeholder color token. The main composer placeholder now uses a lighter, prompt-specific color rather than the generic muted foreground, so it reads as placeholder copy instead of secondary body text.

## Validation

- `npm run format`
- `npm run ts-check`
- `npm run lint`
- `npm test`
- `npm run build`
- Started the dev app with `npm run dev`; Vite, Electron, and the OpenCode sidecar started successfully. Visual screenshot verification was blocked by missing macOS Screen Recording permission in the Codex environment.
