### PR TITLE
fix(billing): scope Wanta plans to teams

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -71,6 +71,7 @@ import { useProjectGit } from "@/hooks/useProjectGit"
 import { useSessions } from "@/hooks/useSessions"
 import { useT } from "@/i18n/i18n"
 import { appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
+import { billingRequestScopeForWorkspace } from "@/lib/billing-scope"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
@@ -1040,6 +1041,10 @@ export function AppShell({ auth }: { auth: UseAuth }) {
       ? `organization:${organizationWorkspace.activeWorkspace.organizationId}`
       : "personal"
   const billingCacheScope = `${auth.state?.account?.id ?? "authenticated"}:${billingWorkspaceCacheScope}`
+  const billingRequestScope = React.useMemo(
+    () => billingRequestScopeForWorkspace(organizationWorkspace.activeWorkspace),
+    [organizationWorkspace.activeWorkspace],
+  )
   const newChatShortcut = appCommandShortcutLabel(APP_COMMANDS.newChat)
   const newChatLabel = labelWithShortcut(
     sidebarSegment === "projects" && activeProject ? t("project.newTask") : t("sidebar.newSession"),
@@ -1238,6 +1243,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                     <ChatArea
                       activeSessionId={activeChatSessionId}
                       billingCacheScope={billingCacheScope}
+                      billingRequestScope={billingRequestScope}
                       composerDraftKey={activeComposerDraftKey}
                       messages={bridgeInitialSendPending ? [] : messages}
                       permissionMode={displayedPermissionMode}

--- a/src/components/app-shell/BillingUsagePopover.tsx
+++ b/src/components/app-shell/BillingUsagePopover.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@/hooks/useAuth"
 import { useBillableSeats } from "@/hooks/useBillableSeats"
 import { useBillingOverview } from "@/hooks/useBillingOverview"
 import { useT } from "@/i18n/i18n"
+import { billingRequestScopeForWorkspace, canManageWantaBilling } from "@/lib/billing-scope"
 import { cn } from "@/lib/utils"
 import { buildCategorySummaries, formatCredit, getSummary, statsTotalCredit, toNumber } from "@/routes/Billing/usage.ts"
 import { buildWantaSubscriptionOverview } from "@/routes/Billing/wanta-subscription-model.ts"
@@ -46,9 +47,11 @@ export function BillingUsagePopover({
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
   const [open, setOpen] = React.useState(false)
   const seatState = useBillableSeats(workspace, open)
+  const billingRequestScope = React.useMemo(() => billingRequestScopeForWorkspace(workspace), [workspace])
   const { data, error, loading, refresh } = useBillingOverview(usagePeriodDays, {
     cacheScope,
     enabled: open,
+    requestScope: billingRequestScope,
     staleMs: cacheFreshMs,
   })
   // 会话过期后全局登录态会失效：重新登录刷新会话，而非误导用户去充值。
@@ -82,6 +85,7 @@ export function BillingUsagePopover({
   const coverageDays = averageDailySpend > 0 ? Math.floor(currentCredit / averageDailySpend) : 0
   const modelSpend = getSummary(summaries, "model").credit
   const connectorSpend = getSummary(summaries, "link").credit
+  const showWantaPlanSection = canManageWantaBilling(workspace)
   const billableSeats = workspace.type === "organization" ? Math.max(1, seatState.count ?? 1) : 1
   const wantaOverview = React.useMemo(
     () =>
@@ -94,10 +98,18 @@ export function BillingUsagePopover({
       }),
     [billableSeats, data?.subscription, data?.wantaPendingPayment, sharedConnectorCount, workspace],
   )
-  const showPlanPrompt = Boolean(data && !error && wantaOverview.recommendedAction === "choose_plan")
-  const showPendingPaymentPrompt = Boolean(data && !error && wantaOverview.recommendedAction === "continue_payment")
-  const showUpgradePrompt = Boolean(data && !error && wantaOverview.recommendedAction === "upgrade_plan")
-  const showSeatPrompt = Boolean(data && !error && wantaOverview.recommendedAction === "add_seats")
+  const showPlanPrompt = Boolean(
+    showWantaPlanSection && data && !error && wantaOverview.recommendedAction === "choose_plan",
+  )
+  const showPendingPaymentPrompt = Boolean(
+    showWantaPlanSection && data && !error && wantaOverview.recommendedAction === "continue_payment",
+  )
+  const showUpgradePrompt = Boolean(
+    showWantaPlanSection && data && !error && wantaOverview.recommendedAction === "upgrade_plan",
+  )
+  const showSeatPrompt = Boolean(
+    showWantaPlanSection && data && !error && wantaOverview.recommendedAction === "add_seats",
+  )
   const availableShare =
     originalCredit > 0
       ? Math.max(0, Math.min(100, (currentCredit / originalCredit) * 100))
@@ -195,64 +207,66 @@ export function BillingUsagePopover({
               <BillingUsageSkeleton />
             ) : (
               <>
-                <section className="rounded-lg border border-border p-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="oo-text-label flex items-center gap-2 text-foreground">
-                        <ShieldCheckIcon className="size-4 text-muted-foreground" />
-                        <span>
-                          {wantaOverview.currentPlan
-                            ? wantaPlanLabel(wantaOverview.currentPlan, t)
-                            : t("billing.wantaNoPlan")}
-                        </span>
+                {showWantaPlanSection ? (
+                  <section className="rounded-lg border border-border p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="oo-text-label flex items-center gap-2 text-foreground">
+                          <ShieldCheckIcon className="size-4 text-muted-foreground" />
+                          <span>
+                            {wantaOverview.currentPlan
+                              ? wantaPlanLabel(wantaOverview.currentPlan, t)
+                              : t("billing.wantaNoPlan")}
+                          </span>
+                        </div>
+                        <div className="oo-text-caption-compact mt-1 text-muted-foreground">
+                          {seatState.loading
+                            ? t("billing.popover.planSeatsLoading")
+                            : wantaOverview.seatCapacity === null
+                              ? t("billing.popover.planMembers", { count: wantaOverview.usedSeats })
+                              : t("billing.popover.planSeats", {
+                                  count: wantaOverview.usedSeats,
+                                  limit: wantaOverview.seatCapacity,
+                                })}
+                          {sharedConnectorCount === undefined
+                            ? ""
+                            : ` · ${t("billing.popover.sharedLinks", { count: sharedConnectorCount })}`}
+                        </div>
                       </div>
-                      <div className="oo-text-caption-compact mt-1 text-muted-foreground">
-                        {seatState.loading
-                          ? t("billing.popover.planSeatsLoading")
-                          : wantaOverview.seatCapacity === null
-                            ? t("billing.popover.planMembers", { count: wantaOverview.usedSeats })
-                            : t("billing.popover.planSeats", {
-                                count: wantaOverview.usedSeats,
-                                limit: wantaOverview.seatCapacity,
-                              })}
-                        {sharedConnectorCount === undefined
-                          ? ""
-                          : ` · ${t("billing.popover.sharedLinks", { count: sharedConnectorCount })}`}
-                      </div>
+                      <PlanStatusBadge
+                        clickable={wantaOverview.currentPlan === null}
+                        label={
+                          wantaOverview.hasPendingPayment
+                            ? t("billing.wantaPaymentPending")
+                            : showSeatPrompt
+                              ? t("billing.popover.seatLimitHint")
+                              : showUpgradePrompt
+                                ? t("billing.popover.upgradeHint")
+                                : wantaOverview.currentPlan === null
+                                  ? t("billing.popover.planInactive")
+                                  : t("billing.popover.planActive")
+                        }
+                        variant={
+                          wantaOverview.hasPendingPayment || showUpgradePrompt || showPlanPrompt || showSeatPrompt
+                            ? "default"
+                            : "outline"
+                        }
+                        onClick={() => openDetails("plans")}
+                      />
                     </div>
-                    <PlanStatusBadge
-                      clickable={wantaOverview.currentPlan === null}
-                      label={
-                        wantaOverview.hasPendingPayment
-                          ? t("billing.wantaPaymentPending")
-                          : showSeatPrompt
-                            ? t("billing.popover.seatLimitHint")
+                    <p className="oo-text-caption mt-3 text-muted-foreground">
+                      {wantaOverview.hasPendingPayment
+                        ? t("billing.popover.pendingPaymentRecommendation")
+                        : showSeatPrompt
+                          ? t("billing.popover.seatRecommendation")
+                          : wantaOverview.currentPlan === null
+                            ? t("billing.popover.noPlanRecommendation")
                             : showUpgradePrompt
-                              ? t("billing.popover.upgradeHint")
-                              : wantaOverview.currentPlan === null
-                                ? t("billing.popover.planInactive")
-                                : t("billing.popover.planActive")
-                      }
-                      variant={
-                        wantaOverview.hasPendingPayment || showUpgradePrompt || showPlanPrompt || showSeatPrompt
-                          ? "default"
-                          : "outline"
-                      }
-                      onClick={() => openDetails("plans")}
-                    />
-                  </div>
-                  <p className="oo-text-caption mt-3 text-muted-foreground">
-                    {wantaOverview.hasPendingPayment
-                      ? t("billing.popover.pendingPaymentRecommendation")
-                      : showSeatPrompt
-                        ? t("billing.popover.seatRecommendation")
-                        : wantaOverview.currentPlan === null
-                          ? t("billing.popover.noPlanRecommendation")
-                          : showUpgradePrompt
-                            ? t("billing.popover.proRecommendation")
-                            : t("billing.popover.planDescription")}
-                  </p>
-                </section>
+                              ? t("billing.popover.proRecommendation")
+                              : t("billing.popover.planDescription")}
+                    </p>
+                  </section>
+                ) : null}
 
                 <section className="grid gap-3">
                   <div className="flex items-start justify-between gap-3">

--- a/src/hooks/useBillingOverview.ts
+++ b/src/hooks/useBillingOverview.ts
@@ -1,4 +1,5 @@
 import type { BillingOverviewResult, BillingPeriodDays } from "../../electron/chat/common.ts"
+import type { BillingRequestScope } from "../lib/billing-client.ts"
 import type { UserFacingError } from "../lib/user-facing-error.ts"
 
 import * as React from "react"
@@ -17,6 +18,7 @@ interface BillingOverviewCacheEntry {
 export interface UseBillingOverviewOptions {
   cacheScope?: string
   enabled?: boolean
+  requestScope?: BillingRequestScope | null
   staleMs?: number
 }
 
@@ -35,11 +37,24 @@ const overviewCache = new Map<string, Map<BillingPeriodDays, BillingOverviewCach
 
 export function useBillingOverview(
   days: BillingPeriodDays,
-  { cacheScope = "default", enabled = true, staleMs = defaultStaleMs }: UseBillingOverviewOptions = {},
+  {
+    cacheScope = "default",
+    enabled = true,
+    requestScope = { type: "personal" },
+    staleMs = defaultStaleMs,
+  }: UseBillingOverviewOptions = {},
 ): UseBillingOverview {
   // 顶部浮层、购买弹窗和账单详情页展示的是同一个账单实体，只是读取字段不同。缓存边界
   // 必须按账号/工作区（由调用方的 cacheScope 提供）划分，不能再按页面展示形态拆成两份。
-  const cacheScopeKey = cacheScope
+  const requestCanManageBilling = requestScope?.type === "organization" ? requestScope.canManageBilling : false
+  const requestOrganizationId = requestScope?.type === "organization" ? requestScope.organizationId : ""
+  const requestOrganizationName = requestScope?.type === "organization" ? requestScope.organizationName : ""
+  const requestScopeType = requestScope?.type ?? "blocked"
+  const requestScopeKey =
+    requestScopeType === "organization"
+      ? `organization:${requestOrganizationId}:${requestOrganizationName}:${requestCanManageBilling}`
+      : requestScopeType
+  const cacheScopeKey = `${cacheScope}\u0000${requestScopeKey}`
   const [data, setData] = React.useState<BillingOverviewResult | null>(() => cachedData(cacheScopeKey, days))
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<UserFacingError | null>(null)
@@ -62,6 +77,9 @@ export function useBillingOverview(
 
   const refresh = React.useCallback(
     async ({ force = false }: RefreshBillingOverviewOptions = {}): Promise<BillingOverviewResult | null> => {
+      if (requestScopeType === "blocked") {
+        return null
+      }
       const currentRequest = requestId.current + 1
       requestId.current = currentRequest
       const entry = cacheEntry(cacheScopeKey, days)
@@ -75,7 +93,16 @@ export function useBillingOverview(
       setError(null)
 
       // 手动刷新也复用已在途请求，避免浮层、详情页或重试按钮同时触发时又发起一套账单聚合请求。
-      const promise = entry.promise ?? startBillingOverviewRequest(entry, () => getBillingOverview(days))
+      const scope: BillingRequestScope =
+        requestScopeType === "organization"
+          ? {
+              canManageBilling: requestCanManageBilling,
+              organizationId: requestOrganizationId,
+              organizationName: requestOrganizationName,
+              type: "organization",
+            }
+          : { type: "personal" }
+      const promise = entry.promise ?? startBillingOverviewRequest(entry, () => getBillingOverview(days, scope))
 
       try {
         const nextData = await promise
@@ -103,14 +130,22 @@ export function useBillingOverview(
         }
       }
     },
-    [cacheScopeKey, days, staleMs],
+    [
+      cacheScopeKey,
+      days,
+      requestCanManageBilling,
+      requestOrganizationId,
+      requestOrganizationName,
+      requestScopeType,
+      staleMs,
+    ],
   )
 
   React.useEffect(() => {
-    if (enabled) {
+    if (enabled && requestScopeType !== "blocked") {
       void refresh()
     }
-  }, [enabled, refresh])
+  }, [enabled, refresh, requestScopeType])
 
   return { data, loading, error, refresh }
 }

--- a/src/lib/billing-client.test.ts
+++ b/src/lib/billing-client.test.ts
@@ -31,7 +31,7 @@ function urlOf(input: string | URL | Request): URL {
 function stubWantaSubscriptionFetch(data: Record<string, unknown>): { requestBody: () => string } {
   let body = ""
   vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
-    expect(urlOf(input).pathname).toBe("/api/user/subscriptions/wanta")
+    expect(urlOf(input).pathname).toBe("/api/org/team-1/subscriptions/wanta")
     body = String(init?.body ?? "")
     return Response.json({ data, success: true })
   })
@@ -58,10 +58,10 @@ describe("billing-client", () => {
     let status = 401
     vi.stubGlobal("fetch", async () => new Response("nope", { status }))
 
-    expect((await rejection(() => getCreditBalance())).message).toBe(billingAuthRequiredMessage)
+    expect((await rejection(() => getCreditBalance({ type: "personal" }))).message).toBe(billingAuthRequiredMessage)
 
     status = 403
-    const error = await rejection(() => getCreditBalance())
+    const error = await rejection(() => getCreditBalance({ type: "personal" }))
     expect(error.message).not.toBe(billingAuthRequiredMessage)
     expect(error).toBeInstanceOf(OomolHttpError)
     expect((error as OomolHttpError).status).toBe(403)
@@ -79,9 +79,12 @@ describe("billing-client", () => {
     expect((await rejection(() => getBillingSummary(30))).message).toBe(billingAuthRequiredMessage)
   })
 
-  it("includes pending Wanta payment in lightweight billing summaries", async () => {
-    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+  it("scopes organization billing reads and includes pending Wanta payment", async () => {
+    vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
       const url = urlOf(input)
+      if (url.hostname === "insight.oomol.com") {
+        expect(new Headers(init?.headers).get("x-oo-organization-name")).toBe("acme")
+      }
       if (url.pathname === "/v1/balance/available") {
         return Response.json({
           data: {
@@ -94,7 +97,7 @@ describe("billing-client", () => {
       if (url.pathname === "/v1/stats/billing" || url.pathname === "/v1/stats/metering") {
         return Response.json({ data: { items: [], sourceTotals: {}, total: { eventCount: 0, totalCredit: "0" } } })
       }
-      if (url.pathname === "/api/user/subscriptions") {
+      if (url.pathname === "/api/org/team-1/subscriptions") {
         return Response.json({
           data: {
             features: [],
@@ -106,7 +109,7 @@ describe("billing-client", () => {
           success: true,
         })
       }
-      if (url.pathname === "/api/user/subscriptions/wanta/pending_payment") {
+      if (url.pathname === "/api/org/team-1/subscriptions/wanta/pending_payment") {
         return Response.json({
           data: {
             additionalSeats: 2,
@@ -129,10 +132,39 @@ describe("billing-client", () => {
       throw new Error(`Unexpected billing test URL: ${url.pathname}`)
     })
 
-    const summary = await getBillingSummary(30)
+    const summary = await getBillingSummary(30, {
+      canManageBilling: true,
+      organizationId: "team-1",
+      organizationName: "acme",
+      type: "organization",
+    })
 
     expect(summary.wantaPendingPayment?.paymentURL).toBe("https://console.example.com/wanta-pay")
     expect(summary.wantaPendingPayment?.additionalSeats).toBe(2)
+    expect(summary.subscription?.plan).toBe("wanta_plus")
+  })
+
+  it("does not request organization subscriptions for members without billing permission", async () => {
+    const paths: string[] = []
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = urlOf(input)
+      paths.push(url.pathname)
+      if (url.pathname === "/v1/balance/available") {
+        return Response.json({ data: { items: [], total: { currentCredit: "0", originalCredit: "0" } } })
+      }
+      return Response.json({ data: { items: [], sourceTotals: {}, total: { eventCount: 0, totalCredit: "0" } } })
+    })
+
+    const summary = await getBillingSummary(30, {
+      canManageBilling: false,
+      organizationId: "team-1",
+      organizationName: "acme",
+      type: "organization",
+    })
+
+    expect(paths.some((path) => path.startsWith("/api/org/"))).toBe(false)
+    expect(summary.subscription).toBeNull()
+    expect(summary.wantaPendingPayment).toBeNull()
   })
 
   it("resolves the console top-up checkout URL", async () => {
@@ -146,8 +178,9 @@ describe("billing-client", () => {
   })
 
   it("reads wrapped balance payloads for payment-required recovery", async () => {
-    vi.stubGlobal("fetch", async () =>
-      Response.json({
+    vi.stubGlobal("fetch", async (_input: string | URL | Request, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("x-oo-organization-name")).toBe("acme")
+      return Response.json({
         data: {
           items: [
             { currentCredit: "7.5", originalCredit: "10", serviceScope: "general" },
@@ -155,10 +188,15 @@ describe("billing-client", () => {
           ],
           total: { currentCredit: "27.5", originalCredit: "30" },
         },
-      }),
-    )
+      })
+    })
 
-    const result = await getCreditBalance()
+    const result = await getCreditBalance({
+      canManageBilling: true,
+      organizationId: "team-1",
+      organizationName: "acme",
+      type: "organization",
+    })
 
     expect(result).toEqual({ balance: "$7.5", hasCredits: true })
   })
@@ -175,7 +213,7 @@ describe("billing-client", () => {
       targetPlan: "wanta_plus",
     })
 
-    const result = await updateWantaSubscription({ additional_seats: 0, plan: "wanta_plus" })
+    const result = await updateWantaSubscription("team-1", { additional_seats: 0, plan: "wanta_plus" })
 
     expect(JSON.parse(request.requestBody())).toEqual({ additional_seats: 0, plan: "wanta_plus" })
     expect(result.paymentURL).toBe("https://console.example.com/wanta-checkout")
@@ -184,7 +222,7 @@ describe("billing-client", () => {
   it("requests a Wanta plan preview before submission", async () => {
     let body = ""
     vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
-      expect(urlOf(input).pathname).toBe("/api/user/subscriptions/wanta/preview")
+      expect(urlOf(input).pathname).toBe("/api/org/team%2Fa%20b/subscriptions/wanta/preview")
       body = String(init?.body ?? "")
       return Response.json({
         data: {
@@ -200,7 +238,7 @@ describe("billing-client", () => {
       })
     })
 
-    const preview = await previewWantaSubscription({ additional_seats: 0, plan: "wanta_plus" })
+    const preview = await previewWantaSubscription("team/a b", { additional_seats: 0, plan: "wanta_plus" })
 
     expect(JSON.parse(body)).toEqual({ additional_seats: 0, plan: "wanta_plus" })
     expect(preview).toEqual({
@@ -226,7 +264,7 @@ describe("billing-client", () => {
       targetPlan: null,
     })
 
-    const result = await updateWantaSubscription({ additional_seats: 1 })
+    const result = await updateWantaSubscription("team-1", { additional_seats: 1 })
 
     expect(JSON.parse(request.requestBody())).toEqual({ additional_seats: 1 })
     expect(result.paymentURL).toBe("https://console.example.com/wanta-seat-checkout")

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -30,6 +30,15 @@ const billingOptionalRequestSoftTimeoutMs = 3_000
 const billingCreditUsagesMaxPages = 100
 export const wantaSubscriptionPlans: readonly WantaSubscriptionPlan[] = ["wanta_plus", "wanta_pro"]
 
+export type BillingRequestScope =
+  | { type: "personal" }
+  | {
+      canManageBilling: boolean
+      organizationId: string
+      organizationName: string
+      type: "organization"
+    }
+
 /** 会话过期/缺失的哨兵文案（与 oomol-http 的 authRequiredMessage 同字面量）；resolveUserFacingError 据此归为 auth_required。 */
 export const billingAuthRequiredMessage = authRequiredMessage
 
@@ -375,25 +384,35 @@ function settleWithSoftTimeout<T>(
   })
 }
 
-function fetchAuthenticatedJson(url: URL): Promise<unknown> {
-  return oomolFetchJson<unknown>(url, { timeoutMs: billingRequestTimeoutMs })
+function billingScopeHeaders(scope: BillingRequestScope): HeadersInit | undefined {
+  if (scope.type !== "organization" || !scope.organizationName.trim()) {
+    return undefined
+  }
+  return { "x-oo-organization-name": scope.organizationName }
 }
 
-export async function getCreditBalance(): Promise<CreditBalanceResult> {
+function fetchAuthenticatedJson(url: URL, scope: BillingRequestScope = { type: "personal" }): Promise<unknown> {
+  return oomolFetchJson<unknown>(url, {
+    headers: billingScopeHeaders(scope),
+    timeoutMs: billingRequestTimeoutMs,
+  })
+}
+
+export async function getCreditBalance(scope: BillingRequestScope): Promise<CreditBalanceResult> {
   const url = new URL("/v1/balance/available", insightBaseUrl)
-  return readCreditBalance(unwrapApiData<unknown>(await fetchAuthenticatedJson(url)))
+  return readCreditBalance(unwrapApiData<unknown>(await fetchAuthenticatedJson(url, scope)))
 }
 
-async function getCreditUsages(nextToken?: string): Promise<CreditUsages> {
+async function getCreditUsages(scope: BillingRequestScope, nextToken?: string): Promise<CreditUsages> {
   const url = new URL("/v1/balance/available", insightBaseUrl)
   if (nextToken) {
     url.searchParams.set("nextToken", nextToken)
   }
-  return readCreditUsages(unwrapApiData<unknown>(await fetchAuthenticatedJson(url)))
+  return readCreditUsages(unwrapApiData<unknown>(await fetchAuthenticatedJson(url, scope)))
 }
 
-async function getAllCreditUsages(): Promise<CreditUsages> {
-  const firstPage = await getCreditUsages()
+async function getAllCreditUsages(scope: BillingRequestScope): Promise<CreditUsages> {
+  const firstPage = await getCreditUsages(scope)
   const items = [...firstPage.items]
   let nextToken = firstPage.nextToken
   let pageCount = 1
@@ -404,7 +423,7 @@ async function getAllCreditUsages(): Promise<CreditUsages> {
       break
     }
     seenTokens.add(nextToken)
-    const nextPage = await getCreditUsages(nextToken)
+    const nextPage = await getCreditUsages(scope, nextToken)
     if (nextPage.items.length === 0) {
       break
     }
@@ -415,44 +434,63 @@ async function getAllCreditUsages(): Promise<CreditUsages> {
   return { ...firstPage, items, nextToken: undefined }
 }
 
-async function getCreditSpendStats(days: number): Promise<BillingSpendStats> {
+async function getCreditSpendStats(days: number, scope: BillingRequestScope): Promise<BillingSpendStats> {
   const { endTime, startTime } = statsRange(days)
   const url = new URL("/v1/stats/billing", insightBaseUrl)
   url.searchParams.set("granularity", "daily")
   url.searchParams.set("startTime", String(startTime))
   url.searchParams.set("endTime", String(endTime))
-  return unwrapApiData<BillingSpendStats>(await fetchAuthenticatedJson(url))
+  return unwrapApiData<BillingSpendStats>(await fetchAuthenticatedJson(url, scope))
 }
 
-async function getCreditMeteringStats(days: number): Promise<BillingSpendStats> {
+async function getCreditMeteringStats(days: number, scope: BillingRequestScope): Promise<BillingSpendStats> {
   const { endTime, startTime } = statsRange(days)
   const url = new URL("/v1/stats/metering", insightBaseUrl)
   url.searchParams.set("granularity", "daily")
   url.searchParams.set("startTime", String(startTime))
   url.searchParams.set("endTime", String(endTime))
-  return unwrapApiData<BillingSpendStats>(await fetchAuthenticatedJson(url))
+  return unwrapApiData<BillingSpendStats>(await fetchAuthenticatedJson(url, scope))
 }
 
-async function getSubscriptionStatus(): Promise<SubscriptionStatus> {
-  const url = new URL("/api/user/subscriptions", consoleServerBaseUrl)
+async function getSubscriptionStatus(scope: BillingRequestScope): Promise<SubscriptionStatus | null> {
+  if (scope.type === "organization" && !scope.canManageBilling) {
+    return null
+  }
+  const path =
+    scope.type === "organization"
+      ? `/api/org/${encodeURIComponent(scope.organizationId)}/subscriptions`
+      : "/api/user/subscriptions"
+  const url = new URL(path, consoleServerBaseUrl)
   return unwrapConsoleData<SubscriptionStatus>(await fetchAuthenticatedJson(url))
 }
 
-async function getWantaPendingPayment(): Promise<WantaPendingPaymentResult | null> {
-  const url = new URL("/api/user/subscriptions/wanta/pending_payment", consoleServerBaseUrl)
+async function getWantaPendingPayment(scope: BillingRequestScope): Promise<WantaPendingPaymentResult | null> {
+  if (scope.type !== "organization" || !scope.canManageBilling) {
+    return null
+  }
+  const url = new URL(
+    `/api/org/${encodeURIComponent(scope.organizationId)}/subscriptions/wanta/pending_payment`,
+    consoleServerBaseUrl,
+  )
   return readWantaPendingPayment(await fetchAuthenticatedJson(url))
 }
 
-export async function getBillingSummary(days: number): Promise<BillingSummaryResult> {
-  return getBillingOverview(days)
+export async function getBillingSummary(
+  days: number,
+  scope: BillingRequestScope = { type: "personal" },
+): Promise<BillingSummaryResult> {
+  return getBillingOverview(days, scope)
 }
 
-export async function getBillingOverview(days: number): Promise<BillingOverviewResult> {
-  const balancePromise = getAllCreditUsages()
-  const spendPromise = getCreditSpendStats(days)
-  const meteringPromise = getCreditMeteringStats(days)
-  const subscriptionPromise = getSubscriptionStatus()
-  const wantaPendingPaymentPromise = getWantaPendingPayment()
+export async function getBillingOverview(
+  days: number,
+  scope: BillingRequestScope = { type: "personal" },
+): Promise<BillingOverviewResult> {
+  const balancePromise = getAllCreditUsages(scope)
+  const spendPromise = getCreditSpendStats(days, scope)
+  const meteringPromise = getCreditMeteringStats(days, scope)
+  const subscriptionPromise = getSubscriptionStatus(scope)
+  const wantaPendingPaymentPromise = getWantaPendingPayment(scope)
 
   preventEarlyUnhandledRejection(subscriptionPromise)
   preventEarlyUnhandledRejection(wantaPendingPaymentPromise)
@@ -484,9 +522,10 @@ export async function getBillingOverview(days: number): Promise<BillingOverviewR
 }
 
 export async function updateWantaSubscription(
+  organizationId: string,
   payload: WantaSubscriptionChangePayload,
 ): Promise<WantaSubscriptionUpdateResult> {
-  const url = new URL("/api/user/subscriptions/wanta", consoleServerBaseUrl)
+  const url = new URL(`/api/org/${encodeURIComponent(organizationId)}/subscriptions/wanta`, consoleServerBaseUrl)
   return readWantaSubscriptionUpdate(
     await oomolFetchJson<unknown>(url, {
       body: JSON.stringify(payload),
@@ -498,9 +537,13 @@ export async function updateWantaSubscription(
 }
 
 export async function previewWantaSubscription(
+  organizationId: string,
   payload: WantaSubscriptionChangePayload,
 ): Promise<WantaSubscriptionPreviewResult> {
-  const url = new URL("/api/user/subscriptions/wanta/preview", consoleServerBaseUrl)
+  const url = new URL(
+    `/api/org/${encodeURIComponent(organizationId)}/subscriptions/wanta/preview`,
+    consoleServerBaseUrl,
+  )
   return readWantaSubscriptionPreview(
     await oomolFetchJson<unknown>(url, {
       body: JSON.stringify(payload),

--- a/src/lib/billing-scope.test.ts
+++ b/src/lib/billing-scope.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { billingRequestScopeForWorkspace, canManageWantaBilling } from "./billing-scope.ts"
+
+describe("billingRequestScopeForWorkspace", () => {
+  it("keeps personal billing unscoped", () => {
+    expect(billingRequestScopeForWorkspace({ type: "personal" })).toEqual({ type: "personal" })
+    expect(canManageWantaBilling({ type: "personal" })).toBe(false)
+  })
+
+  it("carries both organization identifiers and billing permission", () => {
+    const workspace = {
+      canManage: true,
+      organization: {
+        avatar: "",
+        creator_user_id: "user-1",
+        id: "team-1",
+        name: "acme",
+        role: "creator" as const,
+      },
+      organizationId: "team-1",
+      role: "creator" as const,
+      type: "organization" as const,
+    }
+    expect(billingRequestScopeForWorkspace(workspace)).toEqual({
+      canManageBilling: true,
+      organizationId: "team-1",
+      organizationName: "acme",
+      type: "organization",
+    })
+    expect(canManageWantaBilling(workspace)).toBe(true)
+  })
+
+  it("keeps organization members out of Wanta plan management", () => {
+    const workspace = {
+      canManage: false,
+      organization: {
+        avatar: "",
+        creator_user_id: "user-1",
+        id: "team-1",
+        name: "acme",
+        role: "member" as const,
+      },
+      organizationId: "team-1",
+      role: "member" as const,
+      type: "organization" as const,
+    }
+    expect(canManageWantaBilling(workspace)).toBe(false)
+    expect(billingRequestScopeForWorkspace(workspace)).toEqual({
+      canManageBilling: false,
+      organizationId: "team-1",
+      organizationName: "acme",
+      type: "organization",
+    })
+  })
+
+  it("waits for organization metadata before enabling billing", () => {
+    const workspace = {
+      canManage: true,
+      organization: null,
+      organizationId: "team-1",
+      role: "creator" as const,
+      type: "organization" as const,
+    }
+    expect(canManageWantaBilling(workspace)).toBe(false)
+    expect(billingRequestScopeForWorkspace(workspace)).toBeNull()
+  })
+})

--- a/src/lib/billing-scope.ts
+++ b/src/lib/billing-scope.ts
@@ -1,0 +1,24 @@
+import type { WorkspaceSelection } from "@/hooks/useOrganizationWorkspace"
+import type { BillingRequestScope } from "@/lib/billing-client"
+
+type OrganizationWorkspaceSelection = Extract<WorkspaceSelection, { type: "organization" }>
+
+export function canManageWantaBilling(workspace: WorkspaceSelection): workspace is OrganizationWorkspaceSelection {
+  return workspace.type === "organization" && workspace.canManage && Boolean(workspace.organization?.name.trim())
+}
+
+/** 账单读取同时按组织 ID（订阅）与组织名（Insight header）绑定当前工作区。 */
+export function billingRequestScopeForWorkspace(workspace: WorkspaceSelection): BillingRequestScope | null {
+  if (workspace.type !== "organization") {
+    return { type: "personal" }
+  }
+  if (!workspace.organization?.name.trim()) {
+    return null
+  }
+  return {
+    canManageBilling: workspace.canManage,
+    organizationId: workspace.organizationId,
+    organizationName: workspace.organization.name,
+    type: "organization",
+  }
+}

--- a/src/routes/Billing/CreditPurchaseModal.tsx
+++ b/src/routes/Billing/CreditPurchaseModal.tsx
@@ -1,4 +1,5 @@
 import type { RechargePrice } from "../../../electron/chat/common.ts"
+import type { BillingRequestScope } from "@/lib/billing-client"
 
 import { CreditCardIcon, ExternalLinkIcon, LogInIcon, RefreshCwIcon } from "lucide-react"
 import * as React from "react"
@@ -17,6 +18,7 @@ import { cn } from "@/lib/utils"
 export interface CreditPurchaseModalProps {
   cacheScope: string
   open: boolean
+  requestScope?: BillingRequestScope | null
   onClose: () => void
   onCheckoutOpened?: () => void
   onViewDetails?: () => void
@@ -63,12 +65,13 @@ export function CreditPurchaseModal({
   onClose,
   onViewDetails,
   open,
+  requestScope,
   showViewDetails = true,
 }: CreditPurchaseModalProps) {
   const t = useT()
   const { login } = useAuth()
   const chatService = useChatService()
-  const overview = useBillingOverview(30, { cacheScope, enabled: open })
+  const overview = useBillingOverview(30, { cacheScope, enabled: open, requestScope })
   const isSessionExpired = overview.error?.kind === "auth_required"
   const handleSignIn = React.useCallback(() => {
     void login().then(() => overview.refresh({ force: true }))

--- a/src/routes/Billing/index.tsx
+++ b/src/routes/Billing/index.tsx
@@ -33,6 +33,7 @@ import { useAuth } from "@/hooks/useAuth"
 import { useBillableSeats } from "@/hooks/useBillableSeats"
 import { useBillingOverview } from "@/hooks/useBillingOverview"
 import { useT } from "@/i18n/i18n"
+import { billingRequestScopeForWorkspace, canManageWantaBilling } from "@/lib/billing-scope"
 
 interface BillingRouteProps {
   cacheScope: string
@@ -54,7 +55,11 @@ export function BillingRoute({
   const chatService = useChatService()
   const [period, setPeriod] = React.useState<BillingPeriodDays>(30)
   const [purchaseOpen, setPurchaseOpen] = React.useState(false)
-  const { data, error, loading, refresh } = useBillingOverview(period, { cacheScope })
+  const billingRequestScope = React.useMemo(() => billingRequestScopeForWorkspace(workspace), [workspace])
+  const { data, error, loading, refresh } = useBillingOverview(period, {
+    cacheScope,
+    requestScope: billingRequestScope,
+  })
   const seatState = useBillableSeats(workspace)
   const planComparisonRef = React.useRef<HTMLElement | null>(null)
   // 会话过期：引导重新登录刷新会话，并避免在错误下方继续显示误导性的 "$0" 余额标题。
@@ -112,6 +117,8 @@ export function BillingRoute({
     [data?.wantaPendingPayment, wantaOverview.additionalSeats, wantaOverview.currentPlan],
   )
   const pendingWantaPaymentUrl = pendingWantaPaymentTargets.paymentUrl
+  const wantaOrganizationId = canManageWantaBilling(workspace) ? workspace.organizationId : null
+  const showWantaPlans = wantaOrganizationId !== null
   const averageDailySpend = period > 0 ? totalSpend / period : 0
   const coverageDays = averageDailySpend > 0 ? Math.floor(currentCredit / averageDailySpend) : 0
   const availableShare =
@@ -141,6 +148,7 @@ export function BillingRoute({
   const wantaCheckout = useWantaCheckout({
     currentAdditionalSeats: wantaOverview.additionalSeats,
     openExternalCheckout,
+    organizationId: wantaOrganizationId,
     pendingAdditionalSeats: pendingWantaPaymentTargets.additionalSeats,
     pendingPaymentUrl: pendingWantaPaymentUrl || null,
     pendingPlan: pendingWantaPaymentTargets.plan,
@@ -154,20 +162,38 @@ export function BillingRoute({
     isSubmitting: wantaLoading !== null,
   })
   React.useEffect(() => {
-    if (initialTarget !== "plans") {
+    if (initialTarget !== "plans" || !showWantaPlans) {
       return
     }
     const frame = window.requestAnimationFrame(() => {
       planComparisonRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
     })
     return () => window.cancelAnimationFrame(frame)
-  }, [initialTarget])
+  }, [initialTarget, showWantaPlans])
 
   React.useEffect(() => {
     if (initialTarget === "credits") {
       setPurchaseOpen(true)
     }
   }, [initialTarget])
+
+  const balanceOverview = (
+    <BalanceOverview
+      averageDailySpend={averageDailySpend}
+      modelSpend={modelSpend}
+      coverageDays={coverageDays}
+      currentCredit={currentCredit}
+      loading={(loading && !data) || isSessionExpired}
+      totalEvents={totalEvents}
+      totalSpend={totalSpend}
+      availableShare={availableShare}
+      period={period}
+      topUpDisabled={isSessionExpired}
+      onPeriodChange={setPeriod}
+      onRefresh={() => void refresh({ force: true })}
+      onTopUp={openUsagePurchase}
+    />
+  )
 
   return (
     <>
@@ -193,48 +219,40 @@ export function BillingRoute({
 
         {!billingContext.canManage ? <BillingManagePermissionNotice /> : null}
 
-        <PlanSeatOverviewPanel
-          loading={(loading && !data) || isSessionExpired}
-          overview={wantaOverview}
-          seatLoading={seatState.loading}
-          workspaceLabel={billingContext.workspaceLabel}
-        />
+        {showWantaPlans ? (
+          <>
+            <PlanSeatOverviewPanel
+              loading={(loading && !data) || isSessionExpired}
+              overview={wantaOverview}
+              seatLoading={seatState.loading}
+              workspaceLabel={billingContext.workspaceLabel}
+            />
 
-        <PlanComparison
-          ref={planComparisonRef}
-          currentPlan={wantaOverview.currentPlan}
-          disabled={wantaActionDisabled}
-          loadingPlan={wantaLoading}
-          pendingPaymentPlan={pendingWantaPaymentTargets.plan}
-          onChoosePlan={wantaCheckout.choosePlan}
-        />
+            <PlanComparison
+              ref={planComparisonRef}
+              currentPlan={wantaOverview.currentPlan}
+              disabled={wantaActionDisabled}
+              loadingPlan={wantaLoading}
+              pendingPaymentPlan={pendingWantaPaymentTargets.plan}
+              onChoosePlan={wantaCheckout.choosePlan}
+            />
 
-        <section className="grid gap-4 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
-          <AdditionalSeatsPanel
-            currentAdditionalSeats={wantaOverview.additionalSeats}
-            disabled={wantaActionDisabled}
-            loading={wantaLoading !== null}
-            pendingAdditionalSeats={pendingWantaPaymentTargets.additionalSeats}
-            workspaceLabel={billingContext.workspaceLabel}
-            onUpdateSeats={wantaCheckout.updateSeats}
-          />
+            <section className="grid gap-4 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
+              <AdditionalSeatsPanel
+                currentAdditionalSeats={wantaOverview.additionalSeats}
+                disabled={wantaActionDisabled}
+                loading={wantaLoading !== null}
+                pendingAdditionalSeats={pendingWantaPaymentTargets.additionalSeats}
+                workspaceLabel={billingContext.workspaceLabel}
+                onUpdateSeats={wantaCheckout.updateSeats}
+              />
 
-          <BalanceOverview
-            averageDailySpend={averageDailySpend}
-            modelSpend={modelSpend}
-            coverageDays={coverageDays}
-            currentCredit={currentCredit}
-            loading={(loading && !data) || isSessionExpired}
-            totalEvents={totalEvents}
-            totalSpend={totalSpend}
-            availableShare={availableShare}
-            period={period}
-            topUpDisabled={isSessionExpired}
-            onPeriodChange={setPeriod}
-            onRefresh={() => void refresh({ force: true })}
-            onTopUp={openUsagePurchase}
-          />
-        </section>
+              {balanceOverview}
+            </section>
+          </>
+        ) : (
+          balanceOverview
+        )}
 
         <UsageDetailsDisclosure
           balanceLots={data?.balance?.items ?? []}
@@ -256,6 +274,7 @@ export function BillingRoute({
       <CreditPurchaseModal
         cacheScope={cacheScope}
         open={purchaseOpen}
+        requestScope={billingRequestScope}
         showViewDetails={false}
         onClose={() => {
           setPurchaseOpen(false)

--- a/src/routes/Billing/use-wanta-checkout.ts
+++ b/src/routes/Billing/use-wanta-checkout.ts
@@ -14,6 +14,7 @@ import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 export type WantaLoadingTarget = WantaSubscriptionPlan | "checkout" | "seats"
 
 export interface WantaCheckoutPreview {
+  organizationId: string
   payload: WantaSubscriptionChangePayload
   preview: WantaSubscriptionPreviewResult
 }
@@ -21,6 +22,7 @@ export interface WantaCheckoutPreview {
 export function useWantaCheckout({
   currentAdditionalSeats,
   openExternalCheckout,
+  organizationId,
   pendingAdditionalSeats,
   pendingPaymentUrl,
   pendingPlan,
@@ -28,6 +30,7 @@ export function useWantaCheckout({
 }: {
   currentAdditionalSeats: number
   openExternalCheckout: (url: string) => Promise<void>
+  organizationId: string | null
   pendingAdditionalSeats: number | null
   pendingPaymentUrl: string | null
   pendingPlan: WantaSubscriptionPlan | null
@@ -36,6 +39,13 @@ export function useWantaCheckout({
   const t = useT()
   const [loading, setLoading] = React.useState<WantaLoadingTarget | null>(null)
   const [preview, setPreview] = React.useState<WantaCheckoutPreview | null>(null)
+  const requestIdRef = React.useRef(0)
+
+  React.useEffect(() => {
+    requestIdRef.current += 1
+    setLoading(null)
+    setPreview(null)
+  }, [organizationId])
 
   const reportFailure = React.useCallback(
     (operation: string, cause: unknown) => {
@@ -49,13 +59,19 @@ export function useWantaCheckout({
   const openPendingPayment = React.useCallback(
     async (target: WantaLoadingTarget) => {
       if (!pendingPaymentUrl) return false
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
       setLoading(target)
       try {
         await openExternalCheckout(pendingPaymentUrl)
       } catch (cause) {
-        reportFailure("Opening pending Wanta payment failed", cause)
+        if (requestIdRef.current === requestId) {
+          reportFailure("Opening pending Wanta payment failed", cause)
+        }
       } finally {
-        setLoading(null)
+        if (requestIdRef.current === requestId) {
+          setLoading(null)
+        }
       }
       return true
     },
@@ -64,16 +80,26 @@ export function useWantaCheckout({
 
   const loadPreview = React.useCallback(
     async (payload: WantaSubscriptionChangePayload, target: WantaLoadingTarget) => {
+      if (!organizationId) return
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
       setLoading(target)
       try {
-        setPreview({ payload, preview: await previewWantaSubscription(payload) })
+        const nextPreview = await previewWantaSubscription(organizationId, payload)
+        if (requestIdRef.current === requestId) {
+          setPreview({ organizationId, payload, preview: nextPreview })
+        }
       } catch (cause) {
-        reportFailure("Wanta subscription preview failed", cause)
+        if (requestIdRef.current === requestId) {
+          reportFailure("Wanta subscription preview failed", cause)
+        }
       } finally {
-        setLoading(null)
+        if (requestIdRef.current === requestId) {
+          setLoading(null)
+        }
       }
     },
-    [reportFailure],
+    [organizationId, reportFailure],
   )
 
   const choosePlan = React.useCallback(
@@ -96,7 +122,7 @@ export function useWantaCheckout({
     if (!preview) return
     setLoading("checkout")
     try {
-      const result = await updateWantaSubscription(preview.payload)
+      const result = await updateWantaSubscription(preview.organizationId, preview.payload)
       const paymentUrl = result.paymentURL?.trim()
       setPreview(null)
       refresh()

--- a/src/routes/Chat/ChatErrorNotice.tsx
+++ b/src/routes/Chat/ChatErrorNotice.tsx
@@ -3,8 +3,14 @@ import type { ChatErrorKind, ChatErrorSeverity } from "./chat-error.ts"
 import { AlertTriangle, CheckIcon, CopyIcon, ExternalLink, RefreshCw } from "lucide-react"
 import * as React from "react"
 import { toast } from "sonner"
+import { BillingRequestScopeContext } from "./billing-request-scope-context.ts"
 import { resolveChatError } from "./chat-error.ts"
 import { canAutoPromptPayment } from "./payment-auto-prompt.ts"
+import {
+  clearPaymentRecoveryPending,
+  hasPaymentRecoveryPending,
+  markPaymentRecoveryPending,
+} from "./payment-recovery-storage.ts"
 import { Button } from "@/components/ui/button"
 import { Dialog } from "@/components/ui/dialog"
 import { useT } from "@/i18n/i18n"
@@ -21,57 +27,10 @@ interface ChatErrorNoticeProps {
   onViewBilling?: () => void
 }
 
-const paymentRecoveryPendingKey = "wanta-payment-recovery-pending"
-const legacyPaymentRecoveryPendingKey = "lumo-payment-recovery-pending"
-const paymentRecoveryPendingTtlMs = 24 * 60 * 60 * 1000
 const copyFeedbackMs = 1_500
 const CreditPurchaseModal = React.lazy(() =>
   import("@/routes/Billing/CreditPurchaseModal").then((module) => ({ default: module.CreditPurchaseModal })),
 )
-
-function markPaymentRecoveryPending(): void {
-  try {
-    localStorage.setItem(
-      paymentRecoveryPendingKey,
-      JSON.stringify({ expiresAt: Date.now() + paymentRecoveryPendingTtlMs }),
-    )
-  } catch {
-    // localStorage 不可用时只跳过跨刷新恢复；当前弹窗仍可手动刷新余额。
-  }
-}
-
-function clearPaymentRecoveryPending(): void {
-  try {
-    localStorage.removeItem(paymentRecoveryPendingKey)
-    localStorage.removeItem(legacyPaymentRecoveryPendingKey)
-  } catch {
-    // 忽略存储不可用。
-  }
-}
-
-function hasPaymentRecoveryPending(): boolean {
-  try {
-    const currentRaw = localStorage.getItem(paymentRecoveryPendingKey)
-    const legacyRaw = currentRaw === null ? localStorage.getItem(legacyPaymentRecoveryPendingKey) : null
-    const raw = currentRaw ?? legacyRaw
-    if (!raw) {
-      return false
-    }
-    const parsed = JSON.parse(raw) as { expiresAt?: unknown }
-    const expiresAt = typeof parsed.expiresAt === "number" ? parsed.expiresAt : 0
-    if (Date.now() <= expiresAt) {
-      if (legacyRaw !== null) {
-        localStorage.setItem(paymentRecoveryPendingKey, raw)
-        localStorage.removeItem(legacyPaymentRecoveryPendingKey)
-      }
-      return true
-    }
-    clearPaymentRecoveryPending()
-    return false
-  } catch {
-    return false
-  }
-}
 
 function autoPromptStorageKey(autoOpenKey: string): string {
   return `wanta-payment-dialog-opened:${autoOpenKey}`
@@ -132,6 +91,7 @@ export function ChatErrorNotice({
   onViewBilling,
 }: ChatErrorNoticeProps) {
   const t = useT()
+  const billingRequestScope = React.useContext(BillingRequestScopeContext)
   const error = resolveChatError(message, { errorCode, errorKind })
   const [purchaseDialogOpen, setPurchaseDialogOpen] = React.useState(false)
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false)
@@ -144,26 +104,57 @@ export function ChatErrorNotice({
   const [diagnosticsCopied, setDiagnosticsCopied] = React.useState(false)
   const confirmAutoPromptedRef = React.useRef(false)
   const copyFeedbackTimerRef = React.useRef<number | undefined>(undefined)
+  const balanceRequestIdRef = React.useRef(0)
   const isPaymentRequired = error.kind === "payment_required"
 
-  const refreshBalance = React.useCallback(async (): Promise<boolean> => {
+  const refreshBalance = React.useCallback(async (): Promise<boolean | null> => {
+    const requestId = ++balanceRequestIdRef.current
+    if (!billingRequestScope) {
+      setBalance(null)
+      setBalanceChecked(false)
+      setBalanceLoading(false)
+      setHasCredits(null)
+      setRefreshFailed(false)
+      return null
+    }
     setBalanceLoading(true)
     setRefreshFailed(false)
     try {
-      const result = await getCreditBalance()
+      const result = await getCreditBalance(billingRequestScope)
+      if (requestId !== balanceRequestIdRef.current) {
+        return null
+      }
       setBalance(result.balance)
       setHasCredits(result.hasCredits)
       return result.hasCredits
     } catch {
+      if (requestId !== balanceRequestIdRef.current) {
+        return null
+      }
       setBalance(null)
       setHasCredits(null)
       setRefreshFailed(true)
       return false
     } finally {
-      setBalanceChecked(true)
-      setBalanceLoading(false)
+      if (requestId === balanceRequestIdRef.current) {
+        setBalanceChecked(true)
+        setBalanceLoading(false)
+      }
     }
-  }, [])
+  }, [billingRequestScope])
+
+  React.useEffect(() => {
+    balanceRequestIdRef.current += 1
+    setBalance(null)
+    setBalanceChecked(false)
+    setBalanceLoading(false)
+    setHasCredits(null)
+    setRecovered(false)
+    setRefreshFailed(false)
+    setPurchaseDialogOpen(false)
+    setConfirmDialogOpen(false)
+    confirmAutoPromptedRef.current = false
+  }, [billingCacheScope, billingRequestScope])
 
   React.useEffect(() => {
     setBalance(null)
@@ -185,7 +176,7 @@ export function ChatErrorNotice({
         return
       }
       if (hasCredits) {
-        clearPaymentRecoveryPending()
+        clearPaymentRecoveryPending(billingCacheScope, billingRequestScope)
         setRecovered(true)
         setPurchaseDialogOpen(false)
         setConfirmDialogOpen(false)
@@ -194,7 +185,7 @@ export function ChatErrorNotice({
     return () => {
       cancelled = true
     }
-  }, [isPaymentRequired, refreshBalance])
+  }, [billingCacheScope, billingRequestScope, isPaymentRequired, refreshBalance])
 
   React.useEffect(() => {
     const promptKey = autoOpenKey
@@ -207,11 +198,11 @@ export function ChatErrorNotice({
     if (!markAutoPromptOpened(promptKey)) {
       return
     }
-    if (hasPaymentRecoveryPending()) {
+    if (hasPaymentRecoveryPending(billingCacheScope, billingRequestScope)) {
       return
     }
     setPurchaseDialogOpen(true)
-  }, [autoOpenKey, balanceChecked, hasCredits, isPaymentRequired, recovered])
+  }, [autoOpenKey, balanceChecked, billingCacheScope, billingRequestScope, hasCredits, isPaymentRequired, recovered])
 
   React.useEffect(() => {
     confirmAutoPromptedRef.current = false
@@ -241,11 +232,19 @@ export function ChatErrorNotice({
     ) {
       return
     }
-    if (hasPaymentRecoveryPending()) {
+    if (hasPaymentRecoveryPending(billingCacheScope, billingRequestScope)) {
       confirmAutoPromptedRef.current = true
       setConfirmDialogOpen(true)
     }
-  }, [balanceChecked, confirmDialogOpen, hasCredits, isPaymentRequired, recovered])
+  }, [
+    balanceChecked,
+    billingCacheScope,
+    billingRequestScope,
+    confirmDialogOpen,
+    hasCredits,
+    isPaymentRequired,
+    recovered,
+  ])
 
   const handleCopyDiagnostics = React.useCallback(() => {
     void writeClipboardText(error.diagnostics).then((didCopy) => {
@@ -266,15 +265,18 @@ export function ChatErrorNotice({
   }, [error.diagnostics, t])
 
   const handleCheckoutOpened = React.useCallback(() => {
-    markPaymentRecoveryPending()
+    markPaymentRecoveryPending(billingCacheScope, billingRequestScope)
     confirmAutoPromptedRef.current = true
     setConfirmDialogOpen(true)
-  }, [])
+  }, [billingCacheScope, billingRequestScope])
 
   const handlePaymentCompleted = React.useCallback(async () => {
     const hasCredits = await refreshBalance()
+    if (hasCredits === null) {
+      return
+    }
     if (hasCredits) {
-      clearPaymentRecoveryPending()
+      clearPaymentRecoveryPending(billingCacheScope, billingRequestScope)
       setRecovered(true)
       setPurchaseDialogOpen(false)
       setConfirmDialogOpen(false)
@@ -282,7 +284,7 @@ export function ChatErrorNotice({
     }
     setRefreshFailed(true)
     setConfirmDialogOpen(false)
-  }, [refreshBalance])
+  }, [billingCacheScope, billingRequestScope, refreshBalance])
 
   const title = recovered ? t("chatError.paymentReturn.updatedTitle") : t(error.titleKey)
   const description = recovered
@@ -361,6 +363,7 @@ export function ChatErrorNotice({
               <CreditPurchaseModal
                 cacheScope={billingCacheScope}
                 open={purchaseDialogOpen}
+                requestScope={billingRequestScope}
                 onClose={() => setPurchaseDialogOpen(false)}
                 onCheckoutOpened={handleCheckoutOpened}
                 onViewDetails={onViewBilling}

--- a/src/routes/Chat/billing-request-scope-context.ts
+++ b/src/routes/Chat/billing-request-scope-context.ts
@@ -1,0 +1,5 @@
+import type { BillingRequestScope } from "@/lib/billing-client"
+
+import * as React from "react"
+
+export const BillingRequestScopeContext = React.createContext<BillingRequestScope | null>(null)

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -14,6 +14,7 @@ import type { ComposerState } from "./composer-state.ts"
 import type { QuestionDraftStore } from "./question-fields.ts"
 import type { ChatSendRequest, ChatSendResult } from "@/components/app-shell/app-shell-model"
 import type { QueuedChatMessage, QueuedMessageMovePlacement } from "@/components/app-shell/chat-queue"
+import type { BillingRequestScope } from "@/lib/billing-client"
 import type { UserFacingError } from "@/lib/user-facing-error"
 import type { ArtifactSelection } from "@/routes/Chat/GeneratedArtifacts"
 import type { TurnOutputSelection } from "@/routes/Chat/TurnOutputs"
@@ -21,6 +22,7 @@ import type { ChatStatus } from "ai"
 
 import { Building2, ChevronRight, Package, PlugZap } from "lucide-react"
 import * as React from "react"
+import { BillingRequestScopeContext } from "./billing-request-scope-context.ts"
 import { chatTurnShowsGenerating, resolveChatTurnState } from "./chat-turn-state.ts"
 import { ChatComposer } from "./ChatComposer.tsx"
 import { ChatTimeline } from "./ChatTimeline.tsx"
@@ -34,6 +36,7 @@ import { cn } from "@/lib/utils"
 interface ChatAreaProps {
   activeSessionId: string | null
   billingCacheScope: string
+  billingRequestScope: BillingRequestScope | null
   composerDraftKey: string
   composerFocusRequest: number
   messages: ChatMessage[]
@@ -218,6 +221,7 @@ function EmptyCapabilityAction({
 export const ChatArea = React.memo(function ChatArea({
   activeSessionId,
   billingCacheScope,
+  billingRequestScope,
   composerDraftKey,
   composerFocusRequest,
   messages,
@@ -393,19 +397,23 @@ export const ChatArea = React.memo(function ChatArea({
   )
 
   return (
-    <div className="flex h-full min-h-0 w-full min-w-0 overflow-hidden">
-      <div className="flex min-w-0 flex-1 flex-col pb-4">
-        <div className="flex min-h-0 flex-1 overflow-hidden">{content}</div>
+    <BillingRequestScopeContext.Provider value={billingRequestScope}>
+      <div className="flex h-full min-h-0 w-full min-w-0 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col pb-4">
+          <div className="flex min-h-0 flex-1 overflow-hidden">{content}</div>
 
-        {showCenteredEmptyState ? null : (
-          <div className={cn("mx-auto flex w-full flex-col gap-2 px-4", CHAT_CONTENT_MAX_WIDTH_CLASS)}>{composer}</div>
-        )}
+          {showCenteredEmptyState ? null : (
+            <div className={cn("mx-auto flex w-full flex-col gap-2 px-4", CHAT_CONTENT_MAX_WIDTH_CLASS)}>
+              {composer}
+            </div>
+          )}
+        </div>
+        <FullAccessConfirmDialog
+          open={fullAccessDialogOpen}
+          onClose={() => setFullAccessDialogOpen(false)}
+          onConfirm={confirmFullAccess}
+        />
       </div>
-      <FullAccessConfirmDialog
-        open={fullAccessDialogOpen}
-        onClose={() => setFullAccessDialogOpen(false)}
-        onConfirm={confirmFullAccess}
-      />
-    </div>
+    </BillingRequestScopeContext.Provider>
   )
 })

--- a/src/routes/Chat/payment-recovery-storage.test.ts
+++ b/src/routes/Chat/payment-recovery-storage.test.ts
@@ -1,0 +1,87 @@
+import type { PaymentRecoveryStorage } from "./payment-recovery-storage.ts"
+import type { BillingRequestScope } from "@/lib/billing-client"
+
+import { describe, expect, it } from "vitest"
+import {
+  clearPaymentRecoveryPending,
+  hasPaymentRecoveryPending,
+  markPaymentRecoveryPending,
+  paymentRecoveryPendingStorageKey,
+} from "./payment-recovery-storage.ts"
+
+function createStorage(): PaymentRecoveryStorage {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    removeItem: (key) => void values.delete(key),
+    setItem: (key, value) => void values.set(key, value),
+  }
+}
+
+function organizationScope(overrides: Partial<Extract<BillingRequestScope, { type: "organization" }>> = {}) {
+  return {
+    canManageBilling: true,
+    organizationId: "team-1",
+    organizationName: "acme",
+    type: "organization" as const,
+    ...overrides,
+  }
+}
+
+describe("payment recovery storage", () => {
+  it("includes the account cache scope and all organization scope fields in the key", () => {
+    const scope = organizationScope()
+    const key = paymentRecoveryPendingStorageKey("user-1:organization:team-1", scope)
+
+    expect(key).not.toBe(paymentRecoveryPendingStorageKey("user-2:organization:team-1", scope))
+    expect(key).not.toBe(
+      paymentRecoveryPendingStorageKey(
+        "user-1:organization:team-1",
+        organizationScope({
+          canManageBilling: false,
+        }),
+      ),
+    )
+    expect(key).not.toBe(
+      paymentRecoveryPendingStorageKey(
+        "user-1:organization:team-1",
+        organizationScope({
+          organizationId: "team-2",
+        }),
+      ),
+    )
+    expect(key).not.toBe(
+      paymentRecoveryPendingStorageKey(
+        "user-1:organization:team-1",
+        organizationScope({
+          organizationName: "beta",
+        }),
+      ),
+    )
+  })
+
+  it("keeps markers isolated between billing scopes", () => {
+    const storage = createStorage()
+    const teamA = organizationScope()
+    const teamB = organizationScope({ organizationId: "team-2", organizationName: "beta" })
+
+    markPaymentRecoveryPending("user-1:organization:team-1", teamA, storage, 1_000)
+
+    expect(hasPaymentRecoveryPending("user-1:organization:team-1", teamA, storage, 1_001)).toBe(true)
+    expect(hasPaymentRecoveryPending("user-1:organization:team-2", teamB, storage, 1_001)).toBe(false)
+    clearPaymentRecoveryPending("user-1:organization:team-2", teamB, storage)
+    expect(hasPaymentRecoveryPending("user-1:organization:team-1", teamA, storage, 1_001)).toBe(true)
+  })
+
+  it("removes only the expired marker for the requested scope", () => {
+    const storage = createStorage()
+    const scope = organizationScope()
+    const personalScope = { type: "personal" } as const
+
+    markPaymentRecoveryPending("user-1:organization:team-1", scope, storage, 1_000)
+    markPaymentRecoveryPending("user-1:personal", personalScope, storage, 2_000)
+
+    expect(hasPaymentRecoveryPending("user-1:organization:team-1", scope, storage, 86_401_001)).toBe(false)
+    expect(hasPaymentRecoveryPending("user-1:personal", personalScope, storage, 86_401_001)).toBe(true)
+  })
+})

--- a/src/routes/Chat/payment-recovery-storage.ts
+++ b/src/routes/Chat/payment-recovery-storage.ts
@@ -1,0 +1,84 @@
+import type { BillingRequestScope } from "@/lib/billing-client"
+
+const paymentRecoveryPendingKeyPrefix = "wanta-payment-recovery-pending"
+const paymentRecoveryPendingTtlMs = 24 * 60 * 60 * 1000
+
+export interface PaymentRecoveryStorage {
+  getItem(key: string): string | null
+  removeItem(key: string): void
+  setItem(key: string, value: string): void
+}
+
+export function paymentRecoveryPendingStorageKey(cacheScope: string, requestScope: BillingRequestScope): string {
+  const requestScopeKey =
+    requestScope.type === "organization"
+      ? {
+          canManageBilling: requestScope.canManageBilling,
+          organizationId: requestScope.organizationId,
+          organizationName: requestScope.organizationName,
+          type: requestScope.type,
+        }
+      : { type: requestScope.type }
+  return `${paymentRecoveryPendingKeyPrefix}:${encodeURIComponent(JSON.stringify({ cacheScope, requestScopeKey }))}`
+}
+
+export function markPaymentRecoveryPending(
+  cacheScope: string,
+  requestScope: BillingRequestScope | null,
+  storage: PaymentRecoveryStorage = localStorage,
+  now = Date.now(),
+): void {
+  if (!requestScope) {
+    return
+  }
+  try {
+    storage.setItem(
+      paymentRecoveryPendingStorageKey(cacheScope, requestScope),
+      JSON.stringify({ expiresAt: now + paymentRecoveryPendingTtlMs }),
+    )
+  } catch {
+    // localStorage 不可用时只跳过跨刷新恢复；当前弹窗仍可手动刷新余额。
+  }
+}
+
+export function clearPaymentRecoveryPending(
+  cacheScope: string,
+  requestScope: BillingRequestScope | null,
+  storage: PaymentRecoveryStorage = localStorage,
+): void {
+  if (!requestScope) {
+    return
+  }
+  try {
+    storage.removeItem(paymentRecoveryPendingStorageKey(cacheScope, requestScope))
+  } catch {
+    // 忽略存储不可用。
+  }
+}
+
+export function hasPaymentRecoveryPending(
+  cacheScope: string,
+  requestScope: BillingRequestScope | null,
+  storage: PaymentRecoveryStorage = localStorage,
+  now = Date.now(),
+): boolean {
+  if (!requestScope) {
+    return false
+  }
+  try {
+    const scopedKey = paymentRecoveryPendingStorageKey(cacheScope, requestScope)
+    const raw = storage.getItem(scopedKey)
+    if (!raw) {
+      return false
+    }
+    const parsed = JSON.parse(raw) as { expiresAt?: unknown }
+    const expiresAt = typeof parsed.expiresAt === "number" ? parsed.expiresAt : 0
+    if (now <= expiresAt) {
+      return true
+    }
+    storage.removeItem(scopedKey)
+    return false
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Scope Wanta subscription reads, previews, updates, and pending payments to the active organization.
- Send the organization workspace header for balance and usage requests while keeping personal billing unscoped.
- Show Wanta plans and seat management only in manageable Team workspaces, matching the console behavior.
- Isolate billing caches by workspace identity and permission, and discard stale checkout previews after a Team switch.

## Problem

Choosing Wanta Plus or Wanta Pro in the desktop app called the legacy user-scoped subscription routes. The current console flow treats Wanta as an organization product and uses `/api/org/:organizationId/subscriptions/wanta/*`. As a result, the desktop preview request returned `404 Not Found` before a purchase page could be created.

The billing cache was labeled by workspace, but its underlying requests were not workspace-aware. This could also mix personal subscription data with Team seat and usage data.

## Fix

This change introduces an explicit personal-or-organization billing request scope. Organization subscription operations now use encoded organization IDs in the path, while Insight requests carry `x-oo-organization-name`. Billing reads for members without management permission skip organization subscription endpoints.

The billing page, usage popover, and purchase dialog now share the same request scope. Personal workspaces and non-managing Team members no longer show actionable Wanta plan controls. Checkout previews retain their organization identity and are cleared when the active Team changes.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 192 files and 1,292 tests passed
- `npm run dev` — Vite, Electron main/preload, and the agent sidecar started successfully
