### PR TITLE
Add Check for Updates to the macOS application menu

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -806,6 +806,13 @@ function installApplicationMenu(): void {
       buildApplicationMenuTemplate({
         developmentMode: shouldShowDevelopmentMenu(),
         locale: activeLocale(),
+        onCheckForUpdates: () => {
+          sendAppCommand(APP_COMMANDS.openSettings)
+          void updateService.checkForAppUpdate().catch((error: unknown) => {
+            console.warn("[wanta] manual update check from application menu failed:", error)
+            logMainError("manual update check from application menu failed", error)
+          })
+        },
         onCommand: sendAppCommand,
         platform: process.platform,
       }),

--- a/electron/window/application-menu-messages.ts
+++ b/electron/window/application-menu-messages.ts
@@ -4,6 +4,7 @@ import { branding } from "../branding.ts"
 
 export interface ApplicationMenuLabels {
   about: string
+  checkForUpdates: string
   closeWindow: string
   copy: string
   cut: string
@@ -46,6 +47,7 @@ export interface ApplicationMenuLabels {
 export const applicationMenuMessages: Record<AppLocale, ApplicationMenuLabels> = {
   "zh-CN": {
     about: `关于 ${branding.appName}`,
+    checkForUpdates: "检查更新…",
     closeWindow: "关闭窗口",
     copy: "复制",
     cut: "剪切",
@@ -86,6 +88,7 @@ export const applicationMenuMessages: Record<AppLocale, ApplicationMenuLabels> =
   },
   en: {
     about: `About ${branding.appName}`,
+    checkForUpdates: "Check for Updates…",
     closeWindow: "Close Window",
     copy: "Copy",
     cut: "Cut",

--- a/electron/window/application-menu.test.ts
+++ b/electron/window/application-menu.test.ts
@@ -13,6 +13,7 @@ function menuTemplate(input: Partial<Parameters<typeof buildApplicationMenuTempl
   return buildApplicationMenuTemplate({
     developmentMode: false,
     locale: "en",
+    onCheckForUpdates: () => undefined,
     onCommand: () => undefined,
     platform: "darwin",
     ...input,
@@ -108,5 +109,29 @@ describe("buildApplicationMenuTemplate", () => {
     ;(newChatItem.click as MenuClick)()
 
     expect(onCommand).toHaveBeenCalledExactlyOnceWith(APP_COMMANDS.newChat)
+  })
+
+  it("places a localized update check in the macOS application menu", () => {
+    const onCheckForUpdates = vi.fn()
+    const template = menuTemplate({ locale: "zh-CN", onCheckForUpdates, platform: "darwin" })
+    const applicationMenu = findItem(template, branding.appName)
+    const submenu = Array.isArray(applicationMenu.submenu) ? applicationMenu.submenu : []
+    const updateItem = findItem(submenu, "检查更新…")
+
+    expect(
+      submenu
+        .map((item) => item.label)
+        .filter(Boolean)
+        .slice(0, 3),
+    ).toEqual([`关于 ${branding.appName}`, "检查更新…", "设置…"])
+    expect(updateItem.click).toBeTypeOf("function")
+    ;(updateItem.click as MenuClick)()
+    expect(onCheckForUpdates).toHaveBeenCalledOnce()
+  })
+
+  it("keeps the update check out of non-macOS menus", () => {
+    const template = menuTemplate({ locale: "en", platform: "win32" })
+
+    expect(collectLabels(template)).not.toContain("Check for Updates…")
   })
 })

--- a/electron/window/application-menu.ts
+++ b/electron/window/application-menu.ts
@@ -9,6 +9,7 @@ import { applicationMenuLabels } from "./application-menu-messages.ts"
 interface ApplicationMenuOptions {
   developmentMode: boolean
   locale?: string
+  onCheckForUpdates: () => void
   onCommand: (command: AppCommand) => void
   platform: NodeJS.Platform
 }
@@ -39,6 +40,10 @@ export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): Men
       label: branding.appName,
       submenu: [
         roleMenuItem("about", label.about),
+        {
+          click: input.onCheckForUpdates,
+          label: label.checkForUpdates,
+        },
         { type: "separator" },
         settingsMenuItem(input, label.settings),
         { type: "separator" },


### PR DESCRIPTION
## Issue

The macOS application menu did not expose the existing update-check functionality. Users had to navigate to Settings to manually check for a new Wanta version, which made the standard macOS update entry point unavailable.

## Root cause

Wanta already had a complete update service and Settings UI, but the macOS application-menu template only included About, Settings, Services, visibility commands, and Quit. The menu template had no callback or localized label for checking updates.

## Changes

- Add localized “Check for Updates…” and “检查更新…” labels to the application menu messages.
- Place the command directly below About in the macOS Wanta menu.
- Open Settings and invoke the existing main-process update service when the command is selected, so users can see checking, availability, download, install, and error states in the existing UI.
- Keep the command out of Windows and Linux menus.
- Add menu-template tests for placement, localization, callback dispatch, and platform scoping.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` — 181 test files and 1236 tests passed
- macOS development-mode smoke test confirmed that the menu item is visible and clickable
