### PR TITLE
feat(permission): implement trusted project permission handling and tests

### DIFF
--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -1,4 +1,5 @@
 import type { AgentManager } from "../agent/manager.ts"
+import type { SessionProject } from "../session/common.ts"
 import type { ChatMessage } from "./common.ts"
 
 import assert from "node:assert/strict"
@@ -17,25 +18,32 @@ afterEach(() => {
 function createBridgeAgent(): {
   agent: AgentManager
   abort: ReturnType<typeof vi.fn>
+  answerPermission: ReturnType<typeof vi.fn>
   createArtifactDir: ReturnType<typeof vi.fn>
   createProcessDir: ReturnType<typeof vi.fn>
-  emit: (event: { type: string; properties?: Record<string, unknown> }) => void
+  emit: (event: { type: string; data?: Record<string, unknown>; properties?: Record<string, unknown> }) => void
   promptStreaming: ReturnType<typeof vi.fn>
 } {
-  let listener: ((event: { type: string; properties?: Record<string, unknown> }) => void) | undefined
+  let listener:
+    | ((event: { type: string; data?: Record<string, unknown>; properties?: Record<string, unknown> }) => void)
+    | undefined
   const abort = vi.fn(async () => undefined)
+  const answerPermission = vi.fn(async () => undefined)
   const createArtifactDir = vi.fn(async () => path.join(os.tmpdir(), "wanta-test-artifacts"))
   const createProcessDir = vi.fn(async () => path.join(os.tmpdir(), "wanta-test-process"))
   const promptStreaming = vi.fn(async () => undefined)
   const agent = {
     isReady: () => true,
-    subscribe: (callback: (event: { type: string; properties?: Record<string, unknown> }) => void) => {
+    subscribe: (
+      callback: (event: { type: string; data?: Record<string, unknown>; properties?: Record<string, unknown> }) => void,
+    ) => {
       listener = callback
       return () => {
         listener = undefined
       }
     },
     abort,
+    answerPermission,
     createArtifactDir,
     createProcessDir,
     promptStreaming,
@@ -44,6 +52,7 @@ function createBridgeAgent(): {
   return {
     agent,
     abort,
+    answerPermission,
     createArtifactDir,
     createProcessDir,
     emit: (event) => listener?.(event),
@@ -57,6 +66,12 @@ function captureServiceEvents(service: ChatServiceImpl): Array<{ event: string; 
     events.push({ event, data })
   }
   return events
+}
+
+function projectStore(projects: SessionProject[]): { read: () => Promise<Map<string, SessionProject>> } {
+  return {
+    read: async () => new Map(projects.map((project) => [project.id, project])),
+  }
 }
 
 async function waitForInactiveGeneration(service: ChatServiceImpl): Promise<void> {
@@ -553,6 +568,107 @@ test("sendMessage passes selected context, organization skills, and project as p
   assert.match(options?.system ?? "", /\/Users\/example\/code\/wanta/)
   assert.match(options?.system ?? "", /use this project directory as an absolute path/)
   assert.match(options?.system ?? "", /Do not mention the full project directory/)
+})
+
+test("trusted project permissions are approved without showing a permission card", async () => {
+  const bridge = createBridgeAgent()
+  const projectPath = "/Users/example/code/wanta"
+  const service = new ChatServiceImpl(bridge.agent, {
+    projectStore: projectStore([
+      {
+        id: "project-1",
+        name: "wanta",
+        path: projectPath,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+      },
+    ]),
+  })
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({
+    projectContext: {
+      id: "project-1",
+      name: "wanta",
+      path: projectPath,
+    },
+    sessionId: "session-1",
+    text: "Analyze this project",
+  })
+
+  bridge.emit({
+    type: "permission.v2.asked",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      action: "external_directory",
+      resources: [`${projectPath}/src`],
+      save: [`${projectPath}/*`],
+    },
+  })
+  bridge.emit({
+    type: "permission.v2.asked",
+    properties: {
+      id: "permission-2",
+      sessionID: "session-1",
+      action: "edit",
+      resources: [`${projectPath}/src/main.tsx`],
+    },
+  })
+
+  await waitForCondition(() => bridge.answerPermission.mock.calls.length === 2)
+
+  assert.deepEqual(bridge.answerPermission.mock.calls, [
+    ["session-1", "permission-1", "once"],
+    ["session-1", "permission-2", "once"],
+  ])
+  assert.equal(
+    events.some((event) => event.event === "permissionAsked"),
+    false,
+  )
+})
+
+test("trusted project permission approval does not cover paths outside the project", async () => {
+  const bridge = createBridgeAgent()
+  const projectPath = "/Users/example/code/wanta"
+  const service = new ChatServiceImpl(bridge.agent, {
+    projectStore: projectStore([
+      {
+        id: "project-1",
+        name: "wanta",
+        path: projectPath,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+      },
+    ]),
+  })
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({
+    projectContext: {
+      id: "project-1",
+      name: "wanta",
+      path: projectPath,
+    },
+    sessionId: "session-1",
+    text: "Analyze this project",
+  })
+
+  bridge.emit({
+    type: "permission.v2.asked",
+    properties: {
+      id: "permission-1",
+      sessionID: "session-1",
+      action: "external_directory",
+      resources: ["/Users/example/.ssh"],
+    },
+  })
+
+  await waitForCondition(() => events.some((event) => event.event === "permissionAsked"))
+
+  assert.equal(bridge.answerPermission.mock.calls.length, 0)
 })
 
 test("buildContextMentionsSystem returns undefined without selected context", () => {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -59,6 +59,7 @@ import {
 import { normalizeChatError } from "./error.ts"
 import { directoryArtifacts, fileArtifact, localArtifactItem, readArtifactPack } from "./local-artifacts.ts"
 import { attachmentPreview, localArtifactPreview } from "./previews.ts"
+import { projectPermissionRequestInsideRoot } from "./project-permission.ts"
 import { applyStoppedGenerations, recordStoppedGeneration } from "./stopped-generations.ts"
 import {
   intermediateArtifactProcessFiles,
@@ -174,6 +175,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private activeAssistantMessages = new Map<string, string>()
   private activeToolParts = new Map<string, Set<string>>()
   private connectionFailedSessions = new Set<string>()
+  private trustedProjectRoots = new Map<string, string>()
   private readonly deps: ChatServiceDeps
   private agentStatus: AgentRuntimeStatus = { status: "signed_out" }
   private artifactRoots: ArtifactRoots = new Map()
@@ -213,6 +215,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.activeAssistantMessages.clear()
     this.activeToolParts.clear()
     this.connectionFailedSessions.clear()
+    this.trustedProjectRoots.clear()
     this.artifactRoots.clear()
     this.artifactRootsLoaded = false
     this.artifactRootsLoadPromise = null
@@ -285,6 +288,12 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         }
         if (translated.event === "messageStarted") {
           this.emitSessionActivity(translated.data.sessionId)
+        }
+        if (
+          translated.event === "permissionAsked" &&
+          this.answerTrustedProjectPermission(emit, translated.data.request)
+        ) {
+          continue
         }
         if (translated.event === "messageStarted" && translated.data.role === "assistant") {
           this.activeAssistantMessages.set(translated.data.sessionId, translated.data.messageId)
@@ -544,6 +553,32 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     })
   }
 
+  private answerTrustedProjectPermission(
+    emit: (event: string, data: unknown) => Promise<void>,
+    request: ChatPermissionRequest,
+  ): boolean {
+    const projectRoot = this.trustedProjectRoots.get(request.sessionId)
+    if (!this.agent || !projectRoot || !projectPermissionRequestInsideRoot(request, projectRoot)) {
+      return false
+    }
+    void this.agent.answerPermission(request.sessionId, request.id, "once").catch((error: unknown) => {
+      console.warn("[wanta] failed to approve trusted project permission:", error)
+      logDiagnostic(
+        "chat-service",
+        "failed to approve trusted project permission",
+        { action: request.action, error, sessionId: request.sessionId },
+        "warn",
+      )
+      this.sendBestEffort(
+        emit,
+        "permissionAsked",
+        { sessionId: request.sessionId, request },
+        { sessionId: request.sessionId },
+      )
+    })
+    return true
+  }
+
   private beginSessionGeneration(sessionId: string): SessionGeneration {
     const previousGeneration = this.sessionGenerations.get(sessionId)
     previousGeneration?.controller.abort()
@@ -693,6 +728,12 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       if (!this.isCurrentGeneration(req.sessionId, generation.id) || generation.controller.signal.aborted) {
         this.clearSessionGeneration(req.sessionId, generation.id)
         return
+      }
+      const trustedProjectRoot = await this.resolveTrustedProjectRoot(req.projectContext)
+      if (trustedProjectRoot) {
+        this.trustedProjectRoots.set(req.sessionId, trustedProjectRoot)
+      } else {
+        this.trustedProjectRoots.delete(req.sessionId)
       }
       const project = await this.projectBaseline(req.projectContext)
       this.enqueuePendingArtifactDir(req.sessionId, artifactDir)
@@ -909,6 +950,22 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       console.warn("[wanta] failed to capture project baseline", error)
       return {}
     }
+  }
+
+  private async resolveTrustedProjectRoot(project: ChatProjectContext | undefined): Promise<string | undefined> {
+    const projectPath = project?.path.trim()
+    if (!project || !project.id.trim() || !projectPath || !this.deps.projectStore) {
+      return undefined
+    }
+    const registered = (await this.deps.projectStore.read()).get(project.id)
+    if (
+      !registered ||
+      registered.archivedAt ||
+      normalizeProjectPath(registered.path) !== normalizeProjectPath(projectPath)
+    ) {
+      return undefined
+    }
+    return normalizeProjectPath(registered.path)
   }
 
   private async finalizeTurnOutput(sessionId: string, messageId: string | undefined): Promise<void> {

--- a/electron/chat/project-permission.test.ts
+++ b/electron/chat/project-permission.test.ts
@@ -1,0 +1,61 @@
+import type { ChatPermissionRequest } from "./common.ts"
+
+import assert from "node:assert/strict"
+import path from "node:path"
+import { test } from "vitest"
+import {
+  isTrustedProjectPermissionAction,
+  projectPermissionRequestInsideRoot,
+  projectPermissionResourceInsideRoot,
+} from "./project-permission.ts"
+
+function permission(overrides: Partial<ChatPermissionRequest>): ChatPermissionRequest {
+  return {
+    id: "permission-1",
+    sessionId: "session-1",
+    action: "external_directory",
+    resources: [],
+    ...overrides,
+  }
+}
+
+test("trusted project permission actions cover file access but not shell commands", () => {
+  assert.equal(isTrustedProjectPermissionAction("external_directory"), true)
+  assert.equal(isTrustedProjectPermissionAction("edit"), true)
+  assert.equal(isTrustedProjectPermissionAction("write"), true)
+  assert.equal(isTrustedProjectPermissionAction("file.read"), true)
+  assert.equal(isTrustedProjectPermissionAction("bash"), false)
+})
+
+test("project permission resources must stay inside the trusted root", () => {
+  const root = "/Users/example/code/wanta"
+
+  assert.equal(projectPermissionResourceInsideRoot(path.join(root, "src/main.tsx"), root), true)
+  assert.equal(projectPermissionResourceInsideRoot(`${root}/*`, root), true)
+  assert.equal(projectPermissionResourceInsideRoot(`${root}/src/**/*.ts`, root), true)
+  assert.equal(projectPermissionResourceInsideRoot(root, root), true)
+  assert.equal(projectPermissionResourceInsideRoot("/Users/example/code/wanta-other/src/main.tsx", root), false)
+  assert.equal(projectPermissionResourceInsideRoot(`${root}/../outside`, root), false)
+  assert.equal(projectPermissionResourceInsideRoot(`${root}*`, root), false)
+  assert.equal(projectPermissionResourceInsideRoot("src/main.tsx", root), false)
+})
+
+test("trusted project permission requests require every immediate resource to be inside root", () => {
+  const root = "/Users/example/code/wanta"
+
+  assert.equal(
+    projectPermissionRequestInsideRoot(permission({ resources: [path.join(root, "src/main.tsx")], save: ["*"] }), root),
+    true,
+  )
+  assert.equal(
+    projectPermissionRequestInsideRoot(
+      permission({
+        resources: [path.join(root, "src/main.tsx"), "/Users/example/secrets.env"],
+      }),
+      root,
+    ),
+    false,
+  )
+  assert.equal(projectPermissionRequestInsideRoot(permission({ action: "bash", resources: [root] }), root), false)
+  assert.equal(projectPermissionRequestInsideRoot(permission({ resources: [] }), root), false)
+})

--- a/electron/chat/project-permission.ts
+++ b/electron/chat/project-permission.ts
@@ -1,0 +1,89 @@
+import type { ChatPermissionRequest } from "./common.ts"
+
+import path from "node:path"
+
+const trustedProjectPermissionActions = new Set([
+  "directory",
+  "edit",
+  "external_directory",
+  "file",
+  "file.read",
+  "file.write",
+  "fs.read",
+  "fs.write",
+  "read",
+  "write",
+])
+
+function normalizedAction(action: string): string {
+  return action.trim().toLowerCase()
+}
+
+function normalizeRoot(root: string): string | undefined {
+  const normalized = path.resolve(root.trim().replace(/[\\/]+$/, ""))
+  if (!normalized || normalized === path.parse(normalized).root) {
+    return undefined
+  }
+  return normalized
+}
+
+function pathInsideRoot(root: string, target: string): boolean {
+  const relative = path.relative(root, target)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+function pathFromFileUrl(value: string): string | undefined {
+  if (!value.startsWith("file://")) {
+    return undefined
+  }
+  try {
+    const url = new URL(value)
+    return url.protocol === "file:" ? decodeURIComponent(url.pathname) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function concretePathFromResource(resource: string): string | undefined {
+  const trimmed = resource.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  const filePath = pathFromFileUrl(trimmed)
+  const rawPath = filePath ?? trimmed
+  const wildcardIndex = rawPath.search(/[*?[\]{}]/)
+  if (wildcardIndex >= 0) {
+    const prefix = rawPath.slice(0, wildcardIndex)
+    if (!prefix.endsWith("/") && !prefix.endsWith("\\")) {
+      return undefined
+    }
+    const directory = prefix.replace(/[\\/]+$/, "")
+    return directory && path.isAbsolute(directory) ? path.resolve(directory) : undefined
+  }
+  return path.isAbsolute(rawPath) ? path.resolve(rawPath) : undefined
+}
+
+export function isTrustedProjectPermissionAction(action: string): boolean {
+  const normalized = normalizedAction(action)
+  return trustedProjectPermissionActions.has(normalized)
+}
+
+export function projectPermissionResourceInsideRoot(resource: string, root: string): boolean {
+  const normalizedRoot = normalizeRoot(root)
+  const target = concretePathFromResource(resource)
+  return Boolean(normalizedRoot && target && pathInsideRoot(normalizedRoot, target))
+}
+
+export function projectPermissionRequestInsideRoot(request: ChatPermissionRequest, root: string): boolean {
+  if (!isTrustedProjectPermissionAction(request.action)) {
+    return false
+  }
+  const resources = request.resources.map((resource) => resource.trim()).filter(Boolean)
+  if (resources.length === 0) {
+    return false
+  }
+  if (!resources.every((resource) => projectPermissionResourceInsideRoot(resource, root))) {
+    return false
+  }
+  return true
+}

--- a/electron/chat/project-permission.ts
+++ b/electron/chat/project-permission.ts
@@ -1,6 +1,7 @@
 import type { ChatPermissionRequest } from "./common.ts"
 
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 
 const trustedProjectPermissionActions = new Set([
   "directory",
@@ -38,7 +39,7 @@ function pathFromFileUrl(value: string): string | undefined {
   }
   try {
     const url = new URL(value)
-    return url.protocol === "file:" ? decodeURIComponent(url.pathname) : undefined
+    return url.protocol === "file:" ? fileURLToPath(url) : undefined
   } catch {
     return undefined
   }

--- a/src/routes/Connections/index.tsx
+++ b/src/routes/Connections/index.tsx
@@ -581,7 +581,7 @@ function ConnectionListToolbar({
         <div className="oo-connection-filter-row flex min-w-0 items-center overflow-x-auto overflow-y-hidden">
           <ToggleGroup
             type="single"
-            variant="outline"
+            variant="default"
             size="sm"
             spacing={1}
             value={filterValue}
@@ -610,7 +610,11 @@ function ConnectionListToolbar({
         {overflowCategoryFilters.length > 0 ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="gap-1.5 rounded-md">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 rounded-md transition-[background-color,border-color,box-shadow,transform] active:translate-y-px data-[state=open]:border-[var(--accent-ring)] data-[state=open]:bg-[var(--accent-soft)] data-[state=open]:text-foreground data-[state=open]:shadow-[inset_0_0_0_1px_var(--accent-ring)]"
+              >
                 {t("connections.moreCategories")}
                 <ChevronDown className="size-4" />
               </Button>
@@ -637,9 +641,14 @@ function ConnectionListToolbar({
 
 function FilterToggleItem({ count, label, value }: { count: number; label: string; value: string }) {
   return (
-    <ToggleGroupItem value={value} className="max-w-48 gap-1.5 rounded-md border px-2.5">
+    <ToggleGroupItem
+      value={value}
+      className="group/filter max-w-48 cursor-pointer gap-1.5 rounded-md border border-[var(--oo-control-border)] px-2.5 transition-[background-color,border-color,color,box-shadow,transform] hover:border-[var(--selection-ring)] active:translate-y-px active:scale-[0.98] data-[state=on]:!border-[var(--accent-ring)] data-[state=on]:!bg-[var(--accent-soft)] data-[state=on]:!text-foreground data-[state=on]:!shadow-[inset_0_0_0_1px_var(--accent-ring)] data-[state=on]:hover:!bg-[var(--accent-soft)]"
+    >
       <span className="truncate">{label}</span>
-      <span className="oo-text-micro oo-text-muted">{count}</span>
+      <span className="oo-text-micro oo-text-muted transition-colors group-data-[state=on]/filter:text-[var(--accent-strong)]">
+        {count}
+      </span>
     </ToggleGroupItem>
   )
 }
@@ -806,8 +815,9 @@ function ProviderCard({
       type="button"
       onClick={onSelect}
       className={cn(
-        "grid min-w-0 rounded-md border bg-card px-2.5 py-1.5 text-left text-card-foreground transition-colors outline-none hover:bg-[var(--oo-row-hover)] focus-visible:ring-[3px] focus-visible:ring-ring/40",
-        selected && "border-ring bg-accent/55",
+        "group/card relative grid min-w-0 cursor-pointer overflow-hidden rounded-md border bg-card px-2.5 py-1.5 text-left text-card-foreground transition-[background-color,border-color,box-shadow,transform] outline-none hover:border-[var(--selection-ring)] hover:bg-[var(--oo-row-hover)] focus-visible:ring-[3px] focus-visible:ring-ring/40 active:translate-y-px",
+        selected &&
+          "border-[var(--accent-ring)] bg-[var(--accent-soft)] shadow-[inset_0_0_0_1px_var(--accent-ring)] before:absolute before:inset-y-2 before:left-0 before:w-1 before:rounded-r-full before:bg-[var(--accent-strong)] hover:bg-[var(--accent-soft)]",
       )}
       style={{ height: providerGridCardHeightPx }}
     >

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -33,6 +33,7 @@ import {
   getRuntimeHosts,
   getSkillVersionCheck,
   getSkillVersionCheckKey,
+  getSelectedManagedSkillGroup,
   initialPublicPackageCatalogState,
   isInstalledSkillGroup,
   matchesInstalledSkillFilter,
@@ -174,19 +175,12 @@ export function SkillsRoute({
   const myPublishedPackageRequestIdRef = React.useRef(0)
   const { copySkillPath, isRemovingSkill, openSkillFolder, removeSkill, removeTarget, setRemoveTarget } =
     useSkillObjectActions({
-      onDeleted: (nextInventory) => {
-        const nextSelectedSkill = nextInventory.groups.find(isInstalledSkillGroup)
-        setSelectedSkillId(nextSelectedSkill?.id ?? null)
+      onDeleted: () => {
+        setSelectedSkillId(null)
         setNarrowPane("list")
         homeSummaryResource.invalidate()
       },
     })
-
-  React.useEffect(() => {
-    if (!selectedSkillId && inventory?.groups[0]) {
-      setSelectedSkillId(inventory.groups[0].id)
-    }
-  }, [inventory?.groups, selectedSkillId])
 
   const searchedGroups = React.useMemo(() => {
     const groups = inventory?.groups ?? []
@@ -211,7 +205,7 @@ export function SkillsRoute({
       return matchesInstalledSkillFilter(group, installedFilter, getSkillVersionCheck(versionCheckByKey, group))
     })
   }, [installedFilter, installedGroups, versionCheckByKey])
-  const selectedSkill = searchedGroups.find((group) => group.id === selectedSkillId) || searchedGroups[0]
+  const selectedSkill = getSelectedManagedSkillGroup(searchedGroups, selectedSkillId)
   const selectedStatus = selectedSkill ? getGroupStatus(selectedSkill, t, getRuntimeHosts(selectedSkill)) : null
   const selectedVersionCheck = getSkillVersionCheck(versionCheckByKey, selectedSkill)
   const managedOrganizationOptions = React.useMemo<ManagedOrganizationOption[]>(() => {

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -10,6 +10,7 @@ import {
   getPublicPackageInstallState,
   getRuntimeHosts,
   getRuntimeSkillRemoveTarget,
+  getSelectedManagedSkillGroup,
   initialPublicPackageCatalogState,
   isEmojiIcon,
   matchesInstalledSkillFilter,
@@ -127,6 +128,16 @@ test("matchesInstalledSkillFilter can filter by Wanta, Codex, and Claude Code ho
   assert.equal(matchesInstalledSkillFilter(codexGroup, "codex", undefined), true)
   assert.equal(matchesInstalledSkillFilter(codexGroup, "wanta", undefined), false)
   assert.equal(matchesInstalledSkillFilter(claudeCodeGroup, "claude-code", undefined), true)
+})
+
+test("getSelectedManagedSkillGroup does not fall back to the first skill", () => {
+  const first = managedSkillGroup("first", "@alice/first")
+  const second = managedSkillGroup("second", "@alice/second")
+  const groups = [first, second]
+
+  assert.equal(getSelectedManagedSkillGroup(groups, null), undefined)
+  assert.equal(getSelectedManagedSkillGroup(groups, "missing"), undefined)
+  assert.equal(getSelectedManagedSkillGroup(groups, "second"), second)
 })
 
 test("runtime status ignores modified external hosts", () => {

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -235,6 +235,17 @@ export function isInstalledSkillGroup(group: ManagedSkillGroup): boolean {
   return getInstalledSkillHosts(group).length > 0
 }
 
+export function getSelectedManagedSkillGroup(
+  groups: readonly ManagedSkillGroup[],
+  selectedId: SkillSelectionKey | null,
+): ManagedSkillGroup | undefined {
+  if (!selectedId) {
+    return undefined
+  }
+
+  return groups.find((group) => group.id === selectedId)
+}
+
 export function shouldUpdatePublishedSkill(group: ManagedSkillGroup): boolean {
   return (
     group.kind === "registry" &&


### PR DESCRIPTION
## Summary

This PR implements trusted project permission handling for chat sessions that are bound to a registered project. When OpenCode asks for file or directory access inside the active project root, Wanta can now approve that request once without surfacing a permission card to the renderer. Requests for shell commands, empty resources, relative paths, malformed wildcard paths, or resources outside the registered project continue through the normal permission UI.

The previous behavior treated project-local file access the same as every other permission request, which forced users to repeatedly approve routine file reads and writes even after Wanta already knew the selected project and had a registered project store entry for it. That added friction to normal build-mode work and made the permission flow noisier than intended.

The root cause was that chat permission routing did not preserve a trusted project root per session and did not classify OpenCode permission resources before forwarding the event to the renderer. The fix records a verified project root for each send-message request, adds a small parser for project-local permission resources, and auto-replies with a one-time approval only when every immediate resource resolves inside that root.

This PR also tightens two adjacent UI details: connection filters now use clearer selected/active styling, and the Skills route no longer silently selects the first searched skill after deletion or filtering. The skill selection helper is covered by a focused unit test.

## Validation

- `oxlint .`

Note: `npm` is not available in the current shell PATH, so I ran the exact lint script command directly with the bundled Node runtime on PATH.
