### PR TITLE
Fix update restart action on standalone pages

### DIFF
--- a/src/components/AppUpdateTitlebarEntry.test.ts
+++ b/src/components/AppUpdateTitlebarEntry.test.ts
@@ -1,0 +1,46 @@
+import type { UseAppUpdate } from "@/hooks/useAppUpdate"
+
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { expect, it } from "vitest"
+import { AppUpdateTitlebarEntry } from "./AppUpdateTitlebarEntry.tsx"
+import { I18nContext, translate } from "@/i18n/i18n"
+
+function renderEntry(update: UseAppUpdate): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      I18nContext.Provider,
+      {
+        value: {
+          locale: "zh-CN",
+          setLocale: () => undefined,
+          t: (key, vars) => translate("zh-CN", key, vars),
+        },
+      },
+      React.createElement(AppUpdateTitlebarEntry, { update }),
+    ),
+  )
+}
+
+it("renders the restart action after an update is downloaded", () => {
+  const update: UseAppUpdate = {
+    check: async () => null,
+    checkAndDownload: async () => undefined,
+    download: async () => undefined,
+    install: async () => undefined,
+    isDownloadInFlight: false,
+    isInstallTriggered: false,
+    setChannel: async () => undefined,
+    state: {
+      channel: "stable",
+      currentVersion: "0.1.0",
+      isPackaged: true,
+      status: { status: "downloaded", version: "0.1.1" },
+    },
+  }
+
+  const html = renderEntry(update)
+
+  expect(html).toContain(translate("zh-CN", "nav.restartToUpdate"))
+  expect(html).toContain("refresh-cw")
+})

--- a/src/components/AppUpdateTitlebarEntry.tsx
+++ b/src/components/AppUpdateTitlebarEntry.tsx
@@ -1,0 +1,76 @@
+import type { UseAppUpdate } from "@/hooks/useAppUpdate"
+
+import { Download, LoaderCircle, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useT } from "@/i18n/i18n"
+
+export function AppUpdateTitlebarEntry({ update }: { update: UseAppUpdate }) {
+  const t = useT()
+  const state = update.state
+
+  if (!state?.isPackaged) {
+    return null
+  }
+
+  switch (state.status.status) {
+    case "available": {
+      const label = t("nav.updateDownload")
+      return (
+        <Button
+          type="button"
+          size="sm"
+          className="oo-toolbar-button max-w-40 min-w-0"
+          aria-label={label}
+          disabled={update.isDownloadInFlight}
+          onClick={() => void update.download()}
+        >
+          {update.isDownloadInFlight ? (
+            <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+          ) : (
+            <Download className="size-3.5 shrink-0" />
+          )}
+          <span className="truncate">{label}</span>
+        </Button>
+      )
+    }
+    case "downloading": {
+      const percent = Math.round(state.status.percent ?? 0)
+      const label = t("nav.updateDownloading", { percent })
+      return (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="oo-toolbar-button max-w-40 min-w-0"
+          aria-label={label}
+          disabled
+        >
+          <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+          <span className="truncate">{label}</span>
+        </Button>
+      )
+    }
+    case "downloaded": {
+      const label = t("nav.restartToUpdate")
+      return (
+        <Button
+          type="button"
+          size="sm"
+          className="oo-toolbar-button max-w-40 min-w-0"
+          aria-label={label}
+          disabled={update.isInstallTriggered}
+          onClick={() => void update.install()}
+        >
+          {update.isInstallTriggered ? (
+            <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3.5 shrink-0" />
+          )}
+          <span className="truncate">{label}</span>
+        </Button>
+      )
+    }
+    default:
+      return null
+  }
+}

--- a/src/components/PageRouteShell.test.ts
+++ b/src/components/PageRouteShell.test.ts
@@ -1,0 +1,23 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { expect, it } from "vitest"
+import { PageRouteShell } from "./PageRouteShell.tsx"
+
+it("renders supplied titlebar actions inside the page header", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(
+      PageRouteShell,
+      {
+        backLabel: "Back",
+        onBack: () => undefined,
+        titlebarActions: React.createElement("button", { "data-titlebar-action": "update" }, "Restart"),
+      },
+      React.createElement("div", null, "Content"),
+    ),
+  )
+
+  const headerEnd = html.indexOf("</header>")
+  const action = html.indexOf('data-titlebar-action="update"')
+  expect(action).toBeGreaterThanOrEqual(0)
+  expect(action).toBeLessThan(headerEnd)
+})

--- a/src/components/PageRouteShell.tsx
+++ b/src/components/PageRouteShell.tsx
@@ -7,12 +7,13 @@ export function PageRouteShell({
   children,
   contentClassName,
   onBack,
-}: {
+  titlebarActions,
+}: React.PropsWithChildren<{
   backLabel: string
-  children: React.ReactNode
   contentClassName?: string
   onBack: () => void
-}) {
+  titlebarActions?: React.ReactNode
+}>) {
   return (
     <div className="grid h-full min-h-0 grid-rows-[var(--app-titlebar-height)_minmax(0,1fr)] bg-background text-foreground">
       <header className="oo-titlebar oo-page-titlebar oo-border-divider flex h-[var(--app-titlebar-height)] shrink-0 items-center border-b [-webkit-app-region:drag]">
@@ -24,6 +25,9 @@ export function PageRouteShell({
           <ArrowLeftIcon className="size-4" />
           <span>{backLabel}</span>
         </button>
+        {titlebarActions ? (
+          <div className="ml-auto flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">{titlebarActions}</div>
+        ) : null}
       </header>
 
       <main className="min-h-0 overflow-y-auto">

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -65,6 +65,7 @@ import { useWorkspaceActivation } from "./use-workspace-activation.ts"
 import { ProjectContextBar } from "@/components/app-shell/ProjectContextBar"
 import { useAttentionService, useChatService } from "@/components/AppContext"
 import { useSkillInventoryResource } from "@/components/AppDataHooks"
+import { AppUpdateTitlebarEntry } from "@/components/AppUpdateTitlebarEntry"
 import { useAppSettings } from "@/hooks/useAppSettings"
 import { useAppUpdate } from "@/hooks/useAppUpdate"
 import { useAttention } from "@/hooks/useAttention"
@@ -1240,7 +1241,11 @@ export function AppShell({ auth }: { auth: UseAuth }) {
   if (route === "settings") {
     return (
       <React.Suspense fallback={<RouteLoadingFallback />}>
-        <SettingsRoute onBack={() => setRoute("chat")} />
+        <SettingsRoute
+          update={appUpdate}
+          titlebarActions={<AppUpdateTitlebarEntry update={appUpdate} />}
+          onBack={() => setRoute("chat")}
+        />
       </React.Suspense>
     )
   }
@@ -1252,6 +1257,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
           cacheScope={billingCacheScope}
           initialTarget={billingInitialTarget}
           sharedConnectorCount={sharedConnectorCount}
+          titlebarActions={<AppUpdateTitlebarEntry update={appUpdate} />}
           workspace={organizationWorkspace.activeWorkspace}
           onBack={() => setRoute("chat")}
         />
@@ -1275,6 +1281,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
           refreshSessions={refreshSessions}
           removeSession={removeSession}
           ready={ready}
+          titlebarActions={<AppUpdateTitlebarEntry update={appUpdate} />}
           unarchiveSession={unarchive}
         />
       </React.Suspense>

--- a/src/components/app-shell/AppShellMainTitlebar.tsx
+++ b/src/components/app-shell/AppShellMainTitlebar.tsx
@@ -6,8 +6,9 @@ import type { LucideIcon } from "lucide-react"
 
 import * as React from "react"
 import { EditableTitlebarTitle } from "./AppShellDialogs.tsx"
-import { AppUpdateTitlebarEntry, SidebarTitlebarActions } from "./AppShellSidebar.tsx"
+import { SidebarTitlebarActions } from "./AppShellSidebar.tsx"
 import { BillingUsagePopover } from "@/components/app-shell/BillingUsagePopover"
+import { AppUpdateTitlebarEntry } from "@/components/AppUpdateTitlebarEntry"
 import { cn } from "@/lib/utils"
 
 export function AppShellMainTitlebar({

--- a/src/components/app-shell/AppShellSidebar.tsx
+++ b/src/components/app-shell/AppShellSidebar.tsx
@@ -1,13 +1,11 @@
 import type { SessionInfo, SessionProject } from "../../../electron/session/common.ts"
 import type { ProjectSidebarGroup } from "./app-sidebar-model.ts"
 import type { SidebarSegment } from "./sidebar-persistence.ts"
-import type { UseAppUpdate } from "@/hooks/useAppUpdate"
 
 import {
   Archive,
   ChevronDown,
   ChevronRight,
-  Download,
   Ellipsis,
   Folder,
   FolderOpen,
@@ -19,7 +17,6 @@ import {
   Pencil,
   Pin,
   PinOff,
-  RefreshCw,
   Search,
   SquarePen,
   Trash2,
@@ -435,75 +432,4 @@ export function SidebarTitlebarActions({
       </button>
     </div>
   )
-}
-
-export function AppUpdateTitlebarEntry({ update }: { update: UseAppUpdate }) {
-  const t = useT()
-  const state = update.state
-
-  if (!state?.isPackaged) {
-    return null
-  }
-
-  switch (state.status.status) {
-    case "available": {
-      const label = t("nav.updateDownload")
-      return (
-        <Button
-          type="button"
-          size="sm"
-          className="oo-toolbar-button max-w-40 min-w-0"
-          aria-label={label}
-          disabled={update.isDownloadInFlight}
-          onClick={() => void update.download()}
-        >
-          {update.isDownloadInFlight ? (
-            <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
-          ) : (
-            <Download className="size-3.5 shrink-0" />
-          )}
-          <span className="truncate">{label}</span>
-        </Button>
-      )
-    }
-    case "downloading": {
-      const percent = Math.round(state.status.percent ?? 0)
-      const label = t("nav.updateDownloading", { percent })
-      return (
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="oo-toolbar-button max-w-40 min-w-0"
-          aria-label={label}
-          disabled
-        >
-          <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
-          <span className="truncate">{label}</span>
-        </Button>
-      )
-    }
-    case "downloaded": {
-      const label = t("nav.restartToUpdate")
-      return (
-        <Button
-          type="button"
-          size="sm"
-          className="oo-toolbar-button max-w-40 min-w-0"
-          aria-label={label}
-          disabled={update.isInstallTriggered}
-          onClick={() => void update.install()}
-        >
-          {update.isInstallTriggered ? (
-            <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
-          ) : (
-            <RefreshCw className="size-3.5 shrink-0" />
-          )}
-          <span className="truncate">{label}</span>
-        </Button>
-      )
-    }
-    default:
-      return null
-  }
 }

--- a/src/routes/Archived/index.tsx
+++ b/src/routes/Archived/index.tsx
@@ -51,6 +51,7 @@ interface ArchivedRouteProps {
   refreshSessions: () => Promise<void>
   removeSession: (id: string) => Promise<void>
   ready: boolean
+  titlebarActions: React.ReactNode
   unarchiveSession: (id: string) => Promise<SessionInfo | null>
 }
 
@@ -71,6 +72,7 @@ export function ArchivedRoute({
   refreshSessions,
   removeSession,
   ready,
+  titlebarActions,
   unarchiveSession,
 }: ArchivedRouteProps) {
   const { locale, t } = useI18n()
@@ -196,7 +198,12 @@ export function ArchivedRoute({
   }
 
   return (
-    <PageRouteShell backLabel={t("archived.backToChat")} contentClassName="max-w-[82rem] gap-5" onBack={onBack}>
+    <PageRouteShell
+      backLabel={t("archived.backToChat")}
+      contentClassName="max-w-[82rem] gap-5"
+      onBack={onBack}
+      titlebarActions={titlebarActions}
+    >
       <div className="flex min-w-0 items-center justify-between gap-4">
         <h1 className="oo-text-page-title min-w-0 truncate">{t("archived.title")}</h1>
         <ConfirmDialog>

--- a/src/routes/Billing/index.tsx
+++ b/src/routes/Billing/index.tsx
@@ -42,6 +42,7 @@ interface BillingRouteProps {
   initialTarget?: "credits" | "plans" | null
   onBack: () => void
   sharedConnectorCount?: number
+  titlebarActions: React.ReactNode
   workspace: WorkspaceSelection
 }
 
@@ -50,6 +51,7 @@ export function BillingRoute({
   initialTarget,
   onBack,
   sharedConnectorCount,
+  titlebarActions,
   workspace,
 }: BillingRouteProps) {
   const t = useT()
@@ -206,7 +208,12 @@ export function BillingRoute({
 
   return (
     <>
-      <PageRouteShell backLabel={t("billing.backToChat")} contentClassName="max-w-[84rem] gap-5" onBack={onBack}>
+      <PageRouteShell
+        backLabel={t("billing.backToChat")}
+        contentClassName="max-w-[84rem] gap-5"
+        onBack={onBack}
+        titlebarActions={titlebarActions}
+      >
         <h1 className="oo-text-page-title">{t("billing.title")}</h1>
 
         <section className="border-b border-[var(--oo-divider)] pb-5">

--- a/src/routes/Settings/index.tsx
+++ b/src/routes/Settings/index.tsx
@@ -33,7 +33,6 @@ import { Progress } from "@/components/ui/progress"
 import { Switch } from "@/components/ui/switch"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAppSettings } from "@/hooks/useAppSettings"
-import { useAppUpdate } from "@/hooks/useAppUpdate"
 import { useAttention } from "@/hooks/useAttention"
 import { useAuth } from "@/hooks/useAuth"
 import { useI18n } from "@/i18n/i18n"
@@ -64,16 +63,28 @@ const completionNotificationOptions = [
 
 const copyFeedbackMs = 3000
 
-export function SettingsRoute({ onBack }: { onBack: () => void }) {
+export function SettingsRoute({
+  onBack,
+  titlebarActions,
+  update,
+}: {
+  onBack: () => void
+  titlebarActions: React.ReactNode
+  update: UseAppUpdate
+}) {
   const { preference, setPreference } = useTheme()
   const { locale, setLocale, t } = useI18n()
   const auth = useAuth()
-  const update = useAppUpdate()
   const appSettings = useAppSettings()
   const attention = useAttention()
 
   return (
-    <PageRouteShell backLabel={t("settings.backToApp")} contentClassName="max-w-[60rem] gap-6" onBack={onBack}>
+    <PageRouteShell
+      backLabel={t("settings.backToApp")}
+      contentClassName="max-w-[60rem] gap-6"
+      onBack={onBack}
+      titlebarActions={titlebarActions}
+    >
       <h1 className="oo-text-page-title">{t("settings.title")}</h1>
 
       <div className="grid gap-5">


### PR DESCRIPTION
## Issue

After an application update finished downloading, Settings correctly showed its inline restart action, but the titlebar restart action was missing while the user remained on Settings. The same gap affected the other standalone Billing and Archived routes.

## Root cause

The shared update titlebar entry was mounted only in `AppShellMainTitlebar`. Settings, Billing, and Archived return their own `PageRouteShell` before the normal application titlebar is rendered, so those routes could observe the downloaded update state without mounting the corresponding titlebar action.

## Changes

- Extract the update titlebar entry into a reusable component.
- Add a titlebar action slot to `PageRouteShell`.
- Pass the existing `AppShell` update state into Settings instead of creating another update hook subscription.
- Render the shared update action on Settings, Billing, and Archived pages as well as the existing main titlebar.
- Add render regression tests for the downloaded restart action and the page-titlebar action slot.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` — 214 test files and 1414 tests passed
- `npm run build`
- Development-mode Settings route startup smoke test
