### PR TITLE
Improve error diagnostics

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -11,6 +11,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { branding } from "../branding.ts"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { connectorBaseUrl, llmBaseUrl } from "../domain.ts"
 import { DEFAULT_BUILTIN_MODEL_ID, isBuiltinModelId, resolveBuiltinModel } from "../models/builtin.ts"
 import { buildFallbackSessionTitle, sanitizeGeneratedSessionTitle } from "../session/title.ts"
@@ -60,7 +61,15 @@ export async function persistOrganizationScopeUpdate({
   try {
     await writeScope(nextName)
   } catch (error) {
-    await writeScope(currentName).catch(() => undefined)
+    await writeScope(currentName).catch((rollbackError: unknown) => {
+      console.warn("[wanta] failed to rollback agent organization scope:", rollbackError)
+      logDiagnostic(
+        "agent",
+        "failed to rollback agent organization scope",
+        { error: rollbackError, organizationName: currentName },
+        "warn",
+      )
+    })
     throw error
   }
 }
@@ -194,7 +203,9 @@ export class AgentManager {
       this.organizationName = nextOrganizationName
     }
     const task = this.organizationUpdateChain.then(update, update)
-    this.organizationUpdateChain = task.catch(() => undefined)
+    this.organizationUpdateChain = task.catch((error: unknown) => {
+      logDiagnostic("agent", "agent organization scope update failed", { error }, "warn")
+    })
     await task
   }
 
@@ -387,11 +398,31 @@ export class AgentManager {
         if (this.eventLoopStopped) {
           break
         }
-        subscriber.onEvent(event)
+        try {
+          subscriber.onEvent(event)
+        } catch (error) {
+          console.error("[wanta] opencode event handling failed:", error)
+          logDiagnostic(
+            "opencode-event-stream",
+            "opencode event handling failed",
+            {
+              error,
+              eventType: event.type,
+            },
+            "error",
+          )
+        }
       }
     } catch (error) {
       if (!this.eventLoopStopped) {
         console.error("[wanta] opencode event stream ended:", error)
+        logDiagnostic("opencode-event-stream", "opencode event stream ended", { error }, "error")
+        subscriber.onConnectionStatus?.({
+          status: "failed",
+          attempt: eventStreamMaxReconnectAttempts,
+          maxAttempts: eventStreamMaxReconnectAttempts,
+          message: error instanceof Error ? error.message : String(error),
+        })
       }
     } finally {
       if (this.eventStreamAbort === controller) {
@@ -576,12 +607,26 @@ export class AgentManager {
         signal: requestSignal.signal,
       })
       if (!response.ok) {
+        console.warn("[wanta] authorized service lookup failed:", response.status, response.statusText)
+        logDiagnostic(
+          "agent",
+          "authorized service lookup failed",
+          {
+            status: response.status,
+            statusText: response.statusText,
+          },
+          "warn",
+        )
         return []
       }
       const payload = (await response.json()) as { data?: Array<{ service?: string; status?: string }> }
       const apps = payload.data ?? []
       return apps.filter((a) => a.status === "active" && a.service).map((a) => a.service as string)
-    } catch {
+    } catch (error) {
+      if (!signal?.aborted) {
+        console.warn("[wanta] authorized service lookup failed:", error)
+        logDiagnostic("agent", "authorized service lookup failed", { error }, "warn")
+      }
       return []
     } finally {
       requestSignal.cleanup()

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -1,10 +1,12 @@
 import type { Config, OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import type { ChildProcessWithoutNullStreams } from "node:child_process"
+import type { Readable } from "node:stream"
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { spawn } from "node:child_process"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
+import { logDiagnostic } from "../diagnostics-log.ts"
 
 export interface SidecarOptions {
   /** opencode 二进制绝对路径。 */
@@ -31,6 +33,9 @@ export interface SidecarExitInfo {
   signal?: NodeJS.Signals | null
 }
 
+const startupOutputMaxBytes = 64 * 1024
+const runtimeLineMaxLength = 8 * 1024
+
 /** OpenCode 本地 sidecar：spawn `opencode serve`、解析 URL、提供 SDK client、随 app 退出回收。 */
 export class OpencodeSidecar {
   private readonly options: SidecarOptions
@@ -38,6 +43,7 @@ export class OpencodeSidecar {
   private opencodeClient: OpencodeClient | null = null
   private serverUrl = ""
   private disposed = false
+  private streamLogCleanup: (() => void) | null = null
 
   public constructor(options: SidecarOptions) {
     this.options = options
@@ -88,12 +94,15 @@ export class OpencodeSidecar {
     this.proc = proc
 
     let output = ""
+    const appendStartupOutput = (chunk: Buffer): void => {
+      output = appendBoundedOutput(output, chunk.toString(), startupOutputMaxBytes)
+    }
     const url = await new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => {
         reject(new Error(`opencode serve startup timeout after ${timeoutMs}ms\n${output}`))
       }, timeoutMs)
       const onData = (chunk: Buffer): void => {
-        output += chunk.toString()
+        appendStartupOutput(chunk)
         const match = output.match(/listening on\s+(https?:\/\/\S+)/i)
         if (match) {
           clearTimeout(timer)
@@ -111,26 +120,33 @@ export class OpencodeSidecar {
         detach()
         reject(error)
       }
+      const onStderrData = (chunk: Buffer): void => {
+        appendStartupOutput(chunk)
+      }
       const detach = (): void => {
         proc.stdout.off("data", onData)
+        proc.stderr.off("data", onStderrData)
         proc.off("exit", onExit)
         proc.off("error", onError)
       }
       proc.stdout.on("data", onData)
-      proc.stderr.on("data", (chunk: Buffer) => {
-        output += chunk.toString()
-      })
+      proc.stderr.on("data", onStderrData)
       proc.on("exit", onExit)
       proc.on("error", onError)
     })
 
     this.serverUrl = url
+    this.streamLogCleanup = attachRuntimeStreamDiagnostics(proc)
     proc.once("exit", (code, signal) => {
+      this.streamLogCleanup?.()
+      this.streamLogCleanup = null
       if (!this.disposed) {
         this.options.onExit?.({ code, signal })
       }
     })
     proc.once("error", (error) => {
+      this.streamLogCleanup?.()
+      this.streamLogCleanup = null
       if (!this.disposed) {
         this.options.onExit?.({ error })
       }
@@ -145,6 +161,8 @@ export class OpencodeSidecar {
 
   public dispose(): void {
     this.disposed = true
+    this.streamLogCleanup?.()
+    this.streamLogCleanup = null
     if (this.proc) {
       this.proc.kill("SIGTERM")
       this.proc = null
@@ -152,4 +170,64 @@ export class OpencodeSidecar {
     this.opencodeClient = null
     this.serverUrl = ""
   }
+}
+
+function appendBoundedOutput(current: string, next: string, maxBytes: number): string {
+  const combined = current + next
+  if (Buffer.byteLength(combined, "utf8") <= maxBytes) {
+    return combined
+  }
+  return combined.slice(-maxBytes)
+}
+
+function attachRuntimeStreamDiagnostics(proc: ChildProcessWithoutNullStreams): () => void {
+  const cleanupStdout = attachStreamDiagnostics(proc.stdout, "stdout")
+  const cleanupStderr = attachStreamDiagnostics(proc.stderr, "stderr")
+  return () => {
+    cleanupStdout()
+    cleanupStderr()
+  }
+}
+
+function attachStreamDiagnostics(stream: Readable, source: "stdout" | "stderr"): () => void {
+  let pending = ""
+  const onData = (chunk: Buffer): void => {
+    pending += chunk.toString()
+    const lines = pending.split(/\r?\n/)
+    pending = lines.pop() ?? ""
+    if (pending.length > runtimeLineMaxLength) {
+      emitRuntimeLine(source, pending.slice(0, runtimeLineMaxLength), true)
+      pending = ""
+    }
+    for (const line of lines) {
+      emitRuntimeLine(source, line, false)
+    }
+  }
+  stream.on("data", onData)
+  return () => {
+    stream.off("data", onData)
+    if (pending.trim()) {
+      emitRuntimeLine(source, pending, false)
+    }
+    pending = ""
+  }
+}
+
+function emitRuntimeLine(source: "stdout" | "stderr", line: string, truncated: boolean): void {
+  const text = line.trim()
+  if (!text) {
+    return
+  }
+  if (source === "stderr") {
+    console.warn("[wanta] opencode stderr:", text)
+  }
+  logDiagnostic(
+    "opencode-sidecar",
+    `opencode ${source}`,
+    {
+      line: text,
+      ...(truncated ? { truncated: true } : {}),
+    },
+    source === "stderr" ? "warn" : "trace",
+  )
 }

--- a/electron/auth/node.ts
+++ b/electron/auth/node.ts
@@ -4,6 +4,7 @@ import type { IConnectionService } from "@oomol/connection"
 
 import { ConnectionService } from "@oomol/connection"
 import { app, dialog, shell } from "electron"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { apiBaseUrl } from "../domain.ts"
 import { ServiceEvent } from "../service-events.ts"
 import {
@@ -84,6 +85,7 @@ export class AuthManager {
   public getAuthState(): Promise<AuthState> {
     void this.refreshActiveAccountProfile().catch((error: unknown) => {
       console.warn("[wanta] failed to refresh account profile:", error)
+      logDiagnostic("auth", "failed to refresh account profile", { error }, "warn")
     })
     return this.currentState()
   }
@@ -124,6 +126,7 @@ export class AuthManager {
     }
     await clearOomolSessionCookies().catch((error: unknown) => {
       console.warn("[wanta] failed to clear session cookies:", error)
+      logDiagnostic("auth", "failed to clear session cookies", { error }, "warn")
     })
     const state = await this.currentState()
     this.stateChanged.emit(state)
@@ -153,6 +156,7 @@ export class AuthManager {
     } catch (error) {
       const wrapped = error instanceof Error ? error : new Error(String(error))
       console.error("[wanta] browser sign-in failed:", wrapped)
+      logDiagnostic("auth", "browser sign-in failed", { error: wrapped }, "error")
       if (this.pending === pendingAtStart) {
         this.rejectPending(wrapped)
       }
@@ -194,6 +198,7 @@ export class AuthManager {
     await this.emitState(state)
     void this.deps.applyAccount(account).catch((error: unknown) => {
       console.error("[wanta] failed to start agent after sign-in:", error)
+      logDiagnostic("auth", "failed to start agent after sign-in", { error }, "error")
     })
     return state
   }

--- a/electron/auth/store.ts
+++ b/electron/auth/store.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { ooEndpoint } from "../domain.ts"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 /** 持久化的账号资料：只存身份与展示信息，**不含任何凭证**。唯一凭证是会话 token（见 AuthRuntimeAccount）。 */
 export interface AuthAccount {
@@ -99,7 +100,8 @@ export class AuthStore {
   public read(): PersistedAuth {
     try {
       return migrateLegacyAccounts(JSON.parse(readFileSync(this.file, "utf-8")) as PersistedAuth)
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("auth", this.file, error)
       return {}
     }
   }

--- a/electron/chat/artifact-roots.ts
+++ b/electron/chat/artifact-roots.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "./common.ts"
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export type ArtifactRoots = Map<string, Map<string, string>>
 
@@ -111,7 +112,8 @@ export class ArtifactRootStore {
   public async read(): Promise<ArtifactRoots> {
     try {
       return normalizeArtifactRoots(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("artifact roots", this.file, error)
       return new Map()
     }
   }

--- a/electron/chat/authorization.ts
+++ b/electron/chat/authorization.ts
@@ -3,6 +3,7 @@ import type { AuthorizationInfo, ChatMessage } from "./common.ts"
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export type AuthorizationOverlays = Map<string, Map<string, Map<string, AuthorizationInfo>>>
 
@@ -179,7 +180,8 @@ export class AuthorizationOverlayStore {
   public async read(): Promise<AuthorizationOverlays> {
     try {
       return normalizeAuthorizationOverlays(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("authorization overlays", this.file, error)
       return new Map()
     }
   }

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -37,6 +37,7 @@ import { ConnectionService } from "@oomol/connection"
 import { shell } from "electron"
 import os from "node:os"
 import { translateOpencodeEvent } from "../agent/event-translator.ts"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { captureGitTurnBaseline } from "../git/turn-diff.ts"
 import { ServiceEvent } from "../service-events.ts"
 import { applyArtifactRoots, recordArtifactRoot } from "./artifact-roots.ts"
@@ -212,7 +213,10 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
 
   public setAgentStatus(status: AgentRuntimeStatus): void {
     this.agentStatus = status
-    void this.send("agentStatusChanged", { status }).catch(() => undefined)
+    void this.send("agentStatusChanged", { status }).catch((error: unknown) => {
+      console.warn("[wanta] failed to emit agent status:", error)
+      logDiagnostic("chat-service", "failed to emit agent status", { error, status: status.status }, "warn")
+    })
   }
 
   public hasActiveGeneration(): boolean {
@@ -255,7 +259,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
               this.activeAssistantMessages.delete(sessionId)
               this.activeToolParts.delete(sessionId)
               this.emitSessionActivity(sessionId)
-              void emit("generationStopped", { sessionId })
+              this.sendBestEffort(emit, "generationStopped", { sessionId }, { sessionId })
             })
           continue
         }
@@ -277,11 +281,16 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             }
           }
           if (artifactRoot) {
-            void emit("messageArtifacts", {
-              sessionId: translated.data.sessionId,
-              messageId: translated.data.messageId,
-              artifactRoot,
-            })
+            this.sendBestEffort(
+              emit,
+              "messageArtifacts",
+              {
+                sessionId: translated.data.sessionId,
+                messageId: translated.data.messageId,
+                artifactRoot,
+              },
+              { messageId: translated.data.messageId, sessionId: translated.data.sessionId },
+            )
             void this.rememberArtifactRoot(translated.data.sessionId, translated.data.messageId, artifactRoot).catch(
               (error: unknown) => {
                 console.warn("[wanta] failed to record artifact root", error)
@@ -340,11 +349,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
               this.activeAssistantMessages.delete(sessionId)
               this.activeToolParts.delete(sessionId)
               this.emitSessionActivity(sessionId)
-              void emit(translated.event, translated.data)
+              this.sendBestEffort(emit, translated.event, translated.data, { sessionId })
             })
           continue
         }
-        void emit(translated.event, translated.data)
+        this.sendBestEffort(emit, translated.event, translated.data, { sessionId: translated.data.sessionId })
       }
     }, handleConnectionStatus)
   }
@@ -379,15 +388,20 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             : null
     for (const sessionId of sessionIds) {
       const messageId = this.activeAssistantMessages.get(sessionId)
-      void emit("agentConnectionChanged", {
-        sessionId,
-        ...(messageId ? { messageId } : {}),
-        status: status.status,
-        ...(status.attempt ? { attempt: status.attempt } : {}),
-        ...(status.maxAttempts ? { maxAttempts: status.maxAttempts } : {}),
-        ...(status.message ? { message: status.message } : {}),
-        createdAt: Date.now(),
-      })
+      this.sendBestEffort(
+        emit,
+        "agentConnectionChanged",
+        {
+          sessionId,
+          ...(messageId ? { messageId } : {}),
+          status: status.status,
+          ...(status.attempt ? { attempt: status.attempt } : {}),
+          ...(status.maxAttempts ? { maxAttempts: status.maxAttempts } : {}),
+          ...(status.message ? { message: status.message } : {}),
+          createdAt: Date.now(),
+        },
+        { messageId, sessionId },
+      )
       if (!terminalMessage) {
         continue
       }
@@ -486,7 +500,31 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (!this.rememberMessageError(sessionId, message)) {
       return
     }
-    void emit("messageError", createMessageErrorPayload(sessionId, message, messageId))
+    this.sendBestEffort(emit, "messageError", createMessageErrorPayload(sessionId, message, messageId), {
+      messageId,
+      sessionId,
+    })
+  }
+
+  private sendBestEffort(
+    emit: (event: string, data: unknown) => Promise<void>,
+    event: string,
+    data: unknown,
+    context: { messageId?: string; sessionId?: string } = {},
+  ): void {
+    void emit(event, data).catch((error: unknown) => {
+      console.warn("[wanta] failed to emit chat server event:", { event, error, ...context })
+      logDiagnostic(
+        "chat-service",
+        "failed to emit chat server event",
+        {
+          event,
+          error,
+          ...context,
+        },
+        "warn",
+      )
+    })
   }
 
   private beginSessionGeneration(sessionId: string): SessionGeneration {
@@ -721,7 +759,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       return
     }
     const write = this.authorizationOverlayWritePromise
-      .catch(() => undefined)
+      .catch((error: unknown) => {
+        this.logQueuedWriteFailure("authorization overlay", error)
+      })
       .then(async () => {
         await this.deps.authorizationOverlayStore?.write(this.authorizationOverlays)
       })
@@ -740,11 +780,18 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     await this.deps.stoppedGenerationStore?.write(this.stoppedGenerations)
   }
 
+  private logQueuedWriteFailure(scope: string, error: unknown): void {
+    console.warn(`[wanta] previous ${scope} write failed:`, error)
+    logDiagnostic("chat-service", "previous queued write failed", { error, scope }, "warn")
+  }
+
   private async rememberTurnOutput(record: StoredTurnOutputRecord): Promise<void> {
     await this.ensureTurnOutputsLoaded()
     recordTurnOutput(this.turnOutputs, record)
     const write = this.turnOutputWritePromise
-      .catch(() => undefined)
+      .catch((error: unknown) => {
+        this.logQueuedWriteFailure("turn output", error)
+      })
       .then(async () => {
         await this.deps.turnOutputStore?.write(this.turnOutputs)
       })
@@ -811,7 +858,15 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       summary: summarizeTurnFiles(files, artifactGroup?.items.length ?? 0),
     }
     await this.rememberTurnOutput(record)
-    await this.send("turnOutputUpdated", { sessionId, messageId: resolvedMessageId }).catch(() => undefined)
+    await this.send("turnOutputUpdated", { sessionId, messageId: resolvedMessageId }).catch((error: unknown) => {
+      console.warn("[wanta] failed to emit turn output update:", error)
+      logDiagnostic(
+        "chat-service",
+        "failed to emit turn output update",
+        { error, messageId: resolvedMessageId, sessionId },
+        "warn",
+      )
+    })
   }
 
   public async getAttachmentPreview(req: AttachmentPreviewRequest): Promise<AttachmentPreviewResult> {
@@ -948,7 +1003,10 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.activeTurnOutputs.delete(sessionId)
     this.activeAssistantMessages.delete(sessionId)
     this.activeToolParts.delete(sessionId)
-    await this.send("generationStopped", { sessionId }).catch(() => undefined)
+    await this.send("generationStopped", { sessionId }).catch((error: unknown) => {
+      console.warn("[wanta] failed to emit generation stopped:", error)
+      logDiagnostic("chat-service", "failed to emit generation stopped", { error, sessionId }, "warn")
+    })
   }
 
   public async getMessages(sessionId: string): Promise<ChatMessage[]> {

--- a/electron/chat/previews.ts
+++ b/electron/chat/previews.ts
@@ -6,6 +6,7 @@ import type {
 } from "./common.ts"
 
 import { readFile, stat } from "node:fs/promises"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import {
   archivePreview,
   binaryDataPreview,
@@ -33,6 +34,12 @@ function logPath(filePath: string): string {
   return filePath.replace(/[\r\n]/g, " ")
 }
 
+function logPreviewFailure(scope: string, filePath: string, error: unknown, mime?: string): void {
+  const safePath = logPath(filePath)
+  console.error(`[wanta] ${scope} failed`, { error: errorMessage(error), path: safePath })
+  logDiagnostic("chat-preview", `${scope} failed`, { error, mime, path: safePath }, "warn")
+}
+
 function attachmentPreviewMime(req: AttachmentPreviewRequest): string | null {
   if (req.mime.toLowerCase().startsWith("image/")) {
     return req.mime
@@ -53,13 +60,12 @@ export async function attachmentPreview(req: AttachmentPreviewRequest): Promise<
     const bytes = await readFile(req.path)
     return { dataUrl: `data:${mime};base64,${bytes.toString("base64")}` }
   } catch (error) {
-    console.error("[wanta] getAttachmentPreview failed", { path: logPath(req.path), error: errorMessage(error) })
+    logPreviewFailure("getAttachmentPreview", req.path, error, mime)
     return { dataUrl: null }
   }
 }
 
 export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Promise<LocalArtifactPreviewResult> {
-  const safePath = logPath(req.path)
   const item = await localArtifactItem(req.path)
   if (!item || item.kind !== "file") {
     return { kind: "unsupported", mime: "application/octet-stream", reason: "missing" }
@@ -79,7 +85,7 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
         dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
       }
     } catch (error) {
-      console.error("[wanta] getLocalArtifactPreview image failed", { path: safePath, error: errorMessage(error) })
+      logPreviewFailure("getLocalArtifactPreview image", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
   }
@@ -97,7 +103,7 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
         dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
       }
     } catch (error) {
-      console.error("[wanta] getLocalArtifactPreview media failed", { path: safePath, error: errorMessage(error) })
+      logPreviewFailure("getLocalArtifactPreview media", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
   }
@@ -106,16 +112,13 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
     try {
       return await spreadsheetPreview(item.path, item.mime, size)
     } catch (error) {
-      console.error("[wanta] getLocalArtifactPreview spreadsheet failed", {
-        path: safePath,
-        error: errorMessage(error),
-      })
+      logPreviewFailure("getLocalArtifactPreview spreadsheet", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
   }
 
   const archive = await archivePreview(item.path, item.mime, size).catch((error: unknown) => {
-    console.error("[wanta] getLocalArtifactPreview archive failed", { path: safePath, error: errorMessage(error) })
+    logPreviewFailure("getLocalArtifactPreview archive", item.path, error, item.mime)
     return { kind: "unsupported" as const, mime: item.mime, size, reason: "read_failed" as const }
   })
   if (archive) {
@@ -136,7 +139,7 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
         truncated: preview.truncated,
       }
     } catch (error) {
-      console.error("[wanta] getLocalArtifactPreview rtf failed", { path: safePath, error: errorMessage(error) })
+      logPreviewFailure("getLocalArtifactPreview rtf", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
   }
@@ -149,10 +152,7 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
         return richPreview
       }
     } catch (error) {
-      console.error("[wanta] getLocalArtifactPreview rich file failed", {
-        path: safePath,
-        error: errorMessage(error),
-      })
+      logPreviewFailure("getLocalArtifactPreview rich file", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
   } else if (isBinaryDataPreviewArtifact(item.path, item.mime)) {
@@ -176,7 +176,7 @@ export async function localArtifactPreview(req: LocalArtifactPreviewRequest): Pr
       truncated: preview.truncated,
     }
   } catch (error) {
-    console.error("[wanta] getLocalArtifactPreview text failed", { path: safePath, error: errorMessage(error) })
+    logPreviewFailure("getLocalArtifactPreview text", item.path, error, item.mime)
     return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
   }
 }

--- a/electron/chat/stopped-generations.ts
+++ b/electron/chat/stopped-generations.ts
@@ -3,6 +3,7 @@ import type { ChatMessage, ChatMessagePart } from "./common.ts"
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface StoppedMessageRecord {
   partIds: Set<string>
@@ -174,7 +175,8 @@ export class StoppedGenerationStore {
   public async read(): Promise<StoppedGenerations> {
     try {
       return normalizeStoppedGenerations(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("stopped generations", this.file, error)
       return new Map()
     }
   }

--- a/electron/chat/turn-outputs.ts
+++ b/electron/chat/turn-outputs.ts
@@ -3,6 +3,7 @@ import type { TurnFileDiffResult, TurnOutputFile, TurnOutputRecord, TurnOutputSu
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface StoredTurnOutputFile extends TurnOutputFile {
   diff: TurnFileDiffResult
@@ -169,7 +170,8 @@ export class TurnOutputStore {
   public async read(): Promise<TurnOutputRecords> {
     try {
       return normalizeRecords(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("turn outputs", this.file, error)
       return new Map()
     }
   }

--- a/electron/diagnostics-log.ts
+++ b/electron/diagnostics-log.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, rename, rm, stat } from "node:fs/promises"
 import path from "node:path"
 
-type DiagnosticLevel = "trace" | "info" | "warn"
+type DiagnosticLevel = "trace" | "info" | "warn" | "error"
 type DiagnosticFields = Record<string, unknown>
 
 const maxLogBytes = 2 * 1024 * 1024
@@ -10,6 +10,7 @@ const pinoLevels: Record<DiagnosticLevel, number> = {
   trace: 10,
   info: 30,
   warn: 40,
+  error: 50,
 }
 
 let writeQueue = Promise.resolve()
@@ -165,6 +166,15 @@ function normalizeFields(fields: DiagnosticFields): DiagnosticFields {
 function normalizeValue(value: unknown): unknown {
   if (value === undefined || value === null || typeof value === "boolean" || typeof value === "number") {
     return value
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      cause: value.cause ? normalizeValue(value.cause) : undefined,
+    }
   }
 
   if (typeof value === "string") {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,6 +33,7 @@ import { ChatServiceImpl } from "./chat/node.ts"
 import { StoppedGenerationStore } from "./chat/stopped-generations.ts"
 import { TurnOutputStore } from "./chat/turn-outputs.ts"
 import { parseConnectionOAuthCallback } from "./connections/domain.ts"
+import { configureDiagnosticsLog, flushDiagnosticsLog, logDiagnostic } from "./diagnostics-log.ts"
 import { GitServiceImpl } from "./git/node.ts"
 import { ModelsServiceImpl } from "./models/node.ts"
 import { ModelsStore } from "./models/store.ts"
@@ -60,6 +61,8 @@ import { createWindowsTrayLifecycle } from "./window/windows-tray-lifecycle.ts"
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const appRoot = path.join(dirname, "..")
 process.env.APP_ROOT = appRoot
+configureDiagnosticsLog(path.join(app.getPath("userData"), "logs", "diagnostics.jsonl"))
+installMainProcessErrorHandlers()
 
 const viteDevServerUrl = process.env["VITE_DEV_SERVER_URL"]
 const rendererDist = path.join(appRoot, "dist")
@@ -176,7 +179,10 @@ const gitService = new GitServiceImpl({
 })
 
 chatService.sessionActivity.on(({ sessionId, usedAt }) => {
-  void sessionService.recordUseAndEmit(sessionId, usedAt).catch(() => undefined)
+  void sessionService.recordUseAndEmit(sessionId, usedAt).catch((error: unknown) => {
+    console.warn("[wanta] failed to record session activity:", error)
+    logMainError("failed to record session activity", error, { sessionId })
+  })
 })
 
 registerProtocolClient(protocolScheme)
@@ -198,6 +204,7 @@ server.registerService(gitService)
 settingsService.applyStartupTheme()
 registerAttachmentDialogHandler()
 registerAppLocaleHandler()
+registerRendererErrorHandler()
 
 if (isLocked) {
   server.start()
@@ -213,37 +220,45 @@ if (isLocked) {
     })
   }
 
-  app.whenReady().then(() => {
-    // 放行渲染进程对 *.<endpoint> 的已鉴权直连请求（凭证经会话 cookie 自动附带，token 不进渲染层）。
-    installOomolCorsShim(session.defaultSession)
-    installApplicationMenu()
-    createMainWindow()
-    // 启动静默检查（autoDownload=false，下载/安装由设置页 UI 显式触发）；dev 内部短路。
-    void updateService.checkForAppUpdate().catch((error: unknown) => {
-      console.warn("[wanta] startup update check failed:", error)
-    })
+  app
+    .whenReady()
+    .then(() => {
+      // 放行渲染进程对 *.<endpoint> 的已鉴权直连请求（凭证经会话 cookie 自动附带，token 不进渲染层）。
+      installOomolCorsShim(session.defaultSession)
+      installApplicationMenu()
+      createMainWindow()
+      // 启动静默检查（autoDownload=false，下载/安装由设置页 UI 显式触发）；dev 内部短路。
+      void updateService.checkForAppUpdate().catch((error: unknown) => {
+        console.warn("[wanta] startup update check failed:", error)
+        logMainError("startup update check failed", error)
+      })
 
-    // 启动时一次性抹除磁盘上残留的旧长期 api-key（迁移到纯会话 token 后不再落盘任何凭证）。
-    authStore.purgeLegacy()
-    void authManager
-      .activeRuntimeAccount()
-      .then((account) => {
-        if (account) {
-          return applyAuthAccount(account)
+      // 启动时一次性抹除磁盘上残留的旧长期 api-key（迁移到纯会话 token 后不再落盘任何凭证）。
+      authStore.purgeLegacy()
+      void authManager
+        .activeRuntimeAccount()
+        .then((account) => {
+          if (account) {
+            return applyAuthAccount(account)
+          }
+          console.log("[wanta] not signed in (or session expired) — login page will be shown")
+          return undefined
+        })
+        .catch((error: unknown) => {
+          console.error("[wanta] agent sidecar failed to start:", error)
+          logMainError("agent sidecar failed to start", error)
+        })
+
+      app.on("activate", () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+          createMainWindow()
         }
-        console.log("[wanta] not signed in (or session expired) — login page will be shown")
-        return undefined
       })
-      .catch((error: unknown) => {
-        console.error("[wanta] agent sidecar failed to start:", error)
-      })
-
-    app.on("activate", () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        createMainWindow()
-      }
     })
-  })
+    .catch((error: unknown) => {
+      console.error("[wanta] app startup failed:", error)
+      logMainError("app startup failed", error)
+    })
 
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") {
@@ -261,6 +276,44 @@ if (isLocked) {
     windowsTrayLifecycle = null
     agent?.dispose()
     server.dispose()
+    void flushDiagnosticsLog().catch((error: unknown) => {
+      console.warn("[wanta] failed to flush diagnostics log", error)
+    })
+  })
+}
+
+function logMainError(message: string, error: unknown, fields: Record<string, unknown> = {}): void {
+  logDiagnostic("main", message, { ...fields, error }, "error")
+}
+
+function installMainProcessErrorHandlers(): void {
+  process.on("uncaughtExceptionMonitor", (error, origin) => {
+    console.error("[wanta] uncaught exception:", error)
+    logMainError("uncaught exception", error, { origin })
+  })
+  process.on("unhandledRejection", (reason) => {
+    console.error("[wanta] unhandled promise rejection:", reason)
+    logMainError("unhandled promise rejection", reason)
+  })
+  process.on("warning", (warning) => {
+    console.warn("[wanta] process warning:", warning)
+    logDiagnostic("main", "process warning", { warning }, "warn")
+  })
+  app.on("child-process-gone", (_event, details) => {
+    console.error("[wanta] child process gone:", details)
+    logDiagnostic("main", "child process gone", { details }, "error")
+  })
+  app.on("render-process-gone", (_event, webContents, details) => {
+    console.error("[wanta] render process gone:", details)
+    logDiagnostic(
+      "main",
+      "render process gone",
+      {
+        details,
+        url: webContents.getURL(),
+      },
+      "error",
+    )
   })
 }
 
@@ -311,6 +364,43 @@ function registerAttachmentDialogHandler(): void {
   })
 }
 
+function registerRendererErrorHandler(): void {
+  ipcMain.on("wanta:renderer-error", (_event, input: unknown) => {
+    const report = normalizeRendererErrorReport(input)
+    if (!report) {
+      return
+    }
+    console.error("[wanta] renderer error:", report)
+    logDiagnostic("renderer", "renderer error", report, "error")
+  })
+}
+
+function normalizeRendererErrorReport(input: unknown): {
+  message: string
+  scope?: string
+  source: string
+  stack?: string
+} | null {
+  if (!input || typeof input !== "object") {
+    return null
+  }
+  const record = input as Record<string, unknown>
+  const message = typeof record["message"] === "string" ? record["message"].trim() : ""
+  if (!message) {
+    return null
+  }
+  const rawSource = record["source"]
+  const source = rawSource === "unhandledrejection" || rawSource === "handled" ? rawSource : "error"
+  const scope = typeof record["scope"] === "string" ? record["scope"].trim().slice(0, 200) : undefined
+  const stack = typeof record["stack"] === "string" ? record["stack"].slice(0, 16_000) : undefined
+  return {
+    message: message.slice(0, 4_000),
+    ...(scope ? { scope } : {}),
+    source,
+    ...(stack ? { stack } : {}),
+  }
+}
+
 function assertAttachmentPickerKind(kind: unknown): asserts kind is AttachmentPickerKind {
   if (!isAttachmentPickerKind(kind)) {
     throw new Error("Invalid attachment picker kind.")
@@ -358,7 +448,9 @@ function runtimeErrorMessage(error: unknown): string {
 /** 凭证 → 运行时装配：替换 agent（重启 sidecar）并同步 connector 凭证。经 applyChain 串行执行。 */
 function applyAuthAccount(account: AuthRuntimeAccount | null): Promise<void> {
   const next = applyChain.then(() => applyAuthAccountNow(account))
-  applyChain = next.catch(() => undefined)
+  applyChain = next.catch((error: unknown) => {
+    logMainError("auth account application failed", error)
+  })
   return next
 }
 
@@ -522,7 +614,10 @@ function getBrandingResourcePath(fileName: string): string {
 // 仅放行安全的用户意图协议外开；其余（file:、自定义协议等）一律忽略。
 function openExternalUrl(url: string): void {
   if (/^(https?|mailto|tel):/i.test(url)) {
-    void shell.openExternal(url)
+    void shell.openExternal(url).catch((error: unknown) => {
+      console.warn("[wanta] failed to open external URL:", error)
+      logMainError("failed to open external URL", error, { url })
+    })
   }
 }
 
@@ -659,11 +754,42 @@ function createMainWindow(): void {
       openExternalUrl(url)
     }
   })
+  mainWindow.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame) {
+      return
+    }
+    console.error("[wanta] renderer failed to load:", { errorCode, errorDescription, validatedURL })
+    logDiagnostic(
+      "main-window",
+      "renderer failed to load",
+      {
+        errorCode,
+        errorDescription,
+        url: validatedURL,
+      },
+      "error",
+    )
+  })
+  mainWindow.webContents.on("render-process-gone", (_event, details) => {
+    console.error("[wanta] main window render process gone:", details)
+    logDiagnostic("main-window", "main window render process gone", { details }, "error")
+  })
+  mainWindow.on("unresponsive", () => {
+    console.warn("[wanta] main window became unresponsive")
+    logDiagnostic("main-window", "main window became unresponsive", {}, "warn")
+  })
 
   if (viteDevServerUrl) {
-    void mainWindow.loadURL(viteDevServerUrl)
+    void mainWindow.loadURL(viteDevServerUrl).catch((error: unknown) => {
+      console.error("[wanta] failed to load renderer URL:", error)
+      logMainError("failed to load renderer URL", error, { url: viteDevServerUrl })
+    })
   } else {
-    void mainWindow.loadFile(path.join(rendererDist, "index.html"))
+    const rendererEntry = path.join(rendererDist, "index.html")
+    void mainWindow.loadFile(rendererEntry).catch((error: unknown) => {
+      console.error("[wanta] failed to load renderer file:", error)
+      logMainError("failed to load renderer file", error, { path: rendererEntry })
+    })
   }
 
   mainWindow.on("closed", () => {

--- a/electron/models/node.ts
+++ b/electron/models/node.ts
@@ -4,6 +4,7 @@ import type { IConnectionService } from "@oomol/connection"
 
 import { ConnectionService } from "@oomol/connection"
 import { randomUUID } from "node:crypto"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { ModelsService as ModelsServiceName } from "./common.ts"
 import {
   CUSTOM_MODEL_PROVIDERS,
@@ -127,7 +128,10 @@ export class ModelsServiceImpl extends ConnectionService<ModelsService> implemen
 
   private async emitCatalog(): Promise<ModelCatalog> {
     const catalog = await this.deps.store.catalog()
-    await this.send("modelsChanged", catalog).catch(() => undefined)
+    await this.send("modelsChanged", catalog).catch((error: unknown) => {
+      console.warn("[wanta] failed to emit models catalog:", error)
+      logDiagnostic("models-service", "failed to emit models catalog", { error }, "warn")
+    })
     return catalog
   }
 }

--- a/electron/models/store.ts
+++ b/electron/models/store.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { externalModelProviderBaseUrls } from "../domain.ts"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 import { DEFAULT_BUILTIN_MODEL_ID, builtinModelSummaries, isBuiltinModelId } from "./builtin.ts"
 
 const providerBaseUrls = externalModelProviderBaseUrls
@@ -439,7 +440,8 @@ export class ModelsStore {
         selected: isKnownModelChoice(parsed, parsed.selected) ? parsed.selected : defaultModelChoice(),
         customModels: Array.isArray(parsed.customModels) ? parsed.customModels.filter(isPersistedCustomModel) : [],
       }
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("models", this.file, error)
       return { selected: defaultModelChoice(), customModels: [] }
     }
   }

--- a/electron/oo-command.ts
+++ b/electron/oo-command.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process"
 import path from "node:path"
 import { promisify } from "node:util"
+import { logDiagnostic } from "./diagnostics-log.ts"
 import { recordOperationHistory } from "./operation-history.ts"
 
 const execFileAsync = promisify(execFile)
@@ -128,5 +129,6 @@ async function recordOperation(
     })
   } catch (error) {
     console.warn("[wanta] failed to record operation history", error)
+    logDiagnostic("oo-command", "failed to record operation history", { error, owner }, "warn")
   }
 }

--- a/electron/operation-history.ts
+++ b/electron/operation-history.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logDiagnostic } from "./diagnostics-log.ts"
 
 export type OperationHistoryStatus = "failed" | "succeeded"
 
@@ -47,6 +48,7 @@ export async function recordOperationHistory(params: OperationHistoryCreateParam
     })
     .catch((error: unknown) => {
       console.warn("[wanta] failed to record operation", error)
+      logDiagnostic("operation-history", "failed to record operation", { error }, "warn")
     })
 
   await writeQueue

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -28,11 +28,19 @@ export interface SaveClipboardAttachmentInput {
   bytes: ArrayBuffer
 }
 
+export interface RendererErrorReport {
+  message: string
+  source: "error" | "handled" | "unhandledrejection"
+  scope?: string
+  stack?: string
+}
+
 export interface WantaBridge {
   appCommit: string
   getPathForFile(file: File): string
   onAppCommand(callback: (command: AppCommand) => void): () => void
   platform: NodeJS.Platform
+  reportRendererError(input: RendererErrorReport): void
   saveClipboardAttachment(input: SaveClipboardAttachmentInput): Promise<SelectedAttachmentPath>
   selectAttachmentPaths(kind: AttachmentPickerKind): Promise<SelectedAttachmentPath[]>
   selectProjectDirectory(): Promise<SelectedAttachmentPath | null>
@@ -62,6 +70,7 @@ const wanta: WantaBridge = {
     return () => ipcRenderer.removeListener(APP_COMMAND_CHANNEL, listener)
   },
   platform: process.platform,
+  reportRendererError: (input: RendererErrorReport) => ipcRenderer.send("wanta:renderer-error", input),
   saveClipboardAttachment: (input: SaveClipboardAttachmentInput) =>
     electronAPI.ipcRenderer.invoke("wanta:save-clipboard-attachment", input) as Promise<SelectedAttachmentPath>,
   selectAttachmentPaths: (kind: AttachmentPickerKind) =>
@@ -77,7 +86,13 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld("electron", electronAPI)
     contextBridge.exposeInMainWorld(branding.windowBridge, wanta)
   } catch (error) {
-    console.error(error)
+    console.error("[wanta] failed to expose preload bridge:", error)
+    ipcRenderer.send("wanta:renderer-error", {
+      message: "Failed to expose preload bridge",
+      source: "handled",
+      scope: "preload.exposeBridge",
+      stack: error instanceof Error ? error.stack : undefined,
+    } satisfies RendererErrorReport)
   }
 } else {
   window.electron = electronAPI

--- a/electron/protocol.ts
+++ b/electron/protocol.ts
@@ -1,5 +1,6 @@
 import { app } from "electron"
 import path from "node:path"
+import { logDiagnostic } from "./diagnostics-log.ts"
 
 export interface ProtocolHandler {
   handleUrl(url: string): Promise<boolean> | boolean
@@ -44,7 +45,8 @@ export function requestProtocolSingleInstanceLock(
 export function listenProtocolUrls(scheme: string, handler: ProtocolHandler, onSecondInstance: () => void): void {
   const dispatchUrl = (url: string): void => {
     void Promise.resolve(handler.handleUrl(url)).catch((error) => {
-      console.warn("[protocol] failed to handle protocol url", error)
+      console.warn("[wanta] failed to handle protocol url:", error)
+      logDiagnostic("protocol", "failed to handle protocol url", { error }, "warn")
     })
   }
 

--- a/electron/session/activity-store.ts
+++ b/electron/session/activity-store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface PersistedSessionActivity {
   sessions?: Record<string, number>
@@ -42,7 +43,8 @@ export class SessionActivityStore {
   public async read(): Promise<Map<string, number>> {
     try {
       return normalizeActivity(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("session activity", this.file, error)
       return new Map()
     }
   }

--- a/electron/session/metadata-store.ts
+++ b/electron/session/metadata-store.ts
@@ -3,6 +3,7 @@ import type { SessionScope } from "./common.ts"
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface SessionMetadata {
   scope?: SessionScope
@@ -112,7 +113,8 @@ export class SessionMetadataStore {
   public async read(): Promise<Map<string, SessionMetadata>> {
     try {
       return normalizeMetadata(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("session metadata", this.file, error)
       return new Map()
     }
   }

--- a/electron/session/node.ts
+++ b/electron/session/node.ts
@@ -20,6 +20,7 @@ import type { IConnectionService } from "@oomol/connection"
 import { ConnectionService } from "@oomol/connection"
 import { randomUUID } from "node:crypto"
 import path from "node:path"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { SessionService as SessionServiceName } from "./common.ts"
 
 interface SessionServiceDeps {
@@ -187,7 +188,7 @@ export class SessionServiceImpl
       await this.persistProjects()
     }
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("create session")
     return { ...info, scope, ...(scopedProjectId ? { projectId: scopedProjectId } : {}) }
   }
 
@@ -221,7 +222,7 @@ export class SessionServiceImpl
     }
     this.projects.set(project.id, project)
     await this.persistProjects()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("create project")
     return project
   }
 
@@ -243,7 +244,7 @@ export class SessionServiceImpl
     }
     this.setMetadataEntry(req.sessionId, next)
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("assign session project")
   }
 
   public async renameProject(req: { id: string; name: string }): Promise<void> {
@@ -261,7 +262,7 @@ export class SessionServiceImpl
     }
     this.projects.set(req.id, { ...current, name, updatedAt: Date.now() })
     await this.persistProjects()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("rename project")
   }
 
   public async pinProject(req: { id: string; pinned: boolean }): Promise<void> {
@@ -281,7 +282,7 @@ export class SessionServiceImpl
     }
     this.projects.set(req.id, next)
     await this.persistProjects()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("pin project")
   }
 
   public async archiveProject(id: string): Promise<void> {
@@ -320,12 +321,13 @@ export class SessionServiceImpl
       try {
         await this.persistProjects()
         await this.persistMetadata()
-      } catch {
+      } catch (rollbackError) {
         // 回滚落盘是 best-effort；仍向调用方暴露原始持久化错误。
+        this.logFailure("failed to rollback project archive", rollbackError, { projectId: id })
       }
       throw error
     }
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("archive project")
   }
 
   public async removeProject(id: string): Promise<void> {
@@ -347,7 +349,7 @@ export class SessionServiceImpl
     }
     await this.persistProjects()
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("remove project")
   }
 
   public async generateTitle(req: GenerateSessionTitleRequest): Promise<GenerateSessionTitleResult> {
@@ -362,7 +364,7 @@ export class SessionServiceImpl
       return
     }
     await this.agent.renameSession(req.id, req.title)
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("rename session")
   }
 
   public async pin(req: { id: string; pinned: boolean }): Promise<void> {
@@ -382,7 +384,7 @@ export class SessionServiceImpl
       this.setMetadataEntry(req.id, next)
     }
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("pin session")
   }
 
   public async archive(id: string): Promise<void> {
@@ -393,7 +395,7 @@ export class SessionServiceImpl
     const current = this.sessionMetadata.get(id) ?? {}
     this.sessionMetadata.set(id, { ...current, archivedAt: Date.now(), pinnedAt: undefined })
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("archive session")
   }
 
   public async unarchive(id: string): Promise<SessionInfo | null> {
@@ -410,7 +412,7 @@ export class SessionServiceImpl
     this.setMetadataEntry(id, next)
     await this.persistMetadata()
     const restored = await this.resolveSession(id, "active")
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("unarchive session")
     return restored
   }
 
@@ -426,7 +428,7 @@ export class SessionServiceImpl
     await this.deps.onSessionRemoved?.(id)
     await this.persistActivity()
     await this.persistMetadata()
-    void this.broadcastChanged().catch(() => undefined)
+    this.broadcastChangedBestEffort("remove session")
   }
 
   public markUsed(id: string, usedAt = Date.now()): boolean {
@@ -457,7 +459,11 @@ export class SessionServiceImpl
       await this.persistProjects()
     }
     await this.persistActivity()
-    await this.refreshAndEmit().catch(() => undefined)
+    try {
+      await this.refreshAndEmit()
+    } catch (error) {
+      this.logFailure("failed to broadcast sessions changed", error, { action: "record session use", sessionId: id })
+    }
   }
 
   private async ensureActivityLoaded(): Promise<void> {
@@ -643,5 +649,16 @@ export class SessionServiceImpl
     }
     const sessions = await this.list()
     await this.send("sessionsChanged", { sessions })
+  }
+
+  private broadcastChangedBestEffort(action: string): void {
+    void this.broadcastChanged().catch((error: unknown) => {
+      this.logFailure("failed to broadcast sessions changed", error, { action })
+    })
+  }
+
+  private logFailure(message: string, error: unknown, fields: Record<string, unknown> = {}): void {
+    console.warn(`[wanta] ${message}:`, error)
+    logDiagnostic("session-service", message, { error, ...fields }, "warn")
   }
 }

--- a/electron/session/project-store.ts
+++ b/electron/session/project-store.ts
@@ -3,6 +3,7 @@ import type { SessionProject, SessionScope } from "./common.ts"
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface PersistedSessionProjects {
   projects?: Record<string, SessionProject>
@@ -96,7 +97,8 @@ export class SessionProjectStore {
   public async read(): Promise<Map<string, SessionProject>> {
     try {
       return normalizeProjects(JSON.parse(await readFile(this.file, "utf-8")))
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("session projects", this.file, error)
       return new Map()
     }
   }

--- a/electron/settings/store.ts
+++ b/electron/settings/store.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import path from "node:path"
+import { logStoreReadFailure } from "../store-diagnostics.ts"
 
 export interface PersistedSettings {
   themeSource?: string
@@ -18,7 +19,8 @@ export class SettingsStore {
   public read(): PersistedSettings {
     try {
       return JSON.parse(readFileSync(this.file, "utf-8")) as PersistedSettings
-    } catch {
+    } catch (error) {
+      logStoreReadFailure("settings", this.file, error)
       return {}
     }
   }

--- a/electron/skills/file-operations.ts
+++ b/electron/skills/file-operations.ts
@@ -2,6 +2,7 @@ import type { ManagedSkillGroup } from "./common.ts"
 
 import { access, cp, mkdir, rename, rm } from "node:fs/promises"
 import path from "node:path"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { metadataFileName } from "./constants.ts"
 
 export function normalizeSkillId(skillId: string): string {
@@ -122,9 +123,18 @@ export async function replaceDirectory(sourcePath: string, targetPath: string): 
       hasBackup = false
     }
   } finally {
-    await rm(tempPath, { force: true, recursive: true }).catch(() => undefined)
+    await cleanupDirectory(tempPath, "temporary skill directory")
     if (hasBackup && !preserveBackup) {
-      await rm(backupPath, { force: true, recursive: true }).catch(() => undefined)
+      await cleanupDirectory(backupPath, "skill backup directory")
     }
+  }
+}
+
+async function cleanupDirectory(targetPath: string, scope: string): Promise<void> {
+  try {
+    await rm(targetPath, { force: true, recursive: true })
+  } catch (error) {
+    console.warn(`[wanta] failed to clean up ${scope}:`, error)
+    logDiagnostic("skills", "failed to clean up directory", { error, path: targetPath, scope }, "warn")
   }
 }

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -32,7 +32,7 @@ import os from "node:os"
 import path from "node:path"
 import { buildOoEnv } from "../agent/oo.ts"
 import { resolveAgentSkillRoot, supportedAgents } from "../agents/catalog.ts"
-import { logDiagnosticOnChange } from "../diagnostics-log.ts"
+import { logDiagnostic, logDiagnosticOnChange } from "../diagnostics-log.ts"
 import { ooEndpoint } from "../domain.ts"
 import { runOoCommand } from "../oo-command.ts"
 import { ServiceEvent } from "../service-events.ts"
@@ -803,7 +803,10 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       }
 
       const resolvedAllowedPath = path.resolve(allowedPath)
-      const canonicalAllowedPath = await realpath(resolvedAllowedPath).catch(() => undefined)
+      const canonicalAllowedPath = await realpath(resolvedAllowedPath).catch((error: unknown) => {
+        logDiagnostic("skills", "failed to resolve allowed skill path", { error, path: resolvedAllowedPath }, "warn")
+        return undefined
+      })
       if (!canonicalAllowedPath) {
         continue
       }

--- a/electron/store-diagnostics.ts
+++ b/electron/store-diagnostics.ts
@@ -1,0 +1,22 @@
+import { logDiagnostic } from "./diagnostics-log.ts"
+
+export function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && (error as NodeJS.ErrnoException).code === "ENOENT")
+}
+
+export function logStoreReadFailure(scope: string, filePath: string, error: unknown): void {
+  if (isMissingFileError(error)) {
+    return
+  }
+  console.warn(`[wanta] failed to read ${scope}; using default state:`, error)
+  logDiagnostic(
+    "store",
+    "failed to read persisted store",
+    {
+      error,
+      path: filePath,
+      scope,
+    },
+    "warn",
+  )
+}

--- a/electron/update/node.ts
+++ b/electron/update/node.ts
@@ -8,6 +8,7 @@ import { ConnectionService } from "@oomol/connection"
 import { app } from "electron"
 import updaterPkg from "electron-updater"
 import { branding } from "../branding.ts"
+import { logDiagnostic } from "../diagnostics-log.ts"
 import { staticBaseUrl } from "../domain.ts"
 import { resolveUpdateChannel, updaterChannelName } from "./channel.ts"
 import { UpdateService as UpdateServiceName } from "./common.ts"
@@ -139,9 +140,11 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
 
     // feed 重配延迟到下次 getAutoUpdater()（configuredChannel 失配触发 setFeedURL）。
     this.state = { ...this.snapshotBase(), status: { status: "idle" } }
-    void this.send("appUpdateStateChanged", this.state)
+    this.sendStateChanged("set update channel")
     // 切渠道后立即后台检查一次（dev 下 runCheck 内部短路为 not-available）。
-    void this.checkForAppUpdate().catch(() => undefined)
+    void this.checkForAppUpdate().catch((error: unknown) => {
+      this.logFailure("background update check failed after channel change", error, "warn")
+    })
     return Promise.resolve(this.state)
   }
 
@@ -168,7 +171,7 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
 
   private patchStatus(status: AppUpdateStatus): void {
     this.state = { ...this.state, ...this.snapshotBase(), status }
-    void this.send("appUpdateStateChanged", this.state)
+    this.sendStateChanged(`patch ${status.status} status`)
   }
 
   private async runCheck(isMissingAssetRetry: boolean): Promise<AppUpdateState> {
@@ -178,7 +181,7 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
         checkedAt: new Date().toISOString(),
         status: { status: "not-available" },
       }
-      void this.send("appUpdateStateChanged", this.state)
+      this.sendStateChanged("set dev update state")
       return this.state
     }
 
@@ -193,7 +196,9 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
       // 旧渠道在途请求未结清时直接调用会原样复用旧 provider 的结果——generation 是新的、
       // 守卫放行，旧渠道结果就被标上新渠道。必须等上一轮库级请求结清再发起。
       if (this.libraryCheck && !this.libraryCheckSettled) {
-        await withTimeout(this.libraryCheck, checkTimeoutMs, "prior update check settling").catch(() => undefined)
+        await withTimeout(this.libraryCheck, checkTimeoutMs, "prior update check settling").catch((error: unknown) => {
+          this.logFailure("prior update check failed while settling", error, "warn")
+        })
         if (generation !== this.checkGeneration) {
           return this.state
         }
@@ -216,7 +221,7 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
           ? { status: "available", version: info.version, releaseDate: info.releaseDate }
           : { status: "not-available" },
       }
-      void this.send("appUpdateStateChanged", this.state)
+      this.sendStateChanged("complete update check")
       return this.state
     } catch (cause) {
       if (generation !== this.checkGeneration) {
@@ -226,12 +231,14 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
       if (isMissingAssetError(cause)) {
         // 上传/CDN 竞态或渠道 yml 暂缺：按"暂无更新"处理并限次重试，不打扰用户。
         console.warn("[wanta] update check skipped, asset missing (404):", message)
+        logDiagnostic("update-service", "update check skipped because asset is missing", { error: cause }, "warn")
         this.patchStatus({ status: "not-available" })
         this.scheduleMissingAssetRetry()
         return this.state
       }
       // 检查失败不向调用方抛：状态里已带错误，渲染层据此显示。
       console.warn("[wanta] update check failed:", message)
+      logDiagnostic("update-service", "update check failed", { error: cause }, "warn")
       this.patchStatus({ status: "error", error: message })
       return this.state
     }
@@ -309,11 +316,29 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
     const message = cause instanceof Error ? cause.message : String(cause)
     if (isMissingAssetError(cause)) {
       console.warn("[wanta] update download skipped, asset missing (404):", message)
+      logDiagnostic("update-service", "update download skipped because asset is missing", { error: cause }, "warn")
       this.patchStatus({ status: "not-available" })
       this.scheduleMissingAssetRetry()
       return
     }
+    this.logFailure("update download failed", cause, "warn")
     this.patchStatus({ status: "error", error: message })
+  }
+
+  private sendStateChanged(action: string): void {
+    void this.send("appUpdateStateChanged", this.state).catch((error: unknown) => {
+      this.logFailure("failed to emit app update state", error, "warn", { action, status: this.state.status.status })
+    })
+  }
+
+  private logFailure(
+    message: string,
+    error: unknown,
+    level: "warn" | "error" = "warn",
+    fields: Record<string, unknown> = {},
+  ): void {
+    console.warn(`[wanta] ${message}:`, error)
+    logDiagnostic("update-service", message, { error, ...fields }, level)
   }
 
   private getAutoUpdater(): AutoUpdater {
@@ -392,7 +417,9 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
       }
       this.missingAssetRetryTimer = undefined
       this.missingAssetRetryAttempt = nextAttempt
-      void this.runCheck(true).catch(() => undefined)
+      void this.runCheck(true).catch((error: unknown) => {
+        this.logFailure("missing asset retry update check failed", error, "warn")
+      })
     }, missingAssetRetryDelayMs)
     this.missingAssetRetryTimer.unref()
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,10 +62,23 @@ export function App() {
   useGlobalScrollbars()
 
   return (
-    <I18nProvider>
-      <ThemeProvider>
-        <AuthGate />
-      </ThemeProvider>
-    </I18nProvider>
+    <ErrorBoundary fallback={<RootFallback />}>
+      <I18nProvider>
+        <ThemeProvider>
+          <AuthGate />
+        </ThemeProvider>
+      </I18nProvider>
+    </ErrorBoundary>
+  )
+}
+
+function RootFallback() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 bg-background text-foreground">
+      <p className="text-sm text-muted-foreground">Wanta could not render this window.</p>
+      <Button variant="outline" onClick={() => window.location.reload()}>
+        Reload
+      </Button>
+    </div>
   )
 }

--- a/src/components/AppDataHooks.ts
+++ b/src/components/AppDataHooks.ts
@@ -4,6 +4,7 @@ import type { ResourceView } from "@/lib/resource-store"
 
 import * as React from "react"
 import { useAppDataResources } from "@/components/AppDataContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { ResourceStore, toResourceView } from "@/lib/resource-store"
 
 function useResource<T>(resource: ResourceStore<T>, options: { autoLoad?: boolean } = {}): ResourceView<T> {
@@ -18,8 +19,9 @@ function useResource<T>(resource: ResourceStore<T>, options: { autoLoad?: boolea
       return
     }
 
-    void resource.refresh().catch(() => {
+    void resource.refresh().catch((error: unknown) => {
       // 错误保存在 resource snapshot 中，页面按状态展示。
+      reportRendererHandledError("resource", "resource auto-load failed", error)
     })
   }, [options.autoLoad, resource])
 

--- a/src/components/AppDataProvider.tsx
+++ b/src/components/AppDataProvider.tsx
@@ -5,6 +5,7 @@ import type { AppDataResources } from "@/components/AppDataContext"
 import * as React from "react"
 import { useAppContext } from "@/components/AppContext"
 import { AppDataContext } from "@/components/AppDataContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { createResource } from "@/lib/resource-store"
 
 const backgroundRefreshMs = 60_000
@@ -61,8 +62,16 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
       resources.skillInventory.invalidate()
       resources.skillVersions.invalidate()
       if (nextAuthState.status === "authenticated") {
-        void resources.skillInventory.refresh({ forceRefresh: true, silent: true }).catch(() => {})
-        void resources.skillVersions.refresh({ silent: true }).catch(() => {})
+        void resources.skillInventory
+          .refresh({ forceRefresh: true, silent: true })
+          .catch((error: unknown) =>
+            reportRendererHandledError("app-data", "silent skill inventory refresh failed after auth change", error),
+          )
+        void resources.skillVersions
+          .refresh({ silent: true })
+          .catch((error: unknown) =>
+            reportRendererHandledError("app-data", "silent skill version refresh failed after auth change", error),
+          )
       } else {
         resources.skillInventory.reset()
         resources.skillVersions.reset()
@@ -72,7 +81,11 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     return skillService.serverEvents.on("skillInventoryChanged", () => {
-      void resources.skillInventory.refresh({ forceRefresh: true, silent: true }).catch(() => {})
+      void resources.skillInventory
+        .refresh({ forceRefresh: true, silent: true })
+        .catch((error: unknown) =>
+          reportRendererHandledError("app-data", "silent skill inventory refresh failed after inventory event", error),
+        )
       resources.skillVersions.invalidate()
     })
   }, [resources, skillService.serverEvents])
@@ -84,8 +97,14 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
       if (document.visibilityState !== "visible") {
         return
       }
-      void resources.authState.refresh({ silent: true }).catch(() => {})
-      void resources.skillInventory.refresh({ silent: true }).catch(() => {})
+      void resources.authState
+        .refresh({ silent: true })
+        .catch((error: unknown) => reportRendererHandledError("app-data", "silent auth state refresh failed", error))
+      void resources.skillInventory
+        .refresh({ silent: true })
+        .catch((error: unknown) =>
+          reportRendererHandledError("app-data", "silent skill inventory refresh failed", error),
+        )
     }
 
     const sync = () => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 interface ErrorBoundaryProps {
   fallback: React.ReactNode
@@ -19,6 +20,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   componentDidCatch(error: unknown): void {
     console.error("[wanta] render error caught by boundary:", error)
+    reportRendererHandledError("react", "render error caught by boundary", error)
   }
 
   render(): React.ReactNode {

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import type { EffectiveTheme, ThemeContextValue, ThemePreference } from "./theme
 import * as React from "react"
 import { isThemePreference, ThemeContext, themeStorageKey } from "./theme-context.ts"
 import { useSettingsService } from "@/components/AppContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 function readInitialPreference(): ThemePreference {
   const stored = localStorage.getItem(themeStorageKey)
@@ -27,7 +28,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   // 同步 Electron nativeTheme（窗口背景/原生控件随主题）。
   React.useEffect(() => {
-    void settingsService.invoke("setThemeSource", preference).catch(() => {})
+    void settingsService
+      .invoke("setThemeSource", preference)
+      .catch((error: unknown) => reportRendererHandledError("theme", "theme source sync failed", error))
   }, [preference, settingsService])
 
   const effectiveTheme: EffectiveTheme = preference === "system" ? systemTheme : preference

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -65,6 +65,7 @@ import { useProjectGit } from "@/hooks/useProjectGit"
 import { useSessions } from "@/hooks/useSessions"
 import { useT } from "@/i18n/i18n"
 import { appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 import { chatTurnInputKey } from "@/routes/Chat/chat-turns"
@@ -1052,6 +1053,7 @@ export function AppShell() {
 
   const handleShowProjectInFolder = (project: SessionProject): void => {
     void chatService.invoke("showLocalPathInFolder", { path: project.path }).catch((cause: unknown) => {
+      reportRendererHandledError("appShell.showProjectInFolder", "Failed to reveal project folder", cause)
       const notice = resolveUserFacingError(cause, { area: "artifact" })
       toast.error(userFacingErrorDescription(notice, t))
     })
@@ -1162,6 +1164,7 @@ export function AppShell() {
     clearAutoFallbackTitle(sessionId)
     void rename(sessionId, title).catch((cause: unknown) => {
       console.error("[wanta] rename session failed", cause)
+      reportRendererHandledError("appShell.renameSession", "Failed to rename session", cause)
       toast.error(t("session.renameFailed"))
     })
   }

--- a/src/components/app-shell/use-chat-queue-state.ts
+++ b/src/components/app-shell/use-chat-queue-state.ts
@@ -12,6 +12,7 @@ import {
   removeQueuedMessage,
   shouldDispatchQueuedMessage,
 } from "./chat-queue.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 type SendQueuedMessage = (
   text: string,
@@ -164,6 +165,7 @@ export function useChatQueueState({
             : appendQueuedMessage(current, message),
         )
         console.error("[wanta] dispatch queued message failed", cause)
+        reportRendererHandledError("chatQueue.dispatch", "Failed to dispatch queued message", cause)
       })
       .finally(() => {
         dispatchingQueuedSessionsRef.current.delete(activeSessionId)

--- a/src/components/app-shell/use-session-title-generation.ts
+++ b/src/components/app-shell/use-session-title-generation.ts
@@ -13,6 +13,7 @@ import {
   sessionTitleGenerationKey,
   SESSION_TITLE_RETRY_DELAY_MS,
 } from "./app-shell-model.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 interface UseSessionTitleGenerationOptions {
   activeSession?: SessionInfo
@@ -178,6 +179,7 @@ export function useSessionTitleGeneration({
           retryAfter: Date.now() + SESSION_TITLE_RETRY_DELAY_MS,
         })
         console.error("[wanta] generate session title failed", error)
+        reportRendererHandledError("sessionTitle.generate", "Failed to generate session title", error)
       } finally {
         if (titleGenerationInFlightBySession.current.get(sessionId) === generationKey) {
           titleGenerationInFlightBySession.current.delete(sessionId)

--- a/src/components/useSkillObjectActions.ts
+++ b/src/components/useSkillObjectActions.ts
@@ -7,6 +7,7 @@ import { useAppI18n } from "../i18n/index.ts"
 import { resolveUserFacingError, userFacingErrorDescription } from "../lib/user-facing-error.ts"
 import { useSkillService } from "./AppContext.ts"
 import { useHomeSummaryResource, useSkillInventoryResource, useSkillVersionReportResource } from "./AppDataHooks.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 interface UseSkillObjectActionsOptions {
   onDeleted?: (inventory: SkillInventory) => void
@@ -32,7 +33,9 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
   const isRemovingSkillRef = React.useRef(false)
 
   const refreshSkillResources = React.useCallback(async () => {
-    await inventoryResource.refresh({ forceRefresh: true, silent: true, supersede: true }).catch(() => {})
+    await inventoryResource.refresh({ forceRefresh: true, silent: true, supersede: true }).catch((error: unknown) => {
+      reportRendererHandledError("skills", "silent skill inventory refresh failed after action", error)
+    })
   }, [inventoryResource])
 
   const openSkillFolder = React.useCallback(
@@ -40,6 +43,7 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
       try {
         await skillService.invoke("openSkillFolder", { path: pathname })
       } catch (cause) {
+        reportRendererHandledError("skills", "open skill folder failed", cause)
         toast.error(t("skills.openFolderFailed", { error: skillActionErrorMessage(cause, t) }))
       }
     },
@@ -52,6 +56,7 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
         await navigator.clipboard.writeText(pathname)
         toast.success(t("skills.pathCopied"))
       } catch (cause) {
+        reportRendererHandledError("skills", "copy skill path failed", cause)
         toast.error(t("skills.pathCopyFailed", { error: skillActionErrorMessage(cause, t) }))
       }
     },
@@ -83,6 +88,7 @@ export function useSkillObjectActions(options: UseSkillObjectActionsOptions = {}
       setRemoveTarget(null)
       toast.success(t("skills.removeDone", { name: target.skill.name }))
     } catch (cause) {
+      reportRendererHandledError("skills", "remove skill failed", cause)
       toast.error(t("skills.removeFailed", { error: skillActionErrorMessage(cause, t) }))
     } finally {
       isRemovingSkillRef.current = false

--- a/src/hooks/useAppUpdate.ts
+++ b/src/hooks/useAppUpdate.ts
@@ -2,6 +2,7 @@ import type { AppUpdateState, UpdateChannel } from "../../electron/update/common
 
 import * as React from "react"
 import { useUpdateService } from "@/components/AppContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 export interface UseAppUpdate {
   /** null = 初始状态尚未加载。 */
@@ -49,6 +50,26 @@ function getSnapshot(): AppUpdateSnapshot {
   return appUpdateStore.snapshot
 }
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+function patchUpdateError(error: unknown): void {
+  const current = appUpdateStore.snapshot.state
+  if (!current) {
+    return
+  }
+  appUpdateStore.patch({
+    state: {
+      ...current,
+      status: { status: "error", error: errorMessage(error) },
+    },
+  })
+}
+
 export function useAppUpdate(): UseAppUpdate {
   const service = useUpdateService()
   const snapshot = React.useSyncExternalStore(appUpdateStore.subscribe.bind(appUpdateStore), getSnapshot, getSnapshot)
@@ -61,7 +82,11 @@ export function useAppUpdate(): UseAppUpdate {
           appUpdateStore.patch({ state: next })
         }
       },
-      () => undefined,
+      (error: unknown) => {
+        if (!cancelled) {
+          reportRendererHandledError("update", "initial update state load failed", error)
+        }
+      },
     )
     const off = service.serverEvents.on("appUpdateStateChanged", (next) => appUpdateStore.patch({ state: next }))
     return () => {
@@ -80,7 +105,9 @@ export function useAppUpdate(): UseAppUpdate {
     try {
       appUpdateStore.patch({ state: await service.invoke("checkForAppUpdate") })
     } catch (error) {
-      console.error("checkForAppUpdate failed:", error)
+      console.error("[wanta] checkForAppUpdate failed:", error)
+      reportRendererHandledError("update", "update check failed", error)
+      patchUpdateError(error)
     }
   }, [service])
 
@@ -90,9 +117,14 @@ export function useAppUpdate(): UseAppUpdate {
     }
     appUpdateStore.patch({ isDownloadInFlight: true })
     try {
-      // 失败状态经 appUpdateStateChanged 事件回流（status=error），此处吞掉 rejection 防未捕获。
-      await service.invoke("downloadAppUpdate").catch(() => undefined)
-      await refreshState().catch(() => undefined)
+      // 失败状态通常经 appUpdateStateChanged 事件回流（status=error）；这里仍补本地诊断兜底。
+      await service.invoke("downloadAppUpdate").catch((error: unknown) => {
+        reportRendererHandledError("update", "update download failed", error)
+        patchUpdateError(error)
+      })
+      await refreshState().catch((error: unknown) => {
+        reportRendererHandledError("update", "update state refresh after download failed", error)
+      })
     } finally {
       appUpdateStore.patch({ isDownloadInFlight: false })
     }
@@ -106,7 +138,9 @@ export function useAppUpdate(): UseAppUpdate {
         await download()
       }
     } catch (error) {
-      console.error("checkForAppUpdate failed:", error)
+      console.error("[wanta] checkForAppUpdate failed:", error)
+      reportRendererHandledError("update", "update check-and-download failed", error)
+      patchUpdateError(error)
     }
   }, [download, service])
 
@@ -117,7 +151,9 @@ export function useAppUpdate(): UseAppUpdate {
     appUpdateStore.patch({ isInstallTriggered: true })
     await service.invoke("installDownloadedAppUpdate").catch((error: unknown) => {
       appUpdateStore.patch({ isInstallTriggered: false })
-      console.error("installDownloadedAppUpdate failed:", error)
+      console.error("[wanta] installDownloadedAppUpdate failed:", error)
+      reportRendererHandledError("update", "update install failed", error)
+      patchUpdateError(error)
     })
   }, [service])
 
@@ -127,7 +163,9 @@ export function useAppUpdate(): UseAppUpdate {
         appUpdateStore.patch({ state: await service.invoke("setUpdateChannel", channel) })
       } catch (error) {
         // 主进程持久化失败等：渠道未切换，按钮选中态保持原渠道即是反馈。
-        console.error("setUpdateChannel failed:", error)
+        console.error("[wanta] setUpdateChannel failed:", error)
+        reportRendererHandledError("update", "update channel change failed", error)
+        patchUpdateError(error)
       }
     },
     [service],

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import type { UserFacingError } from "../lib/user-facing-error.ts"
 import * as React from "react"
 import { useAuthService } from "../components/AppContext.ts"
 import { resolveUserFacingError } from "../lib/user-facing-error.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 export interface UseAuth {
   /** null = 初始状态尚未加载（避免登录页闪烁）。 */
@@ -33,6 +34,7 @@ export function useAuth(): UseAuth {
       },
       (err) => {
         if (!cancelled) {
+          reportRendererHandledError("auth", "initial auth state load failed", err)
           setError(resolveUserFacingError(err, { area: "auth" }))
         }
       },
@@ -55,6 +57,7 @@ export function useAuth(): UseAuth {
       // resolve 于浏览器 deep-link 回调完成（或超时 reject）。
       setState(await service.invoke("login"))
     } catch (err) {
+      reportRendererHandledError("auth", "login failed", err)
       setError(resolveUserFacingError(err, { area: "auth" }))
     } finally {
       loginInFlight.current = false
@@ -68,6 +71,7 @@ export function useAuth(): UseAuth {
     try {
       setState(await service.invoke("logout"))
     } catch (err) {
+      reportRendererHandledError("auth", "logout failed", err)
       setError(resolveUserFacingError(err, { area: "auth" }))
     } finally {
       setLoggingOut(false)

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -41,6 +41,7 @@ import {
   visibleChatError,
 } from "./chat-message-state.ts"
 import { useChatService } from "@/components/AppContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 type MessagesMap = Record<string, ChatMessage[]>
 type CancelledToolPartsMap = Map<string, Set<string>>
@@ -417,6 +418,7 @@ export function useChat(activeSessionId: string | null, visibleSessionId: string
         }))
       } catch (err) {
         console.error("[wanta] getMessages failed", err)
+        reportRendererHandledError("chat", "getMessages failed", err)
       }
     },
     [chatService, flushPendingToolParts, isSessionUserStopped, rememberCancelledToolParts],
@@ -592,6 +594,7 @@ export function useChat(activeSessionId: string | null, visibleSessionId: string
           reasoningLevel: options.reasoningLevel,
         })
       } catch (err) {
+        reportRendererHandledError("chat", "sendMessage invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
         clearSessionError(sessionId)
@@ -618,6 +621,7 @@ export function useChat(activeSessionId: string | null, visibleSessionId: string
         setStatus(sessionId, "ready")
         setActivity(sessionId, undefined)
       } catch (err) {
+        reportRendererHandledError("chat", "stopGeneration invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
         setSessionError(sessionId, String(err))

--- a/src/hooks/useOrganizationSkills.ts
+++ b/src/hooks/useOrganizationSkills.ts
@@ -18,6 +18,7 @@ import {
   reorderOrganizationSkills,
   updateOrganizationSkill,
 } from "@/lib/organization-skills-client"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError } from "@/lib/user-facing-error"
 
 export interface OrganizationSkillChatContext {
@@ -170,7 +171,9 @@ export function useOrganizationSkills(workspace: WorkspaceSelection): UseOrganiz
   )
 
   React.useEffect(() => {
-    void refresh().catch(() => undefined)
+    void refresh().catch((error: unknown) => {
+      reportRendererHandledError("organization-skills", "organization skills refresh failed", error)
+    })
   }, [refresh])
 
   const reloadAfterMutation = React.useCallback(

--- a/src/hooks/useOrganizationWorkspace.ts
+++ b/src/hooks/useOrganizationWorkspace.ts
@@ -8,6 +8,7 @@ import { dropCachedAvatarImage } from "../lib/avatar-image-cache.ts"
 import { applyOrganizationPatchesToOverview, upsertOverviewOrganization } from "../lib/organization-overview.ts"
 import { organizationCanManage, organizationRole } from "../lib/organization-permissions.ts"
 import { getOrganizationOverview } from "../lib/organizations-client.ts"
+import { reportRendererHandledError } from "../lib/renderer-diagnostics.ts"
 import { resolveUserFacingError } from "../lib/user-facing-error.ts"
 
 export { organizationAvatarStyle, organizationInitials, organizationAvatarPalette } from "../lib/organization-avatar.ts"
@@ -200,7 +201,9 @@ function readCachedWorkspaceOverview(
         workspaceOverviewInFlight = null
       }
     })
-    .catch(() => undefined)
+    .catch((error: unknown) => {
+      reportRendererHandledError("organization-workspace", "organization overview request failed", error)
+    })
   return promise
 }
 

--- a/src/hooks/useProjectGit.ts
+++ b/src/hooks/useProjectGit.ts
@@ -4,6 +4,7 @@ import type { UserFacingError } from "@/lib/user-facing-error"
 
 import * as React from "react"
 import { useGitService } from "@/components/AppContext"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError } from "@/lib/user-facing-error"
 
 export interface UseProjectGit {
@@ -41,6 +42,7 @@ export function useProjectGit(project: SessionProject | undefined): UseProjectGi
       }
       return next
     } catch (cause) {
+      reportRendererHandledError("git", "repository state refresh failed", cause)
       if (requestId === requestSequence.current) {
         setError(resolveUserFacingError(cause, { area: "session" }))
         setState(null)
@@ -72,6 +74,7 @@ export function useProjectGit(project: SessionProject | undefined): UseProjectGi
         }
         return next
       } catch (cause) {
+        reportRendererHandledError("git", "branch checkout failed", cause)
         if (requestId === requestSequence.current) {
           setError(resolveUserFacingError(cause, { area: "session" }))
         }
@@ -100,6 +103,7 @@ export function useProjectGit(project: SessionProject | undefined): UseProjectGi
         }
         return next
       } catch (cause) {
+        reportRendererHandledError("git", "branch create and checkout failed", cause)
         if (requestId === requestSequence.current) {
           setError(resolveUserFacingError(cause, { area: "session" }))
         }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -11,6 +11,7 @@ import type { UserFacingError } from "../lib/user-facing-error.ts"
 import * as React from "react"
 import { useSessionService } from "../components/AppContext.ts"
 import { resolveUserFacingError } from "../lib/user-facing-error.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 const personalSessionScope: SessionScope = { type: "personal" }
 
@@ -137,6 +138,7 @@ export function useSessions({ enabled = true, scope }: { enabled?: boolean; scop
       setError(null)
     } catch (error) {
       console.error("[wanta] list sessions failed", error)
+      reportRendererHandledError("session", "list sessions failed", error)
       if (requestId === requestSequenceRef.current && enabledRef.current) {
         setError(resolveUserFacingError(error, { area: "session" }))
       }

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -17,6 +17,7 @@ import type {
 
 import { consoleBaseUrl, consoleServerBaseUrl, insightBaseUrl } from "@/lib/domain"
 import { authRequiredMessage, oomolFetchJson } from "@/lib/oomol-http"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 // 额度中心的全部网络读取与结账 URL 解析在渲染层直接发起：原先这些是渲染业务驱动、却由主进程
 // BillingClient 代发的请求。凭证经 httpOnly 会话 cookie 自动附带（oomolFetchJson 内 credentials:"include"），
@@ -389,7 +390,14 @@ function unwrapApiData<T>(payload: unknown): T {
 function logSettledFailure(label: string, result: PromiseSettledResult<unknown>): void {
   if (result.status === "rejected") {
     console.warn("[wanta] billing overview request failed", { label, error: errorMessage(result.reason) })
+    reportRendererHandledError("billingClient.request", `Billing overview request failed: ${label}`, result.reason)
   }
+}
+
+function preventEarlyUnhandledRejection(promise: Promise<unknown>): void {
+  void promise.catch(() => {
+    // 调用方稍后会通过 allSettled/settleWithSoftTimeout 统一记录和降级。
+  })
 }
 
 function settleWithSoftTimeout<T>(
@@ -543,7 +551,7 @@ async function getWantaPendingPayment(): Promise<WantaPendingPaymentResult | nul
 
 export async function getBillingSummary(days: number): Promise<BillingSummaryResult> {
   const subscriptionPromise = getSubscriptionStatus()
-  void subscriptionPromise.catch(() => undefined)
+  preventEarlyUnhandledRejection(subscriptionPromise)
   const [balance, spend, metering] = await Promise.allSettled([
     getAllCreditUsages(),
     getCreditSpendStats(days),
@@ -583,10 +591,10 @@ export async function getBillingOverview(days: number): Promise<BillingOverviewR
   const schedulesPromise = getSubscriptionSchedules()
   const wantaPendingPaymentPromise = getWantaPendingPayment()
 
-  void logsPromise.catch(() => undefined)
-  void subscriptionPromise.catch(() => undefined)
-  void schedulesPromise.catch(() => undefined)
-  void wantaPendingPaymentPromise.catch(() => undefined)
+  preventEarlyUnhandledRejection(logsPromise)
+  preventEarlyUnhandledRejection(subscriptionPromise)
+  preventEarlyUnhandledRejection(schedulesPromise)
+  preventEarlyUnhandledRejection(wantaPendingPaymentPromise)
 
   const [balance, spend, metering] = await Promise.allSettled([balancePromise, spendPromise, meteringPromise])
   const [logs, subscription, schedules, wantaPendingPayment] = await Promise.all([

--- a/src/lib/renderer-diagnostics.ts
+++ b/src/lib/renderer-diagnostics.ts
@@ -1,0 +1,38 @@
+type RendererReportSource = "error" | "handled" | "unhandledrejection"
+
+export function reportRendererHandledError(scope: string, message: string, cause: unknown): void {
+  reportRendererIssue("handled", scope, message, cause)
+}
+
+export function reportRendererIssue(
+  source: RendererReportSource,
+  scope: string,
+  message: string,
+  cause: unknown,
+): void {
+  const normalized = normalizeRendererCause(cause)
+  globalThis.wanta?.reportRendererError({
+    source,
+    scope,
+    message: `${message}: ${normalized.message}`,
+    ...(normalized.stack ? { stack: normalized.stack } : {}),
+  })
+}
+
+function normalizeRendererCause(cause: unknown): { message: string; stack?: string } {
+  if (cause instanceof Error) {
+    return {
+      message: cause.message || cause.name,
+      ...(cause.stack ? { stack: cause.stack } : {}),
+    }
+  }
+  if (cause && typeof cause === "object" && typeof (cause as { message?: unknown }).message === "string") {
+    return {
+      message: (cause as { message: string }).message,
+      ...(typeof (cause as { stack?: unknown }).stack === "string"
+        ? { stack: (cause as { stack: string }).stack }
+        : {}),
+    }
+  }
+  return { message: String(cause) }
+}

--- a/src/lib/skills-catalog-client.ts
+++ b/src/lib/skills-catalog-client.ts
@@ -7,6 +7,7 @@ import type {
 import { normalizePublicSkillPackageCatalog, normalizeRegistrySkillPackageInfo } from "../../electron/skills/actions.ts"
 import { registryBaseUrl, searchBaseUrl } from "@/lib/domain"
 import { oomolFetch } from "@/lib/oomol-http"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolvePackageAssetIconSource } from "@/lib/skill-icon-assets.ts"
 
 // 技能 Discover 标签的注册表浏览/搜索请求在渲染层直接发起：原先这些是渲染业务驱动、却由主进程
@@ -253,6 +254,11 @@ export async function listMyPublishedSkillPackages(
           packageInfo = await readRegistrySkillPackageInfo(publishedPackage.name, maintainer)
         } catch (error) {
           console.warn("[wanta] failed to read my published skill package info:", error)
+          reportRendererHandledError(
+            "skillsCatalog.readMyPublishedPackageInfo",
+            "Failed to read published Skill package info",
+            error,
+          )
           packageInfo = undefined
         }
         return mergeMyPublishedPackage(publishedPackage, packageInfo)
@@ -383,6 +389,11 @@ async function enrichPublicSkillSearchGroup(group: PublicSkillSearchGroup): Prom
     packageInfo = await readRegistrySkillPackageInfo(group.packageName, group.maintainer, { version: group.version })
   } catch (error) {
     console.warn("[wanta] failed to read searched skill package info:", error)
+    reportRendererHandledError(
+      "skillsCatalog.readSearchedPackageInfo",
+      "Failed to read searched Skill package info",
+      error,
+    )
     packageInfo = undefined
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,9 +11,11 @@ import { SkillService } from "../electron/skills/common.ts"
 import { UpdateService } from "../electron/update/common.ts"
 import { App } from "@/App"
 import { AppContext } from "@/components/AppContext"
+import { reportRendererIssue } from "@/lib/renderer-diagnostics"
 
 import "./index.css"
 
+const electronConnectionBridgeName = "oomol-connection-electron-bridge"
 const rootElement = document.querySelector("#root")
 if (!rootElement) {
   throw new Error("Wanta: missing #root mount node")
@@ -21,32 +23,66 @@ if (!rootElement) {
 
 document.documentElement.dataset.platform = globalThis.wanta?.platform ?? "browser"
 document.documentElement.dataset.window = "main"
+installRendererErrorReporting()
 
-const client = new ConnectionClient(new ElectronClientAdapter())
-client.start()
+if (!hasElectronConnectionBridge()) {
+  const error = new Error("Wanta: missing Electron connection bridge")
+  reportRendererIssue("handled", "startup.connectionBridge", error.message, error)
+  renderStartupError(rootElement, error.message)
+} else {
+  const client = new ConnectionClient(new ElectronClientAdapter())
+  client.start()
 
-const chatService = client.use(ChatService)
-const gitService = client.use(GitService)
-const sessionService = client.use(SessionService)
-const skillService = client.use(SkillService)
-const modelsService = client.use(ModelsService)
-const settingsService = client.use(SettingsService)
-const authService = client.use(AuthService)
-const updateService = client.use(UpdateService)
+  const chatService = client.use(ChatService)
+  const gitService = client.use(GitService)
+  const sessionService = client.use(SessionService)
+  const skillService = client.use(SkillService)
+  const modelsService = client.use(ModelsService)
+  const settingsService = client.use(SettingsService)
+  const authService = client.use(AuthService)
+  const updateService = client.use(UpdateService)
 
-createRoot(rootElement).render(
-  <AppContext.Provider
-    value={{
-      chatService,
-      gitService,
-      sessionService,
-      skillService,
-      modelsService,
-      settingsService,
-      authService,
-      updateService,
-    }}
-  >
-    <App />
-  </AppContext.Provider>,
-)
+  createRoot(rootElement).render(
+    <AppContext.Provider
+      value={{
+        chatService,
+        gitService,
+        sessionService,
+        skillService,
+        modelsService,
+        settingsService,
+        authService,
+        updateService,
+      }}
+    >
+      <App />
+    </AppContext.Provider>,
+  )
+}
+
+function hasElectronConnectionBridge(): boolean {
+  return Boolean((globalThis as Record<string, unknown>)[electronConnectionBridgeName])
+}
+
+function renderStartupError(container: Element, message: string): void {
+  createRoot(container).render(
+    <main className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+      <div className="max-w-md space-y-2 text-center">
+        <h1 className="text-base font-medium">Wanta failed to start</h1>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+    </main>,
+  )
+}
+
+function installRendererErrorReporting(): void {
+  const report = (source: "error" | "unhandledrejection", cause: unknown): void => {
+    reportRendererIssue(source, "global", "renderer global error", cause)
+  }
+  window.addEventListener("error", (event) => {
+    report("error", event.error ?? event.message)
+  })
+  window.addEventListener("unhandledrejection", (event) => {
+    report("unhandledrejection", event.reason)
+  })
+}

--- a/src/routes/Archived/index.tsx
+++ b/src/routes/Archived/index.tsx
@@ -40,6 +40,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useI18n } from "@/i18n/i18n"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 
@@ -97,6 +98,7 @@ export function ArchivedRoute({
       setError(null)
     } catch (cause) {
       console.error("[wanta] list archived sessions failed", cause)
+      reportRendererHandledError("archived.refresh", "Failed to refresh archived sessions", cause)
       setError(resolveUserFacingError(cause, { area: "session" }))
     } finally {
       setLoaded(true)
@@ -120,6 +122,7 @@ export function ArchivedRoute({
       .catch((cause: unknown) => {
         if (!cancelled) {
           console.error("[wanta] list archived sessions failed", cause)
+          reportRendererHandledError("archived.initialLoad", "Failed to load archived sessions", cause)
           setError(resolveUserFacingError(cause, { area: "session" }))
         }
       })

--- a/src/routes/Chat/AddCustomModelDialog.tsx
+++ b/src/routes/Chat/AddCustomModelDialog.tsx
@@ -18,6 +18,7 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useT } from "@/i18n/i18n"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 type ApiEndpointSource = Pick<CustomModelProvider | CustomModelApiPlan, "apiRegions" | "baseUrl">
 
@@ -290,7 +291,9 @@ export function AddCustomModelDialog({
                 maxOutputTokens: optionalTokenLimit(maxOutputTokens),
                 reasoningVariants,
               })
-                .catch(() => undefined)
+                .catch((error: unknown) => {
+                  reportRendererHandledError("model", "custom model save failed", error)
+                })
                 .finally(() => setSaving(false))
             }}
           >

--- a/src/routes/Chat/ChatAttachments.tsx
+++ b/src/routes/Chat/ChatAttachments.tsx
@@ -16,6 +16,7 @@ import { fileVisualKind } from "./file-type-kind.ts"
 import { ImageViewerModal } from "@/components/ai-elements/message-image"
 import { useChatService } from "@/components/AppContext"
 import { useT } from "@/i18n/i18n"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 
@@ -85,7 +86,9 @@ function AttachmentImageCard({
         setAttachmentPreviewUrl(attachmentPath, result.dataUrl)
         setPreviewUrl(result.dataUrl)
       })
-      .catch(() => undefined)
+      .catch((error: unknown) => {
+        reportRendererHandledError("chat", "attachment preview load failed", error)
+      })
     return () => {
       cancelled = true
     }
@@ -157,6 +160,7 @@ export function AttachmentList({
         return
       }
       void chatService.invoke("showLocalPathInFolder", { path: attachment.path }).catch((cause: unknown) => {
+        reportRendererHandledError("chatAttachments.showInFolder", "Failed to reveal attachment", cause)
         const error = resolveUserFacingError(cause, { area: "artifact" })
         toast.error(userFacingErrorDescription(error, t))
       })

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -33,6 +33,7 @@ import { FileKindIcon, FileKindTile } from "./file-type-icons.tsx"
 import { useChatService } from "@/components/AppContext"
 import { Badge } from "@/components/ui/badge"
 import { useT } from "@/i18n/i18n"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 
@@ -117,6 +118,7 @@ function useArtifactFileActions(): {
         return
       }
       void chatService.invoke("openLocalPath", { path: filePath }).catch((cause: unknown) => {
+        reportRendererHandledError("generatedArtifacts.openPath", "Failed to open artifact file", cause)
         const error = resolveUserFacingError(cause, { area: "artifact" })
         toast.error(userFacingErrorDescription(error, t))
       })
@@ -130,6 +132,7 @@ function useArtifactFileActions(): {
         return
       }
       void chatService.invoke("showLocalPathInFolder", { path: filePath }).catch((cause: unknown) => {
+        reportRendererHandledError("generatedArtifacts.showInFolder", "Failed to reveal artifact file", cause)
         const error = resolveUserFacingError(cause, { area: "artifact" })
         toast.error(userFacingErrorDescription(error, t))
       })
@@ -436,6 +439,7 @@ export function GeneratedArtifacts({ sources, onOpen, onAvailable }: GeneratedAr
       })
       .catch((error: unknown) => {
         console.warn("[wanta] failed to resolve generated artifacts", { error })
+        reportRendererHandledError("generatedArtifacts.resolve", "Failed to resolve generated artifacts", error)
         if (!cancelled) {
           setGroups([])
         }

--- a/src/routes/Chat/TurnOutputs.tsx
+++ b/src/routes/Chat/TurnOutputs.tsx
@@ -28,6 +28,7 @@ import { toast } from "sonner"
 import { useChatService } from "@/components/AppContext"
 import { useT } from "@/i18n/i18n"
 import { writeClipboardText } from "@/lib/clipboard"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 import { FileKindTile } from "@/routes/Chat/file-type-icons"
@@ -251,6 +252,9 @@ function useTurnFileDiff(
           setDiff(result)
         }
       })
+      .catch((error: unknown) => {
+        reportRendererHandledError("turnOutputs.loadDiff", "Failed to load turn file diff", error)
+      })
     return () => {
       cancelled = true
     }
@@ -272,6 +276,7 @@ function useTurnFileActions(): {
           return
         }
         void chatService.invoke("openLocalPath", { path: filePath }).catch((cause: unknown) => {
+          reportRendererHandledError("turnOutputs.openPath", "Failed to open turn output file", cause)
           const error = resolveUserFacingError(cause, { area: "artifact" })
           toast.error(userFacingErrorDescription(error, t))
         })
@@ -281,6 +286,7 @@ function useTurnFileActions(): {
           return
         }
         void chatService.invoke("showLocalPathInFolder", { path: filePath }).catch((cause: unknown) => {
+          reportRendererHandledError("turnOutputs.showInFolder", "Failed to reveal turn output file", cause)
           const error = resolveUserFacingError(cause, { area: "artifact" })
           toast.error(userFacingErrorDescription(error, t))
         })

--- a/src/routes/Chat/useVoiceRecorder.ts
+++ b/src/routes/Chat/useVoiceRecorder.ts
@@ -3,6 +3,7 @@ import type { RecordedWav } from "./voice-wav.ts"
 import * as React from "react"
 import voiceRecorderWorkletUrl from "./voice-recorder-worklet.ts?worker&url"
 import { encodePcm16Wav } from "./voice-wav.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 const barIntervalMs = 50
 const durationIntervalMs = 125
@@ -57,7 +58,9 @@ export function useVoiceRecorder(): VoiceRecorderControls {
     runtime.silentGain.disconnect()
     runtime.source.disconnect()
     runtime.stream.getTracks().forEach((track) => track.stop())
-    void runtime.context.close().catch(() => undefined)
+    void runtime.context.close().catch((error: unknown) => {
+      reportRendererHandledError("voice", "audio context close failed", error)
+    })
   }, [])
 
   const start = React.useCallback(async () => {

--- a/src/routes/Skills/OrganizationSkillManageDialog.tsx
+++ b/src/routes/Skills/OrganizationSkillManageDialog.tsx
@@ -35,6 +35,7 @@ import { Dialog } from "@/components/ui/dialog"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAppI18n } from "@/i18n"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import {
   listPublicSkillPackages,
   readPublicSkillPackageByName,
@@ -208,7 +209,9 @@ export function OrganizationSkillManageDialog({
     }
 
     const load = () => {
-      void loadMarketPackages({ clearItems: true, forceRefresh: true, query: marketQuery }).catch(() => undefined)
+      void loadMarketPackages({ clearItems: true, forceRefresh: true, query: marketQuery }).catch((error: unknown) => {
+        reportRendererHandledError("organization-skills", "market package load failed", error)
+      })
     }
 
     if (!marketQuery) {
@@ -239,7 +242,9 @@ export function OrganizationSkillManageDialog({
             setMarketExactPackage(pkg)
           }
         })
-        .catch(() => undefined)
+        .catch((error: unknown) => {
+          reportRendererHandledError("organization-skills", "exact market package lookup failed", error)
+        })
         .finally(() => {
           if (marketExactRequestIdRef.current === requestId) {
             setMarketExactLoading(false)

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -56,6 +56,7 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { useSkillObjectActions } from "@/components/useSkillObjectActions"
 import { useAppI18n } from "@/i18n"
 import { addOrganizationSkill } from "@/lib/organization-skills-client"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { listMyPublishedSkillPackages, listPublicSkillPackages } from "@/lib/skills-catalog-client"
 import { resolveUserFacingError } from "@/lib/user-facing-error"
 
@@ -234,7 +235,9 @@ export function SkillsRoute({
     }
 
     requestedVersionCheckRef.current = true
-    void versionResource.refresh({ silent: true }).catch(() => {})
+    void versionResource
+      .refresh({ silent: true })
+      .catch((error: unknown) => reportRendererHandledError("skills", "silent skill version refresh failed", error))
   }, [versionResource])
 
   React.useEffect(() => {
@@ -325,7 +328,9 @@ export function SkillsRoute({
       return
     }
 
-    void loadPublicSkillPackages().catch(() => undefined)
+    void loadPublicSkillPackages().catch((error: unknown) => {
+      reportRendererHandledError("skills", "public skill package load failed", error)
+    })
   }, [
     activeTab,
     discoveryFilter,
@@ -345,7 +350,9 @@ export function SkillsRoute({
       return
     }
 
-    void loadMyPublishedSkillPackages().catch(() => undefined)
+    void loadMyPublishedSkillPackages().catch((error: unknown) => {
+      reportRendererHandledError("skills", "published skill package load failed", error)
+    })
   }, [
     activeTab,
     authResource.data?.status,
@@ -648,12 +655,20 @@ export function SkillsRoute({
           visibility: options.visibility,
         })
         inventoryResource.setData(result.inventory)
-        await versionResource.refresh({ forceRefresh: true, silent: true }).catch(() => {})
+        await versionResource
+          .refresh({ forceRefresh: true, silent: true })
+          .catch((error: unknown) =>
+            reportRendererHandledError("skills", "silent skill version refresh failed after publish", error),
+          )
         homeSummaryResource.invalidate()
         toast.success(t("skills.publishDone", { name: skill.name }))
-        void loadMyPublishedSkillPackages({ forceRefresh: true }).catch(() => undefined)
+        void loadMyPublishedSkillPackages({ forceRefresh: true }).catch((error: unknown) => {
+          reportRendererHandledError("skills", "published skill package refresh failed after publish", error)
+        })
         if (publicPackageCatalog.items.length > 0) {
-          void loadPublicSkillPackages({ forceRefresh: true }).catch(() => undefined)
+          void loadPublicSkillPackages({ forceRefresh: true }).catch((error: unknown) => {
+            reportRendererHandledError("skills", "public skill package refresh failed after publish", error)
+          })
         }
         return result
       } catch (cause) {

--- a/src/routes/Skills/provider-skill-package-lookup.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.ts
@@ -4,6 +4,7 @@ import type { ProviderSkillCandidate } from "./provider-skill-recommendations.ts
 
 import * as React from "react"
 import { getConnectedProviderSkillCandidates } from "./provider-skill-recommendations.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { readPublicSkillPackageByName } from "@/lib/skills-catalog-client"
 
 const providerSkillPackageCacheMs = 30_000
@@ -78,6 +79,11 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
           next.set(candidate.service, pkg)
         } catch (cause) {
           console.warn("[wanta] failed to read provider Skill recommendation:", cause)
+          reportRendererHandledError(
+            "providerSkillPackageLookup.readPackage",
+            "Failed to read provider Skill recommendation",
+            cause,
+          )
           firstFailure ??= cause
           next.set(candidate.service, null)
         }


### PR DESCRIPTION
## Summary

This PR improves error visibility across the Electron main process and renderer. Several failures that were previously logged only to the console, swallowed by best-effort catch blocks, or downgraded silently now flow into the diagnostics log with structured context.

## Problem

Main-process failures were hard to diagnose because process-level exceptions, sidecar failures, renderer crashes, failed IPC emissions, store read failures, and some background promise rejections did not consistently reach a persistent log. In the renderer, many handled failures only showed a toast or console message, while global render/runtime failures did not have a bridge back to the main-process diagnostics path.

## Changes

- Extend diagnostics logging with error-level entries and Error serialization including message, stack, name, and cause.
- Install main-process handlers for uncaught exceptions, unhandled rejections, warnings, child process exits, renderer process exits, load failures, and window unresponsiveness.
- Add structured diagnostics for OpenCode sidecar startup/runtime output, event stream handling, service broadcasts, update checks, protocol handling, auth flows, model/session emissions, skill file operations, preview failures, operation history writes, and persisted store read failures.
- Add a renderer diagnostics bridge via preload, global renderer error/unhandled-rejection reporting, a root React error boundary, and a startup fallback for a missing Electron connection bridge.
- Report handled renderer failures from chat, update, auth, session, project, skill, billing, artifact, attachment, and voice-recorder flows without changing their user-facing fallback behavior.

## Validation

- npm run ts-check
- npm run lint
- npm run format
- npm test
