### PR TITLE
Fix Markdown code block rendering

### DIFF
--- a/electron/agent/agent.test.ts
+++ b/electron/agent/agent.test.ts
@@ -311,6 +311,8 @@ test("system prompt treats Link as a contextual capability, not the default path
   assert.match(WANTA_SYSTEM_PROMPT, /Workspace identity is invariant for a turn/)
   assert.match(WANTA_SYSTEM_PROMPT, /never omit or change it to recover from an error/)
   assert.match(WANTA_SYSTEM_PROMPT, /Use Mermaid for processes, timelines, hierarchies/)
+  assert.match(WANTA_SYSTEM_PROMPT, /Do not use plain, text, or unlabeled fenced code blocks/)
+  assert.match(WANTA_SYSTEM_PROMPT, /Do not repeat a Mermaid diagram as an ASCII or plain-text diagram/)
   assert.match(WANTA_SYSTEM_PROMPT, /5-8 core nodes and 5-12 core edges/)
   assert.match(WANTA_SYSTEM_PROMPT, /Chinese quotation marks such as “嫂嫂”/)
   assert.match(WANTA_SYSTEM_PROMPT, /style, classDef, linkStyle/)

--- a/electron/agent/system-prompt.ts
+++ b/electron/agent/system-prompt.ts
@@ -28,6 +28,8 @@ Use a visualization only when it makes relationships, sequence, hierarchy, causa
 - Prefer the smallest useful format. Do not add a diagram for a single fact, one simple relationship, a short list, or content already clear in a few sentences.
 - Use Mermaid for processes, timelines, hierarchies, architectures, state transitions, and labeled entity relationships.
 - Keep one diagram focused on one question. Follow it with a concise conclusion or evidence note instead of repeating every node and edge in prose.
+- Do not use plain, text, or unlabeled fenced code blocks to imitate a diagram or emphasize ordinary prose. If a visualization is useful, use Mermaid; otherwise use normal Markdown paragraphs, lists, or tables.
+- Do not repeat a Mermaid diagram as an ASCII or plain-text diagram, or restate the same relationship chain in a second visual block.
 
 When producing Mermaid:
 - Before drawing, choose the one specific question the diagram will answer. Do not mix unrelated relationship systems, background facts, and event summaries into one graph; move secondary facts to prose or split them into another focused diagram.

--- a/src/components/ai-elements/conversation.tsx
+++ b/src/components/ai-elements/conversation.tsx
@@ -70,7 +70,10 @@ export const ConversationScrollButton = ({ className, ...props }: ConversationSc
   return (
     !isAtBottom && (
       <Button
-        className={cn("absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full", className)}
+        className={cn(
+          "absolute bottom-2 left-[50%] translate-x-[-50%] rounded-full bg-popover text-popover-foreground hover:bg-accent dark:bg-popover dark:hover:bg-accent",
+          className,
+        )}
         onClick={handleScrollToBottom}
         size="icon"
         type="button"

--- a/src/components/ai-elements/message-streamdown.test.ts
+++ b/src/components/ai-elements/message-streamdown.test.ts
@@ -1,12 +1,16 @@
 import type { DiagramPlugin } from "streamdown"
 
+import * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
 import {
+  MessageStreamdown,
   mermaidRendererControls,
   messageStreamdownControls,
   nativeMessageStreamdownControls,
   wrapMermaidPluginWithValidation,
 } from "./message-streamdown.tsx"
+import { I18nContext, translate } from "@/i18n/i18n"
 
 describe("messageStreamdownControls", () => {
   it("adds compact product-owned Mermaid controls without changing existing code controls", () => {
@@ -62,5 +66,28 @@ describe("messageStreamdownControls", () => {
       "Mermaid click actions are not supported",
     )
     expect(render).not.toHaveBeenCalled()
+  })
+
+  it("keeps Mermaid fences on the dedicated Wanta renderer", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        I18nContext.Provider,
+        {
+          value: {
+            locale: "zh-CN",
+            setLocale: () => undefined,
+            t: (key, vars) => translate("zh-CN", key, vars),
+          },
+        },
+        React.createElement(
+          MessageStreamdown,
+          { defaultRenderers: [] },
+          ["```mermaid", "flowchart LR", "A[Start] --> B[Done]", "```"].join("\n"),
+        ),
+      ),
+    )
+
+    expect(html).toContain("oo-mermaid-loading")
+    expect(html).not.toContain('data-streamdown="code-block"')
   })
 })

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -23,6 +23,7 @@ import {
   messageResponseControls,
   nextSmoothedText,
   normalizeSingleLocalPathCodeFences,
+  normalizeUnlabeledCodeFences,
   smoothedTextRevealStep,
 } from "./message.tsx"
 import { AppContext } from "@/components/AppContext"
@@ -67,7 +68,21 @@ describe("MarkdownCodeBlock", () => {
 
   it("leaves Mermaid fences to the dedicated diagram renderer", () => {
     expect(markdownCodeRendererLanguages).not.toContain("mermaid")
-    expect(markdownCodeRendererLanguages).toContain("typescript")
+    expect(markdownCodeRendererLanguages).toContain("text")
+  })
+})
+
+describe("normalizeUnlabeledCodeFences", () => {
+  it("labels bare fences as text so the AI Elements renderer can match them", () => {
+    expect(normalizeUnlabeledCodeFences(["```", "first line", "second line", "```"].join("\n"))).toBe(
+      ["```text", "first line", "second line", "```"].join("\n"),
+    )
+  })
+
+  it("does not rewrite Mermaid or explicitly labeled code fences", () => {
+    const markdown = ["```mermaid", "flowchart LR", "A --> B", "```", "", "```ts", "const value = 1", "```"].join("\n")
+
+    expect(normalizeUnlabeledCodeFences(markdown)).toBe(markdown)
   })
 })
 

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -27,7 +27,6 @@ const Streamdown = lazy(() =>
 const localPathStartPattern = /^(?:file:\/\/|~?[\\/]|[A-Za-z]:[\\/])/
 const singleLocalPathFencePattern =
   /(^|\n)([ \t]{0,3})(`{3,}|~{3,})[ \t]*(?:text|txt|path|file)?[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*\3[ \t]*(?=\n|$)/gi
-
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"]
 }
@@ -294,7 +293,6 @@ const messageResponseComponents = {
 
 // Mermaid 由 Streamdown 的专用渲染器处理；其它常见代码语言继续复用 Wanta 的代码块。
 export const markdownCodeRendererLanguages = [
-  "",
   "bash",
   "c",
   "c#",
@@ -390,6 +388,37 @@ export function normalizeSingleLocalPathCodeFences(markdown: string): string {
       return `${prefix}${indent}\`${value}\``
     },
   )
+}
+
+/**
+ * Streamdown 的自定义 renderer 不匹配空语言名；为无标签 fenced block 补上 text，
+ * 使其继续使用 AI Elements 代码块，同时不拦截 Mermaid 专用 renderer。
+ */
+export function normalizeUnlabeledCodeFences(markdown: string): string {
+  const parts = markdown.split(/(\r?\n)/)
+
+  for (let index = 0; index < parts.length; index += 2) {
+    const opening = parts[index].match(/^([ \t]{0,3})(`{3,}|~{3,})([^\r\n]*)$/)
+    if (!opening) continue
+
+    const openingFence = opening[2]
+    let closingIndex = -1
+    for (let candidateIndex = index + 2; candidateIndex < parts.length; candidateIndex += 2) {
+      const closing = parts[candidateIndex].match(/^[ \t]{0,3}(`+|~+)[ \t]*$/)
+      if (closing && closing[1][0] === openingFence[0] && closing[1].length >= openingFence.length) {
+        closingIndex = candidateIndex
+        break
+      }
+    }
+
+    if (closingIndex < 0) continue
+    if (opening[3].trim().length === 0) {
+      parts[index] = `${opening[1]}${openingFence}text`
+    }
+    index = closingIndex
+  }
+
+  return parts.join("")
 }
 
 const defaultMessageResponseControls = {
@@ -502,7 +531,11 @@ export const MessageResponse = memo(
     const sourceChildren = typeof children === "string" && smooth ? visibleChildren : children
     const responseChildren =
       typeof sourceChildren === "string"
-        ? normalizeMermaidMarkdown(normalizeLocalImageMarkdown(normalizeSingleLocalPathCodeFences(sourceChildren)))
+        ? normalizeMermaidMarkdown(
+            normalizeUnlabeledCodeFences(
+              normalizeLocalImageMarkdown(normalizeSingleLocalPathCodeFences(sourceChildren)),
+            ),
+          )
         : sourceChildren
     const localImagePreviews = typeof responseChildren === "string" ? extractLocalImagePreviews(responseChildren) : []
     return (


### PR DESCRIPTION
## Summary

Restore the intended separation between Mermaid diagrams and ordinary fenced Markdown content in assistant responses.

## Problem

The ordinary code-block renderer previously included an empty language identifier. Streamdown does not match custom renderers against an empty fence language, so unlabeled fenced content fell back to Streamdown's native code card. Re-registering the legacy React `code` component globally fixed ordinary blocks but also intercepted Mermaid fences, causing diagram source to be displayed instead of rendering the diagram.

For users, this made ordinary prose-like fenced content look inconsistent and could regress Mermaid responses into visible source code.

## Fix

- Normalize closed unlabeled fences to the explicit `text` language before rendering, allowing them to use the existing AI Elements code-block renderer.
- Keep `mermaid` excluded from the ordinary renderer language list so Mermaid continues through Wanta's dedicated diagram renderer.
- Add system-prompt guidance that prevents ordinary prose and duplicate ASCII relationship diagrams from being emitted as fenced blocks alongside Mermaid.
- Add regression coverage for unlabeled fence normalization, labeled-fence preservation, and dedicated Mermaid rendering.

## Validation

- `npm run lint:fix`
- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 204 test files and 1,364 tests passed
- `git diff --check`
- Verified the development app rebuilds successfully with `npm run dev`
