### PR TITLE
Unify output shelf cards

### DIFF
--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -25,6 +25,7 @@ import { ChevronDown, ChevronRight, ChevronUp } from "lucide-react"
 import * as React from "react"
 import { isConnectionlessNoAuthProvider } from "../../../electron/connections/summary.ts"
 import { useArtifactBundles } from "./artifact-bundle-records.ts"
+import { shouldRenderGeneratedArtifactsShelf } from "./artifact-shelf-visibility.ts"
 import { splitAssistantTimelineBlocks, textFromTimelineBlocks } from "./assistant-timeline.ts"
 import { attachmentWithPreview } from "./chat-attachment-utils.ts"
 import {
@@ -756,6 +757,12 @@ const ChatTurnView = React.memo(function ChatTurnView({
   const responseActionsText =
     lastAssistant?.id === activeAssistantMessageId ? null : textFromTimelineBlocks(responseRenderBlocks) || null
   const processActionsText = responseRenderBlocks.length > 0 ? null : assistantActionsText
+  const hasRenderableArtifacts = shouldRenderGeneratedArtifactsShelf(artifactGroups)
+  const hasRenderableTurnOutputs = Boolean(
+    activeSessionId &&
+    turnOutputRecord &&
+    turnOutputRecord.files.some((file) => file.role === "process" || file.role === "project_change"),
+  )
   const showSuggestedAuthorization = shouldShowSuggestedAuthorization(process, turnIsActive)
   const suggestedAuthorization = shouldRenderConnectionSuggestion(
     showSuggestedAuthorization ? process.suggestedAuthorization : undefined,
@@ -845,9 +852,9 @@ const ChatTurnView = React.memo(function ChatTurnView({
           ))}
         </>
       )}
-      {artifactGroups.length > 0 || (activeSessionId && turnOutputRecord) ? (
+      {hasRenderableArtifacts || hasRenderableTurnOutputs ? (
         <div className="mt-2 grid gap-2">
-          {artifactGroups.length > 0 ? (
+          {hasRenderableArtifacts ? (
             <React.Suspense fallback={null}>
               <GeneratedArtifacts
                 groups={artifactGroups}
@@ -857,7 +864,7 @@ const ChatTurnView = React.memo(function ChatTurnView({
               />
             </React.Suspense>
           ) : null}
-          {activeSessionId && turnOutputRecord ? (
+          {hasRenderableTurnOutputs && turnOutputRecord ? (
             <TurnOutputShelf record={turnOutputRecord} onOpen={onTurnOutputOpen} />
           ) : null}
         </div>

--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -845,18 +845,22 @@ const ChatTurnView = React.memo(function ChatTurnView({
           ))}
         </>
       )}
-      {artifactGroups.length > 0 ? (
-        <React.Suspense fallback={null}>
-          <GeneratedArtifacts
-            groups={artifactGroups}
-            selectionGroups={artifactSelectionGroups}
-            onOpen={onArtifactsOpen}
-            onAvailable={onArtifactsAvailable}
-          />
-        </React.Suspense>
-      ) : null}
-      {activeSessionId && turnOutputRecord ? (
-        <TurnOutputShelf record={turnOutputRecord} onOpen={onTurnOutputOpen} />
+      {artifactGroups.length > 0 || (activeSessionId && turnOutputRecord) ? (
+        <div className="mt-2 grid gap-2">
+          {artifactGroups.length > 0 ? (
+            <React.Suspense fallback={null}>
+              <GeneratedArtifacts
+                groups={artifactGroups}
+                selectionGroups={artifactSelectionGroups}
+                onOpen={onArtifactsOpen}
+                onAvailable={onArtifactsAvailable}
+              />
+            </React.Suspense>
+          ) : null}
+          {activeSessionId && turnOutputRecord ? (
+            <TurnOutputShelf record={turnOutputRecord} onOpen={onTurnOutputOpen} />
+          ) : null}
+        </div>
       ) : null}
     </React.Fragment>
   )

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -35,6 +35,7 @@ import {
   ArtifactsEmptyState,
 } from "./ArtifactPreviewPane.tsx"
 import { FileKindTile } from "./file-type-icons.tsx"
+import { OutputShelfCard } from "./OutputShelfCard.tsx"
 import { useChatService } from "@/components/AppContext"
 import { useT } from "@/i18n/i18n"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
@@ -360,7 +361,7 @@ export function GeneratedArtifactsShelf({
       return null
     }
     return (
-      <section className="not-prose mt-2">
+      <section className="not-prose mt-0">
         <ArtifactPersistenceWarning />
       </section>
     )
@@ -388,30 +389,25 @@ export function GeneratedArtifactsShelf({
     : artifactMetaLabel(t, primaryDisplayItem, primary.pack)
 
   return (
-    <section className="not-prose mt-2 grid gap-1.5">
+    <section className="not-prose mt-0 grid gap-1.5">
       {newest?.status === "failed" ? (
         <ArtifactPersistenceWarning />
       ) : primary.status === "partial" ? (
         <ArtifactPersistenceWarning partial />
       ) : null}
-      <button
-        type="button"
+      <OutputShelfCard
         title={title}
-        className="oo-border-divider flex min-h-16 min-w-0 items-center gap-3 rounded-lg border bg-muted/55 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        icon={
+          <FileKindTile source={primaryDisplayItem} pack={primary.pack} className="size-9" iconClassName="size-4" />
+        }
+        description={meta}
         onClick={() => onOpen(selection)}
         onContextMenu={(event) => {
           event.preventDefault()
           event.stopPropagation()
           onContextMenu(primaryDisplayItem, event.clientX, event.clientY)
         }}
-      >
-        <FileKindTile source={primaryDisplayItem} pack={primary.pack} className="size-9" iconClassName="size-4" />
-        <span className="min-w-0 flex-1">
-          <span className="oo-text-label block truncate text-foreground">{title}</span>
-          <span className="oo-text-caption-compact block truncate text-muted-foreground">{meta}</span>
-        </span>
-        <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-      </button>
+      />
     </section>
   )
 }

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -27,6 +27,7 @@ import {
 } from "./artifact-metadata.ts"
 import { useLocalArtifactPreview } from "./artifact-preview-cache.ts"
 import { resolveArtifactResultPayloads } from "./artifact-resolution.ts"
+import { shouldRenderGeneratedArtifactsShelf } from "./artifact-shelf-visibility.ts"
 import { useLocalArtifactThumbnail } from "./artifact-thumbnail-cache.ts"
 import {
   ArtifactConsumablePreview,
@@ -355,6 +356,10 @@ export function GeneratedArtifactsShelf({
   const primary = displayable?.resolved
   const primaryDisplayItem = displayable?.displayItem
   const panelGroups = selectionGroups.length > 0 ? selectionGroups : groups
+
+  if (!shouldRenderGeneratedArtifactsShelf(groups)) {
+    return null
+  }
 
   if (!primary || !primaryDisplayItem || entries.length === 0) {
     if (newest?.status !== "failed") {

--- a/src/routes/Chat/OutputShelfCard.tsx
+++ b/src/routes/Chat/OutputShelfCard.tsx
@@ -1,0 +1,34 @@
+import type * as React from "react"
+
+import { ChevronRight } from "lucide-react"
+
+export function OutputShelfCard({
+  description,
+  icon,
+  onClick,
+  onContextMenu,
+  title,
+}: {
+  description: React.ReactNode
+  icon: React.ReactNode
+  onClick: React.MouseEventHandler<HTMLButtonElement>
+  onContextMenu?: React.MouseEventHandler<HTMLButtonElement>
+  title: string
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      className="oo-border-divider flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border bg-muted/55 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+    >
+      {icon}
+      <span className="min-w-0 flex-1">
+        <span className="oo-text-label block truncate text-foreground">{title}</span>
+        <span className="oo-text-caption-compact block truncate text-muted-foreground">{description}</span>
+      </span>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+    </button>
+  )
+}

--- a/src/routes/Chat/TurnOutputShelf.test.ts
+++ b/src/routes/Chat/TurnOutputShelf.test.ts
@@ -78,6 +78,9 @@ describe("TurnOutputShelf", () => {
 
     expect(html).toContain("not-prose mt-2 w-full min-w-0")
     expect(html).not.toContain("max-w-[46rem]")
+    expect(html).toContain(
+      '<button type="button" class="flex w-full min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3 text-left',
+    )
     expect(html).toContain("已编辑 5 个文件")
     expect(html).toContain("审核")
     expect(html).toContain("+23")
@@ -106,10 +109,11 @@ describe("TurnOutputShelf", () => {
 
     const html = renderTurnOutputShelf(record)
 
-    expect(html).toContain('class="flex min-w-0 items-center gap-2 rounded-md')
+    expect(html).toContain(
+      'class="flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30',
+    )
     expect(html).toContain("执行详情")
     expect(html).toContain("1 个过程文件 · 不属于最终制成品")
     expect(html).not.toContain("审核")
-    expect(html).not.toContain("rounded-lg border border-border")
   })
 })

--- a/src/routes/Chat/TurnOutputShelf.test.ts
+++ b/src/routes/Chat/TurnOutputShelf.test.ts
@@ -76,7 +76,7 @@ describe("TurnOutputShelf", () => {
 
     const html = renderTurnOutputShelf(record)
 
-    expect(html).toContain("not-prose mt-2 w-full min-w-0")
+    expect(html).toContain("not-prose mt-0 w-full min-w-0")
     expect(html).not.toContain("max-w-[46rem]")
     expect(html).toContain(
       '<button type="button" class="flex w-full min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3 text-left',
@@ -109,8 +109,9 @@ describe("TurnOutputShelf", () => {
 
     const html = renderTurnOutputShelf(record)
 
+    expect(html).toContain('class="not-prose mt-0 min-w-0"')
     expect(html).toContain(
-      'class="flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30',
+      'class="oo-border-divider flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border bg-muted/55',
     )
     expect(html).toContain("执行详情")
     expect(html).toContain("1 个过程文件 · 不属于最终制成品")

--- a/src/routes/Chat/TurnOutputShelf.tsx
+++ b/src/routes/Chat/TurnOutputShelf.tsx
@@ -3,6 +3,7 @@ import type { TurnOutputSelection } from "./TurnOutputs.tsx"
 
 import { ChevronDown, ChevronRight, FileCode2, FileDiff } from "lucide-react"
 import * as React from "react"
+import { OutputShelfCard } from "./OutputShelfCard.tsx"
 import { useT } from "@/i18n/i18n"
 import { cn } from "@/lib/utils"
 import { FileKindTile } from "@/routes/Chat/file-type-icons"
@@ -117,29 +118,23 @@ export function TurnOutputShelf({
 
   if (!hasProjectChanges) {
     return (
-      <section className="not-prose mt-2 min-w-0">
-        <button
-          type="button"
-          className="flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 px-3 py-2 text-left transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          onClick={() => onOpen({ record, initialRole: "process" })}
-        >
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-            <FileCode2 className="size-4" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="oo-text-label block truncate text-foreground">{t("turnOutputs.processDetails")}</span>
-            <span className="oo-text-caption-compact block truncate">
-              {t("turnOutputs.processNotArtifact", { count: intermediateFiles.length })}
+      <section className="not-prose mt-0 min-w-0">
+        <OutputShelfCard
+          title={t("turnOutputs.processDetails")}
+          icon={
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <FileCode2 className="size-4" />
             </span>
-          </span>
-          <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-        </button>
+          }
+          description={t("turnOutputs.processNotArtifact", { count: intermediateFiles.length })}
+          onClick={() => onOpen({ record, initialRole: "process" })}
+        />
       </section>
     )
   }
 
   return (
-    <div className="not-prose mt-2 w-full min-w-0 rounded-lg border border-border bg-background">
+    <div className="not-prose mt-0 w-full min-w-0 rounded-lg border border-border bg-background">
       <button
         type="button"
         className="flex w-full min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3 text-left transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"

--- a/src/routes/Chat/TurnOutputShelf.tsx
+++ b/src/routes/Chat/TurnOutputShelf.tsx
@@ -117,50 +117,52 @@ export function TurnOutputShelf({
 
   if (!hasProjectChanges) {
     return (
-      <div className="not-prose mt-1 min-w-0">
+      <section className="not-prose mt-2 min-w-0">
         <button
           type="button"
-          className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          className="flex min-h-16 w-full min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 px-3 py-2 text-left transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
           onClick={() => onOpen({ record, initialRole: "process" })}
         >
-          <FileCode2 className="size-4 shrink-0" />
-          <span className="min-w-0">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+            <FileCode2 className="size-4" />
+          </span>
+          <span className="min-w-0 flex-1">
             <span className="oo-text-label block truncate text-foreground">{t("turnOutputs.processDetails")}</span>
             <span className="oo-text-caption-compact block truncate">
               {t("turnOutputs.processNotArtifact", { count: intermediateFiles.length })}
             </span>
           </span>
-          <ChevronRight className="size-3.5 shrink-0" />
+          <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
         </button>
-      </div>
+      </section>
     )
   }
 
   return (
     <div className="not-prose mt-2 w-full min-w-0 rounded-lg border border-border bg-background">
-      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3">
-        <div className="flex min-w-0 items-center gap-3">
+      <button
+        type="button"
+        className="flex w-full min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-3 text-left transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        onClick={() => onOpen({ record, initialRole: "project_change" })}
+      >
+        <span className="flex min-w-0 items-center gap-3">
           <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
             <FileDiff className="size-4" />
           </span>
-          <div className="min-w-0">
-            <div className="oo-text-label flex min-w-0 items-center gap-2 text-foreground">
+          <span className="min-w-0">
+            <span className="oo-text-label flex min-w-0 items-center gap-2 text-foreground">
               <span className="min-w-0 truncate">
                 {t("turnOutputs.editedSummary", { count: projectChangeFiles.length })}
               </span>
-            </div>
+            </span>
             <ChangeCountLabel additions={totals.additions} deletions={totals.deletions} />
-          </div>
-        </div>
-        <button
-          type="button"
-          className="oo-text-control flex h-8 shrink-0 items-center gap-1 rounded-md border border-border px-2.5 font-medium hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-          onClick={() => onOpen({ record, initialRole: "project_change" })}
-        >
+          </span>
+        </span>
+        <span className="oo-text-control flex h-8 shrink-0 items-center gap-1 rounded-md border border-border px-2.5 font-medium">
           {t("turnOutputs.reviewChanges")}
           <ChevronRight className="size-3.5" />
-        </button>
-      </div>
+        </span>
+      </button>
 
       <div className="grid gap-1 px-3 py-2">
         {visibleFiles.map((file) => (

--- a/src/routes/Chat/TurnOutputs.test.ts
+++ b/src/routes/Chat/TurnOutputs.test.ts
@@ -81,5 +81,8 @@ describe("TurnOutputsPanel", () => {
     expect(html).toContain("执行详情")
     expect(html).toContain("1 个过程文件")
     expect(html).toContain("不属于最终制成品；仅在需要检查执行细节时查看")
+    expect(html).not.toContain("分栏")
+    expect(html).not.toContain("统一")
+    expect(html).toContain("全部折叠")
   })
 })

--- a/src/routes/Chat/TurnOutputs.tsx
+++ b/src/routes/Chat/TurnOutputs.tsx
@@ -24,6 +24,7 @@ import { Diff as ReactDiff, Hunk, parseDiff } from "react-diff-view"
 import "react-diff-view/style/index.css"
 
 import { toast } from "sonner"
+import { turnOutputInitialCollapsedPaths } from "./turn-output-collapse.ts"
 import { availableTurnOutputRole } from "./turn-output-role.ts"
 import { useChatService } from "@/components/AppContext"
 import { useT } from "@/i18n/i18n"
@@ -143,7 +144,6 @@ export function TurnOutputsPanel({ maximized, onCollapse, onToggleMaximized, sel
   const MaximizeIcon = maximized ? Minimize2 : Maximize2
   const initialRole = selection?.initialRole ?? "project_change"
   const [viewType, setViewType] = React.useState<ViewType>("split")
-  const [collapsedPaths, setCollapsedPaths] = React.useState<Set<string>>(() => new Set())
   const processFiles = React.useMemo(() => (selection ? roleFiles(selection.record, "process") : []), [selection])
   const changeFiles = React.useMemo(() => (selection ? roleFiles(selection.record, "project_change") : []), [selection])
   const requestedRole = availableTurnOutputRole(initialRole, processFiles.length, changeFiles.length)
@@ -157,9 +157,13 @@ export function TurnOutputsPanel({ maximized, onCollapse, onToggleMaximized, sel
       ? availableTurnOutputRole(roleSelection.role, processFiles.length, changeFiles.length)
       : requestedRole
   const activeFiles = activeRole === "project_change" ? changeFiles : processFiles
+  const activeViewType: ViewType = activeRole === "process" ? "unified" : viewType
+  const [collapsedPaths, setCollapsedPaths] = React.useState<Set<string>>(() =>
+    turnOutputInitialCollapsedPaths(activeRole, activeFiles),
+  )
   const hasRoleSwitch = changeFiles.length > 0 && processFiles.length > 0
   const { openPath, showInFolder } = useTurnFileActions()
-  const allCollapsed = activeFiles.length > 0 && activeFiles.every((file) => collapsedPaths.has(file.path))
+  const allExpanded = activeFiles.length > 0 && activeFiles.every((file) => !collapsedPaths.has(file.path))
   const activeAdditions = activeFiles.reduce((sum, file) => sum + file.additions, 0)
   const activeDeletions = activeFiles.reduce((sum, file) => sum + file.deletions, 0)
 
@@ -171,7 +175,7 @@ export function TurnOutputsPanel({ maximized, onCollapse, onToggleMaximized, sel
   )
 
   React.useEffect(() => {
-    setCollapsedPaths(new Set(activeRole === "process" ? activeFiles.map((file) => file.path) : []))
+    setCollapsedPaths(turnOutputInitialCollapsedPaths(activeRole, activeFiles))
   }, [activeFiles, activeRole, selection?.record.messageId])
 
   const togglePath = React.useCallback((path: string) => {
@@ -279,17 +283,19 @@ export function TurnOutputsPanel({ maximized, onCollapse, onToggleMaximized, sel
                 <ChangeCountLabel additions={activeAdditions} className="shrink-0" deletions={activeDeletions} />
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
-                <DiffViewModeToggle value={viewType} onChange={setViewType} />
+                {activeRole === "project_change" ? (
+                  <DiffViewModeToggle value={viewType} onChange={setViewType} />
+                ) : null}
                 <CopyAllPatchesButton files={activeFiles} selection={selection} />
                 <button
                   type="button"
-                  title={allCollapsed ? t("turnOutputs.expandAll") : t("turnOutputs.collapseAll")}
-                  aria-label={allCollapsed ? t("turnOutputs.expandAll") : t("turnOutputs.collapseAll")}
+                  title={allExpanded ? t("turnOutputs.collapseAll") : t("turnOutputs.expandAll")}
+                  aria-label={allExpanded ? t("turnOutputs.collapseAll") : t("turnOutputs.expandAll")}
                   className="oo-toolbar-button flex h-7 shrink-0 items-center rounded-md px-2 hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground"
-                  onClick={() => setAllCollapsed(!allCollapsed)}
+                  onClick={() => setAllCollapsed(allExpanded)}
                 >
                   <span className="oo-text-caption-compact">
-                    {allCollapsed ? t("turnOutputs.expandAll") : t("turnOutputs.collapseAll")}
+                    {allExpanded ? t("turnOutputs.collapseAll") : t("turnOutputs.expandAll")}
                   </span>
                 </button>
               </div>
@@ -311,7 +317,7 @@ export function TurnOutputsPanel({ maximized, onCollapse, onToggleMaximized, sel
                   openPath={openPath}
                   selection={selection}
                   showInFolder={showInFolder}
-                  viewType={viewType}
+                  viewType={activeViewType}
                 />
               ))}
             </div>

--- a/src/routes/Chat/artifact-shelf-visibility.test.ts
+++ b/src/routes/Chat/artifact-shelf-visibility.test.ts
@@ -1,0 +1,39 @@
+import type { ResolvedArtifactGroup } from "./artifact-resolution.ts"
+
+import { describe, expect, it } from "vitest"
+import { shouldRenderGeneratedArtifactsShelf } from "./artifact-shelf-visibility.ts"
+
+const file = {
+  kind: "file" as const,
+  mime: "text/plain",
+  name: "report.txt",
+  path: "/tmp/report.txt",
+}
+
+function group(overrides: Partial<ResolvedArtifactGroup> = {}): ResolvedArtifactGroup {
+  return {
+    messageId: "assistant-1",
+    group: { items: [file], totalItems: 1, truncated: false },
+    ...overrides,
+  }
+}
+
+describe("shouldRenderGeneratedArtifactsShelf", () => {
+  it("skips ready groups that have no displayable entries", () => {
+    expect(
+      shouldRenderGeneratedArtifactsShelf([group({ group: { items: [], totalItems: 0, truncated: false } })]),
+    ).toBe(false)
+  })
+
+  it("keeps a failed group visible so its persistence warning is shown", () => {
+    expect(
+      shouldRenderGeneratedArtifactsShelf([
+        group({ group: { items: [], totalItems: 0, truncated: false }, status: "failed" }),
+      ]),
+    ).toBe(true)
+  })
+
+  it("shows groups that contain a displayable artifact", () => {
+    expect(shouldRenderGeneratedArtifactsShelf([group()])).toBe(true)
+  })
+})

--- a/src/routes/Chat/artifact-shelf-visibility.ts
+++ b/src/routes/Chat/artifact-shelf-visibility.ts
@@ -1,0 +1,25 @@
+import type { LocalArtifactPack } from "../../../electron/chat/common.ts"
+import type { ResolvedArtifactGroup } from "./artifact-resolution.ts"
+
+import { artifactGroupDisplayItem } from "./artifact-metadata.ts"
+
+function packDisplayItems(pack: LocalArtifactPack) {
+  const supporting = pack.supporting.filter((item) => item.role !== "metadata")
+  return pack.items.length > 0 ? [...pack.items, ...supporting] : supporting
+}
+
+function hasDisplayEntry({ group, pack }: ResolvedArtifactGroup): boolean {
+  const items = pack ? packDisplayItems(pack) : group.items
+  return items.length > 0 || Boolean(group.root)
+}
+
+export function shouldRenderGeneratedArtifactsShelf(groups: readonly ResolvedArtifactGroup[]): boolean {
+  if (groups.at(-1)?.status === "failed") {
+    return true
+  }
+  return (
+    groups.some(
+      (resolved) => resolved.status !== "failed" && Boolean(artifactGroupDisplayItem(resolved.group, resolved.pack)),
+    ) && groups.some(hasDisplayEntry)
+  )
+}

--- a/src/routes/Chat/turn-output-collapse.test.ts
+++ b/src/routes/Chat/turn-output-collapse.test.ts
@@ -1,0 +1,16 @@
+import type { TurnOutputFile } from "../../../electron/chat/common.ts"
+
+import { describe, expect, it } from "vitest"
+import { turnOutputInitialCollapsedPaths } from "./turn-output-collapse.ts"
+
+const files: Pick<TurnOutputFile, "path">[] = [{ path: "/tmp/first.ts" }, { path: "/tmp/second.ts" }]
+
+describe("turnOutputInitialCollapsedPaths", () => {
+  it("keeps the first process file expanded by default", () => {
+    expect(turnOutputInitialCollapsedPaths("process", files)).toEqual(new Set(["/tmp/second.ts"]))
+  })
+
+  it("keeps project changes expanded by default", () => {
+    expect(turnOutputInitialCollapsedPaths("project_change", files)).toEqual(new Set())
+  })
+})

--- a/src/routes/Chat/turn-output-collapse.ts
+++ b/src/routes/Chat/turn-output-collapse.ts
@@ -1,0 +1,12 @@
+import type { TurnOutputFile, TurnOutputFileRole } from "../../../electron/chat/common.ts"
+
+/** 过程文件默认只展开首项，避免临时脚本和日志同时撑满审查面板。 */
+export function turnOutputInitialCollapsedPaths(
+  role: TurnOutputFileRole,
+  files: readonly Pick<TurnOutputFile, "path">[],
+): Set<string> {
+  if (role !== "process") {
+    return new Set()
+  }
+  return new Set(files.slice(1).map((file) => file.path))
+}


### PR DESCRIPTION
## Summary

This PR improves the presentation of chat turn outputs by grouping generated artifacts and execution details into one result cluster and giving their summary cards a shared visual surface.

Previously, generated artifacts and execution details were rendered as separate timeline siblings with independent spacing and nearly duplicated card markup. Their card backgrounds, hover colors, and borders differed, which made two related outputs look like separate UI systems. Execution details also needed to behave differently from project-code review: process files are generated from an empty baseline, so a split diff wasted half of the panel and all files were initially collapsed.

The change groups artifact and execution-summary shelves inside a result container, preserving the existing spacing to surrounding chat messages while reducing only the internal spacing between related outputs. A new shared `OutputShelfCard` component now provides the common card surface, typography, sizing, focus behavior, and chevron affordance for both generated artifacts and execution details. The supplied file icons remain semantically distinct.

Process-file review now defaults to a unified view with the split/unified toggle hidden, opens the first process file by default, and uses an expand-all action whenever any remaining process file is collapsed. Project changes retain their code-review behavior.

## Validation

- `npm run format`
- `npm run ts-check`
- `npm run lint`
- `npm test` (170 test files, 1166 tests)
