### PR TITLE
Fix macOS application menu icons

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -615,17 +615,52 @@ function sendAppCommand(command: AppCommand): void {
   send()
 }
 
+let applicationMenuIcons: {
+  about: Electron.NativeImage
+  checkForUpdates: Electron.NativeImage
+  services: Electron.NativeImage
+  settings: Electron.NativeImage
+} | null = null
+
+function macMenuSymbol(name: string): Electron.NativeImage {
+  const image = nativeImage.createFromNamedImage(name).resize({ height: 16 })
+  image.setTemplateImage(true)
+  return image
+}
+
+function macApplicationMenuIcons(): typeof applicationMenuIcons {
+  if (process.platform !== "darwin") {
+    return null
+  }
+  // 菜单会在语言切换时重建；保留 NativeImage 强引用，避免 AppKit 后续重绘时图标丢失。
+  applicationMenuIcons ??= {
+    about: macMenuSymbol("info.circle"),
+    checkForUpdates: macMenuSymbol("arrow.clockwise"),
+    services: macMenuSymbol("link"),
+    settings: macMenuSymbol("gearshape"),
+  }
+  return applicationMenuIcons
+}
+
 function installApplicationMenu(): void {
-  Menu.setApplicationMenu(
-    Menu.buildFromTemplate(
-      buildApplicationMenuTemplate({
-        developmentMode: shouldShowDevelopmentMenu(),
-        locale: activeLocale(),
-        onCommand: sendAppCommand,
-        platform: process.platform,
-      }),
-    ),
+  const macIcons = macApplicationMenuIcons()
+  const menu = Menu.buildFromTemplate(
+    buildApplicationMenuTemplate({
+      developmentMode: shouldShowDevelopmentMenu(),
+      locale: activeLocale(),
+      macIcons: macIcons ?? undefined,
+      onCommand: sendAppCommand,
+      platform: process.platform,
+    }),
   )
+  // macOS 会先为 Services role 放入系统图标；菜单构建后再替换，保留原生 Services 子菜单行为。
+  if (macIcons) {
+    const aboutItem = menu.getMenuItemById("app-about")
+    const servicesItem = menu.getMenuItemById("app-services")
+    if (aboutItem) aboutItem.icon = macIcons.about
+    if (servicesItem) servicesItem.icon = macIcons.services
+  }
+  Menu.setApplicationMenu(menu)
 }
 
 function activeLocale(): AppLocale {

--- a/electron/window/application-menu.test.ts
+++ b/electron/window/application-menu.test.ts
@@ -128,6 +128,37 @@ describe("buildApplicationMenuTemplate", () => {
     expect(onCommand).toHaveBeenCalledExactlyOnceWith(APP_COMMANDS.checkForUpdates)
   })
 
+  it("keeps stable native icons on custom macOS application menu items", () => {
+    const icons = {
+      about: { name: "about" },
+      checkForUpdates: { name: "check-for-updates" },
+      services: { name: "services" },
+      settings: { name: "settings" },
+    } as unknown as NonNullable<Parameters<typeof buildApplicationMenuTemplate>[0]["macIcons"]>
+    const template = menuTemplate({ locale: "en", macIcons: icons, platform: "darwin" })
+    const applicationMenu = findItem(template, branding.appName)
+    const submenu = Array.isArray(applicationMenu.submenu) ? applicationMenu.submenu : []
+
+    expect(findItem(submenu, "Check for Updates…").icon).toBe(icons.checkForUpdates)
+    expect(findItem(submenu, "Settings…").icon).toBe(icons.settings)
+    expect(findItem(submenu, `About ${branding.appName}`).id).toBe("app-about")
+    expect(findItem(submenu, "Services").id).toBe("app-services")
+  })
+
+  it("does not add macOS menu icons on other platforms", () => {
+    const icons = {
+      about: { name: "about" },
+      checkForUpdates: { name: "check-for-updates" },
+      services: { name: "services" },
+      settings: { name: "settings" },
+    } as unknown as NonNullable<Parameters<typeof buildApplicationMenuTemplate>[0]["macIcons"]>
+    const template = menuTemplate({ locale: "en", macIcons: icons, platform: "win32" })
+    const fileMenu = findItem(template, "File")
+    const submenu = Array.isArray(fileMenu.submenu) ? fileMenu.submenu : []
+
+    expect(findItem(submenu, "Settings…").icon).toBeUndefined()
+  })
+
   it("places the update check in the Windows Help menu", () => {
     const onCommand = vi.fn()
     const template = menuTemplate({ locale: "en", onCommand, platform: "win32" })

--- a/electron/window/application-menu.ts
+++ b/electron/window/application-menu.ts
@@ -1,5 +1,5 @@
 import type { AppCommand } from "../app-command.ts"
-import type { MenuItemConstructorOptions } from "electron"
+import type { MenuItemConstructorOptions, NativeImage } from "electron"
 
 import { APP_COMMANDS } from "../app-command.ts"
 import { normalizeAppLocale } from "../app-locale.ts"
@@ -9,6 +9,12 @@ import { applicationMenuLabels } from "./application-menu-messages.ts"
 interface ApplicationMenuOptions {
   developmentMode: boolean
   locale?: string
+  macIcons?: {
+    about: NativeImage
+    checkForUpdates: NativeImage
+    services: NativeImage
+    settings: NativeImage
+  }
   onCommand: (command: AppCommand) => void
   platform: NodeJS.Platform
 }
@@ -17,6 +23,7 @@ function settingsMenuItem(input: ApplicationMenuOptions, label: string): MenuIte
   return {
     accelerator: "CommandOrControl+,",
     click: () => input.onCommand(APP_COMMANDS.openSettings),
+    ...(input.platform === "darwin" && input.macIcons ? { icon: input.macIcons.settings } : {}),
     label,
   }
 }
@@ -38,15 +45,16 @@ export function buildApplicationMenuTemplate(input: ApplicationMenuOptions): Men
     template.push({
       label: branding.appName,
       submenu: [
-        roleMenuItem("about", label.about),
+        { ...roleMenuItem("about", label.about), id: "app-about" },
         {
           click: () => input.onCommand(APP_COMMANDS.checkForUpdates),
+          ...(input.macIcons ? { icon: input.macIcons.checkForUpdates } : {}),
           label: label.checkForUpdates,
         },
         { type: "separator" },
         settingsMenuItem(input, label.settings),
         { type: "separator" },
-        roleMenuItem("services", label.services),
+        { ...roleMenuItem("services", label.services), id: "app-services" },
         { type: "separator" },
         roleMenuItem("hide", label.hide),
         roleMenuItem("hideOthers", label.hideOthers),


### PR DESCRIPTION
## Issue

The macOS application menu mixed system-provided role icons with custom menu items that had no icons. Check for Updates and Settings were visually inconsistent, the native Services glyph duplicated the Settings gear metaphor, and the role-provided About glyph appeared smaller than the surrounding icons. Earlier custom image attempts could also render black in dark mode or disappear after the menu was rebuilt or redrawn.

## Root cause

Electron delegates standard menu roles such as About and Services to AppKit, while Check for Updates and Settings use custom click handlers and therefore receive no automatic icon. Short-lived `NativeImage` values were not retained across menu reconstruction, resized images were not explicitly marked as macOS template images, and role items needed their custom icons applied after `Menu.buildFromTemplate()` so their native behavior could remain intact.

## Changes

- Add a consistent 16-point SF Symbol set for About, Check for Updates, Settings, and Services.
- Use `info.circle`, `arrow.clockwise`, `gearshape`, and `link` to give each command a distinct meaning.
- Mark every symbol as a macOS template image so AppKit supplies the correct foreground color in light, dark, and selected menu states.
- Cache the `NativeImage` instances for the lifetime of the main process so menu redraws and locale-driven menu reconstruction keep stable icons.
- Apply custom About and Services icons after building the native menu while preserving their standard Electron roles and native actions.
- Keep macOS-only icon data out of Windows and Linux menu templates.
- Add menu-template coverage for icon assignment, stable role item IDs, and non-macOS isolation.

## User impact

The Wanta application menu now presents a consistent set of correctly sized icons. Icons adapt to the active macOS appearance, remain visible after commands are selected or the menu is rebuilt, and Services is visually distinct from Settings without losing the native Services submenu behavior.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 191 test files and 1285 tests passed
- `git diff --check`
- macOS development launch with the Electron main process and Agent sidecar ready
