### PR TITLE
Add logo to chat empty state

### DIFF
--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -74,6 +74,7 @@ import {
   MessageResponse,
 } from "@/components/ai-elements/message"
 import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task"
+import { BrandIcon } from "@/components/BrandIcon"
 import { ErrorNotice } from "@/components/ErrorNotice"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -1341,11 +1342,12 @@ export const ChatArea = React.memo(function ChatArea({
     <div className="grid min-h-full w-full place-items-center px-4 py-6 sm:px-5 lg:px-8">
       <div
         className={cn(
-          "flex w-full translate-y-[3vh] flex-col gap-5 transition-transform duration-300 ease-out",
+          "flex w-full translate-y-[-2vh] flex-col gap-5 transition-transform duration-300 ease-out",
           EMPTY_COMPOSER_MAX_WIDTH_CLASS,
         )}
       >
         <div className="px-4 pb-1 text-center">
+          <BrandIcon className="mx-auto mb-4 size-[72px]" aria-hidden="true" />
           <h2 className="oo-text-empty-title mx-auto max-w-2xl">{emptyTitle ?? t("chat.emptyTitle")}</h2>
         </div>
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary

This PR updates the chat empty state so the Wanta brand is visible above the empty-state slogan and the entire empty-state block sits slightly higher in the viewport.

The previous empty state relied only on the slogan and composer, and the block was translated downward from center. That made the first-run/new-chat view feel visually low, especially once the logo was added above the title. The result was a weaker brand cue and a heavier lower-half composition.

The fix reuses the existing transparent `BrandIcon` asset at a fixed 72px size, places it directly above the empty-state title, and changes the empty-state group transform from a slight downward offset to a slight upward offset. The composer, project selector, and connection actions move together so their internal spacing remains unchanged.

## Validation

- `npm run format`
- `npm run ts-check`
- `npm run lint`
- `npm test` (`115` test files / `741` tests passed)
