### PR TITLE
fix(sidecar): reap opencode tool subprocesses on shutdown

### DIFF
--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -857,15 +857,21 @@ export class AgentManager {
     await writeOoIdentitySettings(path.join(this.options.rootDir, "oo-store", "config"), organizationName)
   }
 
-  public dispose(): void {
+  /**
+   * 销毁 agent：同步摘掉事件流与引用，返回 sidecar 进程树回收的 Promise。
+   * 退出路径应 await（确保 opencode 及其工具子进程被连根回收后再退出主进程，
+   * 否则残留孤儿会被 macOS 判为"正在后台运行"）；重启路径可 fire-and-forget。
+   */
+  public dispose(): Promise<void> {
     this.disposed = true
     this.eventLoopStopped = true
     this.eventStreamAbort?.abort()
     this.eventStreamAbort = null
     this.eventSubscriber = null
     this.started = false
-    this.sidecar?.dispose()
+    const sidecar = this.sidecar
     this.sidecar = null
+    return sidecar?.dispose() ?? Promise.resolve()
   }
 
   private resolveModel(choice: ModelChoice | undefined): { providerID: string; modelID: string } {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -172,6 +172,9 @@ export function isUserVisibleSession(session: RawSession): boolean {
 export class AgentManager {
   private options: AgentManagerOptions
   private sidecar: OpencodeSidecar | null = null
+  // 启动中（尚未就绪、还没赋给 sidecar）的实例：它已 spawn opencode，dispose 必须能回收它，
+  // 否则"启动期间退出/重启"会漏掉这个正在拉起的 opencode，形成新的残留孤儿。
+  private startingSidecar: OpencodeSidecar | null = null
   private eventStreamAbort: AbortController | null = null
   private eventSubscriber: AgentEventSubscriber | null = null
   private eventLoopRestartFailures = 0
@@ -305,8 +308,22 @@ export class AgentManager {
       serverPassword: disableServerAuth ? undefined : randomBytes(24).toString("hex"),
       onExit: (info) => this.handleSidecarExit(info),
     })
-    // 仅在 sidecar 完全就绪后才赋值并标记 ready，避免 client 在启动期被访问。
-    await sidecar.start()
+    // 启动期间也要能被 dispose 回收（此实例已 spawn opencode）：先登记为 startingSidecar，
+    // start 结束后再清掉。仅在 sidecar 完全就绪后才赋值 this.sidecar 并标记 ready，避免 client 在启动期被访问。
+    this.startingSidecar = sidecar
+    try {
+      await sidecar.start()
+    } finally {
+      if (this.startingSidecar === sidecar) {
+        this.startingSidecar = null
+      }
+    }
+    // 启动过程中若已 dispose（退出/重启在启动期插入），此 sidecar 已拉起 opencode，就地回收后返回，
+    // 绝不再赋值/标记 ready。OpencodeSidecar.dispose 幂等，与 dispose() 里对 startingSidecar 的回收互不冲突。
+    if (this.disposed) {
+      await sidecar.dispose()
+      return
+    }
     this.sidecar = sidecar
     this.started = true
   }
@@ -869,8 +886,11 @@ export class AgentManager {
     this.eventStreamAbort = null
     this.eventSubscriber = null
     this.started = false
-    const sidecar = this.sidecar
+    // 同时回收"启动中"的实例：退出/重启可能正卡在 startSidecar 的 await 上，此时 this.sidecar 仍为
+    // null，但 startingSidecar 已 spawn opencode，必须一并连根回收，否则它会成为漏网孤儿。
+    const sidecar = this.sidecar ?? this.startingSidecar
     this.sidecar = null
+    this.startingSidecar = null
     return sidecar?.dispose() ?? Promise.resolve()
   }
 

--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -1,68 +1,145 @@
-import { describe, expect, it, vi } from "vitest"
-import { terminateProcessTree } from "./sidecar.ts"
+import type { ProcessSnapshotEntry } from "./sidecar.ts"
 
-interface Recorder {
-  killGroup: ReturnType<typeof vi.fn>
-  killSelf: ReturnType<typeof vi.fn>
-  scheduled: Array<{ fn: () => void; ms: number }>
+import { describe, expect, it } from "vitest"
+import {
+  collectDescendantTree,
+  distinctProcessGroups,
+  parsePsSnapshot,
+  reapProcessTree,
+  reapWindowsProcessTree,
+} from "./sidecar.ts"
+
+// opencode(100) -> bash 工具子进程(200，自成 session/组) -> 其子(300，与 bash 同组)；
+// 另有无关进程 999。opencode 的工具子进程 setsid 逃逸出 opencode 的进程组，是"正在后台运行"孤儿的根源。
+const SNAPSHOT: ProcessSnapshotEntry[] = [
+  { pid: 50, ppid: 1, pgid: 50 },
+  { pid: 100, ppid: 50, pgid: 100 },
+  { pid: 200, ppid: 100, pgid: 200 },
+  { pid: 300, ppid: 200, pgid: 200 },
+  { pid: 999, ppid: 1, pgid: 999 },
+]
+
+describe("parsePsSnapshot", () => {
+  it("parses pid/ppid/pgid rows and skips junk lines", () => {
+    const stdout = ["  100   50  100", "200 100 200", "", "header garbage", "  x y z  ", "300 200 200"].join("\n")
+    expect(parsePsSnapshot(stdout)).toEqual([
+      { pid: 100, ppid: 50, pgid: 100 },
+      { pid: 200, ppid: 100, pgid: 200 },
+      { pid: 300, ppid: 200, pgid: 200 },
+    ])
+  })
+})
+
+describe("collectDescendantTree", () => {
+  it("collects the whole ppid subtree with root first", () => {
+    const tree = collectDescendantTree(100, SNAPSHOT)
+    expect(tree[0]).toBe(100)
+    expect([...tree].sort((a, b) => a - b)).toEqual([100, 200, 300])
+    expect(tree).not.toContain(999)
+    expect(tree).not.toContain(50)
+  })
+
+  it("returns just the root when it has no descendants", () => {
+    expect(collectDescendantTree(999, SNAPSHOT)).toEqual([999])
+  })
+
+  it("is resilient to a ppid cycle", () => {
+    const cyclic: ProcessSnapshotEntry[] = [
+      { pid: 1, ppid: 2, pgid: 1 },
+      { pid: 2, ppid: 1, pgid: 2 },
+    ]
+    expect(collectDescendantTree(1, cyclic).sort((a, b) => a - b)).toEqual([1, 2])
+  })
+})
+
+describe("distinctProcessGroups", () => {
+  it("includes only groups whose leader is inside the tree", () => {
+    const pids = collectDescendantTree(100, SNAPSHOT)
+    expect(distinctProcessGroups(pids, SNAPSHOT).sort((a, b) => a - b)).toEqual([100, 200])
+  })
+
+  it("excludes groups led by a process outside the tree and pgid<=1", () => {
+    const snapshot: ProcessSnapshotEntry[] = [
+      { pid: 100, ppid: 50, pgid: 100 },
+      { pid: 400, ppid: 100, pgid: 7 }, // 组长 7 不在树内 -> 排除
+      { pid: 500, ppid: 100, pgid: 1 }, // pgid<=1 -> 排除
+    ]
+    expect(distinctProcessGroups([100, 400, 500], snapshot)).toEqual([100])
+  })
+})
+
+interface KillCall {
+  target: number
+  signal: NodeJS.Signals
 }
 
-function makeDeps(platform: NodeJS.Platform, overrides: Partial<Recorder> = {}) {
-  const scheduled: Array<{ fn: () => void; ms: number }> = []
-  const killGroup = overrides.killGroup ?? vi.fn()
-  const killSelf = overrides.killSelf ?? vi.fn()
+function makeReaper(overrides: {
+  snapshot?: ProcessSnapshotEntry[]
+  alivePids?: Set<number>
+  snapshotRejects?: boolean
+}) {
+  const calls: KillCall[] = []
+  const alive = overrides.alivePids
   return {
-    scheduled,
-    killGroup,
-    killSelf,
+    calls,
     deps: {
-      platform,
-      killGroup: killGroup as unknown as (groupId: number, signal: NodeJS.Signals) => void,
-      killSelf: killSelf as unknown as (signal: NodeJS.Signals) => void,
-      schedule: (fn: () => void, ms: number) => scheduled.push({ fn, ms }),
+      snapshot: overrides.snapshotRejects
+        ? () => Promise.reject(new Error("ps failed"))
+        : () => Promise.resolve(overrides.snapshot ?? SNAPSHOT),
+      kill: (target: number, signal: NodeJS.Signals) => {
+        calls.push({ target, signal })
+      },
+      isAlive: (pid: number) => (alive ? alive.has(pid) : false),
+      delay: () => Promise.resolve(),
+      graceMs: 300,
+      pollMs: 100,
     },
   }
 }
 
-describe("terminateProcessTree", () => {
-  it("unix: SIGTERMs the whole process group then escalates to SIGKILL on the group", () => {
-    const { deps, killGroup, killSelf, scheduled } = makeDeps("darwin")
-
-    terminateProcessTree(4321, deps)
-
-    // 组信号用负 pid 命中 opencode 及其后代。
-    expect(killGroup).toHaveBeenCalledWith(-4321, "SIGTERM")
-    expect(killSelf).not.toHaveBeenCalled()
-    expect(scheduled).toHaveLength(1)
-
-    scheduled[0].fn()
-    expect(killGroup).toHaveBeenCalledWith(-4321, "SIGKILL")
-    expect(killGroup).toHaveBeenCalledTimes(2)
-  })
-
-  it("unix: falls back to single-process kill when the group signal throws", () => {
-    const killGroup = vi.fn((_groupId: number, signal: NodeJS.Signals) => {
-      if (signal === "SIGTERM") {
-        throw new Error("ESRCH")
-      }
+describe("reapWindowsProcessTree", () => {
+  it("runs taskkill /PID <pid> /T /F to kill the whole subtree", async () => {
+    const runs: Array<{ command: string; args: string[] }> = []
+    await reapWindowsProcessTree(4321, (command, args) => {
+      runs.push({ command, args })
+      return Promise.resolve()
     })
-    const { deps, killSelf, scheduled } = makeDeps("darwin", { killGroup })
-
-    terminateProcessTree(99, deps)
-
-    expect(killSelf).toHaveBeenCalledWith("SIGTERM")
-    // 仍安排 SIGKILL 兜底，且其中的组信号异常被吞掉不抛。
-    expect(scheduled).toHaveLength(1)
-    expect(() => scheduled[0].fn()).not.toThrow()
+    expect(runs).toEqual([{ command: "taskkill", args: ["/PID", "4321", "/T", "/F"] }])
   })
 
-  it("win32: kills only the single process and schedules nothing", () => {
-    const { deps, killGroup, killSelf, scheduled } = makeDeps("win32")
+  it("swallows taskkill errors (process already gone)", async () => {
+    await expect(reapWindowsProcessTree(7, () => Promise.reject(new Error("not found")))).resolves.toBeUndefined()
+  })
+})
 
-    terminateProcessTree(7, deps)
+describe("reapProcessTree", () => {
+  it("unix: SIGTERMs every group and pid, and skips SIGKILL once the tree is gone", async () => {
+    const { calls, deps } = makeReaper({ alivePids: new Set() }) // nothing alive after SIGTERM
+    await reapProcessTree(100, deps)
+    expect(calls.filter((c) => c.signal === "SIGKILL")).toHaveLength(0)
+    expect(calls).toContainEqual({ target: -100, signal: "SIGTERM" })
+    expect(calls).toContainEqual({ target: -200, signal: "SIGTERM" })
+    for (const pid of [100, 200, 300]) {
+      expect(calls).toContainEqual({ target: pid, signal: "SIGTERM" })
+    }
+  })
 
-    expect(killSelf).toHaveBeenCalledWith("SIGTERM")
-    expect(killGroup).not.toHaveBeenCalled()
-    expect(scheduled).toHaveLength(0)
+  it("unix: escalates to SIGKILL on groups and pids when survivors persist", async () => {
+    const { calls, deps } = makeReaper({ alivePids: new Set([100, 200, 300]) }) // never die
+    await reapProcessTree(100, deps)
+    expect(calls).toContainEqual({ target: -100, signal: "SIGKILL" })
+    expect(calls).toContainEqual({ target: -200, signal: "SIGKILL" })
+    for (const pid of [100, 200, 300]) {
+      expect(calls).toContainEqual({ target: pid, signal: "SIGKILL" })
+    }
+  })
+
+  it("unix: falls back to the root pid and its own process group when the ps snapshot fails", async () => {
+    const { calls, deps } = makeReaper({ snapshotRejects: true, alivePids: new Set() })
+    await reapProcessTree(100, deps)
+    // 降级：至少回收 root 自身进程（正）与其进程组（负，detached 下 pgid===pid）。
+    expect(calls).toContainEqual({ target: 100, signal: "SIGTERM" })
+    expect(calls).toContainEqual({ target: -100, signal: "SIGTERM" })
+    expect(calls.every((c) => Math.abs(c.target) === 100)).toBe(true)
   })
 })

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -3,10 +3,13 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process"
 import type { Readable } from "node:stream"
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
-import { spawn } from "node:child_process"
+import { execFile, spawn } from "node:child_process"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
+import { promisify } from "node:util"
 import { logDiagnostic } from "../diagnostics-log.ts"
+
+const execFileAsync = promisify(execFile)
 
 export interface SidecarOptions {
   /** opencode 二进制绝对路径。 */
@@ -35,8 +38,12 @@ export interface SidecarExitInfo {
 
 const startupOutputMaxBytes = 64 * 1024
 const runtimeLineMaxLength = 8 * 1024
-/** SIGTERM 后给整组进程自行退出的宽限期，超时再 SIGKILL 兜底。 */
-const processGroupKillGraceMs = 2_000
+/** SIGTERM 后给整棵进程树自行退出的宽限期，超时再 SIGKILL 兜底。 */
+const processReapGraceMs = 2_000
+/** 宽限期内轮询后代是否已全部退出的间隔；一旦全部退出立即提前结束，不空等满宽限期。 */
+const processReapPollMs = 100
+/** 请求 opencode 自行 dispose 的超时：卡死时不拖累退出，交由 OS 进程树兜底回收。 */
+const opencodeDisposeTimeoutMs = 2_000
 
 /** OpenCode 本地 sidecar：spawn `opencode serve`、解析 URL、提供 SDK client、随 app 退出回收。 */
 export class OpencodeSidecar {
@@ -92,16 +99,19 @@ export class OpencodeSidecar {
     const proc = spawn(opencodeBinPath, ["serve", `--hostname=${hostname}`, "--port=0"], {
       cwd: workspaceDir,
       env: childEnv,
-      // unix：让 opencode 自成进程组（pgid === pid），dispose 时可对整组发信号，连同它派生的
-      // Bun 工具 worker / oo CLI 一并回收，避免主进程退出后残留孤儿进程。Windows 无对应语义。
+      // unix：让 opencode 自成 session/进程组，dev 下与终端信号隔离（Ctrl-C 不直达 opencode），
+      // 由主进程的 SIGINT/SIGTERM 处理器统一驱动回收。工具子进程的连根回收不再依赖它（见 reap()：
+      // opencode 的工具子进程会各自 setsid 逃逸出本组，改由 opencode 自身 dispose + OS 进程树兜底回收）。
+      // Windows 无进程组语义（回收走 taskkill /T）。
       detached: process.platform !== "win32",
     })
     this.proc = proc
 
     const url = await this.awaitServerUrl(proc, timeoutMs).catch((error: unknown) => {
-      // 启动失败（超时/提前退出/spawn 出错）时一定要回收已 spawn 的 opencode，
-      // 否则 detached 进程会成为孤儿；recoverRuntime 的重试更会不断叠加。
-      this.terminate(proc)
+      // 启动失败（超时/提前退出/spawn 出错）时一定要回收已 spawn 的 opencode 及其后代，
+      // 否则会成为孤儿；recoverRuntime 的重试更会不断叠加。后台回收即可，不阻塞抛错。
+      // 此刻 client 尚未建立（awaitServerUrl 失败），传 null 走 OS 进程树兜底回收。
+      void this.reap(proc, null)
       throw error
     })
 
@@ -174,70 +184,235 @@ export class OpencodeSidecar {
     })
   }
 
-  /** 回收 opencode 及其全部后代（unix 按进程组 SIGTERM，宽限期后 SIGKILL 兜底）。 */
-  private terminate(proc: ChildProcessWithoutNullStreams): void {
-    if (proc.pid === undefined) {
+  /**
+   * 回收 opencode 及其全部工具子进程。两级、互为兜底：
+   * 1. 先请 opencode 自己 dispose（`POST /global/dispose`）——它权威地知道自己 spawn 了哪些工具子进程
+   *    （bash 工具 / oo CLI，各自 setsid 逃逸出 opencode 进程组），会主动全部回收。**这是跨平台**的主路径
+   *    （Windows 同样有效，opencode 用自身机制杀子进程，与 OS 进程组/信号语义无关）；有超时，opencode 卡死不拖累退出。
+   * 2. 再按 OS 进程树杀掉 opencode 服务进程本身，并兜底清扫 dispose 可能漏掉的残留
+   *    （unix：ps 按 ppid 逐个 + 按组 SIGTERM/SIGKILL；win32：`taskkill /T /F` 连子树）。
+   */
+  private async reap(proc: ChildProcessWithoutNullStreams, client: OpencodeClient | null): Promise<void> {
+    const pid = proc.pid
+    // 主路径：让 opencode 回收自己的工具子进程（跨平台、权威、无 ps 竞态）。
+    await requestOpencodeDispose(client)
+    if (pid === undefined) {
       return
     }
-    terminateProcessTree(proc.pid, {
-      platform: process.platform,
-      killGroup: (groupId, signal) => process.kill(groupId, signal),
-      killSelf: (signal) => proc.kill(signal),
-      schedule: (fn, ms) => {
-        const timer = setTimeout(fn, ms)
-        timer.unref?.()
-      },
-    })
+    // 兜底：杀掉 opencode 进程本身 + 清扫任何残留后代（opencode 卡死/dispose 失败时的安全网）。
+    try {
+      if (process.platform === "win32") {
+        await reapWindowsProcessTree(pid, (command, args) => execFileAsync(command, args))
+      } else {
+        await reapProcessTree(pid, {
+          snapshot: listProcessSnapshot,
+          kill: (target, signal) => process.kill(target, signal),
+          isAlive: isProcessAlive,
+          delay: reapDelay,
+        })
+      }
+    } catch (error) {
+      // 回收尽力而为，绝不把异常抛出 dispose（退出/重启路径都不能因此卡住）。
+      console.warn("[wanta] failed to reap opencode process tree:", error)
+      logDiagnostic("opencode-sidecar", "failed to reap opencode process tree", { error, pid }, "warn")
+    }
   }
 
-  public dispose(): void {
+  /**
+   * 回收 sidecar：同步摘掉监听与 client 引用，返回回收 Promise。
+   * 退出路径应 await 该 Promise（确保 opencode 工具子进程连根回收后再让主进程退出）；
+   * 重启路径可 fire-and-forget（回收在后台自完成，不拖慢重启）。
+   */
+  public dispose(): Promise<void> {
     this.disposed = true
     this.streamLogCleanup?.()
     this.streamLogCleanup = null
     const proc = this.proc
+    const client = this.opencodeClient
     this.proc = null
     this.opencodeClient = null
     this.serverUrl = ""
-    if (proc) {
-      this.terminate(proc)
-    }
+    return proc ? this.reap(proc, client) : Promise.resolve()
   }
 }
 
-/** terminateProcessTree 的副作用依赖，便于注入与单测。 */
-export interface ProcessTreeTerminator {
-  platform: NodeJS.Platform
-  /** 向进程组发信号（groupId 传负 pid 表示整组）；组不存在时抛出。 */
-  killGroup: (groupId: number, signal: NodeJS.Signals) => void
-  /** 单进程兜底 kill（Windows 无进程组语义时使用）。 */
-  killSelf: (signal: NodeJS.Signals) => void
-  /** 调度 SIGKILL 兜底（实现应 unref，绝不可阻止进程退出）。 */
-  schedule: (fn: () => void, ms: number) => void
+export interface ProcessSnapshotEntry {
+  pid: number
+  ppid: number
+  pgid: number
+}
+
+/** reapProcessTree 的副作用依赖，便于注入与单测。 */
+export interface ProcessTreeReaper {
+  /** 快照全系统进程（pid/ppid/pgid），用于按 ppid 收集 root 的全部后代。 */
+  snapshot: () => Promise<ProcessSnapshotEntry[]>
+  /** 向单进程（正 target）或进程组（负 target）发信号；目标不存在时抛出。 */
+  kill: (target: number, signal: NodeJS.Signals) => void
+  /** 判断进程是否存活（kill(pid, 0)）。 */
+  isAlive: (pid: number) => boolean
+  /** 宽限期内的等待实现（便于测试注入即时 resolve）。 */
+  delay: (ms: number) => Promise<void>
+  graceMs?: number
+  pollMs?: number
+}
+
+/** 解析 `ps -eo pid=,ppid=,pgid=` 输出为进程快照。非法/空行跳过。 */
+export function parsePsSnapshot(stdout: string): ProcessSnapshotEntry[] {
+  const entries: ProcessSnapshotEntry[] = []
+  for (const line of stdout.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)$/)
+    if (match) {
+      entries.push({ pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]) })
+    }
+  }
+  return entries
+}
+
+/** 按 ppid 从 root 深度收集整棵进程树（含 root 自身，root 在首位）。 */
+export function collectDescendantTree(rootPid: number, snapshot: ProcessSnapshotEntry[]): number[] {
+  const childrenByParent = new Map<number, number[]>()
+  for (const entry of snapshot) {
+    const siblings = childrenByParent.get(entry.ppid)
+    if (siblings) {
+      siblings.push(entry.pid)
+    } else {
+      childrenByParent.set(entry.ppid, [entry.pid])
+    }
+  }
+  const ordered: number[] = []
+  const seen = new Set<number>()
+  const stack = [rootPid]
+  while (stack.length > 0) {
+    const pid = stack.pop()
+    if (pid === undefined || seen.has(pid)) {
+      continue
+    }
+    seen.add(pid)
+    ordered.push(pid)
+    for (const child of childrenByParent.get(pid) ?? []) {
+      stack.push(child)
+    }
+  }
+  return ordered
 }
 
 /**
- * 回收一棵进程树。unix 下目标进程以 detached 方式 spawn，自成进程组（pgid === pid），
- * 故对 -pid 发 SIGTERM 可命中它及其所有后代（Bun 工具 worker / oo CLI）；宽限期后再 SIGKILL 兜底。
- * Windows 无对应语义，退回单进程 kill（与既有行为一致，不处理孙子进程）。
+ * 收集进程树内可安全按组回收的 pgid：仅当组长（pgid 所指进程）本身也在树内时才纳入，
+ * 绝不向组长在树外的进程组发信号，避免误伤无关进程。用于连带回收后代同组的兄弟进程。
  */
-export function terminateProcessTree(pid: number, deps: ProcessTreeTerminator): void {
-  if (deps.platform === "win32") {
-    deps.killSelf("SIGTERM")
+export function distinctProcessGroups(pids: number[], snapshot: ProcessSnapshotEntry[]): number[] {
+  const treePids = new Set(pids)
+  const pgidByPid = new Map(snapshot.map((entry) => [entry.pid, entry.pgid]))
+  const groups = new Set<number>()
+  for (const pid of pids) {
+    const pgid = pgidByPid.get(pid)
+    if (pgid !== undefined && pgid > 1 && treePids.has(pgid)) {
+      groups.add(pgid)
+    }
+  }
+  return [...groups]
+}
+
+/**
+ * 回收一棵进程树（unix）。opencode 的工具子进程（bash 工具 / Bun 工具 worker / oo CLI）会各自
+ * setsid 到独立 session/进程组，无法靠单一 `kill(-opencodePgid)` 命中——必须先快照、按 ppid
+ * 收集整棵树，再对每个后代 pid 及其所在进程组逐个 SIGTERM；宽限期内轮询，全部退出即提前结束，
+ * 否则 SIGKILL 兜底。快照必须在发信号前完成：一旦 opencode 死亡，其子进程会 reparent 到
+ * launchd（ppid=1）而失去关联。Windows 走 reapWindowsProcessTree（taskkill /T）。
+ */
+export async function reapProcessTree(rootPid: number, deps: ProcessTreeReaper): Promise<void> {
+  const safeKill = (target: number, signal: NodeJS.Signals): void => {
+    try {
+      deps.kill(target, signal)
+    } catch {
+      // 目标已退出或无权限：尽力而为，忽略。
+    }
+  }
+
+  const snapshot = await deps.snapshot().catch(() => [] as ProcessSnapshotEntry[])
+  const hasSnapshot = snapshot.length > 0
+  const pids = hasSnapshot ? collectDescendantTree(rootPid, snapshot) : [rootPid]
+  // 快照失败的降级：opencode 以 detached spawn（pgid === pid），至少按其自身进程组回收，
+  // 恢复到"单一进程组 kill"的旧行为，不至于连同组的直接子进程都漏掉。
+  const groups = hasSnapshot ? distinctProcessGroups(pids, snapshot) : [rootPid]
+
+  // SIGTERM：先按组（连带同组兄弟），再逐个 pid（组长已死时的兜底）。
+  for (const group of groups) {
+    safeKill(-group, "SIGTERM")
+  }
+  for (const pid of pids) {
+    safeKill(pid, "SIGTERM")
+  }
+
+  // 宽限期内轮询；后代全部退出即提前返回，避免空等。
+  const graceMs = deps.graceMs ?? processReapGraceMs
+  const pollMs = deps.pollMs ?? processReapPollMs
+  for (let waited = 0; waited < graceMs; waited += pollMs) {
+    await deps.delay(pollMs)
+    if (!pids.some((pid) => deps.isAlive(pid))) {
+      return
+    }
+  }
+
+  // 宽限期后仍有存活：SIGKILL 兜底。
+  for (const group of groups) {
+    safeKill(-group, "SIGKILL")
+  }
+  for (const pid of pids) {
+    safeKill(pid, "SIGKILL")
+  }
+}
+
+/**
+ * 请 opencode 自行 dispose（`POST /global/dispose`）——由 opencode 主动回收它 spawn 的全部工具子进程
+ * （权威、跨平台，不依赖 OS 进程组/信号语义）。带超时：opencode 卡死或已不可达时不拖累退出，
+ * 交由后续 OS 进程树回收兜底。尽力而为，任何错误都吞掉。
+ */
+async function requestOpencodeDispose(client: OpencodeClient | null): Promise<void> {
+  if (!client) {
     return
   }
   try {
-    deps.killGroup(-pid, "SIGTERM")
-  } catch {
-    // 组已消失或无权限：退回单进程，尽力而为。
-    deps.killSelf("SIGTERM")
+    await client.global.dispose({ signal: AbortSignal.timeout(opencodeDisposeTimeoutMs) })
+  } catch (error) {
+    // 已退出/卡死/超时：忽略，兜底回收会处理。
+    logDiagnostic("opencode-sidecar", "opencode self-dispose request failed", { error }, "trace")
   }
-  deps.schedule(() => {
-    try {
-      deps.killGroup(-pid, "SIGKILL")
-    } catch {
-      // 组已在宽限期内退出，无需处理。
-    }
-  }, processGroupKillGraceMs)
+}
+
+/**
+ * Windows 进程树回收：`taskkill /PID <pid> /T /F` 连带终止整棵子树（含孙子进程）。
+ * /T 按 ParentProcessId 递归，/F 强制。目标不存在时 taskkill 以非零码退出——吞掉即可。
+ */
+export async function reapWindowsProcessTree(
+  rootPid: number,
+  run: (command: string, args: string[]) => Promise<unknown>,
+): Promise<void> {
+  try {
+    await run("taskkill", ["/PID", String(rootPid), "/T", "/F"])
+  } catch {
+    // 进程已退出或无权限：尽力而为，忽略。
+  }
+}
+
+async function listProcessSnapshot(): Promise<ProcessSnapshotEntry[]> {
+  // execFile（异步子进程，非同步 fs）：主进程纪律允许；仅在回收路径按需调用。
+  const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,pgid="], { maxBuffer: 8 * 1024 * 1024 })
+  return parsePsSnapshot(stdout)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function reapDelay(ms: number): Promise<void> {
+  // 刻意不 unref：退出路径 await 本回收链时需保持事件循环存活，直到 SIGKILL 兜底送达。
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function appendBoundedOutput(current: string, next: string, maxBytes: number): string {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -95,6 +95,8 @@ let currentLocale: AppLocale | null = null
 let isQuitting = false
 type AppQuitIntent = "none" | "user-quit" | "update-install" | "termination-signal"
 let appQuitIntent: AppQuitIntent = "none"
+// 退出回收只跑一次：记忆化 Promise，多条退出路径（before-quit / 信号 / 更新安装）复用同一次回收。
+let shutdownReap: Promise<void> | null = null
 let windowsTrayLifecycle: {
   dispose: () => void
   setLocale: (locale: string) => void
@@ -175,7 +177,13 @@ const settingsService = new SettingsServiceImpl({
 })
 // 更新渠道（stable/beta）持久化在同一 settings.json；服务内部仅打包态联网。
 const updateService = new UpdateServiceImpl({
-  beforeInstallDownloadedAppUpdate: () => armAppQuit("update-install"),
+  // 安装前先武装退出意图并把 agent（含 opencode 工具子进程树）连根回收，再交给
+  // quitAndInstall。此处刻意在 quitAndInstall 之前 await：安装走 Squirrel 的正常退出流程，
+  // 不能像用户退出那样 preventDefault+app.exit（会跳过安装），故回收必须在退出前完成。
+  beforeInstallDownloadedAppUpdate: async () => {
+    armAppQuit("update-install")
+    await reapAgentForShutdown()
+  },
   store: settingsStore,
 })
 const gitService = new GitServiceImpl({
@@ -278,32 +286,54 @@ if (isLocked) {
   // 终端 Ctrl-C / kill <pid> / OS 关机 / macOS "停止在后台运行" 可能以原始 POSIX 信号（而非 Cocoa
   // Quit 事件，后者走 before-quit）送达主进程。没有信号处理器时进程会被直接终止、不触发 before-quit，
   // opencode sidecar 便沦为永久孤儿（reparent 到 launchd），macOS 仍把 app 判为"后台运行"。
-  // 这里先同步回收内核，再走正常退出（before-quit 会再 dispose 一次，幂等）。
+  // 这里 await 完整回收（进程树 SIGTERM/SIGKILL 送达）后再硬退出。
   // 另注：opencode 现以 detached 独立进程组运行，dev 下 Ctrl-C 不会经前台进程组自然传到它，
   // 全靠此处 SIGINT 处理器显式回收，否则会残留孤儿。
   const onTerminationSignal = (signal: NodeJS.Signals): void => {
     console.log(`[wanta] received ${signal}; shutting down`)
     armAppQuit("termination-signal")
-    agent?.dispose()
-    app.quit()
+    void reapAgentForShutdown().finally(() => app.exit(0))
   }
   process.once("SIGTERM", () => onTerminationSignal("SIGTERM"))
   process.once("SIGINT", () => onTerminationSignal("SIGINT"))
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
+    // 更新安装（quitAndInstall）路径：回收已在 beforeInstallDownloadedAppUpdate 里 await 完成，
+    // 且必须放行 Squirrel 的正常退出流程去执行安装，故绝不 preventDefault/app.exit。
+    if (appQuitIntent === "update-install") {
+      return
+    }
+    // 用户退出（Cmd+Q / 菜单退出 / win-linux 关末窗）：opencode 的工具子进程各自 setsid 逃逸出
+    // opencode 进程组，单发 kill(-pgid) 收不掉，退出后成孤儿被 macOS 判为"正在后台运行"。这里
+    // 始终拦下默认退出，await 按 ppid 进程树连根回收后再 app.exit(0)（回收记忆化，连按 Cmd+Q
+    // 也只回收一次，且每次 before-quit 都 preventDefault，绝不让第二次退出穿透略过回收）。
+    event.preventDefault()
     armAppQuit("user-quit")
+    void reapAgentForShutdown().finally(() => app.exit(0))
+  })
+}
+
+/**
+ * 退出前一次性回收：停掉待处理定时器/托盘，await agent（含 opencode 工具子进程树）连根回收，
+ * 再 dispose 服务与刷日志。记忆化，确保多条退出路径只回收一次。
+ */
+function reapAgentForShutdown(): Promise<void> {
+  shutdownReap ??= (async () => {
     if (pendingSkillRuntimeRefresh) {
       clearTimeout(pendingSkillRuntimeRefresh)
       pendingSkillRuntimeRefresh = undefined
     }
+    // 退出观感：先藏窗口，回收（含最长宽限期）在后台进行，不让用户盯着卡住的窗口。
+    mainWindow?.hide()
     windowsTrayLifecycle?.dispose()
     windowsTrayLifecycle = null
-    agent?.dispose()
+    await agent?.dispose()
     server.dispose()
-    void flushDiagnosticsLog().catch((error: unknown) => {
+    await flushDiagnosticsLog().catch((error: unknown) => {
       console.warn("[wanta] failed to flush diagnostics log", error)
     })
-  })
+  })()
+  return shutdownReap
 }
 
 function armAppQuit(intent: Exclude<AppQuitIntent, "none">): void {
@@ -485,7 +515,8 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   }
   const previousAccountId = appliedAccount?.id
   appliedAccount = null
-  agent?.dispose()
+  // 后台回收旧 agent（含 opencode 工具子进程树）；重启不等回收完成，回收在后台自完成。
+  void agent?.dispose()
   agent = null
   chatService.setAgent(null)
   chatService.setAgentStatus(account ? { status: "starting" } : { status: "signed_out" })
@@ -514,8 +545,8 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   try {
     await nextAgent.start()
   } catch (error) {
-    // 启动失败不留僵尸 agent：清空引用，下次登录可重试。
-    nextAgent.dispose()
+    // 启动失败不留僵尸 agent：清空引用，下次登录可重试。后台回收，不阻塞错误上报。
+    void nextAgent.dispose()
     agent = null
     chatService.setAgent(null)
     chatService.setAgentStatus({ status: "error", message: runtimeErrorMessage(error) })

--- a/electron/update/node.ts
+++ b/electron/update/node.ts
@@ -31,7 +31,7 @@ type ElectronUpdaterModule = typeof import("electron-updater")
 type AutoUpdater = ElectronUpdaterModule["autoUpdater"]
 
 export interface UpdateServiceDeps {
-  beforeInstallDownloadedAppUpdate?: () => void
+  beforeInstallDownloadedAppUpdate?: () => void | Promise<void>
   store: SettingsStore
 }
 
@@ -98,11 +98,11 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
     }
   }
 
-  public installDownloadedAppUpdate(): Promise<void> {
+  public async installDownloadedAppUpdate(): Promise<void> {
     // 不设本地闩锁：quitAndInstall 失败都走异步 'error' 事件（届时状态离开 downloaded，
     // 按钮自然消失），重复调用由 electron-updater 自身去重。
     if (!app.isPackaged || this.state.status.status !== "downloaded") {
-      return Promise.resolve()
+      return
     }
     logDiagnostic(
       "update-service",
@@ -112,9 +112,10 @@ export class UpdateServiceImpl extends ConnectionService<UpdateService> implemen
     )
     // macOS 的 quitAndInstall 会先 close 所有窗口，再触发 app.before-quit。必须提前让
     // 主窗口 close handler 放行，否则窗口会被 hide-on-close 逻辑拦住，安装流程停在重启中。
-    this.deps.beforeInstallDownloadedAppUpdate?.()
+    // 同时 await 该回调：Wanta 在此把 opencode 工具子进程树连根回收——必须在 quitAndInstall
+    // 触发退出之前完成，安装路径不能像用户退出那样 preventDefault+app.exit（会跳过安装）。
+    await this.deps.beforeInstallDownloadedAppUpdate?.()
     this.getAutoUpdater().quitAndInstall()
-    return Promise.resolve()
   }
 
   public setUpdateChannel(channel: UpdateChannel): Promise<AppUpdateState> {


### PR DESCRIPTION
macOS 退出后 Dock 仍显示"正在后台运行"的问题在 #122 之后仍会复现。根因是 #122 的回收前提有误:opencode 的工具子进程(bash 工具、oo CLI)在 spawn 时各自 `setsid` 到独立 session/进程组,并不在 opencode 的进程组内,因此按 `kill(-opencodePgid)` 回收根本命中不到它们——只在 opencode 空闲、没有工具子进程时才"看似生效"。退出后这些子进程存活并 reparent 到 launchd,macOS 27 据此把 app 判定为"正在后台运行";Windows 上同样会残留孤儿进程,虽无该提示,但占用资源、持有文件锁。

改为两级、互为兜底的回收。首选让 opencode 用自带的 `client.global.dispose()`(`POST /global/dispose`,带 2s 超时)回收它自己 spawn 的全部工具子进程——opencode 权威地知道自己派生了谁,这条路径与 OS 进程组/信号语义无关,因此跨平台,Windows 同样有效。随后按 OS 进程树兜底,既清扫 dispose 可能漏掉的残留,也杀掉 opencode 服务进程本身:unix 用 `ps` 按 `ppid` 收整棵树后逐个 + 按组 SIGTERM/SIGKILL,win32 用 `taskkill /PID <pid> /T /F`。

配套把 `dispose()` 改为异步:各退出路径(`before-quit`、`SIGTERM`/`SIGINT`、更新安装)都 await 回收完成后再退出;其中更新安装在 `quitAndInstall` 之前 await,以免像用户退出那样 `preventDefault`+`app.exit` 跳过 Squirrel 安装;agent 重启(登录/登出/切模型/技能变更)则 fire-and-forget 后台回收,不拖慢重启。

用真实 `OpencodeSidecar` 跑了端到端验证:起一个会逃逸出 opencode 进程组的 bash 工具子进程后调真实的 `dispose()`,opencode 与逃逸子进程在约 130ms 内全部回收、系统零残留;另有纯函数单测覆盖 `ps` 解析、`ppid` 收树、进程组筛选、SIGKILL 升级、快照失败降级与 Windows `taskkill` 参数。一个诚实的保留:**Windows 的 `taskkill` 分支未在真 Windows 上实机跑过**(开发环境是 macOS),它靠单测 + 通行做法支撑。