### PR TITLE
Simplify Markdown table rendering

### DIFF
--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -18,7 +18,6 @@ import {
   compactLocalPath,
   markdownCodeLanguage,
   markdownCodeText,
-  MarkdownTable,
   messageClassName,
   messageResponseControls,
   nextSmoothedText,
@@ -164,31 +163,6 @@ describe("compactLocalPath", () => {
     expect(compactLocalPath("file:///C:/Users/me/output%20files/report.pdf")).toBe(
       "C:/Users/me/output files/report.pdf",
     )
-  })
-})
-
-describe("MarkdownTable", () => {
-  it("fits tables inside the message width instead of forcing horizontal scroll", () => {
-    const html = renderToStaticMarkup(
-      React.createElement(
-        MarkdownTable,
-        null,
-        React.createElement(
-          "tbody",
-          null,
-          React.createElement(
-            "tr",
-            null,
-            React.createElement("td", null, "Tailwind CSS 项目的动画时长、排版比例、组件可访问性等设计一致性检查"),
-          ),
-        ),
-      ),
-    )
-
-    expect(html).toContain("overflow-hidden")
-    expect(html).toContain("table-fixed")
-    expect(html).not.toContain("overflow-x-auto")
-    expect(html).not.toContain("min-w-max")
   })
 })
 

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -109,10 +109,6 @@ export type MessageResponseProps = StreamdownProps & {
   smooth?: boolean
 }
 
-type MarkdownTableProps = ComponentProps<"table"> & {
-  node?: unknown
-}
-
 type MarkdownInlineCodeProps = ComponentProps<"code"> & {
   node?: unknown
 }
@@ -190,19 +186,6 @@ export function compactLocalPath(value: string, maxLength = 72): string {
   const head = Math.ceil(keep * 0.45)
   const tail = keep - head
   return `${normalized.slice(0, head)}${ellipsis}${normalized.slice(-tail)}`
-}
-
-export function MarkdownTable({ children, className, node: _, ...props }: MarkdownTableProps) {
-  return (
-    <div className="my-3 max-w-full min-w-0 overflow-hidden">
-      <table
-        className={cn("oo-text-body w-full table-fixed border-collapse border border-border", className)}
-        {...props}
-      >
-        {children}
-      </table>
-    </div>
-  )
 }
 
 function MarkdownLocalPath({ className, value, ...props }: MarkdownLocalPathProps) {
@@ -312,7 +295,6 @@ export function MarkdownCodeBlock({ children, className, node: _, ref: _ref }: M
 const messageResponseComponents = {
   code: MarkdownCodeBlock,
   img: MarkdownImage,
-  table: MarkdownTable,
 } satisfies MessageResponseProps["components"]
 
 interface LocalImagePreview {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -22,13 +22,11 @@
   .oo-markdown ol,
   .oo-markdown pre,
   .oo-markdown blockquote,
-  .oo-markdown table,
   .oo-message-response p,
   .oo-message-response ul,
   .oo-message-response ol,
   .oo-message-response pre,
-  .oo-message-response blockquote,
-  .oo-message-response table {
+  .oo-message-response blockquote {
     margin: 0.5rem 0;
   }
 
@@ -251,6 +249,16 @@
     color: var(--oo-feedback-active-foreground);
   }
 
+  /* 保留 Streamdown 原生表格，只移除聊天中多余的外层卡片。 */
+  .oo-message-response [data-streamdown="table-wrapper"] {
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    padding: 0 !important;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+
   .oo-message-response [data-language] pre {
     margin: 0;
     border: 0;
@@ -309,28 +317,6 @@
     margin: 1rem 0;
     border: 0;
     border-top: 1px solid var(--oo-divider);
-  }
-
-  .oo-markdown table {
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-    max-width: 100%;
-    border-collapse: collapse;
-  }
-
-  .oo-markdown th,
-  .oo-markdown td {
-    border: 1px solid var(--oo-divider);
-    padding: 0.35rem 0.6rem;
-    text-align: left;
-    overflow-wrap: anywhere;
-    word-break: normal;
-  }
-
-  .oo-markdown th {
-    background: var(--muted);
-    font-weight: 600;
   }
 
   /* Markdown 图片专用渲染器样式：不要挂到 .oo-markdown 或通用 img，避免影响表格/其它 Markdown。 */


### PR DESCRIPTION
## Summary

Replace Wanta's custom fixed-layout Markdown table renderer with Streamdown's native table implementation while keeping the lightweight chat presentation.

## Problem

Markdown tables were routed through a project-specific renderer that forced `table-layout: fixed`, clipped overflow, and duplicated table styling in `markdown.css`. Wide or content-heavy tables were compressed into the message width, making columns difficult to scan and increasing maintenance around Streamdown upgrades.

The Streamdown table wrapper also adds an outer card around the actual table. With table controls disabled for chat, that extra border, background, rounding, and padding created unnecessary visual nesting and empty structure.

## Changes

- Remove the custom `MarkdownTable` renderer and allow Streamdown to render tables natively.
- Remove the obsolete fixed-layout table test.
- Delete Wanta-specific table sizing, cell, header, and margin overrides.
- Keep Streamdown's native inner table and horizontal scrolling behavior.
- Remove only the outer table-wrapper card styling so the table sits directly in the message without an extra frame.
- Preserve the existing chat configuration that disables table copy, download, and fullscreen controls, so no toolbar or toolbar spacing is rendered.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 191 test files and 1,283 tests passed
- `git diff --check`
