### PR TITLE
build(oo-cli): bump pinned version to 1.4.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ npm run build:mac    # build:app + prepare:binaries + electron-builder
    deep-link 日志必须脱敏（query 含 authID）。
 5. **版本钉死，禁止浮动**：`opencode-ai` / `@opencode-ai/sdk` / `@opencode-ai/plugin`
    三包同为 `1.17.11`（上游无 API 稳定承诺）；oo CLI 版本由 `scripts/oo-cli.ts` 的
-   `OO_CLI_VERSION = "1.3.0"` 单一锁定。
+   `OO_CLI_VERSION = "1.4.2"` 单一锁定。
 6. **OpenCode permission 的 `"ask"` 必须接 Wanta 两档权限 UI**。当前已处理
    `permission.asked` / `permission.v2.asked` 与 reply；高风险本地能力走 ask。
    默认权限逐次批准/拒绝当前本地 ask，完全访问确认后自动 reply；新增 ask 类权限时必须验证该闭环

--- a/scripts/oo-cli.ts
+++ b/scripts/oo-cli.ts
@@ -3,10 +3,10 @@
 // 本项目只用 oo 的二进制，不再把 @oomol-lab/oo-cli 列为 npm 依赖：
 //   - postinstall（scripts/download-oo.ts）把【当前平台】的 oo 下载到 .oo-bin/（gitignore）；
 //   - dev（electron/main.ts → resolveDevOoBin）与打包前置（scripts/prepare-binaries.ts）共用这一份；
-//   - 上游发布的平台包 tarball 内 bin/oo 是 0644（缺少可执行位，1.2.0 起、1.3.0 复核仍是），故提取后必须 chmod 0o755，
+//   - 上游发布的平台包 tarball 内 bin/oo 是 0644（缺少可执行位，1.2.0 起、1.3.0/1.4.2 复核仍是），故提取后必须 chmod 0o755，
 //     否则直接 spawn 会 EACCES——这正是改造前 dev 直连 node_modules 报错的根因。
 //
-// 平台映射取自 @oomol-lab/oo-cli 的 platform-targets.json（1.2.0；1.3.0 复核平台集未变），含 Linux glibc/musl 判别。
+// 平台映射取自 @oomol-lab/oo-cli 的 platform-targets.json（1.2.0；1.3.0/1.4.2 复核平台集未变），含 Linux glibc/musl 判别。
 
 import { createHash } from "node:crypto"
 import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
@@ -18,7 +18,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 
 // oo-cli 版本：原先经 package-lock 间接锁定，移除依赖后由此处单一锁定。升级 oo 改这里。
-export const OO_CLI_VERSION = "1.3.0"
+export const OO_CLI_VERSION = "1.4.2"
 
 // 下载落地目录（gitignore）。dev 侧的同名路径解析见 electron/agent/binaries.ts resolveDevOoBin。
 const localOoBinDir = path.join(repoRoot, ".oo-bin")


### PR DESCRIPTION
`OO_CLI_VERSION` in `scripts/oo-cli.ts` is the single lock for the oo binary version — the CLI ships as a black-box prebuilt binary rather than an npm dependency, so upgrading oo is this one-line bump plus syncing the version statement in `AGENTS.md` (iron rule 5). This moves it from 1.3.0 to the latest 1.4.2.

Because oo is a black box the repo can't introspect, I re-verified its assumptions against 1.4.2 before bumping instead of trusting the version number alone:

- All 8 platform packages (darwin/win32/linux × arch × libc) publish 1.4.2, so the platform-target map needs no change.
- The darwin-arm64 tarball still lays out `package/bin/oo` at mode 0644, so the post-extract `chmod 0o755` step stays necessary.
- The `connector search / schema / run --json` interfaces the agent's three tools depend on are unchanged, and `schema` still accepts the dotted `<service>.<action>` id — so `tool-display.ts`'s provider-slug parsing still holds.
- Running a real `connector search` with the production `OO_*` env writes only under the redirected store dirs and leaves no `~/.claude`/`~/.agents` home-dir pollution (iron rule 8).

`ts-check`, `lint`, `format`, and the 893-test suite all pass. The `.oo-bin/` binary is gitignored, so CI and other machines pick up 1.4.2 automatically on the next `postinstall` when the version marker mismatches.