### PR TITLE
Fix local image preview parsing

### DIFF
--- a/electron/chat/artifact-bundles.test.ts
+++ b/electron/chat/artifact-bundles.test.ts
@@ -206,6 +206,34 @@ test("markdownImageCount counts final assistant image previews", () => {
   )
 })
 
+test("markdownImageCount repairs spaced local paths and ignores code examples", () => {
+  assert.equal(
+    markdownImageCount(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          createdAt: 1,
+          parts: [
+            {
+              kind: "text",
+              partId: "text-1",
+              text: [
+                "![result](/Users/me/Application Support/wanta/result.png)",
+                "```md",
+                "![example](https://example.com/example.png)",
+                "```",
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
+      "assistant-1",
+    ),
+    1,
+  )
+})
+
 test("generatedImagePreviewCount includes assistant image attachments without double-counting previews", () => {
   assert.equal(
     generatedImagePreviewCount(

--- a/electron/chat/artifact-bundles.ts
+++ b/electron/chat/artifact-bundles.ts
@@ -17,6 +17,7 @@ import { logStoreReadFailure } from "../store-diagnostics.ts"
 import { isOperationalStateArtifact } from "./artifact-file-classification.ts"
 import { mimeFromPath, normalizeLocalPathCandidate } from "./artifacts.ts"
 import { localArtifactItem } from "./local-artifacts.ts"
+import { extractMarkdownImageSources } from "./markdown-images.ts"
 import { dataImage, remoteImage } from "./safe-image-source.ts"
 
 export { readResponseBodyWithinLimit } from "./safe-image-source.ts"
@@ -26,7 +27,6 @@ export type ArtifactBundles = Map<string, Map<string, ArtifactBundle>>
 const maxArtifactBaselineFiles = 10_000
 const maxAssistantArtifactSources = 32
 const maxConcurrentArtifactMaterializations = 4
-const markdownImagePattern = /!\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))(?:\s+["'][^"']*["'])?\s*\)/gu
 
 interface PersistedArtifactBundles {
   version?: number
@@ -240,7 +240,7 @@ function markdownImageSources(messages: readonly ChatMessage[], messageId: strin
   if (!text) {
     return []
   }
-  return [...text.matchAll(markdownImagePattern)].map((match) => (match[1] ?? match[2] ?? "").trim()).filter(Boolean)
+  return extractMarkdownImageSources(text)
 }
 
 export function markdownImageCount(messages: readonly ChatMessage[], messageId: string): number {

--- a/electron/chat/markdown-images.test.ts
+++ b/electron/chat/markdown-images.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest"
+import { extractLocalImagePaths, extractMarkdownImageSources, normalizeLocalImageMarkdown } from "./markdown-images.ts"
+
+test("normalizeLocalImageMarkdown wraps local image paths containing spaces", () => {
+  const path =
+    "/Users/me/Library/Application Support/wanta/agent/artifacts/ses_example/1783833651476-turn/mucha-corgi.png"
+
+  expect(normalizeLocalImageMarkdown(`![穆夏风柯基](${path})`)).toBe(`![穆夏风柯基](<${path}>)`)
+})
+
+test("normalizeLocalImageMarkdown preserves titles and valid destinations", () => {
+  expect(normalizeLocalImageMarkdown('![image](/Users/me/output files/image.png "Preview")')).toBe(
+    '![image](</Users/me/output files/image.png> "Preview")',
+  )
+  expect(normalizeLocalImageMarkdown("![image](</Users/me/output files/image.png> 'Preview')")).toBe(
+    "![image](</Users/me/output files/image.png> 'Preview')",
+  )
+  expect(normalizeLocalImageMarkdown("![image](/tmp/output.png)")).toBe("![image](/tmp/output.png)")
+})
+
+test("normalizeLocalImageMarkdown supports Windows paths and excludes home-relative paths", () => {
+  expect(normalizeLocalImageMarkdown(String.raw`![image](C:\Users\me\output files\image.png)`)).toBe(
+    String.raw`![image](<C:\Users\me\output files\image.png>)`,
+  )
+  expect(normalizeLocalImageMarkdown("![image](~/output files/image.png)")).toBe("![image](~/output files/image.png)")
+})
+
+test("markdown image helpers ignore fenced and indented code", () => {
+  const markdown = [
+    "![real](/Users/me/output files/real.png)",
+    "```md",
+    "![fenced](/Users/me/output files/fenced.png)",
+    "```",
+    "    ![indented](/Users/me/output files/indented.png)",
+  ].join("\n")
+
+  expect(normalizeLocalImageMarkdown(markdown)).toBe(
+    [
+      "![real](</Users/me/output files/real.png>)",
+      "```md",
+      "![fenced](/Users/me/output files/fenced.png)",
+      "```",
+      "    ![indented](/Users/me/output files/indented.png)",
+    ].join("\n"),
+  )
+  expect(extractMarkdownImageSources(markdown)).toEqual(["/Users/me/output files/real.png"])
+})
+
+test("extractMarkdownImageSources reads local, remote, data, and titled images", () => {
+  expect(
+    extractMarkdownImageSources(
+      [
+        "![local](/Users/me/output files/image.png)",
+        "![remote](https://example.com/image.png)",
+        "![data](<data:image/png;base64,abc>)",
+        '![title](https://example.com/titled.png "Preview")',
+      ].join("\n"),
+    ),
+  ).toEqual([
+    "/Users/me/output files/image.png",
+    "https://example.com/image.png",
+    "data:image/png;base64,abc",
+    "https://example.com/titled.png",
+  ])
+})
+
+test("markdown image helpers ignore inline code examples", () => {
+  const markdown = [
+    "`![example](/Users/me/output files/example.png)`",
+    "![real](/Users/me/output files/real.png)",
+  ].join("\n")
+
+  expect(normalizeLocalImageMarkdown(markdown)).toBe(
+    ["`![example](/Users/me/output files/example.png)`", "![real](</Users/me/output files/real.png>)"].join("\n"),
+  )
+  expect(extractMarkdownImageSources(markdown)).toEqual(["/Users/me/output files/real.png"])
+})
+
+test("extractLocalImagePaths ignores code examples but keeps explicit inline paths", () => {
+  expect(
+    extractLocalImagePaths(
+      [
+        "Saved to `/Users/me/output files/real.png`.",
+        "```text",
+        "/Users/me/output files/fenced.png",
+        "```",
+        "Inline example: `![image](/Users/me/output files/example.png)`.",
+        "Remote: https://example.com/remote.png",
+      ].join("\n"),
+    ),
+  ).toEqual(["/Users/me/output files/real.png"])
+})

--- a/electron/chat/markdown-images.ts
+++ b/electron/chat/markdown-images.ts
@@ -1,0 +1,162 @@
+const imageExtensionSource = "(?:avif|bmp|gif|jpe?g|png|svg|webp)"
+const absoluteLocalPathStartSource = "(?:file:\\/\\/|\\/|[A-Za-z]:[\\\\/])"
+const localMarkdownImagePattern = new RegExp(
+  `!\\[([^\\]\\n]*)\\]\\(\\s*(${absoluteLocalPathStartSource}[^<>\\n]*?\\.${imageExtensionSource})(\\s+(?:"[^"\\n]*"|'[^'\\n]*'|\\([^\\)\\n]*\\)))?\\s*\\)`,
+  "gi",
+)
+const markdownImagePattern =
+  /!\[[^\]\n]*\]\(\s*(?:<([^>\n]+)>|([^\s)<]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/gi
+const localImagePathPattern = new RegExp(
+  `(?:(?<![A-Za-z0-9])(?:file:\\/\\/|[A-Za-z]:[\\\\/])|(?<![:/])\\/)[^<>"'\\u0060，。；：、\\n]*?\\.${imageExtensionSource}(?=$|[\\s<>"'\\u0060，。；：、,;:!?)\\]])`,
+  "gi",
+)
+const exactLocalImagePathPattern = new RegExp(
+  `^(?:file:\\/\\/|\\/|[A-Za-z]:[\\\\/]).*?\\.${imageExtensionSource}$`,
+  "i",
+)
+
+function fenceStart(line: string): { character: "`" | "~"; length: number } | null {
+  const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line)
+  const marker = match?.[1]
+  if (!marker) {
+    return null
+  }
+  return { character: marker[0] as "`" | "~", length: marker.length }
+}
+
+function isFenceEnd(line: string, fence: { character: "`" | "~"; length: number }): boolean {
+  const marker = fence.character.repeat(fence.length)
+  return new RegExp(`^ {0,3}${marker}${fence.character}*\\s*$`).test(line)
+}
+
+function mapInlineCode(
+  markdown: string,
+  transform: (prose: string) => string,
+  visitCode?: (code: string) => void,
+): string {
+  let result = ""
+  let cursor = 0
+  while (cursor < markdown.length) {
+    const open = markdown.indexOf("`", cursor)
+    if (open < 0) {
+      return result + transform(markdown.slice(cursor))
+    }
+    let markerLength = 1
+    while (markdown[open + markerLength] === "`") {
+      markerLength += 1
+    }
+    const marker = "`".repeat(markerLength)
+    let close = open + markerLength
+    while (close < markdown.length) {
+      close = markdown.indexOf(marker, close)
+      if (close < 0) {
+        return result + transform(markdown.slice(cursor))
+      }
+      if (markdown[close - 1] !== "`" && markdown[close + markerLength] !== "`") {
+        break
+      }
+      close += markerLength
+    }
+    result += transform(markdown.slice(cursor, open))
+    const codeEnd = close + markerLength
+    const code = markdown.slice(open + markerLength, close)
+    visitCode?.(code)
+    result += markdown.slice(open, codeEnd)
+    cursor = codeEnd
+  }
+  return result
+}
+
+function mapMarkdownBlocks(markdown: string, transform: (prose: string) => string): string {
+  const lines = markdown.match(/.*(?:\r?\n|$)/g)?.filter(Boolean) ?? []
+  let result = ""
+  let prose = ""
+  let fence: { character: "`" | "~"; length: number } | null = null
+  const flushProse = (): void => {
+    if (prose) {
+      result += transform(prose)
+      prose = ""
+    }
+  }
+
+  for (const line of lines) {
+    if (fence) {
+      result += line
+      if (isFenceEnd(line.replace(/\r?\n$/, ""), fence)) {
+        fence = null
+      }
+      continue
+    }
+    const nextFence = fenceStart(line)
+    if (nextFence) {
+      flushProse()
+      result += line
+      fence = nextFence
+      continue
+    }
+    if (/^(?: {4}|\t)/.test(line)) {
+      flushProse()
+      result += line
+      continue
+    }
+    prose += line
+  }
+  flushProse()
+  return result
+}
+
+/** 只变换 Markdown 正文，跳过 fenced、indented 与 inline code。 */
+export function mapMarkdownProse(markdown: string, transform: (prose: string) => string): string {
+  return mapMarkdownBlocks(markdown, (prose) => mapInlineCode(prose, transform))
+}
+
+function normalizeLocalImageProse(markdown: string): string {
+  return markdown.replace(localMarkdownImagePattern, (match, alt: string, path: string, title?: string) => {
+    const trimmedPath = path.trim()
+    if (!/\s/.test(trimmedPath)) {
+      return match
+    }
+    return `![${alt}](<${trimmedPath}>${title ?? ""})`
+  })
+}
+
+export function normalizeLocalImageMarkdown(markdown: string): string {
+  return mapMarkdownProse(markdown, normalizeLocalImageProse)
+}
+
+export function extractMarkdownImageSources(markdown: string): string[] {
+  const sources: string[] = []
+  mapMarkdownProse(normalizeLocalImageMarkdown(markdown), (prose) => {
+    for (const match of prose.matchAll(markdownImagePattern)) {
+      const source = (match[1] ?? match[2] ?? "").trim()
+      if (source) {
+        sources.push(source)
+      }
+    }
+    return prose
+  })
+  return sources
+}
+
+export function extractLocalImagePaths(markdown: string): string[] {
+  const paths: string[] = []
+  const appendMatches = (prose: string): string => {
+    const localOnlyProse = prose.replace(/https?:\/\/[^\s<>"'`，。；：、]+/gi, "")
+    for (const match of localOnlyProse.matchAll(localImagePathPattern)) {
+      const candidate = match[0]?.trim()
+      if (candidate && !paths.includes(candidate)) {
+        paths.push(candidate)
+      }
+    }
+    return prose
+  }
+  mapMarkdownBlocks(markdown, (prose) =>
+    mapInlineCode(prose, appendMatches, (code) => {
+      const candidate = code.trim()
+      if (exactLocalImagePathPattern.test(candidate) && !paths.includes(candidate)) {
+        paths.push(candidate)
+      }
+    }),
+  )
+  return paths
+}

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -124,12 +124,13 @@ async function waitForEventCount(events: Array<{ event: string; data: unknown }>
 }
 
 async function waitForCondition(condition: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
     if (condition()) {
       return
     }
     await new Promise((resolve) => setTimeout(resolve, 5))
   }
+  assert.fail("Timed out waiting for condition")
 }
 
 async function waitForMessageErrorCount(events: Array<{ event: string; data: unknown }>, count: number): Promise<void> {

--- a/scripts/renderer-boundary.test.ts
+++ b/scripts/renderer-boundary.test.ts
@@ -16,6 +16,7 @@ const rendererElectronAllowlist = new Set([
   "electron/branding.ts",
   "electron/chat/authorization-signal.ts",
   "electron/chat/error.ts",
+  "electron/chat/markdown-images.ts",
   "electron/chat/permission-request.ts",
   "electron/connections/domain.ts",
   "electron/connections/executions.ts",

--- a/src/components/ai-elements/message-image.tsx
+++ b/src/components/ai-elements/message-image.tsx
@@ -111,7 +111,7 @@ export function localImagePathFromSrc(src: string | undefined): string | null {
   if (!value || /^(?:https?:|data:|blob:|wanta:|wanta-local:)/i.test(value)) {
     return null
   }
-  if (value.startsWith("file://")) {
+  if (/^file:\/\//i.test(value)) {
     try {
       const url = new URL(value)
       const decoded = decodeURIComponent(url.pathname)
@@ -120,7 +120,7 @@ export function localImagePathFromSrc(src: string | undefined): string | null {
       return null
     }
   }
-  if (/^(?:~?[\\/]|[A-Za-z]:[\\/])/.test(value)) {
+  if (/^(?:[\\/]|[A-Za-z]:[\\/])/.test(value)) {
     return decodeLocalImagePath(value)
   }
   return null

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -3,6 +3,7 @@ import type { AppContextValue } from "@/components/AppContext"
 import * as React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
+import { normalizeLocalImageMarkdown } from "../../../electron/chat/markdown-images.ts"
 import {
   attachmentPreviewSource,
   clampImageViewerOffset,
@@ -92,6 +93,42 @@ describe("normalizeSingleLocalPathCodeFences", () => {
   })
 })
 
+describe("normalizeLocalImageMarkdown", () => {
+  it("wraps a local image destination containing spaces in angle brackets", () => {
+    const path =
+      "/Users/me/Library/Application Support/wanta/agent/artifacts/ses_example/1783833651476-turn/mucha-corgi.png"
+
+    expect(normalizeLocalImageMarkdown(`![穆夏风柯基](${path})`)).toBe(`![穆夏风柯基](<${path}>)`)
+  })
+
+  it("keeps valid local image destinations unchanged", () => {
+    expect(normalizeLocalImageMarkdown("![image](</Users/me/output files/image.png>)")).toBe(
+      "![image](</Users/me/output files/image.png>)",
+    )
+    expect(normalizeLocalImageMarkdown("![image](/tmp/output.png)")).toBe("![image](/tmp/output.png)")
+  })
+
+  it("supports Windows local image destinations containing spaces", () => {
+    expect(normalizeLocalImageMarkdown(String.raw`![image](C:\Users\me\output files\image.png)`)).toBe(
+      String.raw`![image](<C:\Users\me\output files\image.png>)`,
+    )
+  })
+
+  it("does not rewrite image examples inside code", () => {
+    const inline = "Use `![image](/Users/me/output files/image.png)` in the response."
+    const fenced = ["```md", "![image](/Users/me/output files/image.png)", "```"].join("\n")
+
+    expect(normalizeLocalImageMarkdown(inline)).toBe(inline)
+    expect(normalizeLocalImageMarkdown(fenced)).toBe(fenced)
+  })
+
+  it("leaves remote image destinations unchanged", () => {
+    expect(normalizeLocalImageMarkdown("![image](https://example.com/output image.png)")).toBe(
+      "![image](https://example.com/output image.png)",
+    )
+  })
+})
+
 describe("compactLocalPath", () => {
   it("keeps short paths readable", () => {
     expect(compactLocalPath("/tmp/image.png")).toBe("/tmp/image.png")
@@ -159,6 +196,14 @@ describe("MarkdownImage", () => {
 
   it("keeps malformed percent escapes readable instead of rejecting local paths", () => {
     expect(localImagePathFromSrc("/tmp/100% legit/image.png")).toBe("/tmp/100% legit/image.png")
+  })
+
+  it("accepts case-insensitive file URL schemes", () => {
+    expect(localImagePathFromSrc("FILE:///Users/me/output%20files/image.png")).toBe("/Users/me/output files/image.png")
+  })
+
+  it("does not treat home-relative image paths as absolute local paths", () => {
+    expect(localImagePathFromSrc("~/output/image.png")).toBeNull()
   })
 
   it("does not decode escaped path separators inside local path segments", () => {

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -4,6 +4,7 @@ import type { CustomRendererProps, StreamdownProps } from "streamdown"
 
 import { CheckIcon, CopyIcon } from "lucide-react"
 import { lazy, memo, Suspense, useEffect, useRef, useState } from "react"
+import { extractLocalImagePaths, normalizeLocalImageMarkdown } from "../../../electron/chat/markdown-images.ts"
 import {
   CodeBlock,
   CodeBlockActions,
@@ -21,8 +22,6 @@ import { cn } from "@/lib/utils"
 // streamdown 拉入整套 markdown 渲染管线（micromark/remark/rehype + mermaid + katex，约 1.1MB）。
 // 懒加载：聊天外壳先渲染，首条助手消息出现时才加载，不阻塞 AppShell 首帧。
 const Streamdown = lazy(() => import("streamdown").then((m) => ({ default: m.Streamdown })))
-const localImagePathPattern =
-  /(?:file:\/\/[^\s<>"'`，。；：、]+|(?:~?\/|[A-Za-z]:[\\/]).*?\.(?:avif|bmp|gif|jpe?g|png|svg|webp))(?=$|[\s<>"'`，。；：、,;:!?)\]])/gi
 const localPathStartPattern = /^(?:file:\/\/|~?[\\/]|[A-Za-z]:[\\/])/
 const singleLocalPathFencePattern =
   /(^|\n)([ \t]{0,3})(`{3,}|~{3,})[ \t]*(?:text|txt|path|file)?[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*\3[ \t]*(?=\n|$)/gi
@@ -393,18 +392,20 @@ function localImageAltText(value: string): string {
 
 function extractLocalImagePreviews(markdown: string): LocalImagePreview[] {
   const previews: LocalImagePreview[] = []
-  for (const match of markdown.matchAll(localImagePathPattern)) {
-    const candidate = match[0]?.trim()
+  for (const candidate of extractLocalImagePaths(markdown)) {
     if (
       candidate &&
-      !markdown.includes(`](${candidate})`) &&
-      !markdown.includes(`](<${candidate}>)`) &&
+      !hasValidMarkdownImageReference(markdown, candidate) &&
       !previews.some((preview) => preview.path === candidate)
     ) {
       previews.push({ path: candidate, alt: localImageAltText(candidate) })
     }
   }
   return previews
+}
+
+function hasValidMarkdownImageReference(markdown: string, path: string): boolean {
+  return markdown.includes(`](<${path}>)`) || (!/\s/.test(path) && markdown.includes(`](${path})`))
 }
 
 export function normalizeSingleLocalPathCodeFences(markdown: string): string {
@@ -529,7 +530,9 @@ export const MessageResponse = memo(
     const visibleChildren = useSmoothedText(typeof children === "string" ? children : "", smooth)
     const sourceChildren = typeof children === "string" && smooth ? visibleChildren : children
     const responseChildren =
-      typeof sourceChildren === "string" ? normalizeSingleLocalPathCodeFences(sourceChildren) : sourceChildren
+      typeof sourceChildren === "string"
+        ? normalizeLocalImageMarkdown(normalizeSingleLocalPathCodeFences(sourceChildren))
+        : sourceChildren
     const localImagePreviews = typeof responseChildren === "string" ? extractLocalImagePreviews(responseChildren) : []
     return (
       // fallback 直接铺原始 markdown 文本：streamdown chunk 首次加载时内容即可见，加载完再升级为富渲染。


### PR DESCRIPTION
## Problem

Assistant responses can contain absolute local image paths with spaces, such as paths under `Library/Application Support`. When the model omits angle brackets around that destination, the Markdown parser leaves the image syntax as plain text even though the generated artifact exists. The renderer fallback could also mistake malformed image syntax for an already-rendered image, so no inline preview appeared.

Image reference handling was additionally split across the renderer and artifact materialization code. The two paths could disagree about whether a response contained an image, and path-like text inside code examples or remote URLs could be treated as a local preview candidate.

## Changes

- Add a shared, Electron-free Markdown image helper used by both the renderer and artifact materialization.
- Normalize absolute local image destinations containing spaces into angle-bracketed Markdown destinations while preserving optional titles.
- Ignore fenced, indented, and inline code examples when normalizing or extracting Markdown images.
- Keep explicit inline absolute paths eligible for the local preview fallback while excluding remote URL fragments.
- Support case-insensitive `file://` schemes and stop treating unexpanded `~/` paths as absolute local paths.
- Add regression coverage for macOS, Windows, file URL, title, code example, remote URL, and artifact-counting cases.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` (191 files, 1282 tests)
- `npm run build`
- `npm run dev:no-electron`
- `git diff --check`

Full `npm run dev` was initially blocked by a stale local oo CLI binary. The local ignored binary was subsequently refreshed to the repository-pinned `1.5.1`; no oo CLI source change is part of this PR.
