### PR TITLE
Unify skill management interactions

### DIFF
--- a/src/routes/Skills/DiscoverSkillsPane.tsx
+++ b/src/routes/Skills/DiscoverSkillsPane.tsx
@@ -14,6 +14,7 @@ import {
   getPublicSkillInstallKey,
   getPublicSkillInstallStateLabel,
   isNearScrollBottom,
+  shouldOpenPublicSkillManagement,
 } from "./skill-route-model.ts"
 import { SkillErrorNotice } from "./SkillErrorNotice.tsx"
 import { SkillListRow } from "./SkillListRow.tsx"
@@ -300,7 +301,13 @@ function PublicSkillPackageRow({
           </Button>
         ) : null
       }
-      onSelect={onSelect}
+      onSelect={() => {
+        if (primarySkill && shouldOpenPublicSkillManagement(state)) {
+          onOpenManagedSkill(primarySkill.name)
+          return
+        }
+        onSelect()
+      }}
     />
   )
 }

--- a/src/routes/Skills/InstalledSkillsPane.tsx
+++ b/src/routes/Skills/InstalledSkillsPane.tsx
@@ -21,7 +21,7 @@ import {
 } from "./skill-route-model.ts"
 import { SkillErrorNotice } from "./SkillErrorNotice.tsx"
 import { SkillListRow } from "./SkillListRow.tsx"
-import { SkillIconFrame, SkillManagementSheet, SkillPageScrollArea } from "./SkillUiParts.tsx"
+import { SkillIconFrame, SkillPageScrollArea } from "./SkillUiParts.tsx"
 import { AgentIcon } from "@/components/AgentIcon"
 import { AppIcons } from "@/components/AppIcons"
 import { Badge } from "@/components/ui/badge"
@@ -34,11 +34,8 @@ const publishableSkillBadgeClassName = "oo-badge-info oo-text-micro h-5 shrink-0
 interface InstalledSkillsPaneProps {
   cliUpdateError: string | null
   cliVersionCheck: SkillVersionReport["cli"] | undefined
-  detailContent: React.ReactNode
   groups: ManagedSkillGroup[]
   isExecutingCliUpdate: boolean
-  isDetailOpen: boolean
-  onCloseDetail: () => void
   onSelectSkill: (skillId: string) => void
   onUpdateCli: () => void
   selectedSkill: ManagedSkillGroup | undefined
@@ -50,11 +47,8 @@ interface InstalledSkillsPaneProps {
 export function InstalledSkillsPane({
   cliUpdateError,
   cliVersionCheck,
-  detailContent,
   groups,
   isExecutingCliUpdate,
-  isDetailOpen,
-  onCloseDetail,
   onSelectSkill,
   onUpdateCli,
   selectedSkill,
@@ -91,12 +85,6 @@ export function InstalledSkillsPane({
           </div>
         )}
       </div>
-
-      {isDetailOpen && selectedSkill ? (
-        <SkillManagementSheet title={selectedSkill.name} onClose={onCloseDetail}>
-          {detailContent}
-        </SkillManagementSheet>
-      ) : null}
     </SkillPageScrollArea>
   )
 }

--- a/src/routes/Skills/OrganizationManagement.tsx
+++ b/src/routes/Skills/OrganizationManagement.tsx
@@ -1,15 +1,16 @@
 import type { ConnectionProvider } from "../../../electron/connections/common.ts"
+import type { ManagedSkillGroup, PublicSkillPackage } from "../../../electron/skills/common.ts"
 import type { BusyAction, ProviderAccessForm } from "./organization-management-model.ts"
 import type { UseOrganizationSkills } from "@/hooks/useOrganizationSkills"
 import type { UseOrganizationWorkspace } from "@/hooks/useOrganizationWorkspace"
 
+import { RefreshCwIcon } from "lucide-react"
 import * as React from "react"
 import {
   buildGrantViews,
   buildOrganizationMemberViews,
   initialProviderAccessForm,
   providerOptionsWithSelected,
-  runtimeSkillRemoveBusyKey,
 } from "./organization-management-model.ts"
 import {
   EmptyOrganizationsState,
@@ -28,9 +29,26 @@ import {
   ProviderAccessDialog,
 } from "./OrganizationMembersPanel.tsx"
 import { OrganizationMembersSheet } from "./OrganizationMembersSheet.tsx"
-import { RuntimeSkillRemoveConfirmDialog } from "./OrganizationSkillManageDialog.tsx"
+import { PublicSkillPackageSheet } from "./PublicSkillPackageSheet.tsx"
+import {
+  getPublicPackagePrimaryInstallSkill,
+  getPublicPackagePrimarySkill,
+  getPublicSkillInstallKey,
+  getGroupStatus,
+  getRuntimeHosts,
+  getSkillVersionCheck,
+  getSkillVersionCheckKey,
+  getSelectedManagedSkillGroup,
+} from "./skill-route-model.ts"
+import { SkillDetailContent } from "./SkillDetailContent.tsx"
+import { SkillManagementSheet } from "./SkillUiParts.tsx"
+import { useSkillService } from "@/components/AppContext"
 import { useAuthStateResource, useSkillInventoryResource } from "@/components/AppDataHooks"
+import { useHomeSummaryResource, useSkillVersionReportResource } from "@/components/AppDataHooks"
+import { DeleteSkillConfirmDialog } from "@/components/DeleteSkillConfirmDialog"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useSkillObjectActions } from "@/components/useSkillObjectActions"
 import { useAppI18n } from "@/i18n"
 import { userFacingErrorDescription } from "@/lib/user-facing-error"
 import { useProviderSkillPackageLookup } from "@/routes/Skills/provider-skill-package-lookup"
@@ -52,9 +70,12 @@ export function OrganizationManagementRoute({
   organizationSkills?: UseOrganizationSkills
   workspace: UseOrganizationWorkspace
 }) {
-  const { t } = useAppI18n()
+  const { locale, t } = useAppI18n()
   const authResource = useAuthStateResource()
   const skillInventory = useSkillInventoryResource()
+  const skillVersions = useSkillVersionReportResource()
+  const homeSummary = useHomeSummaryResource()
+  const skillService = useSkillService()
   const activeAccount = authResource.data?.status === "authenticated" ? authResource.data.account : undefined
   const activeAccountId = activeAccount?.id
   const activeWorkspace = workspace.activeWorkspace
@@ -70,6 +91,11 @@ export function OrganizationManagementRoute({
   const [addMemberOpen, setAddMemberOpen] = React.useState(false)
   const [addMemberError, setAddMemberError] = React.useState<string | null>(null)
   const [membersPanelOpen, setMembersPanelOpen] = React.useState(false)
+  const [managedSkillId, setManagedSkillId] = React.useState<string | null>(null)
+  const [selectedPackage, setSelectedPackage] = React.useState<PublicSkillPackage | null>(null)
+  const [updatingRegistrySkillId, setUpdatingRegistrySkillId] = React.useState<string | null>(null)
+  const [managedSkillError, setManagedSkillError] = React.useState<{ cause: unknown; skillId: string } | null>(null)
+  const updateRegistryInFlightRef = React.useRef(false)
   const [providerAccessForm, setProviderAccessForm] = React.useState<ProviderAccessForm>(initialProviderAccessForm)
   const avatarPreviewUrls = workspace.organizationAvatarPreviewUrls
   const clearOrganizationAvatarPreview = workspace.clearOrganizationAvatarPreview
@@ -92,9 +118,6 @@ export function OrganizationManagementRoute({
     addOrganizationSkillFromRecommendation,
     installRuntimeSkill,
     installRuntimeSkills,
-    removeRuntimeSkill,
-    runtimeSkillRemoveTarget,
-    setRuntimeSkillRemoveTarget,
   } = useOrganizationSkillActions({
     busyAction,
     organizationSkills: selectedOrganizationSkills,
@@ -104,6 +127,69 @@ export function OrganizationManagementRoute({
     () => new Map((skillInventory.data?.groups ?? []).map((group) => [group.id, group])),
     [skillInventory.data?.groups],
   )
+  const selectedPackagePrimarySkill = selectedPackage ? getPublicPackagePrimarySkill(selectedPackage) : undefined
+  const selectedPackageInstallSkill = selectedPackage
+    ? (getPublicPackagePrimaryInstallSkill(skillGroupById, selectedPackage) ?? selectedPackagePrimarySkill)
+    : undefined
+  const selectedPackageInstallBusy = Boolean(
+    selectedPackage &&
+    selectedPackageInstallSkill &&
+    busyAction === `installSkill:${selectedPackage.name}:${selectedPackageInstallSkill.name}`,
+  )
+  const selectedPackageAddBusy = Boolean(
+    selectedPackage &&
+    selectedPackagePrimarySkill &&
+    busyAction === `addSkill:${selectedPackage.name}:${selectedPackagePrimarySkill.name}`,
+  )
+  const managedSkill = getSelectedManagedSkillGroup(skillInventory.data?.groups ?? [], managedSkillId)
+  const managedSkillStatus = managedSkill ? getGroupStatus(managedSkill, t, getRuntimeHosts(managedSkill)) : null
+  const skillVersionCheckByKey = React.useMemo(
+    () =>
+      new Map(
+        (skillVersions.data?.skills ?? []).map((check) => [
+          getSkillVersionCheckKey(check.skillId, check.packageName),
+          check,
+        ]),
+      ),
+    [skillVersions.data?.skills],
+  )
+  const managedSkillVersionCheck = getSkillVersionCheck(skillVersionCheckByKey, managedSkill)
+  const { copySkillPath, isRemovingSkill, openSkillFolder, removeSkill, removeTarget, setRemoveTarget } =
+    useSkillObjectActions({ onDeleted: () => setManagedSkillId(null) })
+
+  const updateRegistrySkill = React.useCallback(
+    async (skill: Pick<ManagedSkillGroup, "id" | "kind" | "packageName">) => {
+      const packageName = skill.packageName?.trim()
+      if (updateRegistryInFlightRef.current || skill.kind !== "registry" || !packageName) {
+        return
+      }
+      updateRegistryInFlightRef.current = true
+      setUpdatingRegistrySkillId(skill.id)
+      setManagedSkillError(null)
+      try {
+        const nextInventory = await skillService.invoke("updateRegistrySkill", { packageName, skillId: skill.id })
+        skillInventory.setData(nextInventory)
+        await skillVersions.refresh({ forceRefresh: true, silent: true })
+        homeSummary.invalidate()
+      } catch (cause) {
+        setManagedSkillError({ cause, skillId: skill.id })
+      } finally {
+        updateRegistryInFlightRef.current = false
+        setUpdatingRegistrySkillId(null)
+      }
+    },
+    [homeSummary, skillInventory, skillService, skillVersions],
+  )
+  const openManagedSkill = React.useCallback((skillId: string) => {
+    setSelectedPackage(null)
+    setManagedSkillError(null)
+    setManagedSkillId(skillId)
+  }, [])
+  const openPackageDetail = React.useCallback((pkg: PublicSkillPackage) => {
+    setManagedSkillId(null)
+    setManagedSkillError(null)
+    setSelectedPackage(pkg)
+  }, [])
   const providerSkillPackageLookup = useProviderSkillPackageLookup(connectedProviders)
   const providerSkillRecommendations = React.useMemo(
     () =>
@@ -160,6 +246,9 @@ export function OrganizationManagementRoute({
 
   React.useEffect(() => {
     setMembersPanelOpen(false)
+    setManagedSkillId(null)
+    setManagedSkillError(null)
+    setSelectedPackage(null)
   }, [selectedOrganization?.id])
 
   React.useEffect(() => {
@@ -266,7 +355,8 @@ export function OrganizationManagementRoute({
                         onAddMarketPackage={addOrganizationSkillFromPackage}
                         onInstallRuntimeSkill={installRuntimeSkill}
                         onInstallRuntimeSkills={installRuntimeSkills}
-                        onRequestRemoveRuntimeSkill={setRuntimeSkillRemoveTarget}
+                        onOpenManagedSkill={openManagedSkill}
+                        onOpenPackageDetail={openPackageDetail}
                       />
                     ) : (
                       <Panel
@@ -319,6 +409,87 @@ export function OrganizationManagementRoute({
           </div>
         )}
       </div>
+      {managedSkill ? (
+        <SkillManagementSheet
+          title={managedSkill.name}
+          onClose={() => {
+            setManagedSkillId(null)
+            setManagedSkillError(null)
+          }}
+        >
+          <SkillDetailContent
+            copySkillPath={copySkillPath}
+            inventoryInitialLoading={skillInventory.isInitialLoading}
+            isRemovingSkill={isRemovingSkill}
+            isSkillLinkedToOrganization={Boolean(
+              selectedOrganizationSkills?.skills.some((skill) => skill.packageName === managedSkill.packageName),
+            )}
+            openSkillFolder={openSkillFolder}
+            publishSkill={() => undefined}
+            publishingSkillId={null}
+            requestRemoveSkill={(skill) => setRemoveTarget({ skill })}
+            requestOrganizationLink={() => undefined}
+            selectedPlanError={managedSkillError?.skillId === managedSkill.id ? managedSkillError.cause : null}
+            selectedSkill={managedSkill}
+            selectedStatus={managedSkillStatus}
+            selectedVersionCheck={managedSkillVersionCheck}
+            showOrganizationLinkAction={false}
+            showPublishAction={false}
+            updateRegistrySkill={updateRegistrySkill}
+            updatingRegistrySkillId={updatingRegistrySkillId}
+          />
+        </SkillManagementSheet>
+      ) : null}
+      {selectedPackage ? (
+        <PublicSkillPackageSheet
+          groupById={skillGroupById}
+          installingKey={
+            selectedPackageInstallBusy
+              ? getPublicSkillInstallKey(selectedPackage, selectedPackageInstallSkill?.name)
+              : null
+          }
+          locale={locale}
+          pkg={selectedPackage}
+          additionalActions={
+            canManage &&
+            !selectedOrganizationSkills?.skills.some((skill) => skill.packageName === selectedPackage.name) &&
+            selectedPackagePrimarySkill ? (
+              <Button
+                type="button"
+                size="sm"
+                disabled={Boolean(busyAction)}
+                onClick={() =>
+                  void addOrganizationSkillFromPackage(selectedPackage, {
+                    installRuntime: false,
+                    skillName: selectedPackagePrimarySkill.name,
+                  })
+                }
+              >
+                {selectedPackageAddBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : null}
+                {selectedPackageAddBusy ? t("skills.organizationAdding") : t("organizations.skillManageAddOnly")}
+              </Button>
+            ) : null
+          }
+          onClose={() => setSelectedPackage(null)}
+          onInstall={(pkg, skillName) => {
+            const targetSkillName = skillName ?? getPublicPackagePrimarySkill(pkg)?.name
+            if (targetSkillName) {
+              void installRuntimeSkill({ packageName: pkg.name, skillName: targetSkillName })
+            }
+          }}
+          onOpenManagedSkill={openManagedSkill}
+        />
+      ) : null}
+      <DeleteSkillConfirmDialog
+        isRemoving={isRemovingSkill}
+        target={removeTarget}
+        onConfirm={removeSkill}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            setRemoveTarget(null)
+          }
+        }}
+      />
       <CreateOrganizationDialog
         avatarFile={organizationForms.create.avatarFile}
         busy={busyAction === "create"}
@@ -383,16 +554,6 @@ export function OrganizationManagementRoute({
         onClose={memberActions.closeProviderAccess}
         onFormChange={setProviderAccessForm}
         onSubmit={memberActions.saveProviderAccess}
-      />
-      <RuntimeSkillRemoveConfirmDialog
-        busy={runtimeSkillRemoveTarget ? busyAction === runtimeSkillRemoveBusyKey(runtimeSkillRemoveTarget) : false}
-        target={runtimeSkillRemoveTarget}
-        onClose={() => {
-          if (!busyAction?.startsWith("removeSkill:")) {
-            setRuntimeSkillRemoveTarget(null)
-          }
-        }}
-        onConfirm={() => void removeRuntimeSkill()}
       />
     </>
   )

--- a/src/routes/Skills/OrganizationManagementPanels.tsx
+++ b/src/routes/Skills/OrganizationManagementPanels.tsx
@@ -4,7 +4,6 @@ import type { BusyAction, MemberView } from "./organization-management-model.ts"
 import type { UseOrganizationSkills } from "@/hooks/useOrganizationSkills"
 import type { WorkspaceSelection } from "@/hooks/useOrganizationWorkspace"
 import type { ProviderSkillRecommendation } from "@/routes/Skills/provider-skill-recommendations.ts"
-import type { RuntimeSkillRemoveTarget } from "@/routes/Skills/skill-route-model.ts"
 
 import { Building2Icon, CheckIcon, ChevronsUpDownIcon, PencilIcon, PlusIcon } from "lucide-react"
 import * as React from "react"
@@ -299,7 +298,8 @@ export function OrganizationSkillGuidePanel({
   onAddMarketPackage,
   onInstallRuntimeSkill,
   onInstallRuntimeSkills,
-  onRequestRemoveRuntimeSkill,
+  onOpenManagedSkill,
+  onOpenPackageDetail,
 }: {
   busyAction: BusyAction | null
   groupById: ReadonlyMap<string, ManagedSkillGroup>
@@ -322,7 +322,8 @@ export function OrganizationSkillGuidePanel({
   ) => Promise<void>
   onInstallRuntimeSkill: (skill: { packageName: string; skillName: string }) => void
   onInstallRuntimeSkills: (skills: readonly { packageName: string; skillName: string }[]) => void
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
+  onOpenManagedSkill: (skillName: string) => void
+  onOpenPackageDetail: (pkg: PublicSkillPackage) => void
 }) {
   const { t } = useAppI18n()
   const statusLabel = organizationSkillGuideStatus(organizationSkills, t)
@@ -336,6 +337,7 @@ export function OrganizationSkillGuidePanel({
             <Badge variant="outline" className="max-w-full shrink-0">
               <span className="truncate">{statusLabel}</span>
             </Badge>
+            {!organizationSkills.canManage ? <Badge variant="outline">{t("organizations.readOnly")}</Badge> : null}
           </div>
           <p className="oo-text-caption mt-0.5 truncate text-muted-foreground">
             {t("organizations.skillGuideDescription")}
@@ -357,7 +359,8 @@ export function OrganizationSkillGuidePanel({
           onAddMarketPackage={onAddMarketPackage}
           onInstallRuntimeSkill={onInstallRuntimeSkill}
           onInstallRuntimeSkills={onInstallRuntimeSkills}
-          onRequestRemoveRuntimeSkill={onRequestRemoveRuntimeSkill}
+          onOpenManagedSkill={onOpenManagedSkill}
+          onOpenPackageDetail={onOpenPackageDetail}
         />
       </div>
     </section>

--- a/src/routes/Skills/OrganizationSkillManageDialog.tsx
+++ b/src/routes/Skills/OrganizationSkillManageDialog.tsx
@@ -2,7 +2,6 @@ import type { ManagedSkillGroup, PublicSkillPackage } from "../../../electron/sk
 import type { BusyAction } from "./organization-management-model.ts"
 import type { UseOrganizationSkills } from "@/hooks/useOrganizationSkills"
 import type { ProviderSkillRecommendation } from "@/routes/Skills/provider-skill-recommendations"
-import type { RuntimeSkillRemoveTarget } from "@/routes/Skills/skill-route-model"
 
 import { ChevronDownIcon, PackageIcon, RefreshCwIcon } from "lucide-react"
 import * as React from "react"
@@ -66,8 +65,9 @@ export function OrganizationSkillManageDialog({
   onClose = () => undefined,
   onInstallRuntimeSkill,
   onInstallRuntimeSkills,
+  onOpenManagedSkill,
+  onOpenPackageDetail,
   onOpenAdvanced,
-  onRequestRemoveRuntimeSkill,
   open = true,
   organizationSkills,
   providerRecommendationsLoading = false,
@@ -93,8 +93,9 @@ export function OrganizationSkillManageDialog({
   onClose?: () => void
   onInstallRuntimeSkill: (skill: { packageName: string; skillName: string }) => void
   onInstallRuntimeSkills: (skills: readonly { packageName: string; skillName: string }[]) => void
+  onOpenManagedSkill: (skillName: string) => void
+  onOpenPackageDetail: (pkg: PublicSkillPackage) => void
   onOpenAdvanced?: () => void
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
   open?: boolean
   organizationSkills: UseOrganizationSkills
   providerRecommendationsLoading?: boolean
@@ -598,8 +599,8 @@ export function OrganizationSkillManageDialog({
                           skillName: item.skill.skillName,
                         })
                       }
+                      onOpenManagedSkill={() => onOpenManagedSkill(item.skill.skillName)}
                       onRemove={() => setOrganizationRemoveTarget(item.skill)}
-                      onRequestRemoveRuntimeSkill={onRequestRemoveRuntimeSkill}
                       onToggleEnabled={() => void updateOrganizationSkill(item.skill, { enabled: !item.skill.enabled })}
                     />
                   ) : (
@@ -607,17 +608,16 @@ export function OrganizationSkillManageDialog({
                       key={item.id}
                       busyAction={busyAction}
                       canManage={organizationSkills.canManage}
-                      groupById={groupById}
                       recommendation={item.recommendation}
                       onAdd={() => onAddRecommendation(item.recommendation, { installRuntime: false })}
-                      onAddAndInstall={() => onAddRecommendation(item.recommendation, { installRuntime: true })}
                       onInstallRuntime={() =>
                         onInstallRuntimeSkill({
                           packageName: item.recommendation.packageName,
                           skillName: item.recommendation.skillId,
                         })
                       }
-                      onRequestRemoveRuntimeSkill={onRequestRemoveRuntimeSkill}
+                      onOpenManagedSkill={() => onOpenManagedSkill(item.recommendation.skillId)}
+                      onOpenPackageDetail={() => onOpenPackageDetail(item.recommendation.package)}
                     />
                   ),
                 )}
@@ -675,12 +675,9 @@ export function OrganizationSkillManageDialog({
                       linked={organizationSkillPackageLinked(linkedPackageKeys, pkg.name)}
                       pkg={pkg}
                       onAdd={(skillName) => onAddMarketPackage(pkg, { installRuntime: false, skillName })}
-                      onAddAndInstall={(skillName) => onAddMarketPackage(pkg, { installRuntime: true, skillName })}
-                      onManageLinked={() => {
-                        setActiveTab("recommendations")
-                        setRecommendationSourceFilter("configured")
-                        setSearchQuery(pkg.name)
-                      }}
+                      onInstallRuntime={(skillName) => onInstallRuntimeSkill({ packageName: pkg.name, skillName })}
+                      onOpenManagedSkill={onOpenManagedSkill}
+                      onOpenPackageDetail={() => onOpenPackageDetail(pkg)}
                     />
                   ))}
                   <div ref={marketLoadMoreAnchorRef} className="h-px" aria-hidden="true" />

--- a/src/routes/Skills/OrganizationSkillManageRows.tsx
+++ b/src/routes/Skills/OrganizationSkillManageRows.tsx
@@ -5,22 +5,22 @@ import type { ProviderSkillRecommendation } from "@/routes/Skills/provider-skill
 import type { RuntimeSkillRemoveTarget } from "@/routes/Skills/skill-route-model"
 
 import {
-  CheckCircle2Icon,
   Link2OffIcon,
   MoreHorizontalIcon,
-  PackageMinusIcon,
   PackageIcon,
   PauseCircleIcon,
   PlayCircleIcon,
   RefreshCwIcon,
 } from "lucide-react"
-import { runtimeSkillRemoveBusyKey } from "./organization-management-model.ts"
 import {
   canInstallProviderRecommendationRuntime,
+  canOpenManagedProviderRecommendation,
   organizationRuntimeStatusLabel,
   organizationRuntimeStatusTone,
   providerRecommendationSkillDescription,
+  shouldOpenOrganizationSkillManagement,
 } from "./organization-skill-manage-helpers.ts"
+import { SkillListRow } from "./SkillListRow.tsx"
 import { normalizeSkillIconSource } from "@/components/skill-icon-source"
 import { SkillIcon } from "@/components/SkillIcon"
 import { Badge } from "@/components/ui/badge"
@@ -53,10 +53,10 @@ import {
   getPublicPackagePrimaryInstallSkill,
   getPublicPackagePrimarySkill,
   getPublicSkillInstallStateLabel,
-  getRuntimeSkillRemoveTarget,
   getSkillRowStatusBadgeClassName,
   isEmojiIcon,
   isImageIcon,
+  shouldOpenPublicSkillManagement,
 } from "@/routes/Skills/skill-route-model"
 
 const skillManageMenuLabelClassName = "oo-text-caption-compact px-2 py-1 text-muted-foreground"
@@ -225,8 +225,9 @@ export function OrganizationSkillMarketRow({
   groupById,
   linked,
   onAdd,
-  onAddAndInstall,
-  onManageLinked,
+  onInstallRuntime,
+  onOpenManagedSkill,
+  onOpenPackageDetail,
   pkg,
 }: {
   busyAction: BusyAction | null
@@ -234,8 +235,9 @@ export function OrganizationSkillMarketRow({
   groupById: ReadonlyMap<string, ManagedSkillGroup>
   linked: boolean
   onAdd: (skillName?: string) => Promise<void>
-  onAddAndInstall: (skillName?: string) => Promise<void>
-  onManageLinked: () => void
+  onInstallRuntime: (skillName: string) => void
+  onOpenManagedSkill: (skillName: string) => void
+  onOpenPackageDetail: () => void
   pkg: PublicSkillPackage
 }) {
   const { t } = useAppI18n()
@@ -244,91 +246,66 @@ export function OrganizationSkillMarketRow({
   const installState = getPublicPackageInstallState(groupById, pkg)
   const canInstallRuntime = canInstallPublicSkill(installState)
   const targetSkillName = canInstallRuntime ? primaryInstallSkill?.name : primarySkill?.name
-  const busy = targetSkillName ? busyAction === `addSkill:${pkg.name}:${targetSkillName}` : false
-  const disabled = Boolean(busyAction && !busy)
+  const addBusy = targetSkillName ? busyAction === `addSkill:${pkg.name}:${targetSkillName}` : false
+  const installBusy = targetSkillName ? busyAction === `installSkill:${pkg.name}:${targetSkillName}` : false
+  const disabled = Boolean(busyAction && !addBusy && !installBusy)
   const canLink = canManage && Boolean(primarySkill) && !linked
   const skillDescription = primarySkill?.description ?? pkg.description
   const skillLine = primarySkill
     ? `${pkg.name} · ${primarySkill.name} · ${pkg.version}`
     : `${pkg.name} · ${pkg.version}`
-  const primaryLabel = busy
-    ? t("skills.organizationAdding")
-    : canInstallRuntime
-      ? t("organizations.skillManageAddAndInstall")
-      : t("organizations.skillManageAddOnly")
+  const opensManagement = Boolean(primarySkill && shouldOpenPublicSkillManagement(installState))
 
   return (
-    <div
-      className={cn(
-        "grid min-w-0 gap-3 border-b border-[var(--oo-divider)] px-3 py-2.5 md:items-center",
-        "md:grid-cols-[auto_minmax(0,1fr)_auto_auto]",
-      )}
-    >
-      <OrganizationSkillIconFrame icon={pkg.icon} />
-      <div className="grid min-w-0 gap-0.5">
-        <div className="oo-text-label min-w-0 truncate text-foreground">{pkg.displayName}</div>
-        {skillDescription ? (
-          <div className="oo-text-caption line-clamp-1 text-foreground/75">{skillDescription}</div>
-        ) : null}
-        <div className="oo-text-caption-compact min-w-0 truncate text-muted-foreground" title={skillLine}>
+    <SkillListRow
+      icon={<OrganizationSkillIconFrame icon={pkg.icon} />}
+      showTrailingDivider
+      title={pkg.displayName}
+      description={skillDescription}
+      badges={
+        <Badge variant={linked ? "secondary" : "outline"}>
+          {linked ? t("skills.organizationAdded") : getPublicSkillInstallStateLabel(installState, t)}
+        </Badge>
+      }
+      meta={
+        <div className="min-w-0 truncate" title={skillLine}>
           {skillLine}
         </div>
-      </div>
-      <Badge className="shrink-0 justify-self-start md:justify-self-end" variant={linked ? "secondary" : "outline"}>
-        {linked ? t("skills.organizationAdded") : getPublicSkillInstallStateLabel(installState, t)}
-      </Badge>
-      <div className="flex min-w-0 flex-wrap justify-start gap-2 md:justify-end">
-        {linked ? (
-          <Button type="button" variant="outline" size="sm" onClick={onManageLinked}>
-            {t("skills.discoverOpenManage")}
-          </Button>
-        ) : !canManage ? (
-          <Badge variant="outline">{t("organizations.readOnly")}</Badge>
-        ) : canInstallRuntime && canLink ? (
-          <div className="inline-flex items-center gap-0">
+      }
+      actions={
+        <>
+          {primarySkill && opensManagement ? (
+            <Button type="button" variant="ghost" size="sm" onClick={() => onOpenManagedSkill(primarySkill.name)}>
+              {t("skills.installedManage")}
+            </Button>
+          ) : null}
+          {canInstallRuntime && targetSkillName ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled || installBusy || !targetSkillName}
+              onClick={() => onInstallRuntime(targetSkillName)}
+            >
+              {installBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <PackageIcon className="size-3.5" />}
+              {installBusy ? t("skills.registryInstalling") : t("organizations.skillManageInstallRuntime")}
+            </Button>
+          ) : null}
+          {!linked && canManage && canLink ? (
             <Button
               type="button"
               size="sm"
-              className="rounded-r-none"
-              disabled={disabled || busy || !targetSkillName}
-              onClick={() => void onAddAndInstall(targetSkillName)}
+              disabled={disabled || addBusy}
+              onClick={() => void onAdd(primarySkill?.name)}
             >
-              {busy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <PackageIcon className="size-3.5" />}
-              {primaryLabel}
+              {addBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : null}
+              {addBusy ? t("skills.organizationAdding") : t("organizations.skillManageAddOnly")}
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="default"
-                  size="sm"
-                  className="-ml-px w-[var(--oo-control-height-compact)] rounded-l-none border-l border-primary-foreground/25 px-0"
-                  disabled={disabled || busy}
-                  aria-label={t("organizations.skillManageMoreActions")}
-                >
-                  <MoreHorizontalIcon className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onSelect={() => void onAdd(primarySkill?.name)}>
-                  {t("organizations.skillManageLinkOnly")}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ) : (
-          <Button
-            type="button"
-            size="sm"
-            disabled={disabled || busy || !canLink}
-            onClick={() => void onAdd(primarySkill?.name)}
-          >
-            {busy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : null}
-            {primaryLabel}
-          </Button>
-        )}
-      </div>
-    </div>
+          ) : null}
+        </>
+      }
+      onSelect={primarySkill && opensManagement ? () => onOpenManagedSkill(primarySkill.name) : onOpenPackageDetail}
+    />
   )
 }
 
@@ -337,23 +314,16 @@ function OrganizationConfiguredSkillActionsMenu({
   canManage,
   enabled,
   onRemove,
-  onRequestRemoveRuntimeSkill,
   onToggleEnabled,
-  removeBusy,
-  runtimeRemoveTarget,
 }: {
   busy: boolean
   canManage: boolean
   enabled: boolean
   onRemove: () => void
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
   onToggleEnabled: () => void
-  removeBusy: boolean
-  runtimeRemoveTarget: RuntimeSkillRemoveTarget | null
 }) {
   const { t } = useAppI18n()
-  const hasRuntimeRemoveAction = Boolean(runtimeRemoveTarget)
-  if (!canManage && !hasRuntimeRemoveAction) {
+  if (!canManage) {
     return null
   }
 
@@ -365,125 +335,31 @@ function OrganizationConfiguredSkillActionsMenu({
           variant="ghost"
           size="sm"
           className="w-[var(--oo-control-height-compact)] px-0"
-          disabled={busy || removeBusy}
+          disabled={busy}
           aria-label={t("organizations.skillManageMoreActions")}
         >
-          {busy || removeBusy ? (
-            <RefreshCwIcon className="size-3.5 animate-spin" />
-          ) : (
-            <MoreHorizontalIcon className="size-4" />
-          )}
+          {busy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <MoreHorizontalIcon className="size-4" />}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
-        {canManage ? (
-          <>
-            <DropdownMenuLabel className={skillManageMenuLabelClassName}>
-              {t("organizations.skillManageOrganizationSection")}
-            </DropdownMenuLabel>
-            <DropdownMenuItem onSelect={onToggleEnabled}>
-              {enabled ? (
-                <PauseCircleIcon className={skillManageMenuIconClassName} />
-              ) : (
-                <PlayCircleIcon className={skillManageMenuIconClassName} />
-              )}
-              {enabled
-                ? t("organizations.skillManagePauseRecommendation")
-                : t("organizations.skillManageResumeRecommendation")}
-            </DropdownMenuItem>
-          </>
-        ) : null}
-        {runtimeRemoveTarget ? (
-          <>
-            {canManage ? <DropdownMenuSeparator /> : null}
-            <DropdownMenuLabel className={skillManageMenuLabelClassName}>
-              {t("organizations.skillManageRuntimeSection")}
-            </DropdownMenuLabel>
-            <DropdownMenuItem onSelect={() => onRequestRemoveRuntimeSkill(runtimeRemoveTarget)}>
-              <PackageMinusIcon className={skillManageMenuIconClassName} />
-              {t("organizations.skillManageRemoveRuntime")}
-            </DropdownMenuItem>
-          </>
-        ) : null}
-        {canManage ? (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onSelect={onRemove}>
-              <Link2OffIcon className="size-4" />
-              {t("organizations.skillManageUnrecommend")}
-            </DropdownMenuItem>
-          </>
-        ) : null}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-function OrganizationRecommendedSkillActionsMenu({
-  addBusy,
-  busy,
-  canManage,
-  onAdd,
-  onRequestRemoveRuntimeSkill,
-  removeBusy,
-  runtimeRemoveTarget,
-}: {
-  addBusy: boolean
-  busy: boolean
-  canManage: boolean
-  onAdd: () => Promise<void>
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
-  removeBusy: boolean
-  runtimeRemoveTarget: RuntimeSkillRemoveTarget | null
-}) {
-  const { t } = useAppI18n()
-  const hasRuntimeRemoveAction = Boolean(runtimeRemoveTarget)
-  if (!canManage && !hasRuntimeRemoveAction) {
-    return null
-  }
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="w-[var(--oo-control-height-compact)] px-0"
-          disabled={busy || addBusy || removeBusy}
-          aria-label={t("organizations.skillManageMoreActions")}
-        >
-          {busy || addBusy || removeBusy ? (
-            <RefreshCwIcon className="size-3.5 animate-spin" />
+        <DropdownMenuLabel className={skillManageMenuLabelClassName}>
+          {t("organizations.skillManageOrganizationSection")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={onToggleEnabled}>
+          {enabled ? (
+            <PauseCircleIcon className={skillManageMenuIconClassName} />
           ) : (
-            <MoreHorizontalIcon className="size-4" />
+            <PlayCircleIcon className={skillManageMenuIconClassName} />
           )}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        {canManage ? (
-          <>
-            <DropdownMenuLabel className={skillManageMenuLabelClassName}>
-              {t("organizations.skillManageOrganizationSection")}
-            </DropdownMenuLabel>
-            <DropdownMenuItem onSelect={() => void onAdd()}>
-              <CheckCircle2Icon className={skillManageMenuIconClassName} />
-              {t("organizations.skillManageAddOnly")}
-            </DropdownMenuItem>
-          </>
-        ) : null}
-        {canManage && runtimeRemoveTarget ? <DropdownMenuSeparator /> : null}
-        {runtimeRemoveTarget ? (
-          <>
-            <DropdownMenuLabel className={skillManageMenuLabelClassName}>
-              {t("organizations.skillManageRuntimeSection")}
-            </DropdownMenuLabel>
-            <DropdownMenuItem onSelect={() => onRequestRemoveRuntimeSkill(runtimeRemoveTarget)}>
-              <PackageMinusIcon className={skillManageMenuIconClassName} />
-              {t("organizations.skillManageRemoveRuntime")}
-            </DropdownMenuItem>
-          </>
-        ) : null}
+          {enabled
+            ? t("organizations.skillManagePauseRecommendation")
+            : t("organizations.skillManageResumeRecommendation")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onSelect={onRemove}>
+          <Link2OffIcon className="size-4" />
+          {t("organizations.skillManageUnrecommend")}
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )
@@ -598,8 +474,8 @@ export function OrganizationSkillManageRow({
   groupById,
   installBusy,
   onInstallRuntime,
+  onOpenManagedSkill,
   onRemove,
-  onRequestRemoveRuntimeSkill,
   onToggleEnabled,
   skill,
 }: {
@@ -609,8 +485,8 @@ export function OrganizationSkillManageRow({
   groupById: ReadonlyMap<string, ManagedSkillGroup>
   installBusy: boolean
   onInstallRuntime: () => void
+  onOpenManagedSkill: () => void
   onRemove: () => void
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
   onToggleEnabled: () => void
   skill: UseOrganizationSkills["skills"][number]
 }) {
@@ -618,20 +494,17 @@ export function OrganizationSkillManageRow({
   const runtimeStatus = getOrganizationSkillRuntimeStatus(groupById, skill)
   const runtimeTone = organizationRuntimeStatusTone(runtimeStatus.state)
   const runtimeInstallable = runtimeStatus.state === "missing" || runtimeStatus.state === "external-only"
-  const runtimeRemoveTarget = getRuntimeSkillRemoveTarget(groupById, {
-    displayName: skill.displayName,
-    packageName: skill.packageName,
-    skillName: skill.skillName,
-  })
-  const removeBusy = runtimeRemoveTarget ? busyAction === runtimeSkillRemoveBusyKey(runtimeRemoveTarget) : false
-  const menuBusy = Boolean(busyAction && !removeBusy) || busy || installBusy
+  const menuBusy = Boolean(busyAction) || busy || installBusy
+  const opensManagement = shouldOpenOrganizationSkillManagement(runtimeStatus.state)
 
   return (
-    <div className="group/skill-row grid min-w-0 gap-3 border-b border-[var(--oo-divider)] px-3 py-2.5 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center">
-      <OrganizationSkillIconFrame icon={skill.icon} />
-      <div className="grid min-w-0 gap-0.5">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <div className="oo-text-label min-w-0 truncate text-foreground">{skill.displayName}</div>
+    <SkillListRow
+      icon={<OrganizationSkillIconFrame icon={skill.icon} />}
+      showTrailingDivider
+      title={skill.displayName}
+      description={skill.description}
+      badges={
+        <>
           <Badge variant="secondary" className="shrink-0">
             {t("organizations.skillManageConfigured")}
           </Badge>
@@ -641,56 +514,55 @@ export function OrganizationSkillManageRow({
           <Badge className={cn("shrink-0", getSkillRowStatusBadgeClassName(runtimeTone))} variant="outline">
             {organizationRuntimeStatusLabel(runtimeStatus.state, t)}
           </Badge>
-        </div>
-        {skill.description ? (
-          <div className="oo-text-caption line-clamp-1 text-foreground/75">{skill.description}</div>
-        ) : null}
-        <div
-          className="oo-text-caption-compact min-w-0 truncate text-muted-foreground"
-          title={`${skill.packageName} · ${skill.skillName} · ${skill.version}`}
-        >
+        </>
+      }
+      meta={
+        <div className="min-w-0 truncate" title={`${skill.packageName} · ${skill.skillName} · ${skill.version}`}>
           {skill.packageName} · {skill.skillName} · {skill.version}
         </div>
-      </div>
-      <div className="flex min-w-0 flex-wrap justify-start gap-2 md:justify-end">
-        {runtimeInstallable ? (
-          <Button type="button" variant="outline" size="sm" disabled={installBusy} onClick={onInstallRuntime}>
-            {installBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <PackageIcon className="size-3.5" />}
-            {installBusy ? t("skills.registryInstalling") : t("organizations.skillManageInstallRuntime")}
-          </Button>
-        ) : null}
-        <OrganizationConfiguredSkillActionsMenu
-          busy={menuBusy}
-          canManage={canManage}
-          enabled={skill.enabled}
-          removeBusy={removeBusy}
-          runtimeRemoveTarget={runtimeRemoveTarget}
-          onRemove={onRemove}
-          onRequestRemoveRuntimeSkill={onRequestRemoveRuntimeSkill}
-          onToggleEnabled={onToggleEnabled}
-        />
-      </div>
-    </div>
+      }
+      actions={
+        <>
+          {runtimeInstallable ? (
+            <Button type="button" variant="outline" size="sm" disabled={installBusy} onClick={onInstallRuntime}>
+              {installBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <PackageIcon className="size-3.5" />}
+              {installBusy ? t("skills.registryInstalling") : t("organizations.skillManageInstallRuntime")}
+            </Button>
+          ) : null}
+          {opensManagement ? (
+            <Button type="button" variant="ghost" size="sm" onClick={onOpenManagedSkill}>
+              {t("skills.installedManage")}
+            </Button>
+          ) : null}
+          <OrganizationConfiguredSkillActionsMenu
+            busy={menuBusy}
+            canManage={canManage}
+            enabled={skill.enabled}
+            onRemove={onRemove}
+            onToggleEnabled={onToggleEnabled}
+          />
+        </>
+      }
+      onSelect={opensManagement ? onOpenManagedSkill : undefined}
+    />
   )
 }
 
 export function OrganizationSkillRecommendationRow({
   busyAction,
   canManage,
-  groupById,
   onAdd,
-  onAddAndInstall,
   onInstallRuntime,
-  onRequestRemoveRuntimeSkill,
+  onOpenManagedSkill,
+  onOpenPackageDetail,
   recommendation,
 }: {
   busyAction: BusyAction | null
   canManage: boolean
-  groupById: ReadonlyMap<string, ManagedSkillGroup>
   onAdd: () => Promise<void>
-  onAddAndInstall: () => Promise<void>
   onInstallRuntime: () => void
-  onRequestRemoveRuntimeSkill: (target: RuntimeSkillRemoveTarget) => void
+  onOpenManagedSkill: () => void
+  onOpenPackageDetail: () => void
   recommendation: ProviderSkillRecommendation
 }) {
   const { t } = useAppI18n()
@@ -701,96 +573,55 @@ export function OrganizationSkillRecommendationRow({
   const installBusy = busyAction === installBusyKey || busyAction === "installSkillBatch"
   const disabled = Boolean(busyAction && !addBusy && !installBusy)
   const skillDescription = providerRecommendationSkillDescription(recommendation)
-  const runtimeRemoveTarget = getRuntimeSkillRemoveTarget(
-    groupById,
-    {
-      displayName: recommendation.package.displayName,
-      packageName: recommendation.packageName,
-      skillName: recommendation.skillId,
-    },
-    { requirePackageMatch: true },
-  )
-  const runtimeRemoveBusy = runtimeRemoveTarget ? busyAction === runtimeSkillRemoveBusyKey(runtimeRemoveTarget) : false
-  const menuBusy = Boolean(busyAction && !addBusy && !runtimeRemoveBusy)
+  const menuBusy = Boolean(busyAction && !addBusy)
+  const opensManagement = canOpenManagedProviderRecommendation(recommendation)
 
   return (
-    <div className="group/skill-row grid min-w-0 gap-3 border-b border-[var(--oo-divider)] px-3 py-2.5 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center">
-      <OrganizationSkillIconFrame icon={recommendation.package.icon} />
-      <div className="grid min-w-0 gap-0.5">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <div className="oo-text-label min-w-0 truncate text-foreground">{recommendation.package.displayName}</div>
+    <SkillListRow
+      icon={<OrganizationSkillIconFrame icon={recommendation.package.icon} />}
+      showTrailingDivider
+      title={recommendation.package.displayName}
+      description={skillDescription}
+      badges={
+        <>
           <Badge variant="secondary" className="shrink-0">
             {t("organizations.skillManageRecommended")}
           </Badge>
-        </div>
-        {skillDescription ? (
-          <div className="oo-text-caption line-clamp-1 text-foreground/75">{skillDescription}</div>
-        ) : null}
-        <div
-          className="oo-text-caption-compact min-w-0 truncate text-muted-foreground"
-          title={recommendation.packageName}
-        >
+        </>
+      }
+      meta={
+        <div className="min-w-0 truncate" title={recommendation.packageName}>
           {recommendation.providerDisplayName} · {recommendation.packageName} · {recommendation.skillId}
         </div>
-      </div>
-      <div className="flex min-w-0 flex-wrap justify-start gap-2 md:justify-end">
-        {runtimeRemoveTarget ? (
-          <OrganizationRecommendedSkillActionsMenu
-            addBusy={addBusy}
-            busy={menuBusy}
-            canManage={canManage}
-            removeBusy={runtimeRemoveBusy}
-            runtimeRemoveTarget={runtimeRemoveTarget}
-            onAdd={onAdd}
-            onRequestRemoveRuntimeSkill={onRequestRemoveRuntimeSkill}
-          />
-        ) : canInstallRuntime ? (
-          <div className="inline-flex items-center gap-0">
+      }
+      actions={
+        <>
+          {opensManagement ? (
+            <Button type="button" variant="ghost" size="sm" onClick={onOpenManagedSkill}>
+              {t("skills.installedManage")}
+            </Button>
+          ) : null}
+          {canInstallRuntime ? (
             <Button
               type="button"
-              variant={canManage ? "default" : "outline"}
+              variant="outline"
               size="sm"
-              className={cn(canManage && "rounded-r-none")}
               disabled={disabled || installBusy}
               onClick={onInstallRuntime}
             >
               {installBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : <PackageIcon className="size-3.5" />}
               {installBusy ? t("skills.registryInstalling") : t("organizations.skillManageInstallRuntime")}
             </Button>
-            {canManage ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="default"
-                    size="sm"
-                    className="-ml-px w-[var(--oo-control-height-compact)] rounded-l-none border-l border-primary-foreground/25 px-0"
-                    disabled={disabled || addBusy || installBusy}
-                    aria-label={t("organizations.skillManageMoreActions")}
-                  >
-                    <MoreHorizontalIcon className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={() => void onAddAndInstall()}>
-                    {t("organizations.skillManageAddAndInstall")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => void onAdd()}>
-                    {t("organizations.skillManageLinkOnly")}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-          </div>
-        ) : !canManage ? (
-          <Badge variant="outline">{getPublicSkillInstallStateLabel(recommendation.installState, t)}</Badge>
-        ) : (
-          <Button type="button" size="sm" disabled={disabled || addBusy} onClick={() => void onAdd()}>
-            {addBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : null}
-            {t("organizations.skillManageAddOnly")}
-          </Button>
-        )}
-      </div>
-    </div>
+          ) : null}
+          {canManage ? (
+            <Button type="button" size="sm" disabled={menuBusy || addBusy} onClick={() => void onAdd()}>
+              {addBusy ? <RefreshCwIcon className="size-3.5 animate-spin" /> : null}
+              {t("organizations.skillManageAddOnly")}
+            </Button>
+          ) : null}
+        </>
+      }
+      onSelect={opensManagement ? onOpenManagedSkill : onOpenPackageDetail}
+    />
   )
 }

--- a/src/routes/Skills/OrganizationSkillsPane.tsx
+++ b/src/routes/Skills/OrganizationSkillsPane.tsx
@@ -18,6 +18,7 @@ import {
   organizationRuntimeStatusLabel,
   organizationRuntimeStatusTone,
   providerRecommendationSkillDescription,
+  shouldOpenOrganizationSkillManagement,
   shouldShowOrganizationRuntimeStatusOnCard,
 } from "./organization-skill-manage-helpers.ts"
 import { OrganizationRecommendationRemoveConfirmDialog } from "./OrganizationSkillManageRows.tsx"
@@ -84,6 +85,13 @@ export function OrganizationSkillsPane({
     UseOrganizationSkills["skills"][number] | null
   >(null)
   const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null)
+  const openManagedSkill = React.useCallback(
+    (skillName: string) => {
+      setSelectedItemId(null)
+      onOpenManagedSkill(skillName)
+    },
+    [onOpenManagedSkill],
+  )
 
   if (workspace.activeWorkspace.type !== "organization") {
     return (
@@ -223,7 +231,7 @@ export function OrganizationSkillsPane({
                     onInstallRuntime={() =>
                       onInstallRuntimeSkill({ packageName: item.skill.packageName, skillName: item.skill.skillName })
                     }
-                    onOpenManagedSkill={() => onOpenManagedSkill(item.skill.skillName)}
+                    onOpenManagedSkill={() => openManagedSkill(item.skill.skillName)}
                     onSelect={() => setSelectedItemId(item.id)}
                   />
                 ) : (
@@ -238,7 +246,7 @@ export function OrganizationSkillsPane({
                         skillName: item.recommendation.skillId,
                       })
                     }
-                    onOpenManagedSkill={() => onOpenManagedSkill(item.recommendation.skillId)}
+                    onOpenManagedSkill={() => openManagedSkill(item.recommendation.skillId)}
                     onSelect={() => setSelectedItemId(item.id)}
                   />
                 ),
@@ -274,7 +282,7 @@ export function OrganizationSkillsPane({
             onDisableConfiguredSkill={(skill) => void updateOrganizationSkill(skill, { enabled: false })}
             onEnableConfiguredSkill={(skill) => void updateOrganizationSkill(skill, { enabled: true })}
             onInstallRuntimeSkill={onInstallRuntimeSkill}
-            onOpenManagedSkill={onOpenManagedSkill}
+            onOpenManagedSkill={openManagedSkill}
             onRemoveConfiguredSkill={setOrganizationRemoveTarget}
           />
         </SkillManagementSheet>
@@ -440,7 +448,13 @@ function OrganizationConfiguredSkillCard({
           ) : null}
         </>
       }
-      onSelect={onSelect}
+      onSelect={() => {
+        if (shouldOpenOrganizationSkillManagement(runtimeStatus.state)) {
+          onOpenManagedSkill()
+          return
+        }
+        onSelect()
+      }}
     />
   )
 }
@@ -514,7 +528,13 @@ function OrganizationRecommendedSkillCard({
           ) : null}
         </>
       }
-      onSelect={onSelect}
+      onSelect={() => {
+        if (canOpenManage) {
+          onOpenManagedSkill()
+          return
+        }
+        onSelect()
+      }}
     />
   )
 }

--- a/src/routes/Skills/PublicSkillPackageSheet.tsx
+++ b/src/routes/Skills/PublicSkillPackageSheet.tsx
@@ -22,6 +22,7 @@ import { useAppI18n } from "@/i18n"
 import { cn } from "@/lib/utils"
 
 interface PublicSkillPackageSheetProps {
+  additionalActions?: React.ReactNode
   groupById: ManagedSkillGroupById
   installingKey: string | null
   locale: string
@@ -32,6 +33,7 @@ interface PublicSkillPackageSheetProps {
 }
 
 export function PublicSkillPackageSheet({
+  additionalActions,
   groupById,
   installingKey,
   locale,
@@ -126,6 +128,7 @@ export function PublicSkillPackageSheet({
         </div>
         <div className="min-h-0 overflow-auto p-3">
           <PublicSkillPackageDetail
+            additionalActions={additionalActions}
             groupById={groupById}
             installingKey={installingKey}
             locale={locale}
@@ -140,6 +143,7 @@ export function PublicSkillPackageSheet({
 }
 
 interface PublicSkillPackageDetailProps {
+  additionalActions?: React.ReactNode
   className?: string
   groupById: ManagedSkillGroupById
   installingKey: string | null
@@ -150,6 +154,7 @@ interface PublicSkillPackageDetailProps {
 }
 
 function PublicSkillPackageDetail({
+  additionalActions,
   className,
   groupById,
   installingKey,
@@ -214,7 +219,10 @@ function PublicSkillPackageDetail({
                         : t("organizations.skillManageInstallRuntime")}
                 </Button>
               )}
+              {additionalActions}
             </div>
+          ) : additionalActions ? (
+            <div className="flex min-w-0 flex-wrap gap-1">{additionalActions}</div>
           ) : null}
         </CardContent>
       </InspectorCard>

--- a/src/routes/Skills/SkillDetailContent.tsx
+++ b/src/routes/Skills/SkillDetailContent.tsx
@@ -151,6 +151,7 @@ export interface SkillDetailContentProps {
   publishingSkillId: string | null
   requestRemoveSkill: (skill: ManagedSkillGroup) => void
   requestOrganizationLink: (skill: ManagedSkillGroup) => void
+  showPublishAction?: boolean
   showOrganizationLinkAction: boolean
   selectedPlanError: unknown
   selectedSkill: ManagedSkillGroup | undefined
@@ -170,6 +171,7 @@ export function SkillDetailContent({
   publishingSkillId,
   requestRemoveSkill,
   requestOrganizationLink,
+  showPublishAction = true,
   selectedPlanError,
   selectedSkill,
   selectedStatus,
@@ -199,6 +201,7 @@ export function SkillDetailContent({
         selectedSkill={selectedSkill}
         selectedStatus={selectedStatus}
         showOrganizationLinkAction={showOrganizationLinkAction}
+        showPublishAction={showPublishAction}
         selectedVersionCheck={selectedVersionCheck}
         updateRegistrySkill={updateRegistrySkill}
         updatingRegistrySkillId={updatingRegistrySkillId}
@@ -222,6 +225,7 @@ interface SkillPeekProps {
   selectedSkill: ManagedSkillGroup
   selectedStatus: ReturnType<typeof getGroupStatus>
   showOrganizationLinkAction: boolean
+  showPublishAction: boolean
   selectedVersionCheck?: SkillVersionReport["skills"][number]
   updateRegistrySkill: (skill: Pick<ManagedSkillGroup, "id" | "kind" | "packageName">) => void
   updatingRegistrySkillId: string | null
@@ -240,6 +244,7 @@ function SkillPeek({
   selectedSkill,
   selectedStatus,
   showOrganizationLinkAction,
+  showPublishAction,
   selectedVersionCheck,
   updateRegistrySkill,
   updatingRegistrySkillId,
@@ -254,7 +259,7 @@ function SkillPeek({
   const canRestoreRegistrySkill = selectedSkill.kind === "registry" && Boolean(selectedSkill.packageName?.trim())
   const isUpdatingRegistrySkill = updatingRegistrySkillId === selectedSkill.id
   const localPublishPath = getLocalSkillPublishPath(selectedSkill)
-  const canPublishLocalSkill = Boolean(localPublishPath)
+  const canPublishLocalSkill = showPublishAction && Boolean(localPublishPath)
   const isPublishingSkill = publishingSkillId === selectedSkill.id
   const attentionHosts = runtimeHosts.filter(
     (host) => host.controlState === "modified" || host.controlState === "source-missing",

--- a/src/routes/Skills/SkillDetailContent.tsx
+++ b/src/routes/Skills/SkillDetailContent.tsx
@@ -418,7 +418,7 @@ function SkillPeek({
                     {isUpdatingRegistrySkill ? t("skills.updatingRegistry") : t("skills.restoreRegistryVersion")}
                   </Button>
                 ) : null}
-                {localPublishPath ? (
+                {canPublishLocalSkill ? (
                   <Button
                     type="button"
                     variant="outline"

--- a/src/routes/Skills/SkillListRow.tsx
+++ b/src/routes/Skills/SkillListRow.tsx
@@ -7,8 +7,9 @@ interface SkillListRowProps {
   description?: React.ReactNode
   icon: React.ReactNode
   meta?: React.ReactNode
-  onSelect: () => void
+  onSelect?: () => void
   selected?: boolean
+  showTrailingDivider?: boolean
   subtitle?: React.ReactNode
   title: React.ReactNode
 }
@@ -21,33 +22,45 @@ export function SkillListRow({
   meta,
   onSelect,
   selected = false,
+  showTrailingDivider = false,
   subtitle,
   title,
 }: SkillListRowProps) {
+  const content = (
+    <>
+      {icon}
+      <div className="grid min-w-0 gap-0.5">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+          <div className="oo-text-label min-w-0 truncate text-foreground">{title}</div>
+          {subtitle ? <div className="oo-text-caption min-w-0 truncate text-muted-foreground">{subtitle}</div> : null}
+          {badges}
+        </div>
+        {description ? <div className="oo-text-caption line-clamp-1 text-foreground/75">{description}</div> : null}
+        {meta ? <div className="oo-text-caption-compact min-w-0 text-muted-foreground">{meta}</div> : null}
+      </div>
+    </>
+  )
+
   return (
     <div
       className={cn(
-        "oo-list-render-boundary grid min-w-0 gap-2 border-b border-[var(--oo-divider)] px-3 py-2.5 transition-colors last:border-b-0 md:grid-cols-[minmax(0,1fr)_auto] md:items-center",
-        "hover:bg-[var(--oo-row-hover)]",
+        "oo-list-render-boundary grid min-w-0 gap-2 border-b border-[var(--oo-divider)] px-3 py-2.5 transition-colors md:grid-cols-[minmax(0,1fr)_auto] md:items-center",
+        !showTrailingDivider && "last:border-b-0",
+        onSelect && "hover:bg-[var(--oo-row-hover)]",
         selected && "bg-[var(--oo-row-selected)] hover:bg-[var(--oo-row-selected)]",
       )}
     >
-      <button
-        type="button"
-        className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-3 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40"
-        onClick={onSelect}
-      >
-        {icon}
-        <div className="grid min-w-0 gap-0.5">
-          <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
-            <div className="oo-text-label min-w-0 truncate text-foreground">{title}</div>
-            {subtitle ? <div className="oo-text-caption min-w-0 truncate text-muted-foreground">{subtitle}</div> : null}
-            {badges}
-          </div>
-          {description ? <div className="oo-text-caption line-clamp-1 text-foreground/75">{description}</div> : null}
-          {meta ? <div className="oo-text-caption-compact min-w-0 text-muted-foreground">{meta}</div> : null}
-        </div>
-      </button>
+      {onSelect ? (
+        <button
+          type="button"
+          className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-3 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40"
+          onClick={onSelect}
+        >
+          {content}
+        </button>
+      ) : (
+        <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-3 text-left">{content}</div>
+      )}
       {actions ? (
         <div className="flex min-w-0 flex-wrap items-center justify-start gap-2 md:justify-end">{actions}</div>
       ) : null}

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -45,6 +45,7 @@ import {
 import { SkillDetailContent } from "./SkillDetailContent.tsx"
 import { SkillPageHeader } from "./SkillPageHeader.tsx"
 import { OrganizationLinkDialog, PublishSkillDialog } from "./SkillPublishDialogs.tsx"
+import { SkillManagementSheet } from "./SkillUiParts.tsx"
 import { useOrganizationSkillActions } from "./use-organization-skill-actions.ts"
 import { useSkillService } from "@/components/AppContext"
 import {
@@ -155,7 +156,6 @@ export function SkillsRoute({
   const [updatingRegistrySkillId, setUpdatingRegistrySkillId] = React.useState<string | null>(null)
   const [organizationSkillBusyAction, setOrganizationSkillBusyAction] = React.useState<BusyAction | null>(null)
   const [isExecutingCliUpdate, setIsExecutingCliUpdate] = React.useState(false)
-  const [narrowPane, setNarrowPane] = React.useState<"detail" | "list">("list")
   const publishSkillInFlightRef = React.useRef(false)
   const updateRegistryInFlightRef = React.useRef(false)
   const cliUpdateInFlightRef = React.useRef(false)
@@ -167,7 +167,6 @@ export function SkillsRoute({
     useSkillObjectActions({
       onDeleted: () => {
         setSelectedSkillId(null)
-        setNarrowPane("list")
         homeSummaryResource.invalidate()
       },
     })
@@ -195,7 +194,7 @@ export function SkillsRoute({
       return matchesInstalledSkillFilter(group, installedFilter, getSkillVersionCheck(versionCheckByKey, group))
     })
   }, [installedFilter, installedGroups, versionCheckByKey])
-  const selectedSkill = getSelectedManagedSkillGroup(searchedGroups, selectedSkillId)
+  const selectedSkill = getSelectedManagedSkillGroup(inventory?.groups ?? [], selectedSkillId)
   const selectedStatus = selectedSkill ? getGroupStatus(selectedSkill, t, getRuntimeHosts(selectedSkill)) : null
   const selectedVersionCheck = getSkillVersionCheck(versionCheckByKey, selectedSkill)
   const managedOrganizationOptions = React.useMemo<ManagedOrganizationOption[]>(() => {
@@ -254,7 +253,6 @@ export function SkillsRoute({
 
   const selectSkill = React.useCallback((skillId: SkillSelectionKey) => {
     setSelectedSkillId(skillId)
-    setNarrowPane("detail")
   }, [])
 
   const loadPublicSkillPackages = React.useCallback(
@@ -368,11 +366,9 @@ export function SkillsRoute({
   }, [activePackageCatalog.items, activePackageCatalog.selectedId])
 
   const openManagedPublicSkill = React.useCallback((skillName: string) => {
-    setActiveTab("installed")
-    setInstalledFilter("all")
-    setQuery("")
+    dispatchPublicPackageCatalog({ id: null, type: "select" })
+    dispatchMyPublishedPackageCatalog({ id: null, type: "select" })
     setSelectedSkillId(skillName)
-    setNarrowPane("detail")
   }, [])
 
   const installPublicSkill = React.useCallback(
@@ -754,10 +750,8 @@ export function SkillsRoute({
           <InstalledSkillsPane
             cliUpdateError={cliUpdateError}
             cliVersionCheck={versionResource.data?.cli}
-            detailContent={<SkillDetailContent {...detailContentProps} />}
             groups={filteredInstalledGroups}
             isExecutingCliUpdate={isExecutingCliUpdate}
-            isDetailOpen={narrowPane === "detail"}
             updateRegistrySkill={updateRegistrySkill}
             updatingRegistrySkillId={updatingRegistrySkillId}
             versionCheckByKey={versionCheckByKey}
@@ -766,14 +760,16 @@ export function SkillsRoute({
                 ? selectedSkill
                 : undefined
             }
-            onCloseDetail={() => setNarrowPane("list")}
-            onSelectSkill={(skillId) => {
-              selectSkill(skillId)
-            }}
+            onSelectSkill={selectSkill}
             onUpdateCli={executeCliUpdate}
           />
         )}
       </section>
+      {selectedSkill ? (
+        <SkillManagementSheet title={selectedSkill.name} onClose={() => setSelectedSkillId(null)}>
+          <SkillDetailContent {...detailContentProps} />
+        </SkillManagementSheet>
+      ) : null}
       <DeleteSkillConfirmDialog
         isRemoving={isRemovingSkill}
         target={removeTarget}

--- a/src/routes/Skills/organization-skill-manage-helpers.test.ts
+++ b/src/routes/Skills/organization-skill-manage-helpers.test.ts
@@ -7,6 +7,8 @@ import { test } from "vitest"
 import {
   buildInstallableOrganizationRecommendationSkills,
   buildOrganizationSkillRecommendationItems,
+  canOpenManagedProviderRecommendation,
+  shouldOpenOrganizationSkillManagement,
 } from "./organization-skill-manage-helpers.ts"
 
 function organizationSkill(input: Partial<OrganizationSkillConfigItem>): OrganizationSkillConfigItem {
@@ -116,4 +118,25 @@ test("buildInstallableOrganizationRecommendationSkills includes runtime-missing 
     { packageName: "oo-gmail", skillName: "gmail" },
     { packageName: "oo-slack", skillName: "slack" },
   ])
+})
+
+test("downloaded organization skills open management directly", () => {
+  assert.equal(shouldOpenOrganizationSkillManagement("installed-same"), true)
+  assert.equal(shouldOpenOrganizationSkillManagement("installed-modified"), true)
+  assert.equal(shouldOpenOrganizationSkillManagement("installed-version-mismatch"), true)
+  assert.equal(shouldOpenOrganizationSkillManagement("external-only"), true)
+  assert.equal(shouldOpenOrganizationSkillManagement("missing"), false)
+  assert.equal(shouldOpenOrganizationSkillManagement("local-conflict"), false)
+  assert.equal(shouldOpenOrganizationSkillManagement("same-id-different-package"), false)
+  assert.equal(shouldOpenOrganizationSkillManagement("unknown-conflict"), false)
+})
+
+test("provider recommendations use the same direct-management policy as the market", () => {
+  assert.equal(canOpenManagedProviderRecommendation(providerRecommendation({ installState: "installed" })), true)
+  assert.equal(
+    canOpenManagedProviderRecommendation(providerRecommendation({ installState: "external-installed" })),
+    true,
+  )
+  assert.equal(canOpenManagedProviderRecommendation(providerRecommendation({ installState: "name-conflict" })), false)
+  assert.equal(canOpenManagedProviderRecommendation(providerRecommendation({ installState: "installable" })), false)
 })

--- a/src/routes/Skills/organization-skill-manage-helpers.ts
+++ b/src/routes/Skills/organization-skill-manage-helpers.ts
@@ -11,7 +11,11 @@ import {
   organizationSkillPackageKey,
   organizationSkillPackageLinked,
 } from "./organization-management-model.ts"
-import { canInstallPublicSkill, getOrganizationSkillRuntimeStatus } from "./skill-route-model.ts"
+import {
+  canInstallPublicSkill,
+  getOrganizationSkillRuntimeStatus,
+  shouldOpenPublicSkillManagement,
+} from "./skill-route-model.ts"
 
 export function looksLikeSkillPackageName(query: string): boolean {
   const normalized = query.trim()
@@ -79,7 +83,7 @@ export function canInstallProviderRecommendationRuntime(recommendation: Provider
 }
 
 export function canOpenManagedProviderRecommendation(recommendation: ProviderSkillRecommendation): boolean {
-  return recommendation.installState === "installed" || recommendation.installState === "name-conflict"
+  return shouldOpenPublicSkillManagement(recommendation.installState)
 }
 
 export type OrganizationSkillRecommendationItem =
@@ -184,6 +188,15 @@ export function canOpenManagedOrganizationSkill(state: OrganizationSkillRuntimeS
     state === "local-conflict" ||
     state === "same-id-different-package" ||
     state === "unknown-conflict"
+  )
+}
+
+export function shouldOpenOrganizationSkillManagement(state: OrganizationSkillRuntimeState): boolean {
+  return (
+    state === "external-only" ||
+    state === "installed-same" ||
+    state === "installed-modified" ||
+    state === "installed-version-mismatch"
   )
 }
 

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -15,6 +15,7 @@ import {
   isEmojiIcon,
   matchesInstalledSkillFilter,
   publicPackageCatalogReducer,
+  shouldOpenPublicSkillManagement,
   skillDocumentPreviewSource,
 } from "./skill-route-model.ts"
 
@@ -97,6 +98,15 @@ test("external installed public skills remain installable into Wanta", () => {
 
   assert.equal(getPublicSkillInstallState(groupById, pkg, "demo"), "external-installed")
   assert.equal(getPublicPackageInstallState(groupById, pkg), "external-installed")
+})
+
+test("downloaded public skills open management directly", () => {
+  assert.equal(shouldOpenPublicSkillManagement("installed"), true)
+  assert.equal(shouldOpenPublicSkillManagement("external-installed"), true)
+  assert.equal(shouldOpenPublicSkillManagement("partially-installed"), false)
+  assert.equal(shouldOpenPublicSkillManagement("name-conflict"), false)
+  assert.equal(shouldOpenPublicSkillManagement("installable"), false)
+  assert.equal(shouldOpenPublicSkillManagement("unavailable"), false)
 })
 
 test("mixed installed and external public skills remain installable into Wanta", () => {

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -705,6 +705,10 @@ export function canInstallPublicSkill(state: PublicSkillInstallState): boolean {
   return state === "installable" || state === "partially-installed" || state === "external-installed"
 }
 
+export function shouldOpenPublicSkillManagement(state: PublicSkillInstallState): boolean {
+  return state === "installed" || state === "external-installed"
+}
+
 export function getPublicSkillInstallKey(pkg: PublicSkillPackage, skillName: string | undefined): string {
   return `${pkg.id}:${skillName ?? ""}`
 }


### PR DESCRIPTION
## Summary

This PR unifies skill discovery and management across the Skills route and the organization recommendation/market views.

Previously, managing an installed marketplace skill changed the underlying tab before opening its management UI. Organization skill rows also used different actions and interaction patterns, which made the same skill behave differently depending on where the user encountered it.

The changes keep the current list context stable and choose the side-panel view from the local installation state. Installed skills open the full management view directly, while uninstalled skills open the package detail view with local installation actions. Organization-level recommendation controls remain permission-gated, but local installation and removal remain available independently of organization ownership.

## Changes

- Keep the active Skills tab unchanged when opening an installed skill for management.
- Open installed marketplace and organization skills directly in the shared management sheet.
- Open uninstalled organization recommendations and marketplace packages in the shared package detail sheet.
- Add an organization-aware recommendation action to package details when the current member can manage the organization.
- Separate local runtime installation state from organization recommendation state and permissions.
- Replace ambiguous primary overflow actions with explicit Manage actions; keep secondary organization controls in the overflow menu.
- Share the skill list-row layout, spacing, hover behavior, and divider styling across both surfaces.
- Preserve local skill update, path, source preview, and removal controls in the organization management sheet.
- Scope registry update errors to the selected skill and clear stale panels when switching organizations.
- Track local installation and organization recommendation busy states independently.

## User impact

Users now learn one consistent interaction model: an installed skill opens management, an uninstalled skill opens details, and organization permissions only affect organization data changes. Opening a side panel no longer causes a surprising tab switch or loses the user's current browsing context.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 191 test files and 1288 tests passed
- `git diff --check`
