### PR TITLE
Improve skill publish diagnostics

### DIFF
--- a/electron/skills/actions.test.ts
+++ b/electron/skills/actions.test.ts
@@ -11,6 +11,7 @@ import {
   createRegistrySkillVersionCheck,
   createRegistrySkillCheckUpdateArgs,
   createRegistrySkillVersionCheckFromUpdateResult,
+  createSkillPublishErrorMessage,
   normalizePublicSkillPackageCatalog,
   normalizeRegistrySkillPackageInfo,
   createSkillSearchArgs,
@@ -346,6 +347,34 @@ test("createPublishSkillArgs publishes a Skill path non-interactively", () => {
     "--visibility",
     "public",
   ])
+})
+
+test("createSkillPublishErrorMessage prefers publish stderr details", () => {
+  assert.equal(
+    createSkillPublishErrorMessage({
+      message: "Command failed",
+      stderr: "Package version already exists.",
+      stdout: "ignored",
+    }),
+    "Package version already exists.",
+  )
+})
+
+test("createSkillPublishErrorMessage extracts json failure messages", () => {
+  assert.equal(
+    createSkillPublishErrorMessage({
+      stderr: JSON.stringify({ error: { message: "Package name is invalid." } }),
+      stdout: "",
+    }),
+    "Package name is invalid.",
+  )
+  assert.equal(
+    createSkillPublishErrorMessage({
+      stderr: "",
+      stdout: JSON.stringify({ errors: [{ message: "Missing SKILL.md." }] }),
+    }),
+    "Missing SKILL.md.",
+  )
 })
 
 test("createRegistrySkillVersionCheck detects exact package update", () => {

--- a/electron/skills/actions.ts
+++ b/electron/skills/actions.ts
@@ -108,6 +108,12 @@ interface RawSkillOperationError {
   message?: unknown
 }
 
+interface SkillPublishFailureOutput {
+  message?: string
+  stderr?: string
+  stdout?: string
+}
+
 interface RawSkillOperationEntry {
   error?: unknown
   targets?: unknown
@@ -691,6 +697,15 @@ export function createDeleteSkillArgs(request: { skillId: string }): string[] {
   return ["skills", "uninstall", skillId, "--json"]
 }
 
+export function createSkillPublishErrorMessage(result: SkillPublishFailureOutput): string {
+  return (
+    readSkillPublishFailureMessage(result.stderr) ??
+    readSkillPublishFailureMessage(result.stdout) ??
+    asText(result.message) ??
+    "Skill publish failed."
+  )
+}
+
 export function assertSkillOperationSucceeded(stdout: string, expectedCommand: SkillOperationCommand): void {
   const parsed = JSON.parse(stdout) as unknown
 
@@ -788,6 +803,58 @@ function readSkillOperationErrorMessage(error: unknown): string | undefined {
 
   const raw = error as RawSkillOperationError
   return asText(raw.message) ?? asText(raw.code)
+}
+
+function readSkillPublishFailureMessage(output: string | undefined): string | undefined {
+  const text = asText(output)
+  if (!text) {
+    return undefined
+  }
+
+  const parsedMessage = readSkillPublishJsonFailureMessage(text)
+  return parsedMessage ?? text
+}
+
+function readSkillPublishJsonFailureMessage(output: string): string | undefined {
+  try {
+    const parsed = JSON.parse(output) as unknown
+    return readJsonFailureMessage(parsed)
+  } catch {
+    return undefined
+  }
+}
+
+function readJsonFailureMessage(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return asText(value)
+  }
+
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+
+  const record = value as Record<string, unknown>
+  return (
+    asText(record["message"]) ??
+    asText(record["error"]) ??
+    readSkillOperationErrorMessage(record["error"]) ??
+    readFirstJsonFailureMessage(record["errors"])
+  )
+}
+
+function readFirstJsonFailureMessage(errors: unknown): string | undefined {
+  if (!Array.isArray(errors)) {
+    return undefined
+  }
+
+  for (const error of errors) {
+    const message = readJsonFailureMessage(error)
+    if (message) {
+      return message
+    }
+  }
+
+  return undefined
 }
 
 function createRegistrySkillCheckUpdateErrorMessage(error: unknown): string | undefined {

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -41,6 +41,7 @@ import {
   createCliUpdateArgs,
   createInstallRegistrySkillArgs,
   createPublishSkillArgs,
+  createSkillPublishErrorMessage,
   createSkillSearchArgs,
   createUpdateRegistrySkillArgs,
   normalizeSkillSearchResults,
@@ -73,6 +74,7 @@ import {
   writeManifestStore,
 } from "./manifest.ts"
 import { resolveSharedAgentSkillRoot } from "./paths.ts"
+import { ensureSkillPublishMetadata } from "./publish-metadata.ts"
 import { assertSafeResetPaths } from "./reset.ts"
 import { scanInstalledSkills, scanWantaInstalledSkills } from "./scan.ts"
 import { resolveUsableRegistrySkillSourcePath } from "./source.ts"
@@ -267,9 +269,16 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
 
   public async publishSkill(request: PublishSkillRequest): Promise<PublishSkillResult> {
     const skillPath = await this.resolveAllowedSkillPath(request.path)
-    const result = await this.runOoCommand(createPublishSkillArgs({ ...request, path: skillPath }), {
-      owner: "skill-service",
+    await ensureSkillPublishMetadata({
+      accountName: this.authService.activeAccount()?.name,
+      skillPath,
     })
+    const args = createPublishSkillArgs({ ...request, path: skillPath })
+    const result = await this.runOoCommand(args, {
+      owner: "skill-service",
+      rejectOnFailure: false,
+    })
+    assertOoSkillPublishResult(result, args)
     this.invalidateVersionReport()
     this.notifyRuntimeSkillsChanged("publish-skill")
 
@@ -810,6 +819,29 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       cacheKey: `${account.id}@${ooEndpoint}`,
     }
   }
+}
+
+function assertOoSkillPublishResult(result: OoCommandResult, args: readonly string[]): void {
+  if (result.ok) {
+    return
+  }
+
+  const message = createSkillPublishErrorMessage(result)
+  throw Object.assign(new Error(message), {
+    diagnostics: createSkillPublishDiagnostics(message, args, result),
+  })
+}
+
+function createSkillPublishDiagnostics(message: string, args: readonly string[], result: OoCommandResult): string {
+  return [
+    "Skill publish failed.",
+    `command: oo ${args.join(" ")}`,
+    `message: ${message}`,
+    result.stdout.trim() ? `stdout:\n${result.stdout.trim()}` : undefined,
+    result.stderr.trim() ? `stderr:\n${result.stderr.trim()}` : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n")
 }
 
 function assertOoSkillOperationResult(

--- a/electron/skills/publish-metadata.test.ts
+++ b/electron/skills/publish-metadata.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { test } from "vitest"
+import {
+  createDefaultSkillPackageName,
+  ensureSkillPublishMetadata,
+  ensureSkillPublishMetadataContent,
+} from "./publish-metadata.ts"
+
+test("createDefaultSkillPackageName creates a scoped package from account and skill names", () => {
+  assert.equal(createDefaultSkillPackageName("Shaun", "Baseline UI"), "@shaun/baseline-ui")
+  assert.equal(createDefaultSkillPackageName("alice.dev", "demo_skill"), "@alice.dev/demo_skill")
+})
+
+test("ensureSkillPublishMetadataContent adds packageName and version under metadata", () => {
+  const result = ensureSkillPublishMetadataContent(
+    [
+      "---",
+      "name: baseline-ui",
+      "description: Demo",
+      "metadata:",
+      "  icon: ':lucide:wrench:'",
+      "  title: Baseline Ui",
+      "---",
+      "",
+      "# Baseline UI",
+      "",
+    ].join("\n"),
+    { accountName: "Shaun", fallbackSkillName: "baseline-ui" },
+  )
+
+  assert.equal(result.packageName, "@shaun/baseline-ui")
+  assert.equal(result.version, "0.0.1")
+  assert.equal(result.updated, true)
+  assert.match(
+    result.content,
+    /metadata:\n  icon: ':lucide:wrench:'\n  title: Baseline Ui\n  packageName: '@shaun\/baseline-ui'\n  version: 0\.0\.1/,
+  )
+})
+
+test("ensureSkillPublishMetadataContent keeps existing publish metadata", () => {
+  const content = [
+    "---",
+    "name: demo",
+    "metadata:",
+    "  packageName: '@alice/demo'",
+    "  version: 0.2.0",
+    "---",
+    "# Demo",
+    "",
+  ].join("\n")
+
+  assert.deepEqual(ensureSkillPublishMetadataContent(content, { accountName: "Shaun", fallbackSkillName: "demo" }), {
+    content,
+    packageName: "@alice/demo",
+    updated: false,
+    version: "0.2.0",
+  })
+})
+
+test("ensureSkillPublishMetadata writes SKILL.md metadata", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-skill-publish-"))
+  const skillPath = path.join(root, "demo")
+  await mkdir(skillPath, { recursive: true })
+  await writeFile(
+    path.join(skillPath, "SKILL.md"),
+    ["---", "name: demo", "metadata:", "  title: Demo", "---", "# Demo", ""].join("\n"),
+    "utf8",
+  )
+
+  const result = await ensureSkillPublishMetadata({ accountName: "Shaun", skillPath })
+  const content = await readFile(path.join(skillPath, "SKILL.md"), "utf8")
+
+  assert.deepEqual(result, {
+    packageName: "@shaun/demo",
+    updated: true,
+    version: "0.0.1",
+  })
+  assert.match(content, /packageName: '@shaun\/demo'/)
+})

--- a/electron/skills/publish-metadata.ts
+++ b/electron/skills/publish-metadata.ts
@@ -1,0 +1,138 @@
+import { dump as dumpYaml, load as parseYaml } from "js-yaml"
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+interface SkillFrontmatterRange {
+  afterClosingDelimiter: number
+  bodyStart: number
+  eol: "\n" | "\r\n"
+  yamlEnd: number
+}
+
+export interface EnsureSkillPublishMetadataResult {
+  packageName: string
+  updated: boolean
+  version: string
+}
+
+const defaultPublishVersion = "0.0.1"
+
+export async function ensureSkillPublishMetadata(request: {
+  accountName?: string
+  skillPath: string
+}): Promise<EnsureSkillPublishMetadataResult> {
+  const skillFilePath = path.join(request.skillPath, "SKILL.md")
+  const content = await readFile(skillFilePath, "utf8")
+  const next = ensureSkillPublishMetadataContent(content, {
+    accountName: request.accountName,
+    fallbackSkillName: path.basename(request.skillPath),
+  })
+
+  if (next.updated) {
+    await writeFile(skillFilePath, next.content, "utf8")
+  }
+
+  return {
+    packageName: next.packageName,
+    updated: next.updated,
+    version: next.version,
+  }
+}
+
+export function ensureSkillPublishMetadataContent(
+  content: string,
+  request: { accountName?: string; fallbackSkillName: string },
+): EnsureSkillPublishMetadataResult & { content: string } {
+  const range = readFrontmatterRange(content)
+  if (!range) {
+    throw new Error("Skill publishing requires SKILL.md frontmatter.")
+  }
+
+  const frontmatter = readFrontmatter(content.slice(range.bodyStart, range.yamlEnd))
+  const skillName = asText(frontmatter["name"]) ?? request.fallbackSkillName
+  const metadata = isRecord(frontmatter["metadata"]) ? { ...frontmatter["metadata"] } : {}
+  const packageName = asText(metadata["packageName"]) ?? createDefaultSkillPackageName(request.accountName, skillName)
+  const version = asText(metadata["version"]) ?? defaultPublishVersion
+
+  if (metadata["packageName"] === packageName && metadata["version"] === version && isRecord(frontmatter["metadata"])) {
+    return { content, packageName, updated: false, version }
+  }
+
+  metadata["packageName"] = packageName
+  metadata["version"] = version
+  frontmatter["metadata"] = metadata
+
+  const nextYaml = dumpYaml(frontmatter, {
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+  }).trimEnd()
+  const body = content.slice(range.afterClosingDelimiter)
+  const nextContent = `---${range.eol}${nextYaml}${range.eol}---${range.eol}${body}`
+
+  return {
+    content: nextContent,
+    packageName,
+    updated: true,
+    version,
+  }
+}
+
+export function createDefaultSkillPackageName(accountName: string | undefined, skillName: string): string {
+  const scope = normalizePackageNamePart(accountName)
+  if (!scope) {
+    throw new Error("Skill publishing requires a signed-in account name to create a packageName.")
+  }
+
+  const name = normalizePackageNamePart(skillName)
+  if (!name) {
+    throw new Error("Skill publishing requires a valid Skill name to create a packageName.")
+  }
+
+  return `@${scope}/${name}`
+}
+
+function readFrontmatterRange(content: string): SkillFrontmatterRange | undefined {
+  const eol = content.startsWith("---\r\n") ? "\r\n" : content.startsWith("---\n") ? "\n" : undefined
+  if (!eol) {
+    return undefined
+  }
+
+  const bodyStart = 3 + eol.length
+  const endPattern = eol === "\r\n" ? /\r\n---(?:\r\n|$)/ : /\n---(?:\n|$)/
+  const endMatch = endPattern.exec(content.slice(bodyStart))
+  if (!endMatch) {
+    return undefined
+  }
+
+  return {
+    afterClosingDelimiter: bodyStart + endMatch.index + endMatch[0].length,
+    bodyStart,
+    eol,
+    yamlEnd: bodyStart + endMatch.index,
+  }
+}
+
+function readFrontmatter(yamlContent: string): Record<string, unknown> {
+  const parsed = parseYaml(yamlContent)
+  if (!isRecord(parsed)) {
+    throw new Error("Skill publishing requires valid SKILL.md frontmatter.")
+  }
+  return { ...parsed }
+}
+
+function normalizePackageNamePart(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "")
+}
+
+function asText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/scripts/check-oo.ts
+++ b/scripts/check-oo.ts
@@ -5,9 +5,9 @@
 // （主进程禁用同步 fs，会阻塞渲染）。本脚本是独立 Node CLI，用同步 fs 无副作用。
 // 设了 WANTA_OO_BIN 覆盖时跳过检查（信任开发者指定的路径）。
 
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
-import { localOoBinPath } from "./oo-cli.ts"
+import { localOoBinPath, OO_CLI_VERSION, resolvePlatformTarget } from "./oo-cli.ts"
 import { localRipgrepBinPath } from "./ripgrep.ts"
 import { bundledSkillIds, bundledSkillsDir, exportBundledSkills } from "./skills.ts"
 
@@ -16,6 +16,18 @@ if (!process.env.WANTA_OO_BIN) {
   if (!existsSync(ooBin)) {
     console.error(
       `[wanta] oo 二进制缺失：${ooBin}\n` +
+        "  运行 `npm run postinstall` 重新下载，或设 WANTA_OO_BIN 指向已有 oo（见 .env.example）。",
+    )
+    process.exit(1)
+  }
+  const expectedMarker = `${resolvePlatformTarget().packageName}@${OO_CLI_VERSION}`
+  const versionMarker = path.join(path.dirname(ooBin), ".version")
+  const actualMarker = existsSync(versionMarker) ? readFileSync(versionMarker, "utf-8").trim() : ""
+  if (actualMarker !== expectedMarker) {
+    console.error(
+      `[wanta] oo 二进制版本不匹配：${ooBin}\n` +
+        `  expected: ${expectedMarker}\n` +
+        `  actual:   ${actualMarker || "<missing>"}\n` +
         "  运行 `npm run postinstall` 重新下载，或设 WANTA_OO_BIN 指向已有 oo（见 .env.example）。",
     )
     process.exit(1)

--- a/src/lib/user-facing-error.test.ts
+++ b/src/lib/user-facing-error.test.ts
@@ -53,4 +53,16 @@ describe("resolveUserFacingError", () => {
       titleKey: "error.connections.title",
     })
   })
+
+  it("preserves a short message while keeping extended diagnostics copyable", () => {
+    const error = Object.assign(new Error("Package version already exists."), {
+      diagnostics: "command: oo skills publish /tmp/demo\nstderr: Package version already exists.",
+    })
+
+    expect(resolveUserFacingError(error, { area: "skills", preserveMessage: true })).toMatchObject({
+      descriptionText: "Package version already exists.",
+      diagnostics: "command: oo skills publish /tmp/demo\nstderr: Package version already exists.",
+      kind: "operation_failed",
+    })
+  })
 })

--- a/src/lib/user-facing-error.ts
+++ b/src/lib/user-facing-error.ts
@@ -82,6 +82,9 @@ export function errorMessage(cause: unknown): string {
   if (cause instanceof Error) {
     return cause.message
   }
+  if (cause && typeof cause === "object" && typeof (cause as { message?: unknown }).message === "string") {
+    return (cause as { message: string }).message
+  }
   return String(cause)
 }
 
@@ -97,11 +100,13 @@ export function resolveUserFacingError(
   if (isUserFacingError(cause)) {
     return cause
   }
-  const diagnostics = errorMessage(cause).trim()
-  const normalized = diagnostics.toLowerCase()
-  const status = readStatusCode(diagnostics)
+  const message = errorMessage(cause).trim()
+  const diagnostics = errorDiagnostics(cause, message).trim()
+  const normalizedMessage = message.toLowerCase()
+  const normalized = `${normalizedMessage}\n${diagnostics.toLowerCase()}`
+  const status = readStatusCode(`${message}\n${diagnostics}`)
 
-  if (normalized === "wanta_oauth_pending") {
+  if (normalizedMessage === "wanta_oauth_pending") {
     return buildError(
       area,
       "timeout",
@@ -109,10 +114,12 @@ export function resolveUserFacingError(
       "error.connections.oauthPending.title",
       "error.connections.oauthPending.description",
       diagnostics,
+      false,
+      message,
     )
   }
 
-  if (normalized === "wanta_oauth_cancelled") {
+  if (normalizedMessage === "wanta_oauth_cancelled") {
     return buildError(
       area,
       "cancelled",
@@ -120,6 +127,8 @@ export function resolveUserFacingError(
       "error.connections.oauthCancelled.title",
       "error.connections.oauthCancelled.description",
       diagnostics,
+      false,
+      message,
     )
   }
 
@@ -131,11 +140,22 @@ export function resolveUserFacingError(
       "error.agent.title",
       "error.agent.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
   if (isCancelled(normalized)) {
-    return buildError(area, "cancelled", "info", "error.cancelled.title", "error.cancelled.description", diagnostics)
+    return buildError(
+      area,
+      "cancelled",
+      "info",
+      "error.cancelled.title",
+      "error.cancelled.description",
+      diagnostics,
+      preserveMessage,
+      message,
+    )
   }
 
   if (status === 401 || includesAny(normalized, ["unauthorized", "sign in", "login required", "fresh sign-in"])) {
@@ -149,6 +169,8 @@ export function resolveUserFacingError(
       isBilling ? "error.billingSessionExpired.title" : "error.authRequired.title",
       isBilling ? "error.billingSessionExpired.description" : "error.authRequired.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -160,6 +182,8 @@ export function resolveUserFacingError(
       "error.permissionDenied.title",
       "error.permissionDenied.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -171,11 +195,22 @@ export function resolveUserFacingError(
       "error.rateLimited.title",
       "error.rateLimited.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
   if (isTimeout(normalized)) {
-    return buildError(area, "timeout", "warning", "error.timeout.title", "error.timeout.description", diagnostics)
+    return buildError(
+      area,
+      "timeout",
+      "warning",
+      "error.timeout.title",
+      "error.timeout.description",
+      diagnostics,
+      preserveMessage,
+      message,
+    )
   }
 
   if (area === "artifact" || includesAny(normalized, ["enoent", "no such file", "file unavailable"])) {
@@ -186,6 +221,8 @@ export function resolveUserFacingError(
       "error.localFile.title",
       "error.localFile.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -198,6 +235,7 @@ export function resolveUserFacingError(
       area === "model" ? "error.model.validationDescription" : "error.validation.description",
       diagnostics,
       preserveMessage,
+      message,
     )
   }
 
@@ -209,6 +247,8 @@ export function resolveUserFacingError(
       "error.serverUnavailable.title",
       "error.serverUnavailable.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -220,6 +260,8 @@ export function resolveUserFacingError(
       "error.serverUnavailable.title",
       "error.serverUnavailable.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -231,6 +273,8 @@ export function resolveUserFacingError(
       "error.networkUnavailable.title",
       "error.networkUnavailable.description",
       diagnostics,
+      preserveMessage,
+      message,
     )
   }
 
@@ -242,7 +286,15 @@ export function resolveUserFacingError(
     fallbackDescriptionKey ?? areaDescriptionKeys[area],
     diagnostics,
     preserveMessage,
+    message,
   )
+}
+
+function errorDiagnostics(cause: unknown, fallback: string): string {
+  if (cause && typeof cause === "object" && typeof (cause as { diagnostics?: unknown }).diagnostics === "string") {
+    return (cause as { diagnostics: string }).diagnostics
+  }
+  return fallback
 }
 
 function isUserFacingError(value: unknown): value is UserFacingError {
@@ -268,6 +320,7 @@ function buildError(
   descriptionKey: MessageKey,
   diagnostics: string,
   preserveMessage = false,
+  message = diagnostics,
 ): UserFacingError {
   return {
     area,
@@ -275,7 +328,7 @@ function buildError(
     severity,
     titleKey,
     descriptionKey,
-    descriptionText: preserveMessage && diagnostics ? diagnostics : undefined,
+    descriptionText: preserveMessage && message ? message : undefined,
     diagnostics: diagnostics || undefined,
   }
 }

--- a/src/routes/Skills/OrganizationSkillsPane.tsx
+++ b/src/routes/Skills/OrganizationSkillsPane.tsx
@@ -28,7 +28,7 @@ import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-f
 import { cn } from "@/lib/utils"
 
 function skillErrorMessage(cause: unknown, t: TFunction): string {
-  return userFacingErrorDescription(resolveUserFacingError(cause, { area: "skills" }), t)
+  return userFacingErrorDescription(resolveUserFacingError(cause, { area: "skills", preserveMessage: true }), t)
 }
 
 interface OrganizationSkillsPaneProps {
@@ -146,7 +146,10 @@ export function OrganizationSkillsPane({
           {selectedOrganizationSkills.error ? (
             <div className="flex min-w-0 items-start gap-2">
               <ErrorNotice
-                error={resolveUserFacingError(selectedOrganizationSkills.error, { area: "skills" })}
+                error={resolveUserFacingError(selectedOrganizationSkills.error, {
+                  area: "skills",
+                  preserveMessage: true,
+                })}
                 compact
                 className="min-w-0 flex-1"
               />

--- a/src/routes/Skills/SkillDetailContent.tsx
+++ b/src/routes/Skills/SkillDetailContent.tsx
@@ -149,7 +149,7 @@ export interface SkillDetailContentProps {
   publishSkill: (skill: ManagedSkillGroup) => Promise<void>
   publishingSkillId: string | null
   requestRemoveSkill: (skill: ManagedSkillGroup) => void
-  selectedPlanError: string | null
+  selectedPlanError: unknown
   selectedSkill: ManagedSkillGroup | undefined
   selectedStatus: ReturnType<typeof getGroupStatus> | null
   selectedVersionCheck?: SkillVersionReport["skills"][number]
@@ -204,7 +204,7 @@ interface SkillPeekProps {
   copySkillPath: (pathname: string) => void
   isRemovingSkill: boolean
   openSkillFolder: (pathname: string) => void
-  planError: string | null
+  planError: unknown
   publishSkill: (skill: ManagedSkillGroup) => Promise<void>
   publishingSkillId: string | null
   requestRemoveSkill: (skill: ManagedSkillGroup) => void
@@ -523,7 +523,10 @@ function SkillPeek({
               <SkeletonText className="w-3/4" />
             </div>
           ) : skillDocumentError ? (
-            <ErrorNotice error={resolveUserFacingError(skillDocumentError, { area: "skills" })} compact />
+            <ErrorNotice
+              error={resolveUserFacingError(skillDocumentError, { area: "skills", preserveMessage: true })}
+              compact
+            />
           ) : skillDocument ? (
             <div className="max-h-96 min-h-32 overflow-auto rounded-md border bg-background p-3">
               {skillDocumentViewMode === "preview" ? (

--- a/src/routes/Skills/SkillErrorNotice.tsx
+++ b/src/routes/Skills/SkillErrorNotice.tsx
@@ -1,9 +1,15 @@
 import { ErrorNotice } from "@/components/ErrorNotice"
 import { resolveUserFacingError } from "@/lib/user-facing-error"
 
-export function SkillErrorNotice({ className, error }: { className?: string; error: string | null | undefined }) {
+export function SkillErrorNotice({ className, error }: { className?: string; error: unknown }) {
   if (!error) {
     return null
   }
-  return <ErrorNotice error={resolveUserFacingError(error, { area: "skills" })} compact className={className} />
+  return (
+    <ErrorNotice
+      error={resolveUserFacingError(error, { area: "skills", preserveMessage: true })}
+      compact
+      className={className}
+    />
+  )
 }

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -52,9 +52,10 @@ import { DeleteSkillConfirmDialog } from "@/components/DeleteSkillConfirmDialog"
 import { useSkillObjectActions } from "@/components/useSkillObjectActions"
 import { useAppI18n } from "@/i18n"
 import { listMyPublishedSkillPackages, listPublicSkillPackages } from "@/lib/skills-catalog-client"
+import { resolveUserFacingError } from "@/lib/user-facing-error"
 
 type SkillOperationError = {
-  message: string
+  cause: unknown
   operation: "publish" | "update"
   skillId: SkillSelectionKey
 }
@@ -62,12 +63,12 @@ type SkillOperationError = {
 function visibleSkillOperationError(
   error: SkillOperationError | null,
   skillId: SkillSelectionKey | undefined,
-): string | null {
+): unknown {
   if (!error) {
     return null
   }
   if (error.skillId === skillId) {
-    return error.message
+    return error.cause
   }
   return null
 }
@@ -552,7 +553,7 @@ export function SkillsRoute({
         homeSummaryResource.invalidate()
       } catch (cause) {
         setPlanError({
-          message: cause instanceof Error ? cause.message : String(cause),
+          cause: resolveUserFacingError(cause, { area: "skills", preserveMessage: true }),
           operation: "update",
           skillId: skill.id,
         })
@@ -594,8 +595,11 @@ export function SkillsRoute({
           void loadPublicSkillPackages({ forceRefresh: true }).catch(() => undefined)
         }
       } catch (cause) {
-        const message = skillErrorMessage(cause, t)
-        setPlanError({ message, operation: "publish", skillId: skill.id })
+        setPlanError({
+          cause: resolveUserFacingError(cause, { area: "skills", preserveMessage: true }),
+          operation: "publish",
+          skillId: skill.id,
+        })
       } finally {
         publishSkillInFlightRef.current = false
         setPublishingSkillId(null)

--- a/src/routes/Skills/skill-errors.ts
+++ b/src/routes/Skills/skill-errors.ts
@@ -3,5 +3,5 @@ import type { TranslateFn as TFunction } from "@/i18n"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 
 export function skillErrorMessage(cause: unknown, t: TFunction): string {
-  return userFacingErrorDescription(resolveUserFacingError(cause, { area: "skills" }), t)
+  return userFacingErrorDescription(resolveUserFacingError(cause, { area: "skills", preserveMessage: true }), t)
 }


### PR DESCRIPTION
## Summary

This PR improves the Skill publishing flow so failed publishes expose the actual oo CLI error instead of collapsing into the generic “Skill operation failed” message. It also makes local Skill publishing work for Skills that are missing the package metadata required by the registry.

The user-visible issue was that publishing a local Skill to the Skill Market could fail with only a generic message. The real failure details were available from oo CLI stderr/stdout, but the renderer converted them to a broad localized fallback before showing the error card or copying diagnostics. That made actionable failures such as a missing scoped packageName invisible.

The root cause was split across the publish path: the main process used the default rejecting command wrapper for `oo skills publish`, while the renderer stored only the user-facing description string. Once the error was normalized, the raw CLI message and diagnostics were no longer available to the Skill detail panel.

## Changes

- Preserve Skill operation error messages in the renderer with `preserveMessage: true`, while keeping extended diagnostics copyable.
- Run `oo skills publish` with explicit result handling so stderr/stdout can be parsed into a useful publish failure message.
- Add publish diagnostics that include the command, short message, stdout, and stderr.
- Automatically add missing local publish metadata to `SKILL.md` before publishing: `metadata.packageName` is generated from the signed-in account and Skill name, and `metadata.version` defaults to `0.0.1`.
- Add a dev preflight check that fails when `.oo-bin/.version` does not match the source-locked oo CLI version.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test`
- Manual dev validation with `npm run dev` and publishing a local Skill that previously failed because it lacked `metadata.packageName`.
