### PR TITLE
Improve voice recorder readiness and member sheet layout

### DIFF
--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -283,6 +283,7 @@ export const enMessages = {
   "chat.likeMessage": "Good response",
   "chat.dislikeMessage": "Bad response",
   "chat.voiceInput": "Voice input",
+  "chat.voiceStarting": "Preparing microphone",
   "chat.voiceStop": "Stop voice input",
   "chat.voiceCancel": "Cancel voice input",
   "chat.voiceRetry": "Retry voice recognition",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -271,6 +271,7 @@ export const zhCNMessages = {
   "chat.likeMessage": "赞",
   "chat.dislikeMessage": "踩",
   "chat.voiceInput": "语音输入",
+  "chat.voiceStarting": "正在准备麦克风",
   "chat.voiceStop": "停止语音输入",
   "chat.voiceCancel": "取消语音输入",
   "chat.voiceRetry": "重试语音识别",

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -649,6 +649,7 @@ export function ChatComposer({
           voiceError={voiceInput.error}
           voiceRecorderError={voiceInput.recorderError}
           voiceRetryBlob={voiceInput.retryBlob}
+          voiceStarting={voiceInput.starting}
           voiceTranscribing={voiceInput.transcribing}
           onAddModel={modelCatalogState.openDialog}
           onCancelVoice={voiceInput.cancel}

--- a/src/routes/Chat/ComposerTrailingControls.tsx
+++ b/src/routes/Chat/ComposerTrailingControls.tsx
@@ -32,6 +32,7 @@ interface ComposerTrailingControlsProps {
   voiceError: string | null
   voiceRecorderError?: string
   voiceRetryBlob: Blob | null
+  voiceStarting: boolean
   voiceTranscribing: boolean
   onAddModel: () => void
   onCancelVoice: () => void
@@ -304,11 +305,27 @@ function ContextUsageIndicator({ usage }: { usage: ContextUsageInfo | null }) {
   )
 }
 
-function VoiceRecorderPanel({ bars, durationMs }: { bars: readonly number[]; durationMs: number }) {
+function VoiceRecorderPanel({
+  bars,
+  durationMs,
+  loading,
+}: {
+  bars: readonly number[]
+  durationMs: number
+  loading: boolean
+}) {
+  const t = useT()
   return (
     <div className="flex min-w-0 flex-1 items-center gap-3">
       <div className="flex h-8 min-w-0 flex-1 items-center justify-center overflow-hidden">
-        <VoiceWaveCanvas bars={bars} height={32} />
+        {loading ? (
+          <div className="oo-text-control flex min-w-0 items-center gap-2 text-muted-foreground">
+            <Loader2 className="size-4 shrink-0 animate-spin" />
+            <span className="truncate">{t("chat.voiceStarting")}</span>
+          </div>
+        ) : (
+          <VoiceWaveCanvas bars={bars} height={32} />
+        )}
       </div>
       <span className="oo-text-control min-w-9 shrink-0 text-right font-normal text-muted-foreground tabular-nums">
         {voiceDurationLabel(durationMs)}
@@ -333,6 +350,7 @@ export function ComposerTrailingControls({
   voiceError,
   voiceRecorderError,
   voiceRetryBlob,
+  voiceStarting,
   voiceTranscribing,
   onAddModel,
   onCancelVoice,
@@ -347,14 +365,16 @@ export function ComposerTrailingControls({
 }: ComposerTrailingControlsProps) {
   const t = useT()
   const visibleVoiceError = voiceError ?? voiceRecorderError
-  const voiceMode = composerVoiceControlMode({ voiceActive, voiceTranscribing, visibleVoiceError })
+  const voiceMode = composerVoiceControlMode({ voiceActive, voiceStarting, voiceTranscribing, visibleVoiceError })
   const submit = composerSubmitState({ canSubmit, initialSendPending, isGenerating, status })
   const retryDisabled = !voiceRetryBlob || voiceTranscribing
   const stopLabel = labelWithShortcut(t("aria.stop"), appCommandShortcutLabel(APP_COMMANDS.stopGeneration))
 
   return (
     <>
-      {voiceActive ? <VoiceRecorderPanel bars={voiceBars} durationMs={voiceDurationMs} /> : null}
+      {voiceActive ? (
+        <VoiceRecorderPanel bars={voiceBars} durationMs={voiceDurationMs} loading={voiceMode === "starting"} />
+      ) : null}
       <div className={cn("flex min-w-0 items-center justify-end gap-1", voiceActive ? "shrink-0" : "flex-1")}>
         {voiceActive ? (
           <>
@@ -371,7 +391,7 @@ export function ComposerTrailingControls({
               >
                 <RotateCcw className="size-4" />
               </Button>
-            ) : voiceMode === "transcribing" ? (
+            ) : voiceMode === "starting" || voiceMode === "transcribing" ? (
               <Button
                 type="button"
                 variant="ghost"

--- a/src/routes/Chat/composer-controls.test.ts
+++ b/src/routes/Chat/composer-controls.test.ts
@@ -3,15 +3,34 @@ import { composerSubmitState, composerVoiceControlMode } from "./composer-contro
 
 describe("composer controls", () => {
   it("selects the voice control mode from active and error state", () => {
-    expect(composerVoiceControlMode({ voiceActive: false, voiceTranscribing: false })).toBe("idle")
-    expect(
-      composerVoiceControlMode({ voiceActive: false, voiceTranscribing: false, visibleVoiceError: "No mic" }),
-    ).toBe("idle-error")
-    expect(composerVoiceControlMode({ voiceActive: true, voiceTranscribing: false })).toBe("recording")
-    expect(composerVoiceControlMode({ voiceActive: true, voiceTranscribing: false, visibleVoiceError: "Failed" })).toBe(
-      "recording-error",
+    expect(composerVoiceControlMode({ voiceActive: false, voiceStarting: false, voiceTranscribing: false })).toBe(
+      "idle",
     )
-    expect(composerVoiceControlMode({ voiceActive: true, voiceTranscribing: true })).toBe("transcribing")
+    expect(
+      composerVoiceControlMode({
+        voiceActive: false,
+        voiceStarting: false,
+        voiceTranscribing: false,
+        visibleVoiceError: "No mic",
+      }),
+    ).toBe("idle-error")
+    expect(composerVoiceControlMode({ voiceActive: true, voiceStarting: true, voiceTranscribing: false })).toBe(
+      "starting",
+    )
+    expect(composerVoiceControlMode({ voiceActive: true, voiceStarting: false, voiceTranscribing: false })).toBe(
+      "recording",
+    )
+    expect(
+      composerVoiceControlMode({
+        voiceActive: true,
+        voiceStarting: false,
+        voiceTranscribing: false,
+        visibleVoiceError: "Failed",
+      }),
+    ).toBe("recording-error")
+    expect(composerVoiceControlMode({ voiceActive: true, voiceStarting: true, voiceTranscribing: true })).toBe(
+      "transcribing",
+    )
   })
 
   it("keeps streaming submit clickable as an explicit stop control", () => {

--- a/src/routes/Chat/composer-controls.ts
+++ b/src/routes/Chat/composer-controls.ts
@@ -1,6 +1,12 @@
 import type { ChatStatus } from "ai"
 
-export type ComposerVoiceControlMode = "idle" | "idle-error" | "recording" | "recording-error" | "transcribing"
+export type ComposerVoiceControlMode =
+  | "idle"
+  | "idle-error"
+  | "recording"
+  | "recording-error"
+  | "starting"
+  | "transcribing"
 export type ComposerSubmitAria = "send" | "sending" | "stop"
 
 export interface ComposerSubmitState {
@@ -12,18 +18,23 @@ export interface ComposerSubmitState {
 
 export function composerVoiceControlMode({
   voiceActive,
+  voiceStarting,
   voiceTranscribing,
   visibleVoiceError,
 }: {
   voiceActive: boolean
+  voiceStarting: boolean
   voiceTranscribing: boolean
   visibleVoiceError?: string | null
 }): ComposerVoiceControlMode {
-  if (voiceActive && visibleVoiceError) {
-    return "recording-error"
-  }
   if (voiceTranscribing) {
     return "transcribing"
+  }
+  if (voiceStarting) {
+    return "starting"
+  }
+  if (voiceActive && visibleVoiceError) {
+    return "recording-error"
   }
   if (voiceActive) {
     return "recording"

--- a/src/routes/Chat/useVoiceComposerInput.ts
+++ b/src/routes/Chat/useVoiceComposerInput.ts
@@ -79,7 +79,7 @@ export function useVoiceComposerInput(onTranscription: (text: string) => void) {
     }
   }, [retryBlob, transcribeBlob])
 
-  const busy = recorder.isRecording || transcribing
+  const busy = recorder.isBusy || transcribing
 
   return React.useMemo(
     () => ({
@@ -93,6 +93,7 @@ export function useVoiceComposerInput(onTranscription: (text: string) => void) {
       retry,
       retryBlob,
       start,
+      starting: recorder.isStarting,
       stop,
       transcribing,
     }),
@@ -103,6 +104,7 @@ export function useVoiceComposerInput(onTranscription: (text: string) => void) {
       recorder.bars,
       recorder.durationMs,
       recorder.error,
+      recorder.isStarting,
       retry,
       retryBlob,
       start,

--- a/src/routes/Chat/useVoiceRecorder.ts
+++ b/src/routes/Chat/useVoiceRecorder.ts
@@ -7,16 +7,19 @@ import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 const barIntervalMs = 50
 const durationIntervalMs = 125
+const firstAudioChunkTimeoutMs = 3_000
 const maxBars = 240
 
-export type VoiceRecorderStatus = "idle" | "requesting-permission" | "recording" | "stopping" | "error"
+export type VoiceRecorderStatus = "idle" | "requesting-permission" | "starting" | "recording" | "stopping" | "error"
 
 export interface VoiceRecorderControls {
   status: VoiceRecorderStatus
   bars: number[]
   durationMs: number
   error?: string
+  isBusy: boolean
   isRecording: boolean
+  isStarting: boolean
   start: () => Promise<void>
   stop: () => Promise<RecordedWav | undefined>
   cancel: () => void
@@ -37,8 +40,57 @@ interface RecorderRuntime {
   animationFrame: number
 }
 
+function disposeRuntime(runtime: RecorderRuntime): void {
+  cancelAnimationFrame(runtime.animationFrame)
+  runtime.worklet.port.onmessage = null
+  runtime.worklet.disconnect()
+  runtime.silentGain.disconnect()
+  runtime.source.disconnect()
+  runtime.stream.getTracks().forEach((track) => track.stop())
+  void runtime.context.close().catch((error: unknown) => {
+    reportRendererHandledError("voice", "audio context close failed", error)
+  })
+}
+
+function stopStream(stream: MediaStream): void {
+  stream.getTracks().forEach((track) => track.stop())
+}
+
+function closeAudioContext(context: AudioContext): void {
+  void context.close().catch((error: unknown) => {
+    reportRendererHandledError("voice", "audio context close failed", error)
+  })
+}
+
+function waitForFirstAudioChunk(worklet: AudioWorkletNode, chunks: Float32Array[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timeout = window.setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      reject(new Error("Microphone did not start producing audio."))
+    }, firstAudioChunkTimeoutMs)
+
+    worklet.port.onmessage = (event) => {
+      if (!(event.data instanceof Float32Array)) {
+        return
+      }
+      chunks.push(event.data)
+      if (settled) {
+        return
+      }
+      settled = true
+      window.clearTimeout(timeout)
+      resolve()
+    }
+  })
+}
+
 export function useVoiceRecorder(): VoiceRecorderControls {
   const runtimeRef = React.useRef<RecorderRuntime | undefined>(undefined)
+  const startTokenRef = React.useRef(0)
   const [state, setState] = React.useState({
     status: "idle" as VoiceRecorderStatus,
     bars: [] as number[],
@@ -52,21 +104,17 @@ export function useVoiceRecorder(): VoiceRecorderControls {
       return
     }
     runtimeRef.current = undefined
-    cancelAnimationFrame(runtime.animationFrame)
-    runtime.worklet.port.onmessage = null
-    runtime.worklet.disconnect()
-    runtime.silentGain.disconnect()
-    runtime.source.disconnect()
-    runtime.stream.getTracks().forEach((track) => track.stop())
-    void runtime.context.close().catch((error: unknown) => {
-      reportRendererHandledError("voice", "audio context close failed", error)
-    })
+    disposeRuntime(runtime)
   }, [])
 
   const start = React.useCallback(async () => {
+    const startToken = startTokenRef.current + 1
+    startTokenRef.current = startToken
     cleanupRuntime()
     setState({ status: "requesting-permission", bars: [], durationMs: 0, error: undefined })
 
+    let pendingStream: MediaStream | undefined
+    let pendingContext: AudioContext | undefined
     try {
       if (!navigator.mediaDevices?.getUserMedia) {
         throw new Error("Microphone capture is not available in this environment.")
@@ -77,8 +125,20 @@ export function useVoiceRecorder(): VoiceRecorderControls {
           noiseSuppression: true,
         },
       })
+      pendingStream = stream
+      if (startTokenRef.current !== startToken) {
+        stopStream(stream)
+        return
+      }
+      setState({ status: "starting", bars: [], durationMs: 0, error: undefined })
       const context = new AudioContext()
+      pendingContext = context
       await context.audioWorklet.addModule(voiceRecorderWorkletUrl)
+      if (startTokenRef.current !== startToken) {
+        stopStream(stream)
+        closeAudioContext(context)
+        return
+      }
 
       const source = context.createMediaStreamSource(stream)
       const analyser = context.createAnalyser()
@@ -103,16 +163,25 @@ export function useVoiceRecorder(): VoiceRecorderControls {
         animationFrame: 0,
       }
       runtimeRef.current = runtime
+      pendingStream = undefined
+      pendingContext = undefined
 
-      worklet.port.onmessage = (event) => {
-        if (event.data instanceof Float32Array) {
-          chunks.push(event.data)
-        }
-      }
       source.connect(analyser)
       source.connect(worklet)
       worklet.connect(silentGain)
       silentGain.connect(context.destination)
+      if (context.state !== "running") {
+        await context.resume()
+      }
+      await waitForFirstAudioChunk(worklet, chunks)
+      if (startTokenRef.current !== startToken || runtimeRef.current !== runtime) {
+        return
+      }
+
+      const startedAt = performance.now()
+      runtime.startedAt = startedAt
+      runtime.lastBarAt = startedAt
+      runtime.lastStateAt = startedAt
 
       const samples = new Float32Array(analyser.fftSize)
       const update = () => {
@@ -152,6 +221,15 @@ export function useVoiceRecorder(): VoiceRecorderControls {
       setState({ status: "recording", bars: [], durationMs: 0, error: undefined })
       runtime.animationFrame = requestAnimationFrame(update)
     } catch (error) {
+      if (pendingStream) {
+        stopStream(pendingStream)
+      }
+      if (pendingContext) {
+        closeAudioContext(pendingContext)
+      }
+      if (startTokenRef.current !== startToken) {
+        return
+      }
       cleanupRuntime()
       setState({
         status: "error",
@@ -164,7 +242,7 @@ export function useVoiceRecorder(): VoiceRecorderControls {
 
   const stop = React.useCallback(async (): Promise<RecordedWav | undefined> => {
     const runtime = runtimeRef.current
-    if (!runtime) {
+    if (!runtime || state.status !== "recording") {
       return undefined
     }
     setState((previous) => ({ ...previous, status: "stopping" }))
@@ -174,20 +252,32 @@ export function useVoiceRecorder(): VoiceRecorderControls {
     const wav = encodePcm16Wav(chunks, sampleRate)
     setState((previous) => ({ ...previous, status: "idle", durationMs: wav.durationMs }))
     return wav
-  }, [cleanupRuntime])
+  }, [cleanupRuntime, state.status])
 
   const cancel = React.useCallback(() => {
+    startTokenRef.current += 1
     cleanupRuntime()
     setState({ status: "idle", bars: [], durationMs: 0, error: undefined })
   }, [cleanupRuntime])
 
-  React.useEffect(() => cleanupRuntime, [cleanupRuntime])
+  React.useEffect(
+    () => () => {
+      startTokenRef.current += 1
+      cleanupRuntime()
+    },
+    [cleanupRuntime],
+  )
 
   return React.useMemo(
     () => ({
       ...state,
-      isRecording:
-        state.status === "recording" || state.status === "requesting-permission" || state.status === "stopping",
+      isBusy:
+        state.status === "requesting-permission" ||
+        state.status === "starting" ||
+        state.status === "recording" ||
+        state.status === "stopping",
+      isRecording: state.status === "recording" || state.status === "stopping",
+      isStarting: state.status === "requesting-permission" || state.status === "starting",
       start,
       stop,
       cancel,

--- a/src/routes/Skills/OrganizationMembersPanel.tsx
+++ b/src/routes/Skills/OrganizationMembersPanel.tsx
@@ -903,7 +903,7 @@ function MemberActionsMenu({
           type="button"
           variant="ghost"
           size="icon"
-          className={compact ? "size-6" : undefined}
+          className={compact ? "size-[1.375rem]" : undefined}
           disabled={disabled}
           aria-label={t("organizations.actions")}
         >

--- a/src/routes/Skills/OrganizationMembersPanel.tsx
+++ b/src/routes/Skills/OrganizationMembersPanel.tsx
@@ -451,7 +451,7 @@ function MembersTable({
             const selectable = isBulkEditableMember(member)
             return (
               <div key={member.user_id} className="grid min-w-0 gap-2 px-3 py-3">
-                <div className="flex min-w-0 items-start gap-2.5">
+                <div className="flex min-w-0 items-center gap-3">
                   {canBulkManage ? (
                     <MemberStatusCheckbox
                       ariaLabel={t("organizations.selectMember", { name: member.displayName })}
@@ -461,20 +461,26 @@ function MembersTable({
                     />
                   ) : null}
                   <UserAvatar avatar={member.avatar} fallback={member.fallback} />
-                  <div className="min-w-0 flex-1">
-                    <MemberIdentity member={member} showRole />
-                    {showStatusColumn ? (
-                      <div className="mt-1">
-                        <MemberStatusBadge member={member} />
-                      </div>
-                    ) : null}
+                  <div className="min-w-0 flex-1 self-center">
+                    <MemberIdentity member={member} />
                   </div>
-                  {canRemove ? (
-                    <MemberActionsMenu
-                      disabled={bulkBusy || busyAction === `remove:${member.user_id}`}
-                      onRemove={() => setRemoveTarget(member)}
-                    />
-                  ) : null}
+                  <div className="grid shrink-0 grid-rows-[1.375rem_1.375rem] justify-items-end gap-1">
+                    <div className="flex h-[1.375rem] items-center justify-end gap-2">
+                      <Badge variant="secondary">
+                        {member.role === "creator" ? t("organizations.roleCreator") : t("organizations.roleMember")}
+                      </Badge>
+                      {showStatusColumn ? <MemberStatusBadge member={member} /> : null}
+                    </div>
+                    <div className="flex h-[1.375rem] items-center justify-end">
+                      {canRemove ? (
+                        <MemberActionsMenu
+                          compact
+                          disabled={bulkBusy || busyAction === `remove:${member.user_id}`}
+                          onRemove={() => setRemoveTarget(member)}
+                        />
+                      ) : null}
+                    </div>
+                  </div>
                 </div>
                 {canRemove && showProviderAccess ? (
                   <div className="grid min-w-0 gap-2 pl-10">
@@ -660,23 +666,18 @@ function MembersTable({
   )
 }
 
-function MemberIdentity({ member, showRole = false }: { member: MemberView; showRole?: boolean }) {
+function MemberIdentity({ member }: { member: MemberView }) {
   const { t } = useAppI18n()
 
   return (
     <div className="group/member-identity grid min-w-0 gap-0.5">
-      <div className="flex min-w-0 items-center gap-1.5">
-        <span className="oo-text-label min-w-0 truncate">{member.displayName}</span>
-        <CopyValueButton
+      <div className="flex min-w-0 items-center">
+        <CopyTextButton
           ariaLabel={t("organizations.copyMemberName")}
+          className="oo-text-label min-w-0 truncate"
           copiedLabel={t("organizations.memberNameCopied")}
           value={member.displayName}
         />
-        {showRole ? (
-          <Badge variant="secondary" className="shrink-0">
-            {member.role === "creator" ? t("organizations.roleCreator") : t("organizations.roleMember")}
-          </Badge>
-        ) : null}
       </div>
       <div className="flex min-w-0 items-center gap-1.5">
         <Tooltip>
@@ -694,6 +695,47 @@ function MemberIdentity({ member, showRole = false }: { member: MemberView; show
         />
       </div>
     </div>
+  )
+}
+
+function CopyTextButton({
+  ariaLabel,
+  className,
+  copiedLabel,
+  value,
+}: {
+  ariaLabel: string
+  className?: string
+  copiedLabel: string
+  value: string
+}) {
+  const { t } = useAppI18n()
+  const { copied, copyText } = useClipboardCopy({ failureMessage: t("organizations.memberCopyFailed") })
+
+  const copyValue = React.useCallback(async () => {
+    await copyText(value)
+  }, [copyText, value])
+
+  const buttonAriaLabel = copied ? copiedLabel : ariaLabel
+  const tooltipLabel = copied ? copiedLabel : `${ariaLabel}: ${value}`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "rounded-sm text-left transition hover:text-foreground hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
+            className,
+          )}
+          aria-label={buttonAriaLabel}
+          onClick={() => void copyValue()}
+        >
+          {value}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipLabel}</TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -843,13 +885,28 @@ function CopyValueButton({ ariaLabel, copiedLabel, value }: { ariaLabel: string;
   )
 }
 
-function MemberActionsMenu({ disabled, onRemove }: { disabled: boolean; onRemove: () => void }) {
+function MemberActionsMenu({
+  compact = false,
+  disabled,
+  onRemove,
+}: {
+  compact?: boolean
+  disabled: boolean
+  onRemove: () => void
+}) {
   const { t } = useAppI18n()
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="ghost" size="icon" disabled={disabled} aria-label={t("organizations.actions")}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={compact ? "size-6" : undefined}
+          disabled={disabled}
+          aria-label={t("organizations.actions")}
+        >
           <MoreHorizontalIcon className="size-4" />
         </Button>
       </DropdownMenuTrigger>

--- a/src/routes/Skills/OrganizationMembersSheet.tsx
+++ b/src/routes/Skills/OrganizationMembersSheet.tsx
@@ -72,7 +72,7 @@ export function OrganizationMembersSheet({
         aria-modal="true"
         aria-label={t("organizations.memberManagement")}
         tabIndex={-1}
-        className="absolute top-0 right-0 grid h-full w-[min(24rem,calc(100vw-2rem))] grid-rows-[auto_minmax(0,1fr)] border-l bg-background shadow-xl outline-none [-webkit-app-region:no-drag]"
+        className="absolute top-0 right-0 grid h-full w-[min(42rem,calc(100vw-2rem))] grid-rows-[auto_minmax(0,1fr)] border-l bg-background shadow-xl outline-none [-webkit-app-region:no-drag]"
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.stopPropagation()


### PR DESCRIPTION
## Summary

This PR combines the current branch work into one reviewable change set:

- Refines the organization members sheet layout so member details and management controls scan more cleanly.
- Hardens voice input startup so the composer only shows the recorder as ready after the microphone audio pipeline has actually produced audio.

## Voice Recorder Issue

The voice recorder previously treated microphone permission and audio pipeline setup as an active recording state. That meant the UI could show the recording controls while `getUserMedia`, `AudioContext`, and the `AudioWorklet` were still initializing. Users could start speaking during that window and lose the beginning of the utterance, or in worse cases see recording UI while no audio chunks were being collected.

The voice recorder now separates startup from active recording. It shows a preparing state while opening the microphone and building the audio graph, explicitly resumes the `AudioContext`, waits for the first worklet audio chunk, and only then flips the UI to the waveform/stop-recording state. The recording duration is also anchored to the first confirmed audio chunk instead of the initial click. Startup tokens invalidate stale async starts when the user cancels or clicks quickly, and pending streams/contexts are cleaned up on failure.

## Organization Members Layout

The existing branch also includes the organization member sheet layout refinement, keeping member metadata and actions better aligned in the management UI.

## Validation

- `oxlint .`
- `tsgo -p tsconfig.json`
- `oxfmt --check .`
- `vitest run`
- `vite build`
