### PR TITLE
feat(chat): improve diagram touch navigation

### DIFF
--- a/src/components/ai-elements/diagram-viewer.test.ts
+++ b/src/components/ai-elements/diagram-viewer.test.ts
@@ -5,7 +5,9 @@ import {
   diagramViewerWheelAction,
   mermaidSvgSize,
   panDiagramViewerState,
+  pinchDiagramViewerState,
   zoomDiagramViewerState,
+  zoomDiagramViewerToScale,
 } from "./diagram-viewer.ts"
 
 describe("diagramViewerFitScale", () => {
@@ -23,13 +25,13 @@ describe("diagram viewer navigation", () => {
   const stage = { width: 800, height: 600 }
 
   it("clamps panning to the rendered diagram bounds", () => {
-    expect(clampDiagramViewerOffset({ x: 900, y: -900 }, 1, diagram, stage)).toEqual({ x: 200, y: -100 })
-    expect(clampDiagramViewerOffset({ x: 40, y: 40 }, 0.5, diagram, stage)).toEqual({ x: 0, y: 0 })
+    expect(clampDiagramViewerOffset({ x: 2000, y: -2000 }, 1, diagram, stage)).toEqual({ x: 936, y: -636 })
+    expect(clampDiagramViewerOffset({ x: 40, y: 40 }, 0.5, diagram, stage)).toEqual({ x: 40, y: 40 })
   })
 
   it("zooms and pans without leaving invalid offsets", () => {
     expect(zoomDiagramViewerState({ offset: { x: 200, y: 100 }, scale: 1 }, -0.5, diagram, stage)).toEqual({
-      offset: { x: 0, y: 0 },
+      offset: { x: 100, y: 50 },
       scale: 0.5,
     })
     expect(panDiagramViewerState({ offset: { x: 0, y: 0 }, scale: 1 }, 80, -60, diagram, stage)).toEqual({
@@ -38,15 +40,40 @@ describe("diagram viewer navigation", () => {
     })
   })
 
+  it("keeps the diagram point below the gesture anchor stationary while zooming", () => {
+    const largeDiagram = { width: 2000, height: 1600 }
+    expect(
+      zoomDiagramViewerToScale({ offset: { x: 0, y: 0 }, scale: 1 }, 2, { x: 100, y: 50 }, largeDiagram, stage),
+    ).toEqual({
+      offset: { x: -100, y: -50 },
+      scale: 2,
+    })
+  })
+
+  it("combines pinch zoom with movement of the gesture midpoint", () => {
+    expect(
+      pinchDiagramViewerState(
+        { offset: { x: 0, y: 0 }, scale: 1 },
+        2,
+        { x: 100, y: 0 },
+        { x: 120, y: 10 },
+        { width: 2000, height: 1600 },
+        stage,
+      ),
+    ).toEqual({
+      offset: { x: -80, y: 10 },
+      scale: 2,
+    })
+  })
+
   it("maps precision scrolling to pan and modifier or wheel scrolling to zoom", () => {
     expect(diagramViewerWheelAction({ deltaX: 8, deltaY: 12 })).toEqual({ kind: "pan", deltaX: -8, deltaY: -12 })
-    expect(diagramViewerWheelAction({ ctrlKey: true, deltaX: 0, deltaY: -10 })).toEqual({
-      kind: "zoom",
-      delta: 0.1,
-    })
+    const trackpadPinch = diagramViewerWheelAction({ ctrlKey: true, deltaX: 0, deltaY: -10 })
+    expect(trackpadPinch.kind).toBe("zoom")
+    expect(trackpadPinch.kind === "zoom" ? trackpadPinch.factor : 0).toBeCloseTo(2 ** 0.2)
     expect(diagramViewerWheelAction({ deltaMode: 1, deltaX: 0, deltaY: 3 })).toEqual({
+      factor: 2 ** -0.15,
       kind: "zoom",
-      delta: -0.1,
     })
   })
 })

--- a/src/components/ai-elements/diagram-viewer.ts
+++ b/src/components/ai-elements/diagram-viewer.ts
@@ -8,18 +8,23 @@ export interface DiagramViewerOffset {
   y: number
 }
 
+export type DiagramViewerPoint = DiagramViewerOffset
+
 export interface DiagramViewerState {
   offset: DiagramViewerOffset
   scale: number
 }
 
-export type DiagramViewerWheelAction = { kind: "pan"; deltaX: number; deltaY: number } | { kind: "zoom"; delta: number }
+export type DiagramViewerWheelAction =
+  | { kind: "pan"; deltaX: number; deltaY: number }
+  | { factor: number; kind: "zoom" }
 
 export const diagramViewerMinScale = 0.1
-export const diagramViewerMaxScale = 3
-export const diagramViewerScaleStep = 0.1
+export const diagramViewerMaxScale = 4
+export const diagramViewerButtonScaleFactor = 1.2
 const diagramViewerMargin = 48
 const diagramViewerMaxFitScale = 1.25
+const diagramViewerMinimumVisible = 64
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
@@ -44,8 +49,10 @@ export function clampDiagramViewerOffset(
   diagramSize: DiagramViewerSize,
   stageSize: DiagramViewerSize,
 ): DiagramViewerOffset {
-  const maxX = Math.max(0, (diagramSize.width * scale - stageSize.width) / 2)
-  const maxY = Math.max(0, (diagramSize.height * scale - stageSize.height) / 2)
+  const scaledWidth = diagramSize.width * scale
+  const scaledHeight = diagramSize.height * scale
+  const maxX = Math.max(0, (scaledWidth + stageSize.width) / 2 - Math.min(diagramViewerMinimumVisible, scaledWidth))
+  const maxY = Math.max(0, (scaledHeight + stageSize.height) / 2 - Math.min(diagramViewerMinimumVisible, scaledHeight))
   return {
     x: clamp(offset.x, -maxX, maxX),
     y: clamp(offset.y, -maxY, maxY),
@@ -57,10 +64,54 @@ export function zoomDiagramViewerState(
   delta: number,
   diagramSize: DiagramViewerSize,
   stageSize: DiagramViewerSize,
+  anchor: DiagramViewerPoint = { x: 0, y: 0 },
 ): DiagramViewerState {
-  const scale = clamp(current.scale + delta, diagramViewerMinScale, diagramViewerMaxScale)
+  return zoomDiagramViewerToScale(current, current.scale + delta, anchor, diagramSize, stageSize)
+}
+
+export function zoomDiagramViewerToScale(
+  current: DiagramViewerState,
+  requestedScale: number,
+  anchor: DiagramViewerPoint,
+  diagramSize: DiagramViewerSize,
+  stageSize: DiagramViewerSize,
+): DiagramViewerState {
+  const scale = clamp(requestedScale, diagramViewerMinScale, diagramViewerMaxScale)
+  const ratio = scale / current.scale
   return {
-    offset: clampDiagramViewerOffset(current.offset, scale, diagramSize, stageSize),
+    offset: clampDiagramViewerOffset(
+      {
+        x: anchor.x - (anchor.x - current.offset.x) * ratio,
+        y: anchor.y - (anchor.y - current.offset.y) * ratio,
+      },
+      scale,
+      diagramSize,
+      stageSize,
+    ),
+    scale,
+  }
+}
+
+export function pinchDiagramViewerState(
+  start: DiagramViewerState,
+  scaleRatio: number,
+  startMidpoint: DiagramViewerPoint,
+  currentMidpoint: DiagramViewerPoint,
+  diagramSize: DiagramViewerSize,
+  stageSize: DiagramViewerSize,
+): DiagramViewerState {
+  const scale = clamp(start.scale * scaleRatio, diagramViewerMinScale, diagramViewerMaxScale)
+  const appliedRatio = scale / start.scale
+  return {
+    offset: clampDiagramViewerOffset(
+      {
+        x: currentMidpoint.x - (startMidpoint.x - start.offset.x) * appliedRatio,
+        y: currentMidpoint.y - (startMidpoint.y - start.offset.y) * appliedRatio,
+      },
+      scale,
+      diagramSize,
+      stageSize,
+    ),
     scale,
   }
 }
@@ -91,8 +142,21 @@ export function diagramViewerWheelAction(event: {
   metaKey?: boolean
   shiftKey?: boolean
 }): DiagramViewerWheelAction {
-  if (event.ctrlKey || event.metaKey || (event.deltaMode ?? 0) !== 0 || Math.abs(event.deltaY) >= 48) {
-    return { kind: "zoom", delta: -Math.sign(event.deltaY || 1) * diagramViewerScaleStep }
+  if (event.ctrlKey || event.metaKey) {
+    // 沿用 d3-zoom 的默认 wheelDelta 曲线；Chromium 用 Ctrl+wheel 表达触控板捏合，因此放大十倍响应。
+    const deltaModeFactor = event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002
+    const modifierFactor = event.ctrlKey ? 10 : 1
+    return {
+      factor: 2 ** (-event.deltaY * deltaModeFactor * modifierFactor),
+      kind: "zoom",
+    }
+  }
+  if ((event.deltaMode ?? 0) !== 0 || (Math.abs(event.deltaY) >= 48 && Math.abs(event.deltaX) < 1)) {
+    const deltaModeFactor = event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002
+    return {
+      factor: 2 ** (-event.deltaY * deltaModeFactor),
+      kind: "zoom",
+    }
   }
   if (event.shiftKey) {
     return { kind: "pan", deltaX: -event.deltaY, deltaY: 0 }

--- a/src/components/ai-elements/mermaid-renderer.tsx
+++ b/src/components/ai-elements/mermaid-renderer.tsx
@@ -1,4 +1,4 @@
-import type { DiagramViewerSize, DiagramViewerState } from "./diagram-viewer.ts"
+import type { DiagramViewerPoint, DiagramViewerSize, DiagramViewerState } from "./diagram-viewer.ts"
 import type { MermaidConfig } from "@streamdown/mermaid"
 import type { ComponentType, PointerEvent, ReactNode, WheelEvent } from "react"
 import type { CustomRendererProps, DiagramPlugin, MermaidErrorComponentProps } from "streamdown"
@@ -17,14 +17,15 @@ import {
 } from "react"
 import { createPortal } from "react-dom"
 import {
+  diagramViewerButtonScaleFactor,
   diagramViewerFitScale,
   diagramViewerMaxScale,
   diagramViewerMinScale,
-  diagramViewerScaleStep,
   diagramViewerWheelAction,
   mermaidSvgSize,
   panDiagramViewerState,
-  zoomDiagramViewerState,
+  pinchDiagramViewerState,
+  zoomDiagramViewerToScale,
 } from "./diagram-viewer.ts"
 import { useT } from "@/i18n/i18n"
 
@@ -44,13 +45,20 @@ interface MermaidRendererProviderProps extends MermaidRendererContextValue {
   children: ReactNode
 }
 
-interface DiagramViewerDragState {
-  originX: number
-  originY: number
-  pointerId: number
-  startX: number
-  startY: number
-}
+type DiagramViewerGestureState =
+  | {
+      kind: "pan"
+      pointerId: number
+      startPoint: DiagramViewerPoint
+      startState: DiagramViewerState
+    }
+  | {
+      kind: "pinch"
+      pointerIds: [number, number]
+      startDistance: number
+      startMidpoint: DiagramViewerPoint
+      startState: DiagramViewerState
+    }
 
 const MermaidRendererContext = createContext<MermaidRendererContextValue | null>(null)
 let mermaidRenderSequence = 0
@@ -83,6 +91,17 @@ async function copyText(value: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+function pointDistance(first: DiagramViewerPoint, second: DiagramViewerPoint): number {
+  return Math.hypot(second.x - first.x, second.y - first.y)
+}
+
+function pointMidpoint(first: DiagramViewerPoint, second: DiagramViewerPoint): DiagramViewerPoint {
+  return {
+    x: (first.x + second.x) / 2,
+    y: (first.y + second.y) / 2,
   }
 }
 
@@ -196,15 +215,25 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
   const [dragging, setDragging] = useState(false)
   const stageRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
-  const dragRef = useRef<DiagramViewerDragState | null>(null)
+  const viewerStateRef = useRef(viewerState)
+  const activePointersRef = useRef(new Map<number, DiagramViewerPoint>())
+  const gestureRef = useRef<DiagramViewerGestureState | null>(null)
   const userAdjustedRef = useRef(false)
+
+  const updateViewerState = useCallback((update: (current: DiagramViewerState) => DiagramViewerState): void => {
+    setViewerState((current) => {
+      const next = update(current)
+      viewerStateRef.current = next
+      return next
+    })
+  }, [])
 
   const fitToWindow = useCallback((): void => {
     if (stageSize.width <= 0 || stageSize.height <= 0) {
       return
     }
-    setViewerState({ offset: { x: 0, y: 0 }, scale: diagramViewerFitScale(stageSize, diagramSize) })
-  }, [diagramSize, stageSize])
+    updateViewerState(() => ({ offset: { x: 0, y: 0 }, scale: diagramViewerFitScale(stageSize, diagramSize) }))
+  }, [diagramSize, stageSize, updateViewerState])
 
   useEffect(() => {
     const previousOverflow = document.body.style.overflow
@@ -231,18 +260,34 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
       } else if (event.key === "+" || event.key === "=") {
         event.preventDefault()
         userAdjustedRef.current = true
-        setViewerState((current) => zoomDiagramViewerState(current, diagramViewerScaleStep, diagramSize, stageSize))
+        updateViewerState((current) =>
+          zoomDiagramViewerToScale(
+            current,
+            current.scale * diagramViewerButtonScaleFactor,
+            { x: 0, y: 0 },
+            diagramSize,
+            stageSize,
+          ),
+        )
       } else if (event.key === "-") {
         event.preventDefault()
         userAdjustedRef.current = true
-        setViewerState((current) => zoomDiagramViewerState(current, -diagramViewerScaleStep, diagramSize, stageSize))
+        updateViewerState((current) =>
+          zoomDiagramViewerToScale(
+            current,
+            current.scale / diagramViewerButtonScaleFactor,
+            { x: 0, y: 0 },
+            diagramSize,
+            stageSize,
+          ),
+        )
       }
     }
     document.addEventListener("keydown", onKeyDown)
     return () => {
       document.removeEventListener("keydown", onKeyDown)
     }
-  }, [diagramSize, fitToWindow, onClose, stageSize])
+  }, [diagramSize, fitToWindow, onClose, stageSize, updateViewerState])
 
   useEffect(() => {
     const stage = stageRef.current
@@ -265,64 +310,135 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
     }
   }, [fitToWindow])
 
-  const zoomBy = (delta: number): void => {
+  const zoomBy = (factor: number): void => {
     userAdjustedRef.current = true
-    setViewerState((current) => zoomDiagramViewerState(current, delta, diagramSize, stageSize))
+    updateViewerState((current) =>
+      zoomDiagramViewerToScale(current, current.scale * factor, { x: 0, y: 0 }, diagramSize, stageSize),
+    )
+  }
+
+  const stagePoint = (point: DiagramViewerPoint): DiagramViewerPoint => {
+    const rect = stageRef.current?.getBoundingClientRect()
+    if (!rect) {
+      return { x: 0, y: 0 }
+    }
+    return {
+      x: point.x - rect.left - rect.width / 2,
+      y: point.y - rect.top - rect.height / 2,
+    }
   }
 
   const handleWheel = (event: WheelEvent<HTMLDivElement>): void => {
     event.preventDefault()
     userAdjustedRef.current = true
     const action = diagramViewerWheelAction(event)
-    setViewerState((current) =>
+    const anchor = stagePoint({ x: event.clientX, y: event.clientY })
+    updateViewerState((current) =>
       action.kind === "zoom"
-        ? zoomDiagramViewerState(current, action.delta, diagramSize, stageSize)
+        ? zoomDiagramViewerToScale(current, current.scale * action.factor, anchor, diagramSize, stageSize)
         : panDiagramViewerState(current, action.deltaX, action.deltaY, diagramSize, stageSize),
     )
   }
 
+  const startPan = (pointerId: number, point: DiagramViewerPoint): void => {
+    gestureRef.current = {
+      kind: "pan",
+      pointerId,
+      startPoint: point,
+      startState: viewerStateRef.current,
+    }
+    setDragging(true)
+  }
+
+  const startPinch = (): void => {
+    const pointers = Array.from(activePointersRef.current.entries()).slice(0, 2)
+    if (pointers.length < 2) {
+      return
+    }
+    const [[firstId, firstPoint], [secondId, secondPoint]] = pointers
+    gestureRef.current = {
+      kind: "pinch",
+      pointerIds: [firstId, secondId],
+      startDistance: Math.max(1, pointDistance(firstPoint, secondPoint)),
+      startMidpoint: stagePoint(pointMidpoint(firstPoint, secondPoint)),
+      startState: viewerStateRef.current,
+    }
+    setDragging(true)
+  }
+
   const handlePointerDown = (event: PointerEvent<HTMLDivElement>): void => {
-    if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) {
+    if (event.pointerType === "mouse" && event.button !== 0) {
       return
     }
     event.preventDefault()
     event.currentTarget.setPointerCapture(event.pointerId)
-    dragRef.current = {
-      originX: viewerState.offset.x,
-      originY: viewerState.offset.y,
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
+    const point = { x: event.clientX, y: event.clientY }
+    activePointersRef.current.set(event.pointerId, point)
+    if (activePointersRef.current.size >= 2) {
+      startPinch()
+    } else {
+      startPan(event.pointerId, point)
     }
     userAdjustedRef.current = true
-    setDragging(true)
   }
 
   const handlePointerMove = (event: PointerEvent<HTMLDivElement>): void => {
-    const drag = dragRef.current
-    if (!drag || drag.pointerId !== event.pointerId) {
+    if (!activePointersRef.current.has(event.pointerId)) {
       return
     }
-    setViewerState((current) =>
-      panDiagramViewerState(
-        { ...current, offset: { x: drag.originX, y: drag.originY } },
-        event.clientX - drag.startX,
-        event.clientY - drag.startY,
+    const point = { x: event.clientX, y: event.clientY }
+    activePointersRef.current.set(event.pointerId, point)
+    const gesture = gestureRef.current
+    if (!gesture) {
+      return
+    }
+    if (gesture.kind === "pan") {
+      if (gesture.pointerId !== event.pointerId) {
+        return
+      }
+      updateViewerState(() =>
+        panDiagramViewerState(
+          gesture.startState,
+          point.x - gesture.startPoint.x,
+          point.y - gesture.startPoint.y,
+          diagramSize,
+          stageSize,
+        ),
+      )
+      return
+    }
+    const [firstPoint, secondPoint] = gesture.pointerIds.map((pointerId) => activePointersRef.current.get(pointerId))
+    if (!firstPoint || !secondPoint) {
+      return
+    }
+    updateViewerState(() =>
+      pinchDiagramViewerState(
+        gesture.startState,
+        pointDistance(firstPoint, secondPoint) / gesture.startDistance,
+        gesture.startMidpoint,
+        stagePoint(pointMidpoint(firstPoint, secondPoint)),
         diagramSize,
         stageSize,
       ),
     )
   }
 
-  const stopDragging = (event: PointerEvent<HTMLDivElement>): void => {
-    if (dragRef.current?.pointerId !== event.pointerId) {
-      return
-    }
-    dragRef.current = null
-    setDragging(false)
+  const finishPointer = (event: PointerEvent<HTMLDivElement>): void => {
+    activePointersRef.current.delete(event.pointerId)
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId)
     }
+    if (activePointersRef.current.size >= 2) {
+      startPinch()
+      return
+    }
+    const remaining = activePointersRef.current.entries().next().value as [number, DiagramViewerPoint] | undefined
+    if (remaining) {
+      startPan(remaining[0], remaining[1])
+      return
+    }
+    gestureRef.current = null
+    setDragging(false)
   }
 
   const handleCopy = async (): Promise<void> => {
@@ -366,16 +482,11 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
           userAdjustedRef.current = false
           fitToWindow()
         }}
-        onPointerCancel={stopDragging}
+        onPointerCancel={finishPointer}
         onPointerDown={handlePointerDown}
-        onLostPointerCapture={(event) => {
-          if (dragRef.current?.pointerId === event.pointerId) {
-            dragRef.current = null
-            setDragging(false)
-          }
-        }}
+        onLostPointerCapture={finishPointer}
         onPointerMove={handlePointerMove}
-        onPointerUp={stopDragging}
+        onPointerUp={finishPointer}
         onWheel={handleWheel}
       >
         <div className="oo-mermaid-viewer-center">
@@ -396,7 +507,7 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
           className="oo-mermaid-viewer-zoom-button"
           aria-label={t("chat.diagramZoomOut")}
           disabled={viewerState.scale <= diagramViewerMinScale}
-          onClick={() => zoomBy(-diagramViewerScaleStep)}
+          onClick={() => zoomBy(1 / diagramViewerButtonScaleFactor)}
         >
           <MinusIcon className="size-4" />
         </button>
@@ -406,7 +517,7 @@ function MermaidViewer({ code, onClose, svg }: { code: string; onClose: () => vo
           className="oo-mermaid-viewer-zoom-button"
           aria-label={t("chat.diagramZoomIn")}
           disabled={viewerState.scale >= diagramViewerMaxScale}
-          onClick={() => zoomBy(diagramViewerScaleStep)}
+          onClick={() => zoomBy(diagramViewerButtonScaleFactor)}
         >
           <PlusIcon className="size-4" />
         </button>

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -519,6 +519,30 @@
     background: var(--oo-border-subtle);
   }
 
+  @media (any-pointer: coarse) {
+    .oo-mermaid-viewer-actions {
+      gap: 0.375rem;
+    }
+
+    .oo-mermaid-viewer-action,
+    .oo-mermaid-viewer-zoom-button {
+      width: 2.75rem;
+      height: 2.75rem;
+    }
+
+    .oo-mermaid-viewer-zoom {
+      bottom: max(1rem, env(safe-area-inset-bottom));
+      height: 3.25rem;
+      gap: 0.375rem;
+      padding: 0.1875rem;
+    }
+
+    .oo-mermaid-viewer-percent {
+      min-width: 3.25rem;
+      font-size: var(--oo-font-body);
+    }
+  }
+
   .oo-mermaid-error {
     min-height: 0;
     margin: 0.75rem 0;


### PR DESCRIPTION
## Summary

- add focal-point zooming and real two-pointer pinch/pan gestures to the Mermaid diagram viewer
- allow diagrams to be repositioned at any zoom level while keeping a recoverable visible edge
- use established D3-style wheel sensitivity, 1.2x discrete zoom steps, and larger coarse-pointer controls
- expand diagram navigation coverage for anchored zoom, pinch movement, wheel input, and bounds

## Testing

- npm run ts-check
- npm run lint
- npm run format
- npm test
- npm run dev (manual touchpad verification)
