### PR TITLE
Remove duplicate workspace menu loading row

### DIFF
--- a/src/components/app-shell/AppShellSidebar.tsx
+++ b/src/components/app-shell/AppShellSidebar.tsx
@@ -168,12 +168,6 @@ function WorkspaceMenuContent({
           {personalDescription}
         </Badge>
       </button>
-      {loading ? (
-        <div className="relative flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-muted-foreground">
-          <LoaderCircle className="size-4 animate-spin" />
-          {t("organizations.loading")}
-        </div>
-      ) : null}
       {showBlockingError && error ? (
         <div className="px-2 py-1.5">
           <ErrorNotice error={error} compact />


### PR DESCRIPTION
## Summary

This change removes the extra loading row from the workspace switcher menu. While workspace information is refreshing, the menu now keeps the existing workspace list stable and shows progress only through the refresh button in the menu header.

## Issue

The workspace switcher had two loading indicators for the same refresh request: the header refresh icon spun, and a separate loading row was inserted between the personal workspace item and organization entries. That made the menu look like an additional workspace item was loading and interrupted the list layout.

## Fix

- Removed the inline workspace-menu loading row.
- Kept the existing refresh-button spinner as the single loading indicator for workspace list refreshes.
- Left workspace switching feedback unchanged, so the footer workspace button can still show switching progress when the active workspace is changing.

## Validation

- tsgo -p tsconfig.json
- oxlint .
- oxfmt --check .
- vitest run: 140 test files and 916 tests passed
