### PR TITLE
fix(sidecar): reap opencode process tree on shutdown

### DIFF
--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest"
+import { terminateProcessTree } from "./sidecar.ts"
+
+interface Recorder {
+  killGroup: ReturnType<typeof vi.fn>
+  killSelf: ReturnType<typeof vi.fn>
+  scheduled: Array<{ fn: () => void; ms: number }>
+}
+
+function makeDeps(platform: NodeJS.Platform, overrides: Partial<Recorder> = {}) {
+  const scheduled: Array<{ fn: () => void; ms: number }> = []
+  const killGroup = overrides.killGroup ?? vi.fn()
+  const killSelf = overrides.killSelf ?? vi.fn()
+  return {
+    scheduled,
+    killGroup,
+    killSelf,
+    deps: {
+      platform,
+      killGroup: killGroup as unknown as (groupId: number, signal: NodeJS.Signals) => void,
+      killSelf: killSelf as unknown as (signal: NodeJS.Signals) => void,
+      schedule: (fn: () => void, ms: number) => scheduled.push({ fn, ms }),
+    },
+  }
+}
+
+describe("terminateProcessTree", () => {
+  it("unix: SIGTERMs the whole process group then escalates to SIGKILL on the group", () => {
+    const { deps, killGroup, killSelf, scheduled } = makeDeps("darwin")
+
+    terminateProcessTree(4321, deps)
+
+    // 组信号用负 pid 命中 opencode 及其后代。
+    expect(killGroup).toHaveBeenCalledWith(-4321, "SIGTERM")
+    expect(killSelf).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(1)
+
+    scheduled[0].fn()
+    expect(killGroup).toHaveBeenCalledWith(-4321, "SIGKILL")
+    expect(killGroup).toHaveBeenCalledTimes(2)
+  })
+
+  it("unix: falls back to single-process kill when the group signal throws", () => {
+    const killGroup = vi.fn((_groupId: number, signal: NodeJS.Signals) => {
+      if (signal === "SIGTERM") {
+        throw new Error("ESRCH")
+      }
+    })
+    const { deps, killSelf, scheduled } = makeDeps("darwin", { killGroup })
+
+    terminateProcessTree(99, deps)
+
+    expect(killSelf).toHaveBeenCalledWith("SIGTERM")
+    // 仍安排 SIGKILL 兜底，且其中的组信号异常被吞掉不抛。
+    expect(scheduled).toHaveLength(1)
+    expect(() => scheduled[0].fn()).not.toThrow()
+  })
+
+  it("win32: kills only the single process and schedules nothing", () => {
+    const { deps, killGroup, killSelf, scheduled } = makeDeps("win32")
+
+    terminateProcessTree(7, deps)
+
+    expect(killSelf).toHaveBeenCalledWith("SIGTERM")
+    expect(killGroup).not.toHaveBeenCalled()
+    expect(scheduled).toHaveLength(0)
+  })
+})

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -35,6 +35,8 @@ export interface SidecarExitInfo {
 
 const startupOutputMaxBytes = 64 * 1024
 const runtimeLineMaxLength = 8 * 1024
+/** SIGTERM 后给整组进程自行退出的宽限期，超时再 SIGKILL 兜底。 */
+const processGroupKillGraceMs = 2_000
 
 /** OpenCode 本地 sidecar：spawn `opencode serve`、解析 URL、提供 SDK client、随 app 退出回收。 */
 export class OpencodeSidecar {
@@ -90,14 +92,50 @@ export class OpencodeSidecar {
     const proc = spawn(opencodeBinPath, ["serve", `--hostname=${hostname}`, "--port=0"], {
       cwd: workspaceDir,
       env: childEnv,
+      // unix：让 opencode 自成进程组（pgid === pid），dispose 时可对整组发信号，连同它派生的
+      // Bun 工具 worker / oo CLI 一并回收，避免主进程退出后残留孤儿进程。Windows 无对应语义。
+      detached: process.platform !== "win32",
     })
     this.proc = proc
 
-    let output = ""
-    const appendStartupOutput = (chunk: Buffer): void => {
-      output = appendBoundedOutput(output, chunk.toString(), startupOutputMaxBytes)
+    const url = await this.awaitServerUrl(proc, timeoutMs).catch((error: unknown) => {
+      // 启动失败（超时/提前退出/spawn 出错）时一定要回收已 spawn 的 opencode，
+      // 否则 detached 进程会成为孤儿；recoverRuntime 的重试更会不断叠加。
+      this.terminate(proc)
+      throw error
+    })
+
+    this.serverUrl = url
+    this.streamLogCleanup = attachRuntimeStreamDiagnostics(proc)
+    proc.once("exit", (code, signal) => {
+      this.streamLogCleanup?.()
+      this.streamLogCleanup = null
+      if (!this.disposed) {
+        this.options.onExit?.({ code, signal })
+      }
+    })
+    proc.once("error", (error) => {
+      this.streamLogCleanup?.()
+      this.streamLogCleanup = null
+      if (!this.disposed) {
+        this.options.onExit?.({ error })
+      }
+    })
+    const headers: Record<string, string> = {}
+    if (serverPassword) {
+      const token = Buffer.from(`opencode:${serverPassword}`).toString("base64")
+      headers.Authorization = `Basic ${token}`
     }
-    const url = await new Promise<string>((resolve, reject) => {
+    this.opencodeClient = createOpencodeClient({ baseUrl: url, headers })
+  }
+
+  /** 解析 opencode 启动输出，拿到 "listening on <url>"；超时/提前退出/出错则 reject。 */
+  private awaitServerUrl(proc: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      let output = ""
+      const appendStartupOutput = (chunk: Buffer): void => {
+        output = appendBoundedOutput(output, chunk.toString(), startupOutputMaxBytes)
+      }
       const timer = setTimeout(() => {
         reject(new Error(`opencode serve startup timeout after ${timeoutMs}ms\n${output}`))
       }, timeoutMs)
@@ -134,42 +172,72 @@ export class OpencodeSidecar {
       proc.on("exit", onExit)
       proc.on("error", onError)
     })
+  }
 
-    this.serverUrl = url
-    this.streamLogCleanup = attachRuntimeStreamDiagnostics(proc)
-    proc.once("exit", (code, signal) => {
-      this.streamLogCleanup?.()
-      this.streamLogCleanup = null
-      if (!this.disposed) {
-        this.options.onExit?.({ code, signal })
-      }
-    })
-    proc.once("error", (error) => {
-      this.streamLogCleanup?.()
-      this.streamLogCleanup = null
-      if (!this.disposed) {
-        this.options.onExit?.({ error })
-      }
-    })
-    const headers: Record<string, string> = {}
-    if (serverPassword) {
-      const token = Buffer.from(`opencode:${serverPassword}`).toString("base64")
-      headers.Authorization = `Basic ${token}`
+  /** 回收 opencode 及其全部后代（unix 按进程组 SIGTERM，宽限期后 SIGKILL 兜底）。 */
+  private terminate(proc: ChildProcessWithoutNullStreams): void {
+    if (proc.pid === undefined) {
+      return
     }
-    this.opencodeClient = createOpencodeClient({ baseUrl: url, headers })
+    terminateProcessTree(proc.pid, {
+      platform: process.platform,
+      killGroup: (groupId, signal) => process.kill(groupId, signal),
+      killSelf: (signal) => proc.kill(signal),
+      schedule: (fn, ms) => {
+        const timer = setTimeout(fn, ms)
+        timer.unref?.()
+      },
+    })
   }
 
   public dispose(): void {
     this.disposed = true
     this.streamLogCleanup?.()
     this.streamLogCleanup = null
-    if (this.proc) {
-      this.proc.kill("SIGTERM")
-      this.proc = null
-    }
+    const proc = this.proc
+    this.proc = null
     this.opencodeClient = null
     this.serverUrl = ""
+    if (proc) {
+      this.terminate(proc)
+    }
   }
+}
+
+/** terminateProcessTree 的副作用依赖，便于注入与单测。 */
+export interface ProcessTreeTerminator {
+  platform: NodeJS.Platform
+  /** 向进程组发信号（groupId 传负 pid 表示整组）；组不存在时抛出。 */
+  killGroup: (groupId: number, signal: NodeJS.Signals) => void
+  /** 单进程兜底 kill（Windows 无进程组语义时使用）。 */
+  killSelf: (signal: NodeJS.Signals) => void
+  /** 调度 SIGKILL 兜底（实现应 unref，绝不可阻止进程退出）。 */
+  schedule: (fn: () => void, ms: number) => void
+}
+
+/**
+ * 回收一棵进程树。unix 下目标进程以 detached 方式 spawn，自成进程组（pgid === pid），
+ * 故对 -pid 发 SIGTERM 可命中它及其所有后代（Bun 工具 worker / oo CLI）；宽限期后再 SIGKILL 兜底。
+ * Windows 无对应语义，退回单进程 kill（与既有行为一致，不处理孙子进程）。
+ */
+export function terminateProcessTree(pid: number, deps: ProcessTreeTerminator): void {
+  if (deps.platform === "win32") {
+    deps.killSelf("SIGTERM")
+    return
+  }
+  try {
+    deps.killGroup(-pid, "SIGTERM")
+  } catch {
+    // 组已消失或无权限：退回单进程，尽力而为。
+    deps.killSelf("SIGTERM")
+  }
+  deps.schedule(() => {
+    try {
+      deps.killGroup(-pid, "SIGKILL")
+    } catch {
+      // 组已在宽限期内退出，无需处理。
+    }
+  }, processGroupKillGraceMs)
 }
 
 function appendBoundedOutput(current: string, next: string, maxBytes: number): string {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -262,10 +262,28 @@ if (isLocked) {
     })
 
   app.on("window-all-closed", () => {
+    // 沿用系统惯例：仅 Windows/Linux 在关闭最后一个窗口时退出；macOS 保持存活留在 Dock，
+    // 点图标经 activate 重开窗口。macOS 上"退出后仍显示正在后台运行"的病根是 opencode sidecar
+    // 孤儿化（见下方信号处理器与 sidecar.ts 的按组回收），而非关窗行为，故这里不改。
     if (process.platform !== "darwin") {
       app.quit()
     }
   })
+
+  // 终端 Ctrl-C / kill <pid> / OS 关机 / macOS "停止在后台运行" 可能以原始 POSIX 信号（而非 Cocoa
+  // Quit 事件，后者走 before-quit）送达主进程。没有信号处理器时进程会被直接终止、不触发 before-quit，
+  // opencode sidecar 便沦为永久孤儿（reparent 到 launchd），macOS 仍把 app 判为"后台运行"。
+  // 这里先同步回收内核，再走正常退出（before-quit 会再 dispose 一次，幂等）。
+  // 另注：opencode 现以 detached 独立进程组运行，dev 下 Ctrl-C 不会经前台进程组自然传到它，
+  // 全靠此处 SIGINT 处理器显式回收，否则会残留孤儿。
+  const onTerminationSignal = (signal: NodeJS.Signals): void => {
+    console.log(`[wanta] received ${signal}; shutting down`)
+    isQuitting = true
+    agent?.dispose()
+    app.quit()
+  }
+  process.once("SIGTERM", () => onTerminationSignal("SIGTERM"))
+  process.once("SIGINT", () => onTerminationSignal("SIGINT"))
 
   app.on("before-quit", () => {
     isQuitting = true


### PR DESCRIPTION
起因：`OpencodeSidecar.dispose()` 此前只对 opencode `serve` 主进程发一次 `SIGTERM`，但 opencode 会派生一串后代（Bun 工具 worker、`oo` CLI），这些进程不会被回收。macOS 上 sidecar 会被 reparent 到 `launchd` 继续存活，于是出现"退出应用后系统仍显示正在后台运行"。此外，终端 Ctrl-C、`kill <pid>`、系统关机、macOS"停止在后台运行"这类原始 POSIX 信号会直接终止主进程、不触发 Cocoa 的 Quit 事件，`before-quit` 从不执行，sidecar 就沦为永久孤儿。

解决：unix 下以 `detached` 方式 spawn opencode，让它自成进程组（`pgid === pid`）；dispose 时对 `-pid` 发 `SIGTERM` 命中整组，2s 宽限期后再 `SIGKILL` 兜底，连同全部后代一并回收。主进程新增 `SIGTERM` / `SIGINT` 处理器，使信号驱动的退出也会先 dispose 内核（与 `before-quit` 幂等）。启动失败（超时 / 提前退出 / spawn 出错）时立即回收已 spawn 的进程，避免 detached 孤儿在 `recoverRuntime` 重试中不断叠加。Windows 无进程组语义，保持原有单进程 kill。

进程组回收逻辑抽成可注入依赖的纯函数 `terminateProcessTree`，并补了单测覆盖三条路径：unix 组 `SIGTERM` 后升级 `SIGKILL`、组信号抛错时回退单进程、Windows 仅杀单进程。