### PR TITLE
fix(update): allow macOS restart install

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -93,6 +93,8 @@ const protocolScheme = viteDevServerUrl ? branding.devProtocolScheme : branding.
 let mainWindow: BrowserWindow | null = null
 let currentLocale: AppLocale | null = null
 let isQuitting = false
+type AppQuitIntent = "none" | "user-quit" | "update-install" | "termination-signal"
+let appQuitIntent: AppQuitIntent = "none"
 let windowsTrayLifecycle: {
   dispose: () => void
   setLocale: (locale: string) => void
@@ -173,6 +175,7 @@ const settingsService = new SettingsServiceImpl({
 })
 // 更新渠道（stable/beta）持久化在同一 settings.json；服务内部仅打包态联网。
 const updateService = new UpdateServiceImpl({
+  beforeInstallDownloadedAppUpdate: () => armAppQuit("update-install"),
   store: settingsStore,
 })
 const gitService = new GitServiceImpl({
@@ -280,7 +283,7 @@ if (isLocked) {
   // 全靠此处 SIGINT 处理器显式回收，否则会残留孤儿。
   const onTerminationSignal = (signal: NodeJS.Signals): void => {
     console.log(`[wanta] received ${signal}; shutting down`)
-    isQuitting = true
+    armAppQuit("termination-signal")
     agent?.dispose()
     app.quit()
   }
@@ -288,7 +291,7 @@ if (isLocked) {
   process.once("SIGINT", () => onTerminationSignal("SIGINT"))
 
   app.on("before-quit", () => {
-    isQuitting = true
+    armAppQuit("user-quit")
     if (pendingSkillRuntimeRefresh) {
       clearTimeout(pendingSkillRuntimeRefresh)
       pendingSkillRuntimeRefresh = undefined
@@ -301,6 +304,14 @@ if (isLocked) {
       console.warn("[wanta] failed to flush diagnostics log", error)
     })
   })
+}
+
+function armAppQuit(intent: Exclude<AppQuitIntent, "none">): void {
+  if (appQuitIntent === "none") {
+    appQuitIntent = intent
+    logDiagnostic("app-lifecycle", "application quit armed", { intent }, "info")
+  }
+  isQuitting = true
 }
 
 function logMainError(message: string, error: unknown, fields: Record<string, unknown> = {}): void {
@@ -731,7 +742,7 @@ function createMainWindow(): void {
           iconPath: getBrandingResourcePath("icon.ico"),
           locale: activeLocale(),
           onExit: () => {
-            isQuitting = true
+            armAppQuit("user-quit")
             app.quit()
           },
           onOpen: () => {

--- a/electron/update/node.ts
+++ b/electron/update/node.ts
@@ -31,6 +31,7 @@ type ElectronUpdaterModule = typeof import("electron-updater")
 type AutoUpdater = ElectronUpdaterModule["autoUpdater"]
 
 export interface UpdateServiceDeps {
+  beforeInstallDownloadedAppUpdate?: () => void
   store: SettingsStore
 }
 
@@ -103,6 +104,15 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
     if (!app.isPackaged || this.state.status.status !== "downloaded") {
       return Promise.resolve()
     }
+    logDiagnostic(
+      "update-service",
+      "install downloaded update requested",
+      { channel: this.channel, version: this.state.status.version },
+      "info",
+    )
+    // macOS 的 quitAndInstall 会先 close 所有窗口，再触发 app.before-quit。必须提前让
+    // 主窗口 close handler 放行，否则窗口会被 hide-on-close 逻辑拦住，安装流程停在重启中。
+    this.deps.beforeInstallDownloadedAppUpdate?.()
     this.getAutoUpdater().quitAndInstall()
     return Promise.resolve()
   }

--- a/src/hooks/useAppUpdate.ts
+++ b/src/hooks/useAppUpdate.ts
@@ -24,6 +24,10 @@ interface AppUpdateSnapshot {
 
 type AppUpdateListener = () => void
 
+const installFallbackResetMs = 15_000
+let installAttemptGeneration = 0
+let installFallbackTimer: number | undefined
+
 const appUpdateStore = {
   listeners: new Set<AppUpdateListener>(),
   snapshot: {
@@ -148,6 +152,12 @@ export function useAppUpdate(): UseAppUpdate {
     if (appUpdateStore.snapshot.isInstallTriggered) {
       return
     }
+    installAttemptGeneration += 1
+    const generation = installAttemptGeneration
+    if (installFallbackTimer !== undefined) {
+      window.clearTimeout(installFallbackTimer)
+      installFallbackTimer = undefined
+    }
     appUpdateStore.patch({ isInstallTriggered: true })
     await service.invoke("installDownloadedAppUpdate").catch((error: unknown) => {
       appUpdateStore.patch({ isInstallTriggered: false })
@@ -155,7 +165,20 @@ export function useAppUpdate(): UseAppUpdate {
       reportRendererHandledError("update", "update install failed", error)
       patchUpdateError(error)
     })
-  }, [service])
+    installFallbackTimer = window.setTimeout(() => {
+      if (installAttemptGeneration !== generation) {
+        return
+      }
+      installFallbackTimer = undefined
+      if (!appUpdateStore.snapshot.isInstallTriggered) {
+        return
+      }
+      appUpdateStore.patch({ isInstallTriggered: false })
+      void refreshState().catch((error: unknown) => {
+        reportRendererHandledError("update", "update state refresh after install timeout failed", error)
+      })
+    }, installFallbackResetMs)
+  }, [refreshState, service])
 
   const setChannel = React.useCallback(
     async (channel: UpdateChannel) => {


### PR DESCRIPTION
## Summary

Fix the cross-platform close/update interaction so macOS and Windows keep the intended background-on-close behavior while allowing update installs and explicit quits to close windows normally.

## Issue

Users could reach the `Restart to update` / `重启更新` state after the update zip had already downloaded, but clicking the button left the titlebar action spinning indefinitely. The downloaded `Wanta-0.1.60.zip` and Squirrel staging directory were present locally, which pointed away from CDN or download problems and toward the install handoff.

The same area also needed a clearer platform policy: macOS and Windows should both hide the main window on a normal close button click, but neither platform should let that hide-on-close behavior intercept explicit quits or update installs.

A follow-up review also noted that the renderer fallback timer should be tied to a specific install attempt, otherwise a stale timeout from an earlier failed install request could reset a later install attempt.

## Root Cause

PR #128 generalized the hide-on-close handler from Windows to macOS. On macOS, `electron-updater`'s `quitAndInstall()` closes application windows before Electron emits `app.before-quit`. Wanta only set `isQuitting = true` inside `before-quit`, so the macOS close handler still saw `isQuitting === false`, called `event.preventDefault()`, hid the window, and prevented the updater from finishing the quit/install sequence.

Windows did not reproduce the same failure in the current NSIS path because `electron-updater` triggers the installer and then calls `app.quit()`, which normally reaches `before-quit` before window close handling. That is an implementation detail, though, so this patch makes update install quit intent explicit on both platforms.

## Fix

- Add an explicit app quit intent in `main.ts` and route update installs, user quits, tray exits, and termination signals through one `armAppQuit(...)` helper.
- Keep normal close-button behavior as backgrounding on both macOS and Windows by only allowing the hide-on-close handler to intercept when no real quit intent has been armed.
- Add a pre-install hook to `UpdateServiceImpl` and call it immediately before `autoUpdater.quitAndInstall()` so updater-driven window closes are not hidden.
- Add diagnostics entries for update install requests and quit-intent arming to make future update-install failures easier to inspect.
- Add a renderer-side fallback reset for the install spinner if the app remains alive after the install request, avoiding a permanent loading state if a future updater failure does not reject synchronously.
- Bind that fallback reset to a specific install attempt with a generation token and clear any previous timer before a new attempt starts, so stale timers cannot affect later install attempts.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run dev` reached the Vite dev server and started the Wanta sidecar successfully; stopped manually after startup verification.
