### PR TITLE
fix(runtime): reduce idle CPU and prevent tool row overflow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,11 +63,11 @@ src/routes/Chat (PromptInput)
       （body.system 尾部注入已授权 Link 存在性提示，默认不列 provider 名，R4）
   → OpenCode sidecar 跑 agent loop（LLM ↔ 工具）
   → 全局 SSE: AgentManager.subscribe → event-translator.translateOpencodeEvent
-  → ChatServiceImpl this.send(...) 广播 ServerEvents
+  → ChatServiceImpl 主进程按 32ms 窗口合并同一文本 part，再广播 ServerEvents
   → useChat 状态机（renderer）
 ```
 
-ServerEvents（`electron/chat/common.ts`）：`messageStarted` / `messageDelta`（**累计全文非增量**，渲染层按 `partId` 替换）/ `toolCallStarted` / `toolCallResult` / `authorizationRequired` / `messageCompleted` / `agentError`。`useChat.ts`：按 sessionId→messages map、`upsertPart` 按 partId 原地更新（稳定 React key，不重挂载无闪烁）、发送时插入乐观 user 气泡 `local-user-*`（真实 user 消息到达时清除）、`messageCompleted` 后 reload 全量校正。事件桥由 `ChatServiceImpl.startEventBridge()` 在 agent 装配后启动。
+ServerEvents（`electron/chat/common.ts`）：`messageStarted` / `messageDelta`（**累计全文非增量**，渲染层按 `partId` 替换）/ `toolCallStarted` / `toolCallResult` / `authorizationRequired` / `messageCompleted` / `agentError`。`ChatServiceImpl` 在主进程对同一 session/message/part 的 text/reasoning 事件做有界合并，控制事件到达时立即 flush；重复 `message.updated` 不再重复广播 `messageStarted`。`useChat.ts`：按 sessionId→messages map、`upsertPart` 按 partId 原地更新（稳定 React key，不重挂载无闪烁）、发送时插入乐观 user 气泡 `local-user-*`（真实 user 消息到达时清除）、`messageCompleted` 后 reload 全量校正。事件桥由 `ChatServiceImpl.startEventBridge()` 在 agent 装配后启动。
 
 渲染用 vendored ai-elements（`src/components/ai-elements/`）：Conversation/Message/PromptInput/Task 等；Markdown 走 streamdown（MessageResponse 内置）；工具 part 映射为聊天内的 `Task` 折叠摘要。
 

--- a/docs/skill-catalog-caching.md
+++ b/docs/skill-catalog-caching.md
@@ -42,7 +42,7 @@ src/lib/skills-catalog-client.ts
 | 我的发布 package detail    | `account:{accountId}:package:{name,version}` |                       10 分钟 | 绝不复用到其他账号                        |
 | Provider → package 解析    | `service + provider displayName`             |                       10 分钟 | 找不到 package 仍保留 24 小时负缓存       |
 | 组织 Skill 配置            | `accountId + organizationId`                 | 30 秒新鲜期 / 24 小时本地保留 | 见 `useOrganizationSkills.ts`             |
-| 本机已安装 Skill inventory | 全局 resource                                |                         60 秒 | 本地扫描，不是市场 catalog                |
+| 本机已安装 Skill inventory | 全局 resource + 主进程扫描缓存               |                        5 分钟 | watcher 变化时主动失效；TTL 兜底缺失目录  |
 
 ## Provider 推荐解析
 
@@ -60,6 +60,7 @@ src/lib/skills-catalog-client.ts
 - 发布 Skill 成功：失效当前账号的“我发布的”列表和私有 package detail，以及公共市场 / 搜索缓存。
 - 登录、登出或切换账号：清空整个会话级 catalog cache，避免任何可能受权限影响的 package 响应展示给另一账号。
 - 安装、更新、删除本机 Skill：只更新 `skillInventory`，不失效市场 catalog。
+- 外部 Agent 或 Wanta runtime Skill 文件变化：主进程 watcher 立即失效 inventory 扫描缓存并广播变更；无变化时不重复递归读取和 hash 全部 Skill。
 - 组织配置增删改：失效当前组织配置缓存；不失效公共 market 数据。
 - 连接器集合变化：Provider 推荐层按候选 provider key 重新计算；公共 package detail 继续复用。
 - 用户显式刷新：调用方传 `forceRefresh`，客户端重新请求该 key。

--- a/electron/activity-metrics.test.ts
+++ b/electron/activity-metrics.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest"
+import { ActivityMetrics } from "./activity-metrics.ts"
+
+describe("ActivityMetrics", () => {
+  it("aggregates counts into one bounded snapshot", () => {
+    let now = 100
+    const onFlush = vi.fn()
+    const metrics = new ActivityMetrics(onFlush, { maxKeys: 2, now: () => now })
+
+    metrics.record("message.updated")
+    metrics.record("message.updated", 2)
+    metrics.record("message.part.updated")
+    metrics.record("session.status")
+    now = 250
+    const snapshot = metrics.flush()
+
+    expect(snapshot).toEqual({
+      counts: { "message.part.updated": 1, "message.updated": 3, other: 1 },
+      durationMs: 150,
+      total: 5,
+    })
+    expect(onFlush).toHaveBeenCalledOnce()
+    expect(metrics.flush()).toBeNull()
+  })
+
+  it("flushes on the configured interval", () => {
+    vi.useFakeTimers()
+    const onFlush = vi.fn()
+    const metrics = new ActivityMetrics(onFlush, { flushIntervalMs: 1_000 })
+
+    metrics.record("event")
+    vi.advanceTimersByTime(999)
+    expect(onFlush).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onFlush).toHaveBeenCalledOnce()
+
+    vi.useRealTimers()
+  })
+})

--- a/electron/activity-metrics.test.ts
+++ b/electron/activity-metrics.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { ActivityMetrics } from "./activity-metrics.ts"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe("ActivityMetrics", () => {
   it("aggregates counts into one bounded snapshot", () => {
@@ -33,7 +37,5 @@ describe("ActivityMetrics", () => {
     expect(onFlush).not.toHaveBeenCalled()
     vi.advanceTimersByTime(1)
     expect(onFlush).toHaveBeenCalledOnce()
-
-    vi.useRealTimers()
   })
 })

--- a/electron/activity-metrics.ts
+++ b/electron/activity-metrics.ts
@@ -1,0 +1,73 @@
+export interface ActivityMetricSnapshot {
+  counts: Record<string, number>
+  durationMs: number
+  total: number
+}
+
+const defaultFlushIntervalMs = 10_000
+const defaultMaxKeys = 64
+const overflowMetricKey = "other"
+
+/** 低成本聚合高频活动；固定窗口最多写一条 diagnostics，且限制动态 key 数量。 */
+export class ActivityMetrics {
+  private readonly counts = new Map<string, number>()
+  private readonly flushIntervalMs: number
+  private readonly maxKeys: number
+  private readonly now: () => number
+  private readonly onFlush: (snapshot: ActivityMetricSnapshot) => void
+  private startedAt: number | undefined
+  private timer: NodeJS.Timeout | undefined
+  private total = 0
+
+  public constructor(
+    onFlush: (snapshot: ActivityMetricSnapshot) => void,
+    options: { flushIntervalMs?: number; maxKeys?: number; now?: () => number } = {},
+  ) {
+    this.flushIntervalMs = options.flushIntervalMs ?? defaultFlushIntervalMs
+    this.maxKeys = options.maxKeys ?? defaultMaxKeys
+    this.now = options.now ?? Date.now
+    this.onFlush = onFlush
+  }
+
+  public record(key: string, count = 1): void {
+    if (!Number.isFinite(count) || count <= 0) {
+      return
+    }
+    const normalizedKey = this.counts.has(key) || this.counts.size < this.maxKeys ? key : overflowMetricKey
+    this.counts.set(normalizedKey, (this.counts.get(normalizedKey) ?? 0) + count)
+    this.total += count
+    this.startedAt ??= this.now()
+    if (this.timer) {
+      return
+    }
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      this.flush()
+    }, this.flushIntervalMs)
+    this.timer.unref?.()
+  }
+
+  public flush(): ActivityMetricSnapshot | null {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    if (this.total === 0 || this.startedAt === undefined) {
+      return null
+    }
+    const snapshot = {
+      counts: Object.fromEntries([...this.counts].sort(([left], [right]) => left.localeCompare(right))),
+      durationMs: Math.max(0, this.now() - this.startedAt),
+      total: this.total,
+    }
+    this.counts.clear()
+    this.startedAt = undefined
+    this.total = 0
+    this.onFlush(snapshot)
+    return snapshot
+  }
+
+  public dispose(): void {
+    this.flush()
+  }
+}

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -18,6 +18,7 @@ import { randomBytes, randomUUID } from "node:crypto"
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
+import { ActivityMetrics } from "../activity-metrics.ts"
 import { branding } from "../branding.ts"
 import { logDiagnostic } from "../diagnostics-log.ts"
 import { connectorBaseUrl, llmBaseUrl } from "../domain.ts"
@@ -189,6 +190,9 @@ export class AgentManager {
   private organizationScopePath: string | undefined
   private organizationUpdateChain: Promise<void> = Promise.resolve()
   private sessionOrganizationNames = new Map<string, string>()
+  private readonly eventMetrics = new ActivityMetrics((snapshot) => {
+    logDiagnostic("performance", "opencode event activity", { ...snapshot }, "trace")
+  })
 
   public constructor(options: AgentManagerOptions) {
     this.options = options
@@ -474,6 +478,7 @@ export class AgentManager {
           break
         }
         this.eventLoopRestartFailures = 0
+        this.eventMetrics.record(event.type)
         try {
           subscriber.onEvent(event)
         } catch (error) {
@@ -925,6 +930,7 @@ export class AgentManager {
     this.eventStreamAbort = null
     this.eventSubscriber = null
     this.started = false
+    this.eventMetrics.dispose()
     // 同时回收"启动中"的实例：退出/重启可能正卡在 startSidecar 的 await 上，此时 this.sidecar 仍为
     // null，但 startingSidecar 已 spawn opencode，必须一并连根回收，否则它会成为漏网孤儿。
     const sidecar = this.sidecar ?? this.startingSidecar

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -478,7 +478,10 @@ export class AgentManager {
           break
         }
         this.eventLoopRestartFailures = 0
-        this.eventMetrics.record(event.type)
+        // OpenCode 每十秒发送一次保活；它不承载业务状态，不应触发周期性诊断写盘。
+        if (event.type !== "server.heartbeat") {
+          this.eventMetrics.record(event.type)
+        }
         try {
           subscriber.onEvent(event)
         } catch (error) {

--- a/electron/agent/retirement.test.ts
+++ b/electron/agent/retirement.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+import { AgentRetirementPool } from "./retirement.ts"
+
+describe("AgentRetirementPool", () => {
+  it("tracks a runtime until its disposal settles", async () => {
+    let finish!: () => void
+    const dispose = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    )
+    const pool = new AgentRetirementPool()
+
+    const retirement = pool.retire({ dispose })
+    await Promise.resolve()
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(pool.size).toBe(1)
+
+    finish()
+    await retirement
+
+    expect(pool.size).toBe(0)
+  })
+
+  it("drains runtimes added while an earlier retirement is pending", async () => {
+    let finishFirst!: () => void
+    let finishSecond!: () => void
+    const pool = new AgentRetirementPool()
+    const firstRetirement = pool.retire({
+      dispose: () =>
+        new Promise<void>((resolve) => {
+          finishFirst = resolve
+        }),
+    })
+    await Promise.resolve()
+
+    const draining = pool.drain()
+    pool.retire({
+      dispose: () =>
+        new Promise<void>((resolve) => {
+          finishSecond = resolve
+        }),
+    })
+    await Promise.resolve()
+
+    finishFirst()
+    await firstRetirement
+    expect(pool.size).toBe(1)
+
+    finishSecond()
+    await draining
+    expect(pool.size).toBe(0)
+  })
+
+  it("continues draining when a disposal rejects", async () => {
+    const pool = new AgentRetirementPool()
+    void pool.retire({ dispose: () => Promise.reject(new Error("dispose failed")) }).catch(() => undefined)
+
+    await expect(pool.drain()).resolves.toBeUndefined()
+    expect(pool.size).toBe(0)
+  })
+})

--- a/electron/agent/retirement.ts
+++ b/electron/agent/retirement.ts
@@ -1,0 +1,30 @@
+export interface DisposableAgentRuntime {
+  dispose(): Promise<void>
+}
+
+/**
+ * 跟踪已退出前台引用、但进程树仍在后台回收的 Agent。
+ * shutdown 必须 drain 全部任务，避免旧 sidecar 在主进程退出时被遗留给 launchd。
+ */
+export class AgentRetirementPool {
+  private readonly pending = new Set<Promise<void>>()
+
+  public get size(): number {
+    return this.pending.size
+  }
+
+  public retire(runtime: DisposableAgentRuntime): Promise<void> {
+    const disposal = Promise.resolve().then(() => runtime.dispose())
+    const tracked = disposal.finally(() => {
+      this.pending.delete(tracked)
+    })
+    this.pending.add(tracked)
+    return tracked
+  }
+
+  public async drain(): Promise<void> {
+    while (this.pending.size > 0) {
+      await Promise.allSettled(this.pending)
+    }
+  }
+}

--- a/electron/agent/runtime-output-batch.test.ts
+++ b/electron/agent/runtime-output-batch.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { RuntimeOutputBatch } from "./runtime-output-batch.ts"
+
+describe("RuntimeOutputBatch", () => {
+  it("retains bounded samples and counts dropped lines", () => {
+    const batch = new RuntimeOutputBatch(2)
+    batch.add("first", false)
+    batch.add("second", true)
+    batch.add("third", false)
+
+    expect(batch.take()).toEqual({
+      droppedLineCount: 1,
+      lineCount: 3,
+      lines: ["first", "second"],
+      truncatedLineCount: 1,
+    })
+    expect(batch.take()).toBeNull()
+  })
+})

--- a/electron/agent/runtime-output-batch.ts
+++ b/electron/agent/runtime-output-batch.ts
@@ -1,0 +1,49 @@
+export interface RuntimeOutputBatchSnapshot {
+  droppedLineCount: number
+  lineCount: number
+  lines: string[]
+  truncatedLineCount: number
+}
+
+const defaultMaxRetainedLines = 20
+
+/** 保留固定数量的运行时输出样本，其余只计数，避免异常日志风暴拖高主进程和磁盘。 */
+export class RuntimeOutputBatch {
+  private droppedLineCount = 0
+  private lineCount = 0
+  private readonly lines: string[] = []
+  private readonly maxRetainedLines: number
+  private truncatedLineCount = 0
+
+  public constructor(maxRetainedLines = defaultMaxRetainedLines) {
+    this.maxRetainedLines = Math.max(0, maxRetainedLines)
+  }
+
+  public add(line: string, truncated: boolean): void {
+    this.lineCount += 1
+    if (truncated) {
+      this.truncatedLineCount += 1
+    }
+    if (this.lines.length < this.maxRetainedLines) {
+      this.lines.push(line)
+    } else {
+      this.droppedLineCount += 1
+    }
+  }
+
+  public take(): RuntimeOutputBatchSnapshot | null {
+    if (this.lineCount === 0) {
+      return null
+    }
+    const snapshot = {
+      droppedLineCount: this.droppedLineCount,
+      lineCount: this.lineCount,
+      lines: this.lines.splice(0),
+      truncatedLineCount: this.truncatedLineCount,
+    }
+    this.droppedLineCount = 0
+    this.lineCount = 0
+    this.truncatedLineCount = 0
+    return snapshot
+  }
+}

--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -4,10 +4,28 @@ import { describe, expect, it } from "vitest"
 import {
   collectDescendantTree,
   distinctProcessGroups,
+  OpencodeSidecar,
   parsePsSnapshot,
   reapProcessTree,
   reapWindowsProcessTree,
 } from "./sidecar.ts"
+
+describe("OpencodeSidecar", () => {
+  it("returns the same disposal promise to every caller", () => {
+    const sidecar = new OpencodeSidecar({
+      config: {},
+      env: {},
+      isolationDir: "/tmp/wanta-sidecar-test-isolation",
+      opencodeBinPath: "/tmp/wanta-sidecar-test-opencode",
+      workspaceDir: "/tmp/wanta-sidecar-test-workspace",
+    })
+
+    const first = sidecar.dispose()
+    const second = sidecar.dispose()
+
+    expect(second).toBe(first)
+  })
+})
 
 // opencode(100) -> bash 工具子进程(200，自成 session/组) -> 其子(300，与 bash 同组)；
 // 另有无关进程 999。opencode 的工具子进程 setsid 逃逸出 opencode 的进程组，是"正在后台运行"孤儿的根源。

--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -1,8 +1,11 @@
 import type { ProcessSnapshotEntry } from "./sidecar.ts"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
+import type { ChildProcessWithoutNullStreams } from "node:child_process"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   collectDescendantTree,
+  boundRuntimeOutputLine,
   distinctProcessGroups,
   OpencodeSidecar,
   parsePsSnapshot,
@@ -24,6 +27,115 @@ describe("OpencodeSidecar", () => {
     const second = sidecar.dispose()
 
     expect(second).toBe(first)
+  })
+
+  it("reaps an existing process once and shares the in-flight disposal", async () => {
+    let finishReap: (() => void) | undefined
+    const reapPromise = new Promise<void>((resolve) => {
+      finishReap = resolve
+    })
+    const reap = vi.fn(() => reapPromise)
+    const sidecar = new OpencodeSidecar({
+      config: {},
+      env: {},
+      isolationDir: "/tmp/wanta-sidecar-test-isolation",
+      opencodeBinPath: "/tmp/wanta-sidecar-test-opencode",
+      workspaceDir: "/tmp/wanta-sidecar-test-workspace",
+    })
+    const internals = sidecar as unknown as {
+      proc: ChildProcessWithoutNullStreams | null
+      reap: (proc: ChildProcessWithoutNullStreams, client: OpencodeClient | null) => Promise<void>
+    }
+    const proc = { pid: 1234 } as ChildProcessWithoutNullStreams
+    internals.proc = proc
+    internals.reap = reap
+
+    const first = sidecar.dispose()
+    const second = sidecar.dispose()
+
+    expect(second).toBe(first)
+    expect(reap).toHaveBeenCalledOnce()
+    expect(reap).toHaveBeenCalledWith(proc, null)
+    finishReap?.()
+    await first
+  })
+
+  it("waits for process cleanup already started by a startup failure", async () => {
+    let finishReap: (() => void) | undefined
+    const reapPromise = new Promise<void>((resolve) => {
+      finishReap = resolve
+    })
+    const sidecar = new OpencodeSidecar({
+      config: {},
+      env: {},
+      isolationDir: "/tmp/wanta-sidecar-test-isolation",
+      opencodeBinPath: "/tmp/wanta-sidecar-test-opencode",
+      workspaceDir: "/tmp/wanta-sidecar-test-workspace",
+    })
+    const internals = sidecar as unknown as { processReapPromise: Promise<void> | null }
+    internals.processReapPromise = reapPromise
+
+    const disposal = sidecar.dispose()
+
+    expect(disposal).toBe(reapPromise)
+    finishReap?.()
+    await disposal
+  })
+
+  it("cannot restart after disposal", async () => {
+    const sidecar = new OpencodeSidecar({
+      config: {},
+      env: {},
+      isolationDir: "/tmp/wanta-sidecar-test-isolation",
+      opencodeBinPath: "/tmp/wanta-sidecar-test-opencode",
+      workspaceDir: "/tmp/wanta-sidecar-test-workspace",
+    })
+
+    await sidecar.dispose()
+
+    await expect(sidecar.start()).rejects.toThrow("already disposed")
+  })
+
+  it("does not spawn when disposed during asynchronous startup preparation", async () => {
+    let finishPreparation: (() => void) | undefined
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve
+    })
+    const spawnProcess = vi.fn()
+    const sidecar = new OpencodeSidecar(
+      {
+        config: {},
+        env: {},
+        isolationDir: "/tmp/wanta-sidecar-test-isolation",
+        opencodeBinPath: "/tmp/wanta-sidecar-test-opencode",
+        workspaceDir: "/tmp/wanta-sidecar-test-workspace",
+      },
+      {
+        createDirectory: () => preparation,
+        spawnProcess,
+      },
+    )
+
+    const start = sidecar.start()
+    expect(sidecar.start()).toBe(start)
+    await sidecar.dispose()
+    finishPreparation?.()
+
+    await expect(start).rejects.toThrow("disposed during startup")
+    expect(spawnProcess).not.toHaveBeenCalled()
+  })
+})
+
+describe("boundRuntimeOutputLine", () => {
+  it("truncates complete oversized lines", () => {
+    const bounded = boundRuntimeOutputLine("x".repeat(9 * 1024))
+
+    expect(bounded.text).toHaveLength(8 * 1024)
+    expect(bounded.truncated).toBe(true)
+  })
+
+  it("preserves lines within the limit", () => {
+    expect(boundRuntimeOutputLine("ready")).toEqual({ text: "ready", truncated: false })
   })
 })
 

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -8,6 +8,7 @@ import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { promisify } from "node:util"
 import { logDiagnostic } from "../diagnostics-log.ts"
+import { RuntimeOutputBatch } from "./runtime-output-batch.ts"
 
 const execFileAsync = promisify(execFile)
 
@@ -44,6 +45,7 @@ const processReapGraceMs = 2_000
 const processReapPollMs = 100
 /** 请求 opencode 自行 dispose 的超时：卡死时不拖累退出，交由 OS 进程树兜底回收。 */
 const opencodeDisposeTimeoutMs = 2_000
+const runtimeOutputFlushMs = 1_000
 
 /** OpenCode 本地 sidecar：spawn `opencode serve`、解析 URL、提供 SDK client、随 app 退出回收。 */
 export class OpencodeSidecar {
@@ -441,43 +443,53 @@ function attachRuntimeStreamDiagnostics(proc: ChildProcessWithoutNullStreams): (
 
 function attachStreamDiagnostics(stream: Readable, source: "stdout" | "stderr"): () => void {
   let pending = ""
+  let flushTimer: NodeJS.Timeout | undefined
+  const batch = new RuntimeOutputBatch()
+  const flush = (): void => {
+    if (flushTimer) {
+      clearTimeout(flushTimer)
+      flushTimer = undefined
+    }
+    const snapshot = batch.take()
+    if (!snapshot) {
+      return
+    }
+    if (source === "stderr") {
+      console.warn("[wanta] opencode stderr batch:", snapshot)
+    }
+    logDiagnostic("opencode-sidecar", `opencode ${source}`, { ...snapshot }, source === "stderr" ? "warn" : "trace")
+  }
+  const queue = (line: string, truncated: boolean): void => {
+    const text = line.trim()
+    if (!text) {
+      return
+    }
+    batch.add(text, truncated)
+    if (flushTimer) {
+      return
+    }
+    flushTimer = setTimeout(flush, runtimeOutputFlushMs)
+    flushTimer.unref?.()
+  }
   const onData = (chunk: Buffer): void => {
     pending += chunk.toString()
     const lines = pending.split(/\r?\n/)
     pending = lines.pop() ?? ""
     if (pending.length > runtimeLineMaxLength) {
-      emitRuntimeLine(source, pending.slice(0, runtimeLineMaxLength), true)
+      queue(pending.slice(0, runtimeLineMaxLength), true)
       pending = ""
     }
     for (const line of lines) {
-      emitRuntimeLine(source, line, false)
+      queue(line, false)
     }
   }
   stream.on("data", onData)
   return () => {
     stream.off("data", onData)
     if (pending.trim()) {
-      emitRuntimeLine(source, pending, false)
+      queue(pending, false)
     }
     pending = ""
+    flush()
   }
-}
-
-function emitRuntimeLine(source: "stdout" | "stderr", line: string, truncated: boolean): void {
-  const text = line.trim()
-  if (!text) {
-    return
-  }
-  if (source === "stderr") {
-    console.warn("[wanta] opencode stderr:", text)
-  }
-  logDiagnostic(
-    "opencode-sidecar",
-    `opencode ${source}`,
-    {
-      line: text,
-      ...(truncated ? { truncated: true } : {}),
-    },
-    source === "stderr" ? "warn" : "trace",
-  )
 }

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -52,6 +52,7 @@ export class OpencodeSidecar {
   private opencodeClient: OpencodeClient | null = null
   private serverUrl = ""
   private disposed = false
+  private disposePromise: Promise<void> | null = null
   private streamLogCleanup: (() => void) | null = null
 
   public constructor(options: SidecarOptions) {
@@ -226,6 +227,9 @@ export class OpencodeSidecar {
    * 重启路径可 fire-and-forget（回收在后台自完成，不拖慢重启）。
    */
   public dispose(): Promise<void> {
+    if (this.disposePromise) {
+      return this.disposePromise
+    }
     this.disposed = true
     this.streamLogCleanup?.()
     this.streamLogCleanup = null
@@ -234,7 +238,8 @@ export class OpencodeSidecar {
     this.proc = null
     this.opencodeClient = null
     this.serverUrl = ""
-    return proc ? this.reap(proc, client) : Promise.resolve()
+    this.disposePromise = proc ? this.reap(proc, client) : Promise.resolve()
+    return this.disposePromise
   }
 }
 

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -1,5 +1,5 @@
 import type { Config, OpencodeClient } from "@opencode-ai/sdk/v2/client"
-import type { ChildProcessWithoutNullStreams } from "node:child_process"
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process"
 import type { Readable } from "node:stream"
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
@@ -37,6 +37,18 @@ export interface SidecarExitInfo {
   signal?: NodeJS.Signals | null
 }
 
+export interface SidecarRuntimeDependencies {
+  createDirectory: (directory: string) => Promise<void>
+  spawnProcess: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams
+}
+
+const defaultSidecarRuntimeDependencies: SidecarRuntimeDependencies = {
+  createDirectory: async (directory) => {
+    await mkdir(directory, { recursive: true })
+  },
+  spawnProcess: (command, args, options) => spawn(command, args, options),
+}
+
 const startupOutputMaxBytes = 64 * 1024
 const runtimeLineMaxLength = 8 * 1024
 /** SIGTERM 后给整棵进程树自行退出的宽限期，超时再 SIGKILL 兜底。 */
@@ -47,18 +59,27 @@ const processReapPollMs = 100
 const opencodeDisposeTimeoutMs = 2_000
 const runtimeOutputFlushMs = 1_000
 
+export function boundRuntimeOutputLine(line: string): { text: string; truncated: boolean } {
+  const truncated = line.length > runtimeLineMaxLength
+  return { text: truncated ? line.slice(0, runtimeLineMaxLength) : line, truncated }
+}
+
 /** OpenCode 本地 sidecar：spawn `opencode serve`、解析 URL、提供 SDK client、随 app 退出回收。 */
 export class OpencodeSidecar {
+  private readonly dependencies: SidecarRuntimeDependencies
   private readonly options: SidecarOptions
   private proc: ChildProcessWithoutNullStreams | null = null
   private opencodeClient: OpencodeClient | null = null
   private serverUrl = ""
   private disposed = false
   private disposePromise: Promise<void> | null = null
+  private processReapPromise: Promise<void> | null = null
+  private startPromise: Promise<void> | null = null
   private streamLogCleanup: (() => void) | null = null
 
-  public constructor(options: SidecarOptions) {
+  public constructor(options: SidecarOptions, dependencies: Partial<SidecarRuntimeDependencies> = {}) {
     this.options = options
+    this.dependencies = { ...defaultSidecarRuntimeDependencies, ...dependencies }
   }
 
   public get client(): OpencodeClient {
@@ -72,8 +93,17 @@ export class OpencodeSidecar {
     return this.serverUrl
   }
 
-  public async start(): Promise<void> {
-    this.disposed = false
+  public start(): Promise<void> {
+    if (this.disposed) {
+      return Promise.reject(new Error("OpencodeSidecar already disposed"))
+    }
+    if (!this.startPromise) {
+      this.startPromise = this.startOnce()
+    }
+    return this.startPromise
+  }
+
+  private async startOnce(): Promise<void> {
     const { opencodeBinPath, workspaceDir, config, env, isolationDir, serverPassword } = this.options
     const hostname = this.options.hostname ?? "127.0.0.1"
     const timeoutMs = this.options.startupTimeoutMs ?? 30_000
@@ -83,7 +113,11 @@ export class OpencodeSidecar {
     const xdgDataHome = path.join(isolationDir, "xdg-data")
     // 这些隔离目录必须存在：opencode 会向 XDG_DATA_HOME 写会话/状态，缺失会导致服务端 500。
     for (const dir of [opencodeConfigDir, xdgConfigHome, xdgDataHome]) {
-      await mkdir(dir, { recursive: true })
+      await this.dependencies.createDirectory(dir)
+    }
+    // dispose 可能在异步建目录期间发生；已处置实例绝不能再创建新进程。
+    if (this.disposed) {
+      throw new Error("OpencodeSidecar disposed during startup")
     }
 
     const childEnv: NodeJS.ProcessEnv = {
@@ -101,7 +135,7 @@ export class OpencodeSidecar {
       childEnv.OPENCODE_SERVER_USERNAME = "opencode"
     }
 
-    const proc = spawn(opencodeBinPath, ["serve", `--hostname=${hostname}`, "--port=0"], {
+    const proc = this.dependencies.spawnProcess(opencodeBinPath, ["serve", `--hostname=${hostname}`, "--port=0"], {
       cwd: workspaceDir,
       env: childEnv,
       // unix：让 opencode 自成 session/进程组，dev 下与终端信号隔离（Ctrl-C 不直达 opencode），
@@ -112,11 +146,16 @@ export class OpencodeSidecar {
     })
     this.proc = proc
 
-    const url = await this.awaitServerUrl(proc, timeoutMs).catch((error: unknown) => {
+    const url = await this.awaitServerUrl(proc, timeoutMs).catch(async (error: unknown) => {
       // 启动失败（超时/提前退出/spawn 出错）时一定要回收已 spawn 的 opencode 及其后代，
-      // 否则会成为孤儿；recoverRuntime 的重试更会不断叠加。后台回收即可，不阻塞抛错。
+      // 否则会成为孤儿；recoverRuntime 的重试更会不断叠加。
       // 此刻 client 尚未建立（awaitServerUrl 失败），传 null 走 OS 进程树兜底回收。
-      void this.reap(proc, null)
+      // dispose 已经摘走 proc 时，它持有的同一回收 Promise 是唯一责任方，避免重复发信号。
+      if (this.proc === proc) {
+        this.proc = null
+        this.processReapPromise ??= this.reap(proc, null)
+        await this.processReapPromise
+      }
       throw error
     })
 
@@ -240,7 +279,10 @@ export class OpencodeSidecar {
     this.proc = null
     this.opencodeClient = null
     this.serverUrl = ""
-    this.disposePromise = proc ? this.reap(proc, client) : Promise.resolve()
+    if (proc) {
+      this.processReapPromise ??= this.reap(proc, client)
+    }
+    this.disposePromise = this.processReapPromise ?? Promise.resolve()
     return this.disposePromise
   }
 }
@@ -480,14 +522,16 @@ function attachStreamDiagnostics(stream: Readable, source: "stdout" | "stderr"):
       pending = ""
     }
     for (const line of lines) {
-      queue(line, false)
+      const bounded = boundRuntimeOutputLine(line)
+      queue(bounded.text, bounded.truncated)
     }
   }
   stream.on("data", onData)
   return () => {
     stream.off("data", onData)
     if (pending.trim()) {
-      queue(pending, false)
+      const bounded = boundRuntimeOutputLine(pending)
+      queue(bounded.text, bounded.truncated)
     }
     pending = ""
     flush()

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -2247,6 +2247,20 @@ test("stale permission mode updates do not override newer modes", async () => {
   assert.deepEqual(bridge.answerPermission.mock.calls, [["session-1", "permission-1", "once"]])
 })
 
+test("unchanged permission mode updates do not emit session activity", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const activities: Array<{ sessionId: string; usedAt: number }> = []
+  service.sessionActivity.on((activity) => activities.push(activity))
+
+  await service.setPermissionMode({ sessionId: "session-1", permissionMode: "default", version: 1 })
+  await service.setPermissionMode({ sessionId: "session-1", permissionMode: "full_access", version: 2 })
+  await service.setPermissionMode({ sessionId: "session-1", permissionMode: "full_access", version: 3 })
+
+  assert.equal(activities.length, 1)
+  assert.equal(activities[0]?.sessionId, "session-1")
+})
+
 test("automatic permission replies are deduplicated across pending reload and events", async () => {
   const bridge = createBridgeAgent()
   const service = new ChatServiceImpl(bridge.agent)

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -555,6 +555,36 @@ test("stopGeneration suppresses delayed streaming events until the next send", a
   assert.equal(events.at(-1)?.event, "messageStarted")
 })
 
+test("event bridge deduplicates message starts and coalesces text updates", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  const started = {
+    type: "message.updated",
+    properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+  }
+  bridge.emit(started)
+  bridge.emit(started)
+  for (const text of ["H", "Hello", "Hello world"]) {
+    bridge.emit({
+      type: "message.part.updated",
+      properties: {
+        delta: text === "H" ? "H" : undefined,
+        part: { id: "text-1", sessionID: "session-1", messageID: "assistant-1", type: "text", text },
+      },
+    })
+  }
+
+  await waitForCondition(() => events.some((event) => event.event === "messageDelta"))
+
+  assert.equal(events.filter((event) => event.event === "messageStarted").length, 1)
+  const deltas = events.filter((event) => event.event === "messageDelta")
+  assert.equal(deltas.length, 1)
+  assert.equal((deltas[0]?.data as { text?: string } | undefined)?.text, "Hello world")
+})
+
 test("stopGeneration finalizes process files produced before cancellation", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-chat-stop-turn-output-"))
   try {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -86,6 +86,7 @@ import { evaluateLocalAccessRequest, localAccessGrantForRequest } from "./local-
 import { directoryArtifacts, fileArtifact, localArtifactItem, readArtifactPack } from "./local-artifacts.ts"
 import { attachmentPreview, localArtifactPreview } from "./previews.ts"
 import { applyStoppedGenerations, recordStoppedGeneration } from "./stopped-generations.ts"
+import { ChatStreamEventBuffer } from "./stream-event-buffer.ts"
 import {
   generationNoticeKindForInactivity,
   inactivityWatchdogActionForEvent,
@@ -110,6 +111,7 @@ const generationInactivityTimeoutMs = 2 * 60_000
 const generationActiveToolInactivityTimeoutMs = 10 * 60_000
 const questionRejectTimeoutMs = 5_000
 const defaultMaxDirectoryItems = 80
+const startedMessageLimit = 5_000
 
 function permissionReplyKey(sessionId: string, requestId: string): string {
   return `${sessionId}\n${requestId}`
@@ -332,6 +334,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private transientTurnOutputs: TurnOutputRecords = new Map()
   private scopeMutationQueue: Promise<void> = Promise.resolve()
   private desiredWorkspaceOrganizationName: string | undefined
+  private streamEventBuffer: ChatStreamEventBuffer | null = null
+  private startedMessages = new Set<string>()
 
   public constructor(agent: AgentManager | null = null, deps: ChatServiceDeps = {}) {
     super(ChatServiceName)
@@ -339,8 +343,16 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.deps = deps
   }
 
+  public override dispose(): void {
+    this.streamEventBuffer?.clear()
+    this.streamEventBuffer = null
+    super.dispose()
+  }
+
   /** 登录 / 登出时由 main 重新装配 agent（旧 agent 的事件流随其 dispose 终止）。 */
   public setAgent(agent: AgentManager | null): void {
+    this.streamEventBuffer?.clear()
+    this.streamEventBuffer = null
     this.agent = agent
     this.bridged = false
     this.userStoppedSessions.clear()
@@ -381,6 +393,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.stoppedGenerationsLoadPromise = null
     this.transientTurnOutputs.clear()
     this.desiredWorkspaceOrganizationName = undefined
+    this.startedMessages.clear()
     this.scopeMutationQueue = Promise.resolve()
   }
 
@@ -408,6 +421,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     }
     this.bridged = true
     const emit = this.send.bind(this) as (event: string, data: unknown) => Promise<void>
+    this.streamEventBuffer = new ChatStreamEventBuffer((buffered) => {
+      this.sendBestEffort(emit, buffered.event, buffered.data, { sessionId: buffered.data.sessionId })
+    })
     const handleConnectionStatus = (status: AgentEventConnectionStatus): void => {
       this.handleAgentConnectionStatus(emit, status)
     }
@@ -463,6 +479,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         }
         if (translated.event === "messageStarted") {
           this.emitSessionActivity(generationSessionId ?? translated.data.sessionId)
+          if (!this.rememberMessageStarted(translated)) {
+            continue
+          }
         }
         if (translated.event === "permissionAsked" && this.answerLocalAccessPermission(emit, translated.data.request)) {
           if (generationSessionId) {
@@ -575,7 +594,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             this.scheduleGenerationInactivityWatchdog(generationSessionId)
           }
         }
-        this.sendBestEffort(emit, displayed.event, displayed.data, { sessionId: displayedSessionId })
+        if (displayed.event === "messageDelta" || displayed.event === "messageReasoningDelta") {
+          this.streamEventBuffer?.enqueue(displayed)
+        } else {
+          this.sendBestEffort(emit, displayed.event, displayed.data, { sessionId: displayedSessionId })
+        }
       }
     }, handleConnectionStatus)
   }
@@ -737,6 +760,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     data: unknown,
     context: { messageId?: string; sessionId?: string } = {},
   ): void {
+    if (event !== "messageDelta" && event !== "messageReasoningDelta") {
+      this.streamEventBuffer?.flush()
+    }
     void emit(event, data).catch((error: unknown) => {
       console.warn("[wanta] failed to emit chat server event:", { event, error, ...context })
       logDiagnostic(
@@ -750,6 +776,22 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         "warn",
       )
     })
+  }
+
+  private rememberMessageStarted(event: Extract<ChatEmit, { event: "messageStarted" }>): boolean {
+    const key = `${event.data.sessionId}\0${event.data.messageId}\0${event.data.role}`
+    if (this.startedMessages.has(key)) {
+      return false
+    }
+    while (this.startedMessages.size >= startedMessageLimit) {
+      const oldest = this.startedMessages.values().next().value
+      if (typeof oldest !== "string") {
+        break
+      }
+      this.startedMessages.delete(oldest)
+    }
+    this.startedMessages.add(key)
+    return true
   }
 
   private emitActiveRunUpdated(

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -767,7 +767,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     context: { messageId?: string; sessionId?: string } = {},
   ): void {
     if (event !== "messageDelta" && event !== "messageReasoningDelta") {
-      this.streamEventBuffer?.flush()
+      this.streamEventBuffer?.flush(context.sessionId)
     }
     this.eventMetrics.record(`ipc:${event}`)
     void emit(event, data).catch((error: unknown) => {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -58,6 +58,7 @@ import { ConnectionService } from "@oomol/connection"
 import { shell } from "electron"
 import { realpath, rm } from "node:fs/promises"
 import os from "node:os"
+import { ActivityMetrics } from "../activity-metrics.ts"
 import { translateOpencodeEvent } from "../agent/event-translator.ts"
 import { managedPythonEnvironmentPath } from "../agent/python-environment.ts"
 import { logDiagnostic } from "../diagnostics-log.ts"
@@ -336,6 +337,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private desiredWorkspaceOrganizationName: string | undefined
   private streamEventBuffer: ChatStreamEventBuffer | null = null
   private startedMessages = new Set<string>()
+  private readonly eventMetrics = new ActivityMetrics((snapshot) => {
+    logDiagnostic("performance", "chat event activity", { ...snapshot }, "trace")
+  })
 
   public constructor(agent: AgentManager | null = null, deps: ChatServiceDeps = {}) {
     super(ChatServiceName)
@@ -346,6 +350,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   public override dispose(): void {
     this.streamEventBuffer?.clear()
     this.streamEventBuffer = null
+    this.eventMetrics.dispose()
     super.dispose()
   }
 
@@ -595,6 +600,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           }
         }
         if (displayed.event === "messageDelta" || displayed.event === "messageReasoningDelta") {
+          this.eventMetrics.record(`stream-input:${displayed.event}`)
           this.streamEventBuffer?.enqueue(displayed)
         } else {
           this.sendBestEffort(emit, displayed.event, displayed.data, { sessionId: displayedSessionId })
@@ -763,6 +769,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (event !== "messageDelta" && event !== "messageReasoningDelta") {
       this.streamEventBuffer?.flush()
     }
+    this.eventMetrics.record(`ipc:${event}`)
     void emit(event, data).catch((error: unknown) => {
       console.warn("[wanta] failed to emit chat server event:", { event, error, ...context })
       logDiagnostic(

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -2448,6 +2448,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   }
 
   public async setPermissionMode(req: SetChatPermissionModeRequest): Promise<void> {
+    const changed = this.sessionPermissionMode(req.sessionId) !== req.permissionMode
     if (!this.setSessionPermissionModeValue(req.sessionId, req.permissionMode, req.version)) {
       return
     }
@@ -2460,6 +2461,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (req.permissionMode === "full_access") {
       await Promise.all(affectedSessionIds.map((sessionId) => this.autoAnswerPendingPermissions(sessionId)))
     }
-    this.emitSessionActivity(req.sessionId)
+    if (changed) {
+      this.emitSessionActivity(req.sessionId)
+    }
   }
 }

--- a/electron/chat/stream-event-buffer.test.ts
+++ b/electron/chat/stream-event-buffer.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ChatStreamEventBuffer, coalesceBufferedStreamEvent } from "./stream-event-buffer.ts"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function delta(text: string, increment?: string) {
+  return {
+    event: "messageDelta" as const,
+    data: {
+      sessionId: "session-1",
+      messageId: "message-1",
+      partId: "part-1",
+      text,
+      ...(increment === undefined ? {} : { delta: increment }),
+    },
+  }
+}
+
+describe("coalesceBufferedStreamEvent", () => {
+  it("keeps only the latest cumulative text snapshot", () => {
+    expect(coalesceBufferedStreamEvent(delta("Hello"), delta("Hello world", " world"))).toEqual(
+      delta("Hello world", " world"),
+    )
+  })
+
+  it("combines providers that emit only deltas", () => {
+    expect(coalesceBufferedStreamEvent(delta("", "Hello"), delta("", " world"))).toEqual(delta("", "Hello world"))
+  })
+})
+
+describe("ChatStreamEventBuffer", () => {
+  it("emits at most one update per part in a flush window", () => {
+    vi.useFakeTimers()
+    const emit = vi.fn()
+    const buffer = new ChatStreamEventBuffer(emit, { delayMs: 32 })
+
+    buffer.enqueue(delta("H", "H"))
+    buffer.enqueue(delta("Hello", "ello"))
+    vi.advanceTimersByTime(31)
+    expect(emit).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenCalledWith(delta("Hello", "ello"))
+  })
+
+  it("flushes control boundaries immediately and can discard stale work", () => {
+    vi.useFakeTimers()
+    const emit = vi.fn()
+    const buffer = new ChatStreamEventBuffer(emit)
+
+    buffer.enqueue(delta("first"))
+    buffer.flush()
+    expect(emit).toHaveBeenCalledWith(delta("first"))
+
+    buffer.enqueue(delta("stale"))
+    buffer.clear()
+    vi.runAllTimers()
+    expect(emit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/electron/chat/stream-event-buffer.test.ts
+++ b/electron/chat/stream-event-buffer.test.ts
@@ -18,6 +18,13 @@ function delta(text: string, increment?: string) {
   }
 }
 
+function sessionDelta(sessionId: string, text: string) {
+  return {
+    ...delta(text),
+    data: { ...delta(text).data, sessionId },
+  }
+}
+
 describe("coalesceBufferedStreamEvent", () => {
   it("keeps only the latest cumulative text snapshot", () => {
     expect(coalesceBufferedStreamEvent(delta("Hello"), delta("Hello world", " world"))).toEqual(
@@ -59,5 +66,21 @@ describe("ChatStreamEventBuffer", () => {
     buffer.clear()
     vi.runAllTimers()
     expect(emit).toHaveBeenCalledTimes(1)
+  })
+
+  it("flushes only the selected session and preserves the shared timer", () => {
+    vi.useFakeTimers()
+    const emit = vi.fn()
+    const buffer = new ChatStreamEventBuffer(emit, { delayMs: 32 })
+
+    buffer.enqueue(sessionDelta("parent", "parent text"))
+    buffer.enqueue(sessionDelta("child", "child text"))
+    buffer.flush("parent")
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenLastCalledWith(sessionDelta("parent", "parent text"))
+    vi.advanceTimersByTime(32)
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenLastCalledWith(sessionDelta("child", "child text"))
   })
 })

--- a/electron/chat/stream-event-buffer.ts
+++ b/electron/chat/stream-event-buffer.ts
@@ -1,0 +1,82 @@
+import type { MessageDeltaEvent, MessageReasoningDeltaEvent } from "./common.ts"
+
+export type BufferedStreamEvent =
+  | { event: "messageDelta"; data: MessageDeltaEvent }
+  | { event: "messageReasoningDelta"; data: MessageReasoningDeltaEvent }
+
+type StreamEventData = MessageDeltaEvent | MessageReasoningDeltaEvent
+
+const defaultFlushDelayMs = 32
+
+function streamEventKey(event: BufferedStreamEvent): string {
+  return `${event.event}\0${event.data.sessionId}\0${event.data.messageId}\0${event.data.partId}`
+}
+
+/** 合并同一文本 part 的累计快照；仅有 delta 的 provider 则保留全部增量。 */
+export function coalesceBufferedStreamEvent(
+  current: BufferedStreamEvent | undefined,
+  next: BufferedStreamEvent,
+): BufferedStreamEvent {
+  if (!current || current.event !== next.event) {
+    return next
+  }
+  if (next.data.text) {
+    return next
+  }
+  if (!next.data.delta) {
+    return current
+  }
+  const data: StreamEventData = current.data.text
+    ? { ...next.data, text: current.data.text + next.data.delta, delta: undefined }
+    : { ...next.data, delta: `${current.data.delta ?? ""}${next.data.delta}` }
+  return { event: next.event, data } as BufferedStreamEvent
+}
+
+/** 主进程侧有界合并 OpenCode 文本事件，避免每个 token 都触发一次 Electron structured clone。 */
+export class ChatStreamEventBuffer {
+  private readonly delayMs: number
+  private readonly emit: (event: BufferedStreamEvent) => void
+  private readonly pending = new Map<string, BufferedStreamEvent>()
+  private timer: NodeJS.Timeout | undefined
+
+  public constructor(emit: (event: BufferedStreamEvent) => void, options: { delayMs?: number } = {}) {
+    this.emit = emit
+    this.delayMs = options.delayMs ?? defaultFlushDelayMs
+  }
+
+  public enqueue(event: BufferedStreamEvent): void {
+    const key = streamEventKey(event)
+    this.pending.set(key, coalesceBufferedStreamEvent(this.pending.get(key), event))
+    if (this.timer) {
+      return
+    }
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      this.flush()
+    }, this.delayMs)
+    this.timer.unref?.()
+  }
+
+  public flush(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    if (this.pending.size === 0) {
+      return
+    }
+    const events = [...this.pending.values()]
+    this.pending.clear()
+    for (const event of events) {
+      this.emit(event)
+    }
+  }
+
+  public clear(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    this.pending.clear()
+  }
+}

--- a/electron/chat/stream-event-buffer.ts
+++ b/electron/chat/stream-event-buffer.ts
@@ -57,16 +57,25 @@ export class ChatStreamEventBuffer {
     this.timer.unref?.()
   }
 
-  public flush(): void {
-    if (this.timer) {
+  public flush(sessionId?: string): void {
+    if (sessionId === undefined && this.timer) {
       clearTimeout(this.timer)
       this.timer = undefined
     }
     if (this.pending.size === 0) {
       return
     }
-    const events = [...this.pending.values()]
-    this.pending.clear()
+    const events: BufferedStreamEvent[] = []
+    for (const [key, event] of this.pending) {
+      if (sessionId === undefined || event.data.sessionId === sessionId) {
+        events.push(event)
+        this.pending.delete(key)
+      }
+    }
+    if (sessionId && this.pending.size === 0 && this.timer) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
     for (const event of events) {
       this.emit(event)
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,7 @@ import {
   resolveDevOpencodeBin,
 } from "./agent/binaries.ts"
 import { AgentManager } from "./agent/manager.ts"
+import { AgentRetirementPool } from "./agent/retirement.ts"
 import { APP_COMMAND_CHANNEL, APP_COMMANDS } from "./app-command.ts"
 import { APP_LOCALE_CHANNEL, isAppLocale, normalizeAppLocale } from "./app-locale.ts"
 import { ArtifactResourceLeaseStore } from "./artifact-resource/lease-store.ts"
@@ -105,6 +106,7 @@ type AppQuitIntent = "none" | "user-quit" | "update-install" | "termination-sign
 let appQuitIntent: AppQuitIntent = "none"
 // 退出回收只跑一次：记忆化 Promise，多条退出路径（before-quit / 信号 / 更新安装）复用同一次回收。
 let shutdownReap: Promise<void> | null = null
+const agentRetirementPool = new AgentRetirementPool()
 let windowsTrayLifecycle: {
   dispose: () => void
   setLocale: (locale: string) => void
@@ -349,7 +351,12 @@ function reapAgentForShutdown(): Promise<void> {
     mainWindow?.hide()
     windowsTrayLifecycle?.dispose()
     windowsTrayLifecycle = null
-    await agent?.dispose()
+    const activeAgent = agent
+    agent = null
+    if (activeAgent) {
+      await agentRetirementPool.retire(activeAgent)
+    }
+    await agentRetirementPool.drain()
     await spreadsheetPreviewWorker.dispose()
     server.dispose()
     artifactResourceLeaseStore.clear()
@@ -534,6 +541,9 @@ function runtimeErrorMessage(error: unknown): string {
 
 /** 凭证 → 运行时装配：替换 agent（重启 sidecar）并同步 connector 凭证。经 applyChain 串行执行。 */
 function applyAuthAccount(account: AuthRuntimeAccount | null): Promise<void> {
+  if (isQuitting) {
+    return Promise.resolve()
+  }
   const next = applyChain.then(() => applyAuthAccountNow(account))
   applyChain = next.catch((error: unknown) => {
     logMainError("auth account application failed", error)
@@ -547,6 +557,9 @@ let appliedAccount: AuthRuntimeAccount | null = null
 let activeAgentOrganizationName: string | undefined
 
 async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<void> {
+  if (isQuitting) {
+    return
+  }
   // account 恒带会话 token（来自 activeRuntimeAccount / adoptAccount）；token 缺失即为 null = 登出态。
   // 幂等短路：冷启动 deep-link 与 whenReady 双路径会用同一账号 apply 两次。
   if (
@@ -561,14 +574,18 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   }
   const previousAccountId = appliedAccount?.id
   appliedAccount = null
-  // 后台回收旧 agent（含 opencode 工具子进程树）；重启不等回收完成，回收在后台自完成。
-  void agent?.dispose()
+  // 旧 sidecar 必须在新 sidecar 启动前完成回收，避免共享 workspace/isolation 的两个运行时短暂并存。
+  const previousAgent = agent
   agent = null
   chatService.setAgent(null)
   chatService.setAgentStatus(account ? { status: "starting" } : { status: "signed_out" })
   sessionService.setAgent(null)
 
-  if (!account) {
+  if (previousAgent) {
+    await agentRetirementPool.retire(previousAgent)
+  }
+
+  if (!account || isQuitting) {
     activeAgentOrganizationName = undefined
     return
   }
@@ -576,6 +593,10 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
     activeAgentOrganizationName = undefined
   }
 
+  const customModels = await modelsStore.runtimeCustomModels()
+  if (isQuitting) {
+    return
+  }
   const nextAgent = new AgentManager({
     authToken: account.sessionToken,
     opencodeBinPath,
@@ -583,7 +604,7 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
     bundledSkillsDir,
     organizationName: activeAgentOrganizationName,
     rootDir: path.join(app.getPath("userData"), "agent"),
-    customModels: await modelsStore.runtimeCustomModels(),
+    customModels,
   })
   agent = nextAgent
   chatService.setAgent(nextAgent)
@@ -591,13 +612,22 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   try {
     await nextAgent.start()
   } catch (error) {
-    // 启动失败不留僵尸 agent：清空引用，下次登录可重试。后台回收，不阻塞错误上报。
-    void nextAgent.dispose()
+    // 启动失败不留僵尸 agent：清空引用并完成回收，下次登录可重试。
+    await agentRetirementPool.retire(nextAgent)
     agent = null
     chatService.setAgent(null)
     chatService.setAgentStatus({ status: "error", message: runtimeErrorMessage(error) })
     sessionService.setAgent(null)
     throw error
+  }
+  if (isQuitting) {
+    await agentRetirementPool.retire(nextAgent)
+    if (agent === nextAgent) {
+      agent = null
+      chatService.setAgent(null)
+      sessionService.setAgent(null)
+    }
+    return
   }
   appliedAccount = account
   appliedAgentRuntimeVersion = agentRuntimeVersion
@@ -623,6 +653,9 @@ async function handleAgentOrganizationChanged(organizationName: string | undefin
 }
 
 function restartAgentForModelConfig(): void {
+  if (isQuitting) {
+    return
+  }
   agentRuntimeVersion += 1
   void authManager
     .activeRuntimeAccount()
@@ -643,6 +676,9 @@ function scheduleAgentRefreshForSkillChange(
   delayMs = skillRuntimeRefreshDelayMs,
   busyRetryCount = 0,
 ): void {
+  if (isQuitting) {
+    return
+  }
   if (pendingSkillRuntimeRefresh) {
     clearTimeout(pendingSkillRuntimeRefresh)
   }
@@ -655,6 +691,9 @@ function scheduleAgentRefreshForSkillChange(
 }
 
 function refreshAgentForSkillChange(reason: string, busyRetryCount = 0): void {
+  if (isQuitting) {
+    return
+  }
   if (!authManager.activeAccount() || !agent?.isReady()) {
     return
   }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,6 +81,7 @@ const macTrafficLightPosition = { x: 15, y: 17 }
 const skillRuntimeRefreshDelayMs = 1_500
 const skillRuntimeRefreshBusyRetryMs = 2_000
 const skillRuntimeRefreshMaxBusyRetries = 10
+const shutdownCleanupTimeoutMs = 5_000
 
 interface SelectedAttachmentPath {
   name: string
@@ -353,18 +354,38 @@ function reapAgentForShutdown(): Promise<void> {
     windowsTrayLifecycle = null
     const activeAgent = agent
     agent = null
+    chatService.setAgent(null)
+    sessionService.setAgent(null)
     if (activeAgent) {
-      await agentRetirementPool.retire(activeAgent)
+      await runBoundedShutdownStep("retire active agent", () => agentRetirementPool.retire(activeAgent))
     }
-    await agentRetirementPool.drain()
-    await spreadsheetPreviewWorker.dispose()
+    await runBoundedShutdownStep("drain agent retirements", () => agentRetirementPool.drain())
+    await runBoundedShutdownStep("dispose spreadsheet preview worker", () => spreadsheetPreviewWorker.dispose())
     server.dispose()
     artifactResourceLeaseStore.clear()
-    await flushDiagnosticsLog().catch((error: unknown) => {
-      console.warn("[wanta] failed to flush diagnostics log", error)
-    })
+    await runBoundedShutdownStep("flush diagnostics log", flushDiagnosticsLog)
   })()
   return shutdownReap
+}
+
+async function runBoundedShutdownStep(label: string, task: () => Promise<void>): Promise<void> {
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${shutdownCleanupTimeoutMs}ms`)),
+      shutdownCleanupTimeoutMs,
+    )
+  })
+  try {
+    await Promise.race([Promise.resolve().then(task), timeout])
+  } catch (error) {
+    console.warn(`[wanta] shutdown cleanup failed: ${label}`, error)
+    logDiagnostic("app-lifecycle", "shutdown cleanup failed", { error, label }, "warn")
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
 }
 
 function armAppQuit(intent: Exclude<AppQuitIntent, "none">): void {
@@ -582,7 +603,18 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   sessionService.setAgent(null)
 
   if (previousAgent) {
-    await agentRetirementPool.retire(previousAgent)
+    try {
+      await agentRetirementPool.retire(previousAgent)
+    } catch (error) {
+      // 旧运行时未确认退出时不冒险启动第二个 sidecar；保持 appliedAccount 为空，允许后续重试。
+      console.warn("[wanta] failed to retire previous agent runtime:", error)
+      logMainError("failed to retire previous agent runtime", error)
+      chatService.setAgentStatus({
+        status: "error",
+        message: `Failed to stop the previous OpenCode runtime: ${runtimeErrorMessage(error)}`,
+      })
+      return
+    }
   }
 
   if (!account || isQuitting) {

--- a/electron/skills/inventory-cache.test.ts
+++ b/electron/skills/inventory-cache.test.ts
@@ -1,0 +1,96 @@
+import type { SkillInventory } from "./common.ts"
+
+import { describe, expect, it, vi } from "vitest"
+import { SkillInventoryCache } from "./inventory-cache.ts"
+
+function inventory(updatedAt: string): SkillInventory {
+  return {
+    groups: [],
+    summary: {
+      localSkills: 0,
+      managedSkills: 0,
+      modifiedHosts: 0,
+      needsAttention: 0,
+      publishableSkills: 0,
+      registrySkills: 0,
+      skills: [],
+      sourceMissingHosts: 0,
+    },
+    updatedAt,
+  }
+}
+
+describe("SkillInventoryCache", () => {
+  it("reuses a cached inventory until its TTL expires", async () => {
+    let now = 1_000
+    const cache = new SkillInventoryCache({ now: () => now, ttlMs: 5_000 })
+    const load = vi.fn(async () => inventory(String(now)))
+
+    const first = await cache.get({ writeManifest: true }, load)
+    now = 5_999
+    const cached = await cache.get({ writeManifest: true }, load)
+    now = 6_000
+    const expired = await cache.get({ writeManifest: true }, load)
+
+    expect(cached).toBe(first)
+    expect(expired).not.toBe(first)
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it("invalidates cached and in-flight reads after a file change", async () => {
+    let finish!: (value: SkillInventory) => void
+    const cache = new SkillInventoryCache()
+    const firstLoad = vi.fn(
+      () =>
+        new Promise<SkillInventory>((resolve) => {
+          finish = resolve
+        }),
+    )
+    const stale = cache.get({ writeManifest: true }, firstLoad)
+
+    cache.invalidate()
+    const freshInventory = inventory("fresh")
+    const freshLoad = vi.fn(async () => freshInventory)
+    expect(await cache.get({ writeManifest: true }, freshLoad)).toBe(freshInventory)
+
+    finish(inventory("stale"))
+    await stale
+    expect(await cache.get({ writeManifest: true }, freshLoad)).toBe(freshInventory)
+    expect(freshLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces compatible reads but upgrades a non-persisting read", async () => {
+    let finishWeak!: (value: SkillInventory) => void
+    const cache = new SkillInventoryCache()
+    const weakLoad = vi.fn(
+      () =>
+        new Promise<SkillInventory>((resolve) => {
+          finishWeak = resolve
+        }),
+    )
+    const weak = cache.get({ writeManifest: false }, weakLoad)
+    const coalesced = cache.get({ writeManifest: false }, weakLoad)
+    const strongInventory = inventory("strong")
+    const strongLoad = vi.fn(async () => strongInventory)
+    const strong = cache.get({ writeManifest: true }, strongLoad)
+
+    expect(coalesced).toBe(weak)
+    expect(await strong).toBe(strongInventory)
+    finishWeak(inventory("weak"))
+    await weak
+    expect(await cache.get({ writeManifest: true }, strongLoad)).toBe(strongInventory)
+    expect(weakLoad).toHaveBeenCalledTimes(1)
+    expect(strongLoad).toHaveBeenCalledTimes(1)
+  })
+
+  it("forces a refresh before the TTL expires", async () => {
+    const cache = new SkillInventoryCache()
+    const load = vi.fn().mockResolvedValueOnce(inventory("first")).mockResolvedValueOnce(inventory("second"))
+
+    await cache.get({ writeManifest: true }, load)
+    const refreshed = await cache.refresh({ writeManifest: true }, load)
+
+    expect(refreshed.updatedAt).toBe("second")
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/electron/skills/inventory-cache.ts
+++ b/electron/skills/inventory-cache.ts
@@ -1,0 +1,94 @@
+import type { SkillInventory } from "./common.ts"
+
+interface CachedInventory {
+  expiresAt: number
+  inventory: SkillInventory
+  writeManifest: boolean
+}
+
+interface InventoryLoadRequest {
+  writeManifest: boolean
+}
+
+interface InventoryInFlight extends InventoryLoadRequest {
+  generation: number
+  promise: Promise<SkillInventory>
+}
+
+const defaultInventoryCacheTtlMs = 5 * 60_000
+
+/** 技能目录由 watcher 主动失效；TTL 仅兜底发现启动时尚不存在、因而未能监听的目录。 */
+export class SkillInventoryCache {
+  private cached: CachedInventory | undefined
+  private generation = 0
+  private inFlight: InventoryInFlight | undefined
+  private readonly now: () => number
+  private readonly ttlMs: number
+
+  public constructor(options: { now?: () => number; ttlMs?: number } = {}) {
+    this.now = options.now ?? Date.now
+    this.ttlMs = options.ttlMs ?? defaultInventoryCacheTtlMs
+  }
+
+  public invalidate(): void {
+    this.generation += 1
+    this.cached = undefined
+    this.inFlight = undefined
+  }
+
+  public get(
+    request: InventoryLoadRequest,
+    load: (request: InventoryLoadRequest) => Promise<SkillInventory>,
+  ): Promise<SkillInventory> {
+    const cached = this.cached
+    if (cached && cached.expiresAt > this.now()) {
+      if (!request.writeManifest || cached.writeManifest) {
+        return Promise.resolve(cached.inventory)
+      }
+      this.invalidate()
+    }
+
+    const inFlight = this.inFlight
+    if (inFlight && inFlight.generation === this.generation && (!request.writeManifest || inFlight.writeManifest)) {
+      return inFlight.promise
+    }
+    if (inFlight) {
+      this.invalidate()
+    }
+
+    return this.load(request, load)
+  }
+
+  public refresh(
+    request: InventoryLoadRequest,
+    load: (request: InventoryLoadRequest) => Promise<SkillInventory>,
+  ): Promise<SkillInventory> {
+    this.invalidate()
+    return this.load(request, load)
+  }
+
+  private load(
+    request: InventoryLoadRequest,
+    load: (request: InventoryLoadRequest) => Promise<SkillInventory>,
+  ): Promise<SkillInventory> {
+    const generation = this.generation
+    const promise = load(request).then((inventory) => {
+      if (this.generation === generation) {
+        this.cached = {
+          expiresAt: this.now() + this.ttlMs,
+          inventory,
+          writeManifest: request.writeManifest || Boolean(this.cached?.writeManifest),
+        }
+      }
+      return inventory
+    })
+    this.inFlight = { ...request, generation, promise }
+    const clearInFlight = (): void => {
+      if (this.inFlight?.promise === promise) {
+        this.inFlight = undefined
+      }
+    }
+    void promise.then(clearInFlight, clearInFlight)
+    return promise
+  }
+}

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -1176,6 +1176,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
         registrySkillCount: diagnosticFields.registrySkillCount,
       },
     )
+    logDiagnostic("performance", "skill inventory scan", diagnosticFields, "trace")
     return inventory
   }
 

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -66,6 +66,7 @@ import {
   removeSkillDirectoryIfSafe,
   replaceDirectory,
 } from "./file-operations.ts"
+import { SkillInventoryCache } from "./inventory-cache.ts"
 import { mergeInstalledSkillSnapshots, readSkillCoverageAgents } from "./inventory-snapshot.ts"
 import { buildSummary, groupInstalledSkills } from "./inventory.ts"
 import {
@@ -107,7 +108,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   private versionReportCache: { generation: number; key: string; report: SkillVersionReport; time: number } | undefined
   private versionReportInFlight: { generation: number; key: string; promise: Promise<SkillVersionReport> } | undefined
   private versionReportCacheGeneration = 0
-  private inventoryInFlight: { promise: Promise<SkillInventory>; writeManifest: boolean } | undefined
+  private readonly inventoryCache = new SkillInventoryCache()
   private defaultRegistrySkillInstallInFlight: Promise<void> | undefined
   private externalRuntimeSkillSyncTail: Promise<void> = Promise.resolve()
   private inventoryChangeTimer: NodeJS.Timeout | undefined
@@ -210,7 +211,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   }
 
   public async checkSkillInventory(): Promise<SkillInventory> {
-    const inventory = await this.readSharedSkillInventory({ writeManifest: true })
+    const inventory = await this.refreshSharedSkillInventory({ writeManifest: true })
     await this.emitInventoryChanged()
     return inventory
   }
@@ -353,7 +354,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
     }
 
     const skillId = normalizeSkillId(request.skillId)
-    const inventory = await this.readSkillInventory({ writeManifest: false })
+    const inventory = await this.readSharedSkillInventory({ writeManifest: false })
     const group = inventory.groups.find((item) => item.id === skillId)
 
     if (!group) {
@@ -390,7 +391,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   }
 
   public async checkSkillVersions(request: CheckSkillVersionsRequest = {}): Promise<SkillVersionReport> {
-    const inventory = await this.readSkillInventory({ writeManifest: false })
+    const inventory = await this.readSharedSkillInventory({ writeManifest: false })
     const authSnapshot = await this.readAuthSnapshot()
     const cacheKey = `${authSnapshot.cacheKey}:${createVersionReportCacheKey(inventory)}`
     const cacheGeneration = this.versionReportCacheGeneration
@@ -485,6 +486,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       try {
         this.watchers.push(
           watch(pathname, { persistent: false, recursive }, () => {
+            this.inventoryCache.invalidate()
             this.scheduleInventoryChanged()
             if (affectsRuntimeSkills) {
               this.notifyRuntimeSkillsChanged("skill-files-changed")
@@ -556,6 +558,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       return
     }
 
+    this.inventoryCache.invalidate()
     this.notifyRuntimeSkillsChanged(reason)
     await this.emitInventoryChanged()
   }
@@ -909,7 +912,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   private async syncUpdatedCachedSkillsToSharedAgentRoot(request: UpdateRegistrySkillRequest): Promise<void> {
     const skillId = request.skillId?.trim()
     if (skillId) {
-      const inventory = await this.readSkillInventory({ writeManifest: false })
+      const inventory = await this.readSharedSkillInventory({ writeManifest: false })
       const group = inventory.groups.find((item) => item.id === skillId)
       if (group?.kind !== "registry" || !group.packageName?.trim()) {
         return
@@ -921,7 +924,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       return
     }
 
-    const inventory = await this.readSkillInventory({ writeManifest: false })
+    const inventory = await this.readSharedSkillInventory({ writeManifest: false })
     const registrySkillIds = inventory.groups
       .filter((group) => group.kind === "registry" && Boolean(group.packageName?.trim()))
       .map((group) => group.id)
@@ -1104,29 +1107,17 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
 
   private async readAndPublishSkillInventory(): Promise<SkillInventory> {
     this.invalidateVersionReport()
-    const inventory = await this.readSkillInventory({ writeManifest: true })
+    const inventory = await this.refreshSharedSkillInventory({ writeManifest: true })
     await this.emitInventoryChanged()
     return inventory
   }
 
   private async readSharedSkillInventory(options: { writeManifest: boolean }): Promise<SkillInventory> {
-    if (this.inventoryInFlight && (!options.writeManifest || this.inventoryInFlight.writeManifest)) {
-      return this.inventoryInFlight.promise
-    }
+    return this.inventoryCache.get(options, (request) => this.readSkillInventory(request))
+  }
 
-    const promise = this.readSkillInventory(options)
-    this.inventoryInFlight = {
-      promise,
-      writeManifest: options.writeManifest,
-    }
-
-    try {
-      return await promise
-    } finally {
-      if (this.inventoryInFlight?.promise === promise) {
-        this.inventoryInFlight = undefined
-      }
-    }
+  private async refreshSharedSkillInventory(options: { writeManifest: boolean }): Promise<SkillInventory> {
+    return this.inventoryCache.refresh(options, (request) => this.readSkillInventory(request))
   }
 
   private async readSkillInventory(options: { writeManifest: boolean }): Promise<SkillInventory> {
@@ -1191,7 +1182,7 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
   private async resolveAllowedSkillPath(requestPath: string): Promise<string> {
     const resolvedRequestPath = path.resolve(requestPath)
     const canonicalRequestPath = await realpath(resolvedRequestPath)
-    const inventory = await this.readSkillInventory({ writeManifest: false })
+    const inventory = await this.readSharedSkillInventory({ writeManifest: false })
     const allowedPaths = inventory.groups.flatMap((group) =>
       group.hosts.flatMap((host) => [host.path, host.sourcePath]),
     )

--- a/src/components/AppDataProvider.tsx
+++ b/src/components/AppDataProvider.tsx
@@ -48,7 +48,8 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
       }),
       skillInventory: createResource<SkillInventory>({
         isEqualData: isRefreshDataEqual,
-        staleTimeMs: 60_000,
+        // 主进程 watcher 会在技能变化时主动失效；较长 TTL 仅兜底发现启动时尚不存在的技能目录。
+        staleTimeMs: 5 * 60_000,
         load: () => skillService.invoke("getSkillInventory"),
       }),
       skillVersions: createResource({

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -507,7 +507,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
       return
     }
     setChatPermissionMode(activeChatSessionId, activeSession.permissionMode ?? "default")
-  }, [activeChatSessionId, activeSession, setChatPermissionMode])
+  }, [activeChatSessionId, activeSession?.permissionMode, setChatPermissionMode])
 
   const persistPermissionMode = React.useCallback(
     (sessionId: string, mode: AgentPermissionMode): void => {

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -56,7 +56,27 @@ describe("ToolActivityStep", () => {
     expect(shimmerClassFor(html, "运行命令")).toContain("shrink-0")
     expect(shimmerClassFor(html, "运行命令")).not.toContain("flex-1")
     expect(html).toMatch(/<code class="[^"]*"[^>]*>curl -s -L -o \/tmp\/1688_page\.html<\/code>/)
+    expect(html).toMatch(/<code class="[^"]*w-0[^"]*max-w-full[^"]*truncate[^"]*"/)
+    expect(html).toContain("w-full max-w-full min-w-0 flex-1 items-center gap-2 overflow-hidden")
     expect(html).not.toMatch(/class="[^"]*text-transparent[^"]*"[^>]*>[^<]*curl/)
+  })
+
+  it("keeps a long completed command within the tool row width", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-long-command",
+      callId: "call-long-command",
+      tool: "bash",
+      status: "completed",
+      input: {
+        command:
+          'python3 -m venv "/Users/example/Library/Application Support/wanta/agent/process/session/.wanta-python" && "/Users/example/Library/Application Support/wanta/agent/process/session/.wanta-python/bin/python" -m pip install openpyxl reportlab',
+      },
+    })
+
+    expect(html).toMatch(/<code class="[^"]*w-0[^"]*max-w-full[^"]*truncate[^"]*"/)
+    expect(html).toContain("group/tool-step flex min-h-6 w-full max-w-full min-w-0 flex-1")
+    expect(html).toContain("w-full max-w-full min-w-0 overflow-hidden rounded-md")
   })
 
   it("shimmers only the active web fetch title when the URL is shown inline", () => {

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -71,12 +71,12 @@ function ToolInlineDetail({ line }: { line: ToolDisplayLine }) {
   }
   if (line.detailKind === "code") {
     return (
-      <code className="min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[0.875em] font-medium text-muted-foreground">
+      <code className="w-0 max-w-full min-w-0 flex-1 truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[0.875em] font-medium text-muted-foreground">
         {line.detail}
       </code>
     )
   }
-  return <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground">{line.detail}</span>
+  return <span className="w-0 max-w-full min-w-0 flex-1 truncate font-medium text-muted-foreground">{line.detail}</span>
 }
 
 function formatToolOutput(output: string | undefined): string {
@@ -272,16 +272,16 @@ export function ToolActivityStep({
   const completedMeta = part.status === "completed" && !auth
 
   const row = (
-    <div className="group/tool-step flex min-h-6 min-w-0 flex-1 items-center gap-2">
+    <div className="group/tool-step flex min-h-6 w-full max-w-full min-w-0 flex-1 items-center gap-2 overflow-hidden">
       <span
         className="flex size-5 shrink-0 items-center justify-center"
         title={provider ? `${provider.displayName} · ${statusText}` : statusText}
       >
         <ToolStepIcon part={part} provider={provider} stopped={stopped} />
       </span>
-      <div className="min-w-0 flex-1 overflow-hidden">
+      <div className="w-0 max-w-full min-w-0 flex-1 overflow-hidden">
         {showShimmer ? (
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex w-full max-w-full min-w-0 items-center gap-2 overflow-hidden">
             <LoadingShimmerText className="min-w-0 shrink-0 truncate font-medium">
               {displayLine.title}
             </LoadingShimmerText>
@@ -297,7 +297,7 @@ export function ToolActivityStep({
             </span>
           </div>
         ) : (
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex w-full max-w-full min-w-0 items-center gap-2 overflow-hidden">
             <span
               className={cn("min-w-0 truncate font-medium text-foreground", displayLine.detail ? "shrink-0" : "flex-1")}
             >
@@ -337,10 +337,10 @@ export function ToolActivityStep({
     ) : null
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
-      <div className="rounded-md">
+    <Collapsible className="w-full max-w-full min-w-0 overflow-hidden" open={open} onOpenChange={setOpen}>
+      <div className="w-full max-w-full min-w-0 overflow-hidden rounded-md">
         {details ? (
-          <CollapsibleTrigger className="group/tool-step flex w-full items-center justify-between gap-2 text-left">
+          <CollapsibleTrigger className="group/tool-step flex w-full max-w-full min-w-0 items-center justify-between gap-2 overflow-hidden text-left">
             {row}
             <ChevronRight className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-[opacity,transform] group-hover/tool-step:opacity-100 group-focus-visible/tool-step:opacity-100 group-data-[state=open]/tool-step:rotate-90 group-data-[state=open]/tool-step:opacity-100" />
           </CollapsibleTrigger>


### PR DESCRIPTION
## Summary

This PR fixes a sustained idle CPU regression across Wanta, its Electron renderer, and the bundled OpenCode sidecar. It also folds in the separate tool-row overflow fix so long shell commands and tool details remain constrained to the chat timeline width.

## User impact and root cause

Wanta could remain busy while idle, with OpenCode using roughly half a CPU core and the Wanta main and renderer processes also consuming significant CPU. Runtime sampling ruled out the OpenCode SSE heartbeat as the source: the heartbeat arrives only about once every ten seconds.

The primary issue was a permission-mode feedback loop. Refreshing the session list produced a new `activeSession` object, which retriggered the renderer permission synchronization effect. The main process then treated the unchanged permission mode as session activity, persisted `session-activity.json`, refreshed and broadcast the session list, and caused the same effect to run again. Those refreshes also generated repeated OpenCode session requests, spreading the load across all three processes.

Long tool commands had a separate layout issue: flex children could retain intrinsic width and push the tool activity row beyond its container instead of truncating.

## Changes

- Depend on the active session ID and permission value instead of the whole session object.
- Emit session activity only when the permission mode actually changes, while preserving full-access auto-approval and task-subagent propagation.
- Serialize OpenCode sidecar retirement, make disposal idempotent, and drain pending retirement during shutdown.
- Cache skill inventory scans for five minutes, coalesce concurrent reads, and invalidate on watched or explicit skill changes.
- Coalesce text and reasoning stream updates over a 32 ms window, flush before control events, and suppress duplicate message-start events with a bounded key set.
- Aggregate high-frequency runtime diagnostics, batch sidecar output, and exclude keepalive heartbeats from periodic diagnostic writes.
- Constrain tool activity rows and inline details with explicit flex width and overflow bounds so long commands truncate correctly.
- Document the stream coalescing and skill cache behavior.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 176 files and 1,187 tests passed
- `npm run build`
- Live idle sampling before the fix measured approximately 48.8% OpenCode CPU, 25.2% Wanta main-process CPU, and 54.6% renderer CPU over a ten-second window.
- The same sampling after the fix measured approximately 1.2%, 0.7%, and 0.9%, respectively.
- Verified that `session-activity.json` remains unchanged while idle.
- Verified that the OpenCode sidecar created by the development run exits with Wanta and does not add another orphan process.

## Risk

The stream buffer can add up to roughly 32 ms of display latency. The skill cache may retain externally modified data until watcher invalidation or the five-minute TTL, while Wanta-managed mutations invalidate it immediately. Permission behavior remains unchanged for actual mode transitions and pending full-access approvals.
