### PR TITLE
fix(chat): improve queued message recovery

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -593,6 +593,9 @@ export class AgentManager {
       }
     }
     return messages
+      .map((message, index) => ({ index, message }))
+      .sort((left, right) => left.message.createdAt - right.message.createdAt || left.index - right.index)
+      .map((item) => item.message)
   }
 
   public async getPendingQuestions(sessionId: string): Promise<ChatQuestionRequest[]> {

--- a/electron/chat/authorization-signal.ts
+++ b/electron/chat/authorization-signal.ts
@@ -9,6 +9,7 @@ interface SearchActionResult {
 interface SearchAuthorizationContext {
   keywords?: unknown
   query?: unknown
+  userText?: unknown
 }
 
 function validId(value: string): boolean {
@@ -27,7 +28,9 @@ function searchTokens(value: string): string[] {
 }
 
 function searchContextText(context: SearchAuthorizationContext | undefined): string {
-  return [optionalString(context?.keywords), optionalString(context?.query)].filter(Boolean).join(" ")
+  return [optionalString(context?.keywords), optionalString(context?.query), optionalString(context?.userText)]
+    .filter(Boolean)
+    .join(" ")
 }
 
 export function parseAuthorizationSignal(output: string | undefined): AuthorizationInfo | null {
@@ -58,6 +61,38 @@ function displayNameFromService(service: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ")
+}
+
+function serviceTokens(service: string): string[] {
+  return searchTokens(service).filter((token) => token !== "oo")
+}
+
+function serviceMatchesContext(service: string, contextTokens: Set<string>): boolean {
+  const tokens = serviceTokens(service)
+  return tokens.length > 0 && tokens.every((token) => contextTokens.has(token))
+}
+
+function explicitProviderTokens(value: string): Set<string> {
+  const tokens = new Set<string>()
+  const matches = value.matchAll(/[A-Za-z0-9][A-Za-z0-9._-]*/g)
+  for (const match of matches) {
+    const token = match[0] ?? ""
+    // 品牌名常用 CamelCase（如 PostHog / LaunchDarkly）；只用它来识别“明确点名的 provider”。
+    if (/[a-z][A-Z]/.test(token)) {
+      for (const normalized of searchTokens(token)) {
+        tokens.add(normalized)
+      }
+    }
+  }
+  return tokens
+}
+
+function hasExplicitProviderMismatch(service: string, contextText: string): boolean {
+  const explicitTokens = explicitProviderTokens(contextText)
+  if (explicitTokens.size === 0) {
+    return false
+  }
+  return !serviceTokens(service).some((token) => explicitTokens.has(token))
 }
 
 export function parseSearchAuthorizationSignal(
@@ -93,15 +128,16 @@ export function parseSearchAuthorizationSignal(
     if (services.length === 0) {
       return null
     }
-    const contextTokens = new Set(searchTokens(searchContextText(context)))
+    const contextText = searchContextText(context)
+    const contextTokens = new Set(searchTokens(contextText))
     const matchedServices =
-      contextTokens.size > 0
-        ? services.filter((service) => {
-            const serviceTokens = searchTokens(service)
-            return serviceTokens.length > 0 && serviceTokens.every((token) => contextTokens.has(token))
-          })
-        : []
-    const service = matchedServices.length === 1 ? matchedServices[0] : services.length === 1 ? services[0] : undefined
+      contextTokens.size > 0 ? services.filter((service) => serviceMatchesContext(service, contextTokens)) : []
+    const service =
+      matchedServices.length === 1
+        ? matchedServices[0]
+        : services.length === 1 && !hasExplicitProviderMismatch(services[0] ?? "", contextText)
+          ? services[0]
+          : undefined
     if (!service) {
       return null
     }

--- a/electron/chat/authorization-signal.ts
+++ b/electron/chat/authorization-signal.ts
@@ -67,21 +67,62 @@ function serviceTokens(service: string): string[] {
   return searchTokens(service).filter((token) => token !== "oo")
 }
 
+function serviceMatchTokens(service: string): Set<string> {
+  const tokens = serviceTokens(service)
+  const matchTokens = new Set(tokens)
+  const compact = tokens.join("")
+  if (compact) {
+    matchTokens.add(compact)
+  }
+  return matchTokens
+}
+
 function serviceMatchesContext(service: string, contextTokens: Set<string>): boolean {
   const tokens = serviceTokens(service)
   return tokens.length > 0 && tokens.every((token) => contextTokens.has(token))
 }
+
+const knownProviderAliasTokens = new Set([
+  "airtable",
+  "asana",
+  "clickup",
+  "figma",
+  "github",
+  "gitlab",
+  "gmail",
+  "google",
+  "googledrive",
+  "googlesheets",
+  "hubspot",
+  "jira",
+  "linear",
+  "notion",
+  "posthog",
+  "salesforce",
+  "slack",
+  "supabase",
+  "trello",
+  "zendesk",
+])
 
 function explicitProviderTokens(value: string): Set<string> {
   const tokens = new Set<string>()
   const matches = value.matchAll(/[A-Za-z0-9][A-Za-z0-9._-]*/g)
   for (const match of matches) {
     const token = match[0] ?? ""
-    // 品牌名常用 CamelCase（如 PostHog / LaunchDarkly）；只用它来识别“明确点名的 provider”。
-    if (/[a-z][A-Z]/.test(token)) {
-      for (const normalized of searchTokens(token)) {
-        tokens.add(normalized)
-      }
+    const normalizedTokens = searchTokens(token)
+    const compactToken = normalizedTokens.join("")
+    // 品牌名可能是 CamelCase、首字母大写，或常见全小写别名（如 posthog）。
+    const looksLikeProviderAlias =
+      /[a-z][A-Z]/.test(token) || /^[A-Z][A-Za-z0-9._-]*$/.test(token) || knownProviderAliasTokens.has(compactToken)
+    if (!looksLikeProviderAlias) {
+      continue
+    }
+    for (const normalized of normalizedTokens) {
+      tokens.add(normalized)
+    }
+    if (compactToken) {
+      tokens.add(compactToken)
     }
   }
   return tokens
@@ -92,7 +133,7 @@ function hasExplicitProviderMismatch(service: string, contextText: string): bool
   if (explicitTokens.size === 0) {
     return false
   }
-  return !serviceTokens(service).some((token) => explicitTokens.has(token))
+  return ![...serviceMatchTokens(service)].some((token) => explicitTokens.has(token))
 }
 
 export function parseSearchAuthorizationSignal(

--- a/electron/chat/authorization.test.ts
+++ b/electron/chat/authorization.test.ts
@@ -125,6 +125,26 @@ test("parseSearchAuthorizationSignal prefers the provider named by the search in
   assert.equal(parseSearchAuthorizationSignal(output), null)
 })
 
+test("parseSearchAuthorizationSignal suppresses a single unrelated provider when context names another provider", () => {
+  assert.equal(
+    parseSearchAuthorizationSignal(JSON.stringify([{ service: "launchdarkly", authenticated: false }]), {
+      query: "PostHog feature flags",
+      userText: "PostHog 功能介绍",
+    }),
+    null,
+  )
+  assert.deepEqual(
+    parseSearchAuthorizationSignal(JSON.stringify([{ service: "launchdarkly", authenticated: false }]), {
+      query: "feature flags",
+    }),
+    {
+      service: "launchdarkly",
+      displayName: "Launchdarkly",
+      errorCode: "connection_required",
+    },
+  )
+})
+
 test("parseSearchAuthorizationSignal does not match provider names as arbitrary substrings", () => {
   const output = JSON.stringify([
     { service: "box", name: "upload_file", authenticated: false },

--- a/electron/chat/authorization.test.ts
+++ b/electron/chat/authorization.test.ts
@@ -145,6 +145,34 @@ test("parseSearchAuthorizationSignal suppresses a single unrelated provider when
   )
 })
 
+test("parseSearchAuthorizationSignal detects explicit provider aliases without CamelCase", () => {
+  assert.equal(
+    parseSearchAuthorizationSignal(JSON.stringify([{ service: "launchdarkly", authenticated: false }]), {
+      query: "PostHog feature flags",
+      userText: "posthog 功能介绍",
+    }),
+    null,
+  )
+  assert.equal(
+    parseSearchAuthorizationSignal(JSON.stringify([{ service: "github", authenticated: false }]), {
+      query: "Notion project docs",
+      userText: "Notion project docs",
+    }),
+    null,
+  )
+  assert.deepEqual(
+    parseSearchAuthorizationSignal(JSON.stringify([{ service: "slack", authenticated: false }]), {
+      query: "Slack messages",
+      userText: "Slack messages",
+    }),
+    {
+      service: "slack",
+      displayName: "Slack",
+      errorCode: "connection_required",
+    },
+  )
+})
+
 test("parseSearchAuthorizationSignal does not match provider names as arbitrary substrings", () => {
   const output = JSON.stringify([
     { service: "box", name: "upload_file", authenticated: false },

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -36,6 +36,7 @@ import {
   connectionWorkspaceSwitchKey,
   EMPTY_CONNECTION_PROVIDERS,
   existingSessionComposerDraftKey,
+  getUnlinkedProviderSkillRecommendations,
   initialRoute,
   isWorkspaceSwitchPending,
   newSessionComposerDraftKey,
@@ -48,6 +49,7 @@ import {
   sessionScopeFromWorkspace,
   sessionScopeKey,
   shouldClearWorkspaceSwitchTarget,
+  shouldShowRecommendedSkillEntry,
   workspaceSelectionSwitchKey,
   WORKSPACE_SWITCH_TIMEOUT_MS,
 } from "./app-shell-model.ts"
@@ -75,6 +77,7 @@ import { useConnections } from "@/hooks/useConnections"
 import { useOrganizationSkills } from "@/hooks/useOrganizationSkills"
 import { useOrganizationWorkspace } from "@/hooks/useOrganizationWorkspace"
 import { useProjectGit } from "@/hooks/useProjectGit"
+import { useProviderSkillRecommendations } from "@/hooks/useProviderSkillRecommendations"
 import { useSessions } from "@/hooks/useSessions"
 import { useT } from "@/i18n/i18n"
 import { appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
@@ -149,23 +152,6 @@ export function AppShell() {
     }
     return getInstallableOrganizationSkills(organizationSkillGroupById, enabledOrganizationSkills)
   }, [enabledOrganizationSkills, organizationSkillGroupById, organizationSkills.organizationId, skillInventory.data])
-  const organizationSkillPendingInstallCount = skillInventory.data ? installableOrganizationSkills.length : undefined
-  const organizationSkillEntryVisible = Boolean(
-    organizationSkills.organizationId && enabledOrganizationSkills.length > 0,
-  )
-  const organizationSkillShowcaseItems = React.useMemo<ChatOrganizationSkillContext[]>(() => {
-    const showcaseSkills =
-      installableOrganizationSkills.length > 0 ? installableOrganizationSkills : enabledOrganizationSkills
-    return showcaseSkills.map((skill) => ({
-      ...(skill.description ? { description: skill.description } : {}),
-      ...(skill.icon ? { icon: skill.icon } : {}),
-      id: skill.id,
-      name: skill.displayName || skill.skillName,
-      packageName: skill.packageName,
-      skillName: skill.skillName,
-      version: skill.version,
-    }))
-  }, [enabledOrganizationSkills, installableOrganizationSkills])
   const sessionScope = React.useMemo(
     () => sessionScopeFromWorkspace(organizationWorkspace.activeWorkspace),
     [organizationWorkspace.activeWorkspace],
@@ -353,6 +339,48 @@ export function AppShell() {
   const activeProviders = connectionSummaryMatchesWorkspace
     ? (connections.summary?.providers ?? EMPTY_CONNECTION_PROVIDERS)
     : EMPTY_CONNECTION_PROVIDERS
+  const providerSkillRecommendations = useProviderSkillRecommendations({
+    groupById: organizationSkillGroupById,
+    providers: organizationSkills.organizationId ? activeProviders : EMPTY_CONNECTION_PROVIDERS,
+  })
+  const installableProviderSkillRecommendations = React.useMemo(
+    () => getUnlinkedProviderSkillRecommendations(enabledOrganizationSkills, providerSkillRecommendations.installable),
+    [enabledOrganizationSkills, providerSkillRecommendations.installable],
+  )
+  const recommendedSkillPendingInstallCount = skillInventory.data
+    ? installableOrganizationSkills.length + installableProviderSkillRecommendations.length
+    : undefined
+  const organizationSkillEntryVisible = shouldShowRecommendedSkillEntry({
+    organizationId: organizationSkills.organizationId,
+    organizationSkillCount: enabledOrganizationSkills.length,
+    providerRecommendationCount: installableProviderSkillRecommendations.length,
+  })
+  const organizationSkillShowcaseItems = React.useMemo<ChatOrganizationSkillContext[]>(() => {
+    const organizationShowcaseSkills =
+      installableOrganizationSkills.length > 0 ? installableOrganizationSkills : enabledOrganizationSkills
+    const organizationItems = organizationShowcaseSkills.map((skill) => ({
+      ...(skill.description ? { description: skill.description } : {}),
+      ...(skill.icon ? { icon: skill.icon } : {}),
+      id: skill.id,
+      name: skill.displayName || skill.skillName,
+      packageName: skill.packageName,
+      skillName: skill.skillName,
+      version: skill.version,
+    }))
+    const providerItems = installableProviderSkillRecommendations.map((recommendation) => {
+      const recommendedSkill = recommendation.package.skills.find((skill) => skill.name === recommendation.skillId)
+      return {
+        ...(recommendation.package.description ? { description: recommendation.package.description } : {}),
+        ...(recommendation.providerIconUrl ? { icon: recommendation.providerIconUrl } : {}),
+        id: `provider:${recommendation.service}:${recommendation.packageName}:${recommendation.skillId}`,
+        name: recommendation.package.displayName || recommendedSkill?.title || recommendation.skillId,
+        packageName: recommendation.packageName,
+        skillName: recommendation.skillId,
+        version: recommendation.package.version,
+      }
+    })
+    return [...organizationItems, ...providerItems]
+  }, [enabledOrganizationSkills, installableOrganizationSkills, installableProviderSkillRecommendations])
   const sharedConnectorCount =
     organizationWorkspace.activeWorkspace.type === "organization" && connectionSummaryMatchesWorkspace
       ? connections.summary?.connectedProviderCount
@@ -1751,7 +1779,7 @@ export function AppShell() {
                       sharedConnectorCount={sharedConnectorCount}
                       organizationSkillEntryVisible={organizationSkillEntryVisible}
                       organizationSkillShowcaseItems={organizationSkillShowcaseItems}
-                      organizationSkillPendingInstallCount={organizationSkillPendingInstallCount}
+                      organizationSkillPendingInstallCount={recommendedSkillPendingInstallCount}
                       organizationSkills={organizationSkills.chatContextSkills}
                       providers={activeProviders}
                       queueHeld={activeQueueHeld}

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1194,7 +1194,6 @@ export function AppShell() {
     handleQueuedMessageMove,
     handleQueuedMessageRemove,
     handleQueuedMessageResume,
-    holdActiveQueueIfQueued,
     holdQueuedSessionIfQueued,
     queueActiveMessage,
     releaseActiveQueue,
@@ -1531,10 +1530,9 @@ export function AppShell() {
   }
   const handleChatStop = React.useCallback(async (): Promise<void> => {
     if (activeChatSessionId) {
-      holdActiveQueueIfQueued()
       await stop(activeChatSessionId)
     }
-  }, [activeChatSessionId, holdActiveQueueIfQueued, stop])
+  }, [activeChatSessionId, stop])
   const handlePermissionModeChange = React.useCallback(
     (mode: AgentPermissionMode): void => {
       if (activeChatSessionId) {

--- a/src/components/app-shell/app-shell-model.test.ts
+++ b/src/components/app-shell/app-shell-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 import {
   existingSessionComposerDraftKey,
+  getUnlinkedProviderSkillRecommendations,
   NO_DRAFT_PROJECT_ID,
   isWorkspaceSwitchPending,
   newSessionComposerDraftKey,
@@ -8,6 +9,7 @@ import {
   resolveNewSessionTarget,
   sessionRecordScopeKey,
   shouldClearWorkspaceSwitchTarget,
+  shouldShowRecommendedSkillEntry,
 } from "./app-shell-model.ts"
 
 const readyInput = {
@@ -57,6 +59,40 @@ describe("workspace switch pending state", () => {
 
   test("settles when all target-scoped requests are done", () => {
     expect(isWorkspaceSwitchPending(readyInput)).toBe(false)
+  })
+})
+
+describe("recommended Skill empty state entry", () => {
+  test("shows when a provider recommendation is installable without organization configured Skills", () => {
+    expect(
+      shouldShowRecommendedSkillEntry({
+        organizationId: "org-1",
+        organizationSkillCount: 0,
+        providerRecommendationCount: 1,
+      }),
+    ).toBe(true)
+  })
+
+  test("stays hidden outside an organization workspace", () => {
+    expect(
+      shouldShowRecommendedSkillEntry({
+        organizationId: null,
+        organizationSkillCount: 0,
+        providerRecommendationCount: 1,
+      }),
+    ).toBe(false)
+  })
+
+  test("deduplicates provider recommendations already configured by the organization", () => {
+    const recommendations = getUnlinkedProviderSkillRecommendations(
+      [{ packageName: "oo-posthog", skillName: "posthog" }],
+      [
+        { packageName: "oo-posthog", service: "posthog", skillId: "posthog" },
+        { packageName: "oo-gmail", service: "gmail", skillId: "gmail" },
+      ],
+    )
+
+    expect(recommendations).toEqual([{ packageName: "oo-gmail", service: "gmail", skillId: "gmail" }])
   })
 })
 

--- a/src/components/app-shell/app-shell-model.ts
+++ b/src/components/app-shell/app-shell-model.ts
@@ -41,6 +41,53 @@ export const NO_DRAFT_PROJECT_ID = "__no_project__"
 
 export { connectionWorkspaceKey as connectionWorkspaceSwitchKey } from "@/hooks/connection-oauth-pending"
 
+export interface RecommendedSkillIdentity {
+  packageName?: string
+  skillName: string
+}
+
+export interface ProviderRecommendedSkillIdentity {
+  packageName: string
+  skillId: string
+}
+
+function recommendedSkillKey(packageName: string | undefined, skillName: string): string | null {
+  const normalizedPackageName = packageName?.trim().toLowerCase()
+  const normalizedSkillName = skillName.trim().toLowerCase()
+  if (!normalizedPackageName || !normalizedSkillName) {
+    return null
+  }
+  return `${normalizedPackageName}\u0000${normalizedSkillName}`
+}
+
+export function getUnlinkedProviderSkillRecommendations<T extends ProviderRecommendedSkillIdentity>(
+  organizationSkills: readonly RecommendedSkillIdentity[],
+  providerRecommendations: readonly T[],
+): T[] {
+  const organizationSkillKeys = new Set(
+    organizationSkills
+      .map((skill) => recommendedSkillKey(skill.packageName, skill.skillName))
+      .filter((key): key is string => Boolean(key)),
+  )
+
+  return providerRecommendations.filter((recommendation) => {
+    const key = recommendedSkillKey(recommendation.packageName, recommendation.skillId)
+    return !key || !organizationSkillKeys.has(key)
+  })
+}
+
+export function shouldShowRecommendedSkillEntry({
+  organizationId,
+  organizationSkillCount,
+  providerRecommendationCount,
+}: {
+  organizationId: string | null
+  organizationSkillCount: number
+  providerRecommendationCount: number
+}): boolean {
+  return Boolean(organizationId && (organizationSkillCount > 0 || providerRecommendationCount > 0))
+}
+
 export interface TurnRetryOptions {
   contextMentions?: ChatContextMention[]
   organizationSkills?: ChatOrganizationSkillContext[]

--- a/src/components/app-shell/chat-queue.test.ts
+++ b/src/components/app-shell/chat-queue.test.ts
@@ -130,4 +130,9 @@ describe("chat queue", () => {
     assert.equal(shouldDispatchQueuedMessage("streaming", false, false), false)
     assert.equal(shouldDispatchQueuedMessage("error", false, false), false)
   })
+
+  test("resumes queued messages after a manual stop returns the session to ready", () => {
+    assert.equal(shouldDispatchQueuedMessage("streaming", false, false), false)
+    assert.equal(shouldDispatchQueuedMessage("ready", false, false), true)
+  })
 })

--- a/src/hooks/chat-message-state.ts
+++ b/src/hooks/chat-message-state.ts
@@ -435,14 +435,14 @@ export function setMessageArtifactRoot(msgs: ChatMessage[], event: MessageArtifa
   )
 }
 
-function messageText(message: ChatMessage): string {
+function messageText(message: Pick<ChatMessage, "parts">): string {
   return message.parts
     .filter((part) => part.kind === "text")
     .map((part) => part.text ?? "")
     .join("")
 }
 
-function messageAttachments(message: ChatMessage): ChatAttachment[] {
+function messageAttachments(message: Pick<ChatMessage, "parts">): ChatAttachment[] {
   return message.parts
     .filter((part) => part.kind === "attachment" && part.attachment)
     .map((part) => part.attachment as ChatAttachment)
@@ -455,14 +455,57 @@ function attachmentsKey(attachments: ChatAttachment[] | undefined): string {
     .join("\n")
 }
 
-function hasUserMessage(msgs: ChatMessage[], text: string, attachments?: ChatAttachment[]): boolean {
+function userMessageContentKey(message: Pick<ChatMessage, "parts">): string {
+  return `${messageText(message)}\n---\n${attachmentsKey(messageAttachments(message))}`
+}
+
+function hasLocalUserMessage(msgs: ChatMessage[], text: string, attachments?: ChatAttachment[]): boolean {
   const expectedAttachments = attachmentsKey(attachments)
   return msgs.some(
     (message) =>
       message.role === "user" &&
+      message.id.startsWith("local-user-") &&
       messageText(message) === text &&
       attachmentsKey(messageAttachments(message)) === expectedAttachments,
   )
+}
+
+function userMessageCountsByContent(messages: ChatMessage[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue
+    }
+    const key = userMessageContentKey(message)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  return counts
+}
+
+function missingLocalUserMessages(current: ChatMessage[], fetched: ChatMessage[]): ChatMessage[] {
+  const fetchedCounts = userMessageCountsByContent(fetched)
+  const currentCounts = new Map<string, number>()
+  return current.filter((message) => {
+    if (message.role !== "user") {
+      return false
+    }
+    const key = userMessageContentKey(message)
+    const seen = (currentCounts.get(key) ?? 0) + 1
+    currentCounts.set(key, seen)
+    return message.id.startsWith("local-user-") && seen > (fetchedCounts.get(key) ?? 0)
+  })
+}
+
+function localUsersByContent(current: ChatMessage[]): Map<string, ChatMessage[]> {
+  const localUsers = new Map<string, ChatMessage[]>()
+  for (const message of current) {
+    if (message.role !== "user" || !message.id.startsWith("local-user-")) {
+      continue
+    }
+    const key = userMessageContentKey(message)
+    localUsers.set(key, [...(localUsers.get(key) ?? []), message])
+  }
+  return localUsers
 }
 
 export function appendOptimisticConversationTurn(
@@ -471,7 +514,7 @@ export function appendOptimisticConversationTurn(
   attachments?: ChatAttachment[],
   contextMentions?: ChatContextMention[],
 ): ChatMessage[] {
-  if (hasUserMessage(msgs, text, attachments)) {
+  if (hasLocalUserMessage(msgs, text, attachments)) {
     return msgs
   }
   const now = Date.now()
@@ -532,26 +575,15 @@ export function mergeFetchedMessages(current: ChatMessage[], fetched: ChatMessag
       message.id.startsWith("local-assistant-") &&
       message.parts.some((part) => part.kind === "error" && Boolean(part.errorText)),
   )
-  const missingLocalUsers = current.filter(
-    (message) =>
-      message.role === "user" &&
-      message.id.startsWith("local-user-") &&
-      !hasUserMessage(fetched, messageText(message), messageAttachments(message)),
-  )
-  const localUserByContent = new Map(
-    current
-      .filter((message) => message.role === "user" && message.id.startsWith("local-user-"))
-      .map((message) => [`${messageText(message)}\n---\n${attachmentsKey(messageAttachments(message))}`, message]),
-  )
+  const missingLocalUsers = missingLocalUserMessages(current, fetched)
+  const localUserByContent = localUsersByContent(current)
   const currentById = new Map(current.map((message) => [message.id, message]))
   const artifactRootByMessageId = new Map(
     current.flatMap((message) => (message.artifactRoot ? [[message.id, message.artifactRoot] as const] : [])),
   )
   const fetchedWithLocalState = fetched.map((message) => {
     const matchedLocalUser =
-      message.role === "user"
-        ? localUserByContent.get(`${messageText(message)}\n---\n${attachmentsKey(messageAttachments(message))}`)
-        : undefined
+      message.role === "user" ? localUserByContent.get(userMessageContentKey(message))?.shift() : undefined
     const currentMessage = currentById.get(message.id) ?? matchedLocalUser
     const artifactRoot = artifactRootByMessageId.get(message.id)
     return {
@@ -564,8 +596,33 @@ export function mergeFetchedMessages(current: ChatMessage[], fetched: ChatMessag
       ...(artifactRoot && !message.artifactRoot ? { artifactRoot } : {}),
     }
   })
-  const merged = missingLocalUsers.length > 0 ? [...missingLocalUsers, ...fetchedWithLocalState] : fetchedWithLocalState
+  const merged = insertMessagesByCreatedAt(fetchedWithLocalState, missingLocalUsers)
   return missingLocalAssistants.length > 0 ? [...merged, ...missingLocalAssistants] : merged
+}
+
+function messageCreatedAt(message: ChatMessage): number {
+  return Number.isFinite(message.createdAt) ? message.createdAt : 0
+}
+
+function insertMessagesByCreatedAt(base: ChatMessage[], additions: ChatMessage[]): ChatMessage[] {
+  if (additions.length === 0) {
+    return base
+  }
+  const sortedAdditions = additions
+    .map((message, index) => ({ index, message }))
+    .sort((left, right) => messageCreatedAt(left.message) - messageCreatedAt(right.message) || left.index - right.index)
+    .map((item) => item.message)
+  const merged = base.slice()
+  for (const message of sortedAdditions) {
+    const createdAt = messageCreatedAt(message)
+    const insertAt = merged.findIndex((item) => messageCreatedAt(item) > createdAt)
+    if (insertAt === -1) {
+      merged.push(message)
+    } else {
+      merged.splice(insertAt, 0, message)
+    }
+  }
+  return merged
 }
 
 function preserveLocalErrorParts(

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -110,6 +110,74 @@ describe("chat message identity reconciliation", () => {
     expect(merged[0]?.contextMentions).toEqual([skillMention])
   })
 
+  it("keeps missing optimistic user messages in timeline order after a reload", () => {
+    const projectUser: ChatMessage = {
+      id: "server-user-project",
+      role: "user",
+      parts: [{ kind: "text", partId: "text-1", text: "List projects" }],
+      createdAt: 100,
+    }
+    const projectAssistant: ChatMessage = {
+      id: "server-assistant-project",
+      role: "assistant",
+      parts: [{ kind: "text", partId: "text-2", text: "Here are the projects." }],
+      createdAt: 200,
+    }
+    const localEventUser: ChatMessage = {
+      id: "local-user-event",
+      role: "user",
+      parts: [{ kind: "text", partId: "local", text: "List tracked events" }],
+      createdAt: 300,
+    }
+
+    const merged = mergeFetchedMessages(
+      [projectUser, projectAssistant, localEventUser],
+      [projectUser, projectAssistant],
+    )
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "server-user-project",
+      "server-assistant-project",
+      "local-user-event",
+    ])
+  })
+
+  it("preserves a newer duplicate optimistic user message when fetched history only has the older copy", () => {
+    const serverUser: ChatMessage = {
+      id: "server-user-repeat",
+      role: "user",
+      parts: [{ kind: "text", partId: "text-1", text: "Repeat this question" }],
+      createdAt: 100,
+    }
+    const localUser: ChatMessage = {
+      id: "local-user-repeat",
+      role: "user",
+      parts: [{ kind: "text", partId: "local", text: "Repeat this question" }],
+      createdAt: 300,
+    }
+
+    const merged = mergeFetchedMessages([serverUser, localUser], [serverUser])
+
+    expect(merged.map((message) => message.id)).toEqual(["server-user-repeat", "local-user-repeat"])
+  })
+
+  it("adds an optimistic turn when the same prompt already exists in fetched history", () => {
+    const current: ChatMessage[] = [
+      {
+        id: "server-user-repeat",
+        role: "user",
+        parts: [{ kind: "text", partId: "text-1", text: "Repeat this question" }],
+        createdAt: 100,
+      },
+    ]
+
+    const updated = appendOptimisticConversationTurn(current, "Repeat this question")
+
+    expect(updated).toHaveLength(3)
+    expect(updated.at(-2)?.id).toMatch(/^local-user-/)
+    expect(updated.at(-1)?.id).toMatch(/^local-assistant-/)
+  })
+
   it("attaches message errors to the latest assistant bubble", () => {
     const current = appendOptimisticConversationTurn([], "Create a report", [])
     const updated = setErrorPart(current, {

--- a/src/hooks/useProviderSkillRecommendations.ts
+++ b/src/hooks/useProviderSkillRecommendations.ts
@@ -1,5 +1,4 @@
 import type { ConnectionProvider } from "../../electron/connections/common.ts"
-import type { ManagedSkillGroup } from "../../electron/skills/common.ts"
 import type { ProviderSkillRecommendation } from "@/routes/Skills/provider-skill-recommendations"
 import type { ManagedSkillGroupById } from "@/routes/Skills/skill-route-model"
 
@@ -21,7 +20,7 @@ export function useProviderSkillRecommendations({
   groupById,
   providers,
 }: {
-  groupById: ManagedSkillGroupById | ReadonlyMap<string, ManagedSkillGroup> | undefined
+  groupById: ManagedSkillGroupById | undefined
   providers: readonly ConnectionProvider[]
 }): ProviderSkillRecommendationsState {
   const packageLookup = useProviderSkillPackageLookup(providers)

--- a/src/hooks/useProviderSkillRecommendations.ts
+++ b/src/hooks/useProviderSkillRecommendations.ts
@@ -1,0 +1,48 @@
+import type { ConnectionProvider } from "../../electron/connections/common.ts"
+import type { ManagedSkillGroup } from "../../electron/skills/common.ts"
+import type { ProviderSkillRecommendation } from "@/routes/Skills/provider-skill-recommendations"
+import type { ManagedSkillGroupById } from "@/routes/Skills/skill-route-model"
+
+import * as React from "react"
+import { useProviderSkillPackageLookup } from "@/routes/Skills/provider-skill-package-lookup"
+import {
+  buildProviderSkillRecommendations,
+  getInstallableProviderSkillRecommendations,
+} from "@/routes/Skills/provider-skill-recommendations"
+
+export interface ProviderSkillRecommendationsState {
+  error: string | null
+  installable: ProviderSkillRecommendation[]
+  isLoading: boolean
+  recommendations: ProviderSkillRecommendation[]
+}
+
+export function useProviderSkillRecommendations({
+  groupById,
+  providers,
+}: {
+  groupById: ManagedSkillGroupById | ReadonlyMap<string, ManagedSkillGroup> | undefined
+  providers: readonly ConnectionProvider[]
+}): ProviderSkillRecommendationsState {
+  const packageLookup = useProviderSkillPackageLookup(providers)
+  const recommendations = React.useMemo(
+    () =>
+      buildProviderSkillRecommendations({
+        groupById,
+        packagesByService: packageLookup.packagesByService,
+        providers,
+      }),
+    [groupById, packageLookup.packagesByService, providers],
+  )
+  const installable = React.useMemo(
+    () => getInstallableProviderSkillRecommendations(recommendations),
+    [recommendations],
+  )
+
+  return {
+    error: packageLookup.error,
+    installable,
+    isLoading: packageLookup.isLoading,
+    recommendations,
+  }
+}

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -279,7 +279,7 @@ export const enMessages = {
   "chat.queueRemove": "Remove from queue",
   "chat.queueExpand": "Expand queue",
   "chat.queueCollapse": "Collapse queue",
-  "chat.queuePaused": "The queue is paused because you interrupted the current response",
+  "chat.queuePaused": "The queue is paused",
   "chat.queueReorder": "Drag to reorder",
   "chat.queueResume": "Continue",
   "chat.queueSend": "Add to queue",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -215,7 +215,7 @@ export const zhCNMessages = {
   "chat.emptySharedConnectorsMetaFallback": "来自组织的资源",
   "chat.emptySharedConnectorsAction": "查看",
   "chat.emptyOrganizationsAria": "打开组织，查看团队共享的连接器",
-  "chat.emptyOrganizationSkillsTitle": "组织推荐 Skill",
+  "chat.emptyOrganizationSkillsTitle": "推荐 Skill",
   "chat.emptyOrganizationSkillsMeta": "{count} 个待安装",
   "chat.emptyOrganizationSkillsRecommendedMeta": "{count} 个推荐",
   "chat.emptyOrganizationSkillsAction": "安装",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -266,7 +266,7 @@ export const zhCNMessages = {
   "chat.queueRemove": "移出队列",
   "chat.queueExpand": "展开队列",
   "chat.queueCollapse": "折叠队列",
-  "chat.queuePaused": "由于你中断了当前响应，队列已暂停",
+  "chat.queuePaused": "队列已暂停",
   "chat.queueReorder": "拖动调整顺序",
   "chat.queueResume": "继续",
   "chat.queueSend": "加入队列",

--- a/src/routes/Chat/chat-turns.test.ts
+++ b/src/routes/Chat/chat-turns.test.ts
@@ -197,6 +197,25 @@ describe("summarizeTurnProcess", () => {
     })
   })
 
+  it("does not suggest an unrelated provider when the user explicitly named another provider", () => {
+    const turn = groupChatTurns([
+      message("u1", "user", [text("u1-text", "PostHog 功能介绍")]),
+      message("a1", "assistant", [
+        tool("tool-1", {
+          tool: "search_actions",
+          input: { query: "PostHog feature flags" },
+          output: JSON.stringify([{ service: "launchdarkly", name: "list_feature_flags", authenticated: false }]),
+        }),
+      ]),
+      message("a2", "assistant", [text("a2-text", "PostHog 支持功能开关、数据洞察和事件分析。")]),
+    ])[0]
+
+    expect(turn).toBeDefined()
+    const process = summarizeTurnProcess(turn!, null)
+
+    expect(process.suggestedAuthorization).toBeUndefined()
+  })
+
   it("does not suggest connecting a provider after a successful call action for it", () => {
     const turn = groupChatTurns([
       message("u1", "user", [text("u1-text", "看一下 PostHog 数据")]),

--- a/src/routes/Chat/chat-turns.ts
+++ b/src/routes/Chat/chat-turns.ts
@@ -206,6 +206,17 @@ function suggestedAuthorizationFromTools(tools: ChatMessagePart[]): Authorizatio
   return undefined
 }
 
+function searchAuthorizationContext(
+  input: Record<string, unknown> | undefined,
+  userText: string,
+): { keywords?: unknown; query?: unknown; userText?: string } {
+  return {
+    keywords: input?.keywords,
+    query: input?.query,
+    ...(userText ? { userText } : {}),
+  }
+}
+
 export function shouldShowSuggestedAuthorization(
   process: Pick<ChatTurnProcess, "activity" | "hasActiveTool" | "suggestedAuthorization">,
   turnIsActive: boolean,
@@ -249,6 +260,7 @@ export function summarizeTurnProcess(
   const hasToolError = hasBlockingToolError(tools)
   const hasAuthorization = tools.some((part) => Boolean(parseToolAuthorization(part)))
   const hasSuccessfulConnectorCall = successfulCallActionServices(tools).size > 0
+  const userText = turn.user ? userMessageText(turn.user) : ""
 
   return {
     tools,
@@ -260,7 +272,17 @@ export function summarizeTurnProcess(
     hasStoppedTool: hasStoppedTool(tools),
     hasAuthorization,
     hasSuccessfulConnectorCall,
-    ...(hasAuthorization ? {} : { suggestedAuthorization: suggestedAuthorizationFromTools(tools) }),
+    ...(hasAuthorization
+      ? {}
+      : {
+          suggestedAuthorization: suggestedAuthorizationFromTools(
+            tools.map((part) =>
+              part.tool === "search_actions"
+                ? { ...part, input: searchAuthorizationContext(part.input, userText) }
+                : part,
+            ),
+          ),
+        }),
     activity: activeTurnActivity,
     startedAt,
     endedAt,

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -20,11 +20,6 @@ import { toast } from "sonner"
 import { DiscoverSkillsPane } from "./DiscoverSkillsPane.tsx"
 import { InstalledSkillsPane } from "./InstalledSkillsPane.tsx"
 import { OrganizationSkillsPane } from "./OrganizationSkillsPane.tsx"
-import { useProviderSkillPackageLookup } from "./provider-skill-package-lookup.ts"
-import {
-  buildProviderSkillRecommendations,
-  getInstallableProviderSkillRecommendations,
-} from "./provider-skill-recommendations.ts"
 import { skillErrorMessage } from "./skill-errors.ts"
 import {
   getGroupStatus,
@@ -55,6 +50,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useSkillObjectActions } from "@/components/useSkillObjectActions"
+import { useProviderSkillRecommendations } from "@/hooks/useProviderSkillRecommendations"
 import { useAppI18n } from "@/i18n"
 import { addOrganizationSkill } from "@/lib/organization-skills-client"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
@@ -119,20 +115,12 @@ export function SkillsRoute({
   const installedSkillGroupById = React.useMemo<ManagedSkillGroupById>(() => {
     return new Map((inventory?.groups ?? []).map((group) => [group.id, group]))
   }, [inventory?.groups])
-  const providerSkillPackageLookup = useProviderSkillPackageLookup(connectedProviders)
-  const providerSkillRecommendations = React.useMemo(
-    () =>
-      buildProviderSkillRecommendations({
-        groupById: installedSkillGroupById,
-        packagesByService: providerSkillPackageLookup.packagesByService,
-        providers: connectedProviders,
-      }),
-    [connectedProviders, installedSkillGroupById, providerSkillPackageLookup.packagesByService],
-  )
-  const installableProviderSkillRecommendations = React.useMemo(
-    () => getInstallableProviderSkillRecommendations(providerSkillRecommendations),
-    [providerSkillRecommendations],
-  )
+  const providerSkillRecommendationsState = useProviderSkillRecommendations({
+    groupById: installedSkillGroupById,
+    providers: connectedProviders,
+  })
+  const providerSkillRecommendations = providerSkillRecommendationsState.recommendations
+  const installableProviderSkillRecommendations = providerSkillRecommendationsState.installable
   const versionCheckByKey = React.useMemo<SkillVersionCheckByKey>(() => {
     return new Map(
       (versionResource.data?.skills ?? []).map((check) => [
@@ -773,7 +761,7 @@ export function SkillsRoute({
             organizationFilter={organizationFilter}
             organizationQuery={organizationQuery}
             organizationSkills={organizationSkills}
-            providerRecommendationsLoading={connectedProvidersLoading || providerSkillPackageLookup.isLoading}
+            providerRecommendationsLoading={connectedProvidersLoading || providerSkillRecommendationsState.isLoading}
             providerRecommendations={providerSkillRecommendations}
             workspace={workspace}
             onAddRecommendation={addOrganizationSkillFromRecommendation}

--- a/src/routes/Skills/provider-skill-package-lookup.test.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.test.ts
@@ -1,0 +1,68 @@
+import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import {
+  clearProviderSkillPackageLookupCacheForTest,
+  readProviderSkillPackage,
+} from "./provider-skill-package-lookup.ts"
+import { readPublicSkillPackageByName, searchPublicSkillPackages } from "@/lib/skills-catalog-client"
+
+vi.mock("@/lib/skills-catalog-client", () => ({
+  readPublicSkillPackageByName: vi.fn(),
+  searchPublicSkillPackages: vi.fn(),
+}))
+
+const posthogPackage: PublicSkillPackage = {
+  displayName: "PostHog",
+  id: "oo-posthog",
+  isTemplate: false,
+  maintainers: [{ name: "OOMOL" }],
+  name: "oo-posthog",
+  skills: [{ name: "posthog", title: "PostHog" }],
+  version: "1.0.0",
+  visibility: "public",
+}
+
+describe("provider Skill package lookup", () => {
+  beforeEach(() => {
+    clearProviderSkillPackageLookupCacheForTest()
+    vi.mocked(readPublicSkillPackageByName).mockReset()
+    vi.mocked(searchPublicSkillPackages).mockReset()
+  })
+
+  afterEach(() => {
+    clearProviderSkillPackageLookupCacheForTest()
+  })
+
+  test("shares in-flight package requests for the same provider", async () => {
+    let resolvePackage: (pkg: PublicSkillPackage) => void = () => undefined
+    vi.mocked(readPublicSkillPackageByName).mockReturnValueOnce(
+      new Promise<PublicSkillPackage>((resolve) => {
+        resolvePackage = resolve
+      }),
+    )
+
+    const candidate = { providerDisplayName: "PostHog", service: "posthog" }
+    const first = readProviderSkillPackage(candidate)
+    const second = readProviderSkillPackage(candidate)
+
+    expect(readPublicSkillPackageByName).toHaveBeenCalledTimes(1)
+    resolvePackage(posthogPackage)
+
+    await expect(first).resolves.toBe(posthogPackage)
+    await expect(second).resolves.toBe(posthogPackage)
+  })
+
+  test("retries after a failed in-flight package request", async () => {
+    vi.mocked(readPublicSkillPackageByName).mockResolvedValue(null)
+    vi.mocked(searchPublicSkillPackages)
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ items: [posthogPackage], next: null, updatedAt: "2026-07-08T00:00:00Z" })
+
+    const candidate = { providerDisplayName: "PostHog", service: "posthog" }
+
+    await expect(readProviderSkillPackage(candidate)).rejects.toThrow("temporary failure")
+    await expect(readProviderSkillPackage(candidate)).resolves.toBe(posthogPackage)
+    expect(searchPublicSkillPackages).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/routes/Skills/provider-skill-package-lookup.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.ts
@@ -29,6 +29,7 @@ export interface ProviderSkillPackageLookup {
 }
 
 const providerSkillPackageCache = new Map<string, ProviderSkillPackageCacheEntry>()
+const providerSkillPackagePendingRequests = new Map<string, Promise<PublicSkillPackage | null>>()
 const emptyProviderSkillPackages = new Map<string, PublicSkillPackage | null>()
 
 function providerSkillPackageCacheKey(candidate: ProviderSkillCandidate): string {
@@ -86,11 +87,7 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
         }
 
         try {
-          const pkg = await searchProviderSkillPackage(candidate)
-          providerSkillPackageCache.set(cacheKey, {
-            expiresAt: Date.now() + (pkg ? providerSkillPackageCacheMs : missingProviderSkillPackageCacheMs),
-            package: pkg,
-          })
+          const pkg = await readProviderSkillPackage(candidate)
           next.set(candidate.service, pkg)
         } catch (cause) {
           console.warn("[wanta] failed to read provider Skill recommendation:", cause)
@@ -133,6 +130,39 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
     isStale,
     packagesByService: isStale ? emptyProviderSkillPackages : packagesByService,
   }
+}
+
+export function clearProviderSkillPackageLookupCacheForTest(): void {
+  providerSkillPackageCache.clear()
+  providerSkillPackagePendingRequests.clear()
+}
+
+export async function readProviderSkillPackage(candidate: ProviderSkillCandidate): Promise<PublicSkillPackage | null> {
+  const cacheKey = providerSkillPackageCacheKey(candidate)
+  const cached = providerSkillPackageCache.get(cacheKey)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.package
+  }
+  const pending = providerSkillPackagePendingRequests.get(cacheKey)
+  if (pending) {
+    return pending
+  }
+
+  const request = searchProviderSkillPackage(candidate)
+    .then((pkg) => {
+      providerSkillPackageCache.set(cacheKey, {
+        expiresAt: Date.now() + (pkg ? providerSkillPackageCacheMs : missingProviderSkillPackageCacheMs),
+        package: pkg,
+      })
+      return pkg
+    })
+    .finally(() => {
+      if (providerSkillPackagePendingRequests.get(cacheKey) === request) {
+        providerSkillPackagePendingRequests.delete(cacheKey)
+      }
+    })
+  providerSkillPackagePendingRequests.set(cacheKey, request)
+  return request
 }
 
 async function searchProviderSkillPackage(candidate: ProviderSkillCandidate): Promise<PublicSkillPackage | null> {

--- a/src/routes/Skills/provider-skill-recommendations.ts
+++ b/src/routes/Skills/provider-skill-recommendations.ts
@@ -1,5 +1,5 @@
 import type { ConnectionProvider } from "../../../electron/connections/common.ts"
-import type { ManagedSkillGroup, PublicSkillPackage } from "../../../electron/skills/common.ts"
+import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
 import type { ManagedSkillGroupById, PublicSkillInstallState } from "./skill-route-model.ts"
 
 import {
@@ -148,7 +148,7 @@ export function buildProviderSkillRecommendations({
   packagesByService,
   providers,
 }: {
-  groupById: ManagedSkillGroupById | ReadonlyMap<string, ManagedSkillGroup> | undefined
+  groupById: ManagedSkillGroupById | undefined
   packagesByService: ReadonlyMap<string, PublicSkillPackage | null | undefined>
   providers: readonly ConnectionProvider[]
 }): ProviderSkillRecommendation[] {


### PR DESCRIPTION
## Summary

- improve queued chat message recovery after stopped generations
- preserve optimistic user messages in timeline order and handle repeated prompts correctly
- suppress unrelated connector authorization suggestions and improve provider skill recommendations

## Verification

- npm run ts-check
- npm run lint
- npm run format
- npm test
- npm run dev -- --port 5274