### PR TITLE
Fix trusted project permissions for task subagents

### DIFF
--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -629,6 +629,73 @@ test("trusted project permissions are approved without showing a permission card
   )
 })
 
+test("trusted project permissions are approved for task subagent sessions", async () => {
+  const bridge = createBridgeAgent()
+  const projectPath = "/Users/example/code/wanta"
+  const service = new ChatServiceImpl(bridge.agent, {
+    projectStore: projectStore([
+      {
+        id: "project-1",
+        name: "wanta",
+        path: projectPath,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+      },
+    ]),
+  })
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({
+    projectContext: {
+      id: "project-1",
+      name: "wanta",
+      path: projectPath,
+    },
+    sessionId: "parent-session",
+    text: "Analyze this project",
+  })
+
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "task-1",
+        sessionID: "parent-session",
+        messageID: "assistant-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "task",
+        state: {
+          status: "running",
+          input: {},
+          metadata: {
+            parentSessionId: "parent-session",
+            sessionId: "child-session",
+          },
+        },
+      },
+    },
+  })
+  bridge.emit({
+    type: "permission.v2.asked",
+    properties: {
+      id: "permission-1",
+      sessionID: "child-session",
+      action: "external_directory",
+      resources: [`${projectPath}/*`],
+    },
+  })
+
+  await waitForCondition(() => bridge.answerPermission.mock.calls.length === 1)
+
+  assert.deepEqual(bridge.answerPermission.mock.calls, [["child-session", "permission-1", "once"]])
+  assert.equal(
+    events.some((event) => event.event === "permissionAsked"),
+    false,
+  )
+})
+
 test("trusted project permission approval does not cover paths outside the project", async () => {
   const bridge = createBridgeAgent()
   const projectPath = "/Users/example/code/wanta"

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -29,6 +29,8 @@ import type {
   SendMessageRequest,
   SetAgentOrganizationRequest,
   ShowLocalPathInFolderRequest,
+  ToolCallResultEvent,
+  ToolCallStartedEvent,
   TurnFileDiffRequest,
   TurnFileDiffResult,
   TurnOutputRecord,
@@ -130,6 +132,24 @@ function messageErrorSignature(message: string): string {
   return message.trim() || message
 }
 
+function metadataString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function taskChildSessionId(data: ToolCallStartedEvent | ToolCallResultEvent): string | undefined {
+  if (data.tool !== "task") {
+    return undefined
+  }
+  const metadata = data.metadata
+  const parentSessionId =
+    metadataString(metadata?.parentSessionId) ?? metadataString(metadata?.parentSessionID) ?? data.sessionId
+  const childSessionId = metadataString(metadata?.sessionId) ?? metadataString(metadata?.sessionID)
+  if (!childSessionId || childSessionId === data.sessionId || parentSessionId !== data.sessionId) {
+    return undefined
+  }
+  return childSessionId
+}
+
 interface ChatServiceDeps {
   artifactRootStore?: ArtifactRootStore
   authorizationOverlayStore?: AuthorizationOverlayStore
@@ -176,6 +196,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private activeToolParts = new Map<string, Set<string>>()
   private connectionFailedSessions = new Set<string>()
   private trustedProjectRoots = new Map<string, string>()
+  private trustedSubagentSessionsByParent = new Map<string, Set<string>>()
   private readonly deps: ChatServiceDeps
   private agentStatus: AgentRuntimeStatus = { status: "signed_out" }
   private artifactRoots: ArtifactRoots = new Map()
@@ -216,6 +237,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.activeToolParts.clear()
     this.connectionFailedSessions.clear()
     this.trustedProjectRoots.clear()
+    this.trustedSubagentSessionsByParent.clear()
     this.artifactRoots.clear()
     this.artifactRootsLoaded = false
     this.artifactRootsLoadPromise = null
@@ -329,12 +351,20 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           const partIds = this.activeToolParts.get(translated.data.sessionId) ?? new Set<string>()
           partIds.add(translated.data.partId)
           this.activeToolParts.set(translated.data.sessionId, partIds)
+          const childSessionId = taskChildSessionId(translated.data)
+          if (childSessionId) {
+            this.rememberTrustedSubagentSession(translated.data.sessionId, childSessionId)
+          }
         }
         if (translated.event === "toolCallResult") {
           const partIds = this.activeToolParts.get(translated.data.sessionId)
           partIds?.delete(translated.data.partId)
           if (partIds?.size === 0) {
             this.activeToolParts.delete(translated.data.sessionId)
+          }
+          const childSessionId = taskChildSessionId(translated.data)
+          if (childSessionId) {
+            this.forgetTrustedSubagentSession(translated.data.sessionId, childSessionId)
           }
           if (translated.data.authorization) {
             void this.rememberAuthorizationOverlay(
@@ -579,6 +609,40 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     return true
   }
 
+  private rememberTrustedSubagentSession(parentSessionId: string, childSessionId: string): void {
+    const projectRoot = this.trustedProjectRoots.get(parentSessionId)
+    if (!projectRoot) {
+      return
+    }
+    this.trustedProjectRoots.set(childSessionId, projectRoot)
+    const childSessionIds = this.trustedSubagentSessionsByParent.get(parentSessionId) ?? new Set<string>()
+    childSessionIds.add(childSessionId)
+    this.trustedSubagentSessionsByParent.set(parentSessionId, childSessionIds)
+  }
+
+  private forgetTrustedSubagentSession(parentSessionId: string, childSessionId: string): void {
+    const childSessionIds = this.trustedSubagentSessionsByParent.get(parentSessionId)
+    if (!childSessionIds?.has(childSessionId)) {
+      return
+    }
+    childSessionIds.delete(childSessionId)
+    this.trustedProjectRoots.delete(childSessionId)
+    if (childSessionIds.size === 0) {
+      this.trustedSubagentSessionsByParent.delete(parentSessionId)
+    }
+  }
+
+  private forgetTrustedSubagentSessions(parentSessionId: string): void {
+    const childSessionIds = this.trustedSubagentSessionsByParent.get(parentSessionId)
+    if (!childSessionIds) {
+      return
+    }
+    for (const childSessionId of childSessionIds) {
+      this.trustedProjectRoots.delete(childSessionId)
+    }
+    this.trustedSubagentSessionsByParent.delete(parentSessionId)
+  }
+
   private beginSessionGeneration(sessionId: string): SessionGeneration {
     const previousGeneration = this.sessionGenerations.get(sessionId)
     previousGeneration?.controller.abort()
@@ -609,6 +673,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (generation) {
       this.releaseGenerationScopeLock(generation.id)
     }
+    this.forgetTrustedSubagentSessions(sessionId)
     this.sessionGenerations.delete(sessionId)
   }
 


### PR DESCRIPTION
## Summary

Fixes a stuck-send failure when OpenCode starts a `task` subagent during a trusted project turn. The parent session already records the trusted project root, but the subagent child session previously did not inherit that trust state. When the child asked for a project-local filesystem permission, it was neither auto-approved nor shown in the active parent chat, so the parent task stayed running and the generation lock blocked later sends.

The change reads the child session id from the task tool metadata, temporarily maps the parent trusted project root onto that child session, and removes that mapping when the task or parent generation finishes. This keeps the existing project-root boundary checks in place while allowing subagent permissions inside the selected project to complete.

A regression test covers the stuck path by emitting a task tool event with child session metadata and verifying that a child-session project permission is approved without surfacing a permission card.

## Validation

- `./node_modules/.bin/oxlint .`
- `./node_modules/.bin/vitest run electron/chat/node.test.ts electron/chat/project-permission.test.ts`
- `./node_modules/.bin/tsgo -p tsconfig.json`
- `./node_modules/.bin/oxfmt --check .`
- `./node_modules/.bin/vitest run`
