### PR TITLE
Fix new chat project targeting

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1253,6 +1253,9 @@ export function AppShell() {
 
   const clearActiveProjectIfNeeded = React.useCallback(
     (projectId: string): void => {
+      if (lastChatProjectId.current === projectId) {
+        lastChatProjectId.current = null
+      }
       if (activeProjectId !== projectId) {
         return
       }

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -41,6 +41,7 @@ import {
   NO_DRAFT_PROJECT_ID,
   projectContextFromProject,
   rememberTurnRetryOptions,
+  resolveNewSessionTarget,
   sessionScopeFromWorkspace,
   sessionScopeKey,
   shouldClearWorkspaceSwitchTarget,
@@ -357,6 +358,7 @@ export function AppShell() {
   const turnRetryOptionsBySession = React.useRef<Map<string, Map<string, TurnRetryOptions>>>(new Map())
   const composerDraftsByKey = React.useRef<Map<string, ComposerState>>(new Map())
   const draftProjectFallbacksById = React.useRef<Map<string, SessionProject>>(new Map())
+  const lastChatProjectId = React.useRef<string | null>(null)
   const sendInFlightRef = React.useRef(false)
   const activeSidebarSessions = React.useMemo(
     () => (sidebarSegment === "projects" ? projectSessions : taskSessions),
@@ -587,6 +589,11 @@ export function AppShell() {
     () => projectContextFromProject(activeProject, projectGit.state),
     [activeProject, projectGit.state],
   )
+  React.useEffect(() => {
+    if (route === "chat") {
+      lastChatProjectId.current = activeProjectId ?? null
+    }
+  }, [activeProjectId, route])
   const sidebarSessionGroups = React.useMemo(() => groupSidebarSessions(taskSessions), [taskSessions])
   const projectPinnedSessions = React.useMemo(() => {
     const pinnedProjectIds = new Set(projects.filter((project) => project.pinnedAt).map((project) => project.id))
@@ -738,6 +745,7 @@ export function AppShell() {
 
   React.useEffect(() => {
     draftProjectFallbacksById.current.clear()
+    lastChatProjectId.current = null
   }, [sessionScope])
 
   React.useEffect(() => {
@@ -810,30 +818,41 @@ export function AppShell() {
     setRoute("connections")
   }, [])
 
-  const handleNewSession = React.useCallback((): void => {
-    setActiveSessionId(null)
-    setIsDraftSession(true)
-    setDraftPermissionMode("default")
-    setDraftProjectId(NO_DRAFT_PROJECT_ID)
-    setPendingChatTransition(null)
-    setRoute("chat")
-    setSidebarSegment("tasks")
-    setSearchOpen(false)
-    setComposerFocusRequest((request) => request + 1)
-  }, [])
+  const startNewSessionDraft = React.useCallback(
+    (target: ReturnType<typeof resolveNewSessionTarget>): void => {
+      const targetDraftKey = newSessionComposerDraftKey(sessionScope, target.projectId)
+      clearComposerDraft(targetDraftKey)
+      setActiveSessionId(null)
+      setIsDraftSession(true)
+      setDraftPermissionMode("default")
+      setDraftProjectId(target.projectId ?? NO_DRAFT_PROJECT_ID)
+      setPendingChatTransition(null)
+      setRoute("chat")
+      setSidebarSegment(target.sidebarSegment)
+      setSearchOpen(false)
+      setComposerFocusRequest((request) => request + 1)
+    },
+    [clearComposerDraft, sessionScope],
+  )
 
-  const handleOpenProjectDraft = React.useCallback((project: SessionProject): void => {
-    draftProjectFallbacksById.current.set(project.id, project)
-    setActiveSessionId(null)
-    setIsDraftSession(true)
-    setDraftPermissionMode("default")
-    setDraftProjectId(project.id)
-    setPendingChatTransition(null)
-    setRoute("chat")
-    setSearchOpen(false)
-    setSidebarSegment("projects")
-    setComposerFocusRequest((request) => request + 1)
-  }, [])
+  const handleNewSession = React.useCallback((): void => {
+    startNewSessionDraft(
+      resolveNewSessionTarget({
+        activeSession,
+        draftProjectId,
+        lastProjectId: lastChatProjectId.current,
+        preferLastProject: route !== "chat",
+      }),
+    )
+  }, [activeSession, draftProjectId, route, startNewSessionDraft])
+
+  const handleOpenProjectDraft = React.useCallback(
+    (project: SessionProject): void => {
+      draftProjectFallbacksById.current.set(project.id, project)
+      startNewSessionDraft(resolveNewSessionTarget({ draftProjectId, explicitProjectId: project.id }))
+    },
+    [draftProjectId, startNewSessionDraft],
+  )
 
   const handleSelectComposerProject = React.useCallback(
     async (projectId: string | undefined): Promise<void> => {
@@ -1413,7 +1432,10 @@ export function AppShell() {
   const artifactsToggleLabel = artifactsPanelOpen ? t("artifacts.collapse") : t("artifacts.expand")
   const billingCacheScope = auth.state?.account?.id ?? "authenticated"
   const newChatShortcut = appCommandShortcutLabel(APP_COMMANDS.newChat)
-  const newChatLabel = labelWithShortcut(t("sidebar.newSession"), newChatShortcut)
+  const newChatLabel = labelWithShortcut(
+    activeProject ? t("project.newTask") : t("sidebar.newSession"),
+    newChatShortcut,
+  )
 
   if (route === "settings") {
     return (

--- a/src/components/app-shell/app-shell-model.test.ts
+++ b/src/components/app-shell/app-shell-model.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest"
-import { isWorkspaceSwitchPending, shouldClearWorkspaceSwitchTarget } from "./app-shell-model.ts"
+import {
+  NO_DRAFT_PROJECT_ID,
+  isWorkspaceSwitchPending,
+  resolveNewSessionTarget,
+  shouldClearWorkspaceSwitchTarget,
+} from "./app-shell-model.ts"
 
 const readyInput = {
   connectionSettledWorkspaceKey: "personal",
@@ -98,5 +103,57 @@ describe("workspace switch target cleanup", () => {
         organizationIds: [],
       }),
     ).toBe(false)
+  })
+})
+
+describe("new session target resolution", () => {
+  test("opens a root task draft without project context", () => {
+    expect(resolveNewSessionTarget({ draftProjectId: null })).toEqual({ sidebarSegment: "tasks" })
+  })
+
+  test("keeps a new chat inside the active project session", () => {
+    expect(resolveNewSessionTarget({ activeSession: { projectId: "project-a" }, draftProjectId: null })).toEqual({
+      projectId: "project-a",
+      sidebarSegment: "projects",
+    })
+  })
+
+  test("keeps a new chat inside the active project draft", () => {
+    expect(resolveNewSessionTarget({ draftProjectId: "project-b" })).toEqual({
+      projectId: "project-b",
+      sidebarSegment: "projects",
+    })
+  })
+
+  test("treats the explicit no-project draft marker as a root task", () => {
+    expect(resolveNewSessionTarget({ draftProjectId: NO_DRAFT_PROJECT_ID })).toEqual({ sidebarSegment: "tasks" })
+  })
+
+  test("lets an explicit project row target override the active task context", () => {
+    expect(
+      resolveNewSessionTarget({
+        activeSession: {},
+        draftProjectId: NO_DRAFT_PROJECT_ID,
+        explicitProjectId: "project-c",
+      }),
+    ).toEqual({
+      projectId: "project-c",
+      sidebarSegment: "projects",
+    })
+  })
+
+  test("can fall back to the last chat project from non-chat routes", () => {
+    expect(
+      resolveNewSessionTarget({ draftProjectId: null, lastProjectId: "project-d", preferLastProject: true }),
+    ).toEqual({
+      projectId: "project-d",
+      sidebarSegment: "projects",
+    })
+  })
+
+  test("ignores last project context unless requested", () => {
+    expect(resolveNewSessionTarget({ draftProjectId: null, lastProjectId: "project-d" })).toEqual({
+      sidebarSegment: "tasks",
+    })
   })
 })

--- a/src/components/app-shell/app-shell-model.ts
+++ b/src/components/app-shell/app-shell-model.ts
@@ -360,6 +360,37 @@ export function activeProjectIdForComposer({
   return undefined
 }
 
+export interface NewSessionTarget {
+  projectId?: string
+  sidebarSegment: "projects" | "tasks"
+}
+
+function validProjectId(projectId: string | null | undefined): string | undefined {
+  const normalized = projectId?.trim()
+  return normalized && normalized !== NO_DRAFT_PROJECT_ID ? normalized : undefined
+}
+
+export function resolveNewSessionTarget({
+  activeSession,
+  draftProjectId,
+  explicitProjectId,
+  lastProjectId,
+  preferLastProject = false,
+}: {
+  activeSession?: Pick<SessionInfo, "projectId"> | null
+  draftProjectId: string | null
+  explicitProjectId?: string | null
+  lastProjectId?: string | null
+  preferLastProject?: boolean
+}): NewSessionTarget {
+  const projectId =
+    validProjectId(explicitProjectId) ??
+    validProjectId(activeSession?.projectId) ??
+    validProjectId(draftProjectId) ??
+    (preferLastProject ? validProjectId(lastProjectId) : undefined)
+  return projectId ? { projectId, sidebarSegment: "projects" } : { sidebarSegment: "tasks" }
+}
+
 export function newSessionComposerDraftKey(scope: SessionScope | null, projectId: string | undefined): string {
   return `${NEW_SESSION_COMPOSER_DRAFT_KEY}:${sessionScopeKey(scope)}:${projectId ?? "none"}`
 }


### PR DESCRIPTION
## Summary

This updates the new chat entrypoint so it respects the current work context instead of always falling back to the root task list. When a user starts a new chat from an active project conversation or project draft, Wanta now opens a fresh draft under that project. Explicit project-row creation still wins, while non-chat routes can return to the last chat project context without leaking across workspace changes.

## Root Cause

The global new chat handler unconditionally cleared the active session, marked a draft session, set the draft project to the no-project sentinel, and switched the sidebar to Tasks. That made project-local new chat creation behave like a root task action, and it could feel like the app had jumped back into an unrelated previous task.

## Changes

- Added a pure `resolveNewSessionTarget` helper for deciding whether a new chat belongs under Tasks or a specific Project.
- Routed both global new chat and project-row new chat through one `startNewSessionDraft` path.
- Preserved the last chat project context for non-chat routes, and clear it when the session workspace scope changes.
- Added unit coverage for root tasks, active project sessions, project drafts, explicit project-row targets, and non-chat fallback behavior.

## Validation

- `oxlint .`
- `tsgo -p tsconfig.json`
- `oxfmt --check .`
- `vitest run`
- `vite build`
