### PR TITLE
fix: preview Excel Craft workbooks

### DIFF
--- a/electron/chat/spreadsheet-excel-craft-compat.test.ts
+++ b/electron/chat/spreadsheet-excel-craft-compat.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+import { isEmptyInlineStringParseFailure, normalizeExcelCraftWorksheetXml } from "./spreadsheet-excel-craft-compat.ts"
+
+test("normalizeExcelCraftWorksheetXml expands Openpyxl empty inline strings", () => {
+  const xml = [
+    '<row r="1">',
+    '<c r="A1" s="3" t="inlineStr" />',
+    '<c r="B1" t="inlineStr" s="4"></c>',
+    '<c r="C1" t="inlineStr"><is><t>kept</t></is></c>',
+    '<c r="D1" t="n"><v>42</v></c>',
+    "</row>",
+  ].join("")
+
+  assert.equal(
+    normalizeExcelCraftWorksheetXml(xml),
+    [
+      '<row r="1">',
+      '<c r="A1" s="3" t="inlineStr"><is><t></t></is></c>',
+      '<c r="B1" t="inlineStr" s="4"><is><t></t></is></c>',
+      '<c r="C1" t="inlineStr"><is><t>kept</t></is></c>',
+      '<c r="D1" t="n"><v>42</v></c>',
+      "</row>",
+    ].join(""),
+  )
+})
+
+test("isEmptyInlineStringParseFailure only accepts the parser compatibility error", () => {
+  assert.equal(
+    isEmptyInlineStringParseFailure(
+      new Error('Unsupported "inline string" cell value structure: <c r="A1" t="inlineStr"></c>'),
+    ),
+    true,
+  )
+  assert.equal(isEmptyInlineStringParseFailure(new Error('Couldn\'t read "inline string" cell value')), true)
+  assert.equal(isEmptyInlineStringParseFailure(new Error("Invalid XLSX ZIP central directory")), false)
+  assert.equal(isEmptyInlineStringParseFailure("inline string"), false)
+})

--- a/electron/chat/spreadsheet-excel-craft-compat.ts
+++ b/electron/chat/spreadsheet-excel-craft-compat.ts
@@ -1,0 +1,47 @@
+import JSZip from "jszip"
+
+const worksheetPathPattern = /^xl\/worksheets\/[^/]+\.xml$/u
+const emptyInlineStringCellPattern = /<c\b([^>]*\bt=(['"])inlineStr\2[^>]*)\/>/gu
+const emptyInlineStringCellPairPattern = /<c\b([^>]*\bt=(['"])inlineStr\2[^>]*)>\s*<\/c>/gu
+
+export function isEmptyInlineStringParseFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return (
+    error.message.startsWith('Unsupported "inline string" cell value structure:') ||
+    error.message === 'Couldn\'t read "inline string" cell value'
+  )
+}
+
+export function normalizeExcelCraftWorksheetXml(xml: string): string {
+  const expandCell = (_match: string, attributes: string): string => `<c${attributes.trimEnd()}><is><t></t></is></c>`
+  return xml.replace(emptyInlineStringCellPattern, expandCell).replace(emptyInlineStringCellPairPattern, expandCell)
+}
+
+export async function normalizeExcelCraftWorkbook(bytes: Buffer): Promise<Buffer | null> {
+  const workbook = await JSZip.loadAsync(bytes)
+  let normalized = false
+
+  for (const entry of Object.values(workbook.files)) {
+    if (entry.dir || !worksheetPathPattern.test(entry.name)) {
+      continue
+    }
+    const xml = await entry.async("string")
+    const next = normalizeExcelCraftWorksheetXml(xml)
+    if (next === xml) {
+      continue
+    }
+    workbook.file(entry.name, next)
+    normalized = true
+  }
+
+  if (!normalized) {
+    return null
+  }
+  return workbook.generateAsync({
+    type: "nodebuffer",
+    compression: "DEFLATE",
+    compressionOptions: { level: 6 },
+  })
+}

--- a/electron/chat/spreadsheet-preview-worker.test.ts
+++ b/electron/chat/spreadsheet-preview-worker.test.ts
@@ -28,7 +28,7 @@ async function xlsxFixture(): Promise<Buffer> {
   )
   zip.file(
     "xl/worksheets/sheet1.xml",
-    '<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1:B1"/><sheetData><row r="1"><c r="A1"><v>42</v></c><c r="B1"><v>7</v></c></row></sheetData></worksheet>',
+    '<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1:C1"/><sheetData><row r="1"><c r="A1"><v>42</v></c><c r="B1" s="3" t="inlineStr" /><c r="C1" t="inlineStr"><is><t>kept</t></is></c></row></sheetData></worksheet>',
   )
   return zip.generateAsync({ type: "nodebuffer" })
 }
@@ -55,7 +55,7 @@ test("spreadsheet preview worker parses an XLSX end to end", async () => {
     assert.ok("result" in response)
     assert.equal(response.result.kind, "spreadsheet")
     assert.equal(response.result.spreadsheet?.activeSheet, "Summary")
-    assert.deepEqual(response.result.spreadsheet?.rows, [["42", "7"]])
+    assert.deepEqual(response.result.spreadsheet?.rows, [["42", "", "kept"]])
   } finally {
     await worker.terminate()
     await rm(directory, { force: true, recursive: true })

--- a/electron/chat/spreadsheet-preview.ts
+++ b/electron/chat/spreadsheet-preview.ts
@@ -6,6 +6,7 @@ import type {
 
 import { readFile } from "node:fs/promises"
 import readXlsxFile from "read-excel-file/universal"
+import { isEmptyInlineStringParseFailure, normalizeExcelCraftWorkbook } from "./spreadsheet-excel-craft-compat.ts"
 import { zipArchiveStats } from "./zip-central-directory.ts"
 
 export const spreadsheetPreviewMaxBytes = 8 * 1024 * 1024
@@ -34,6 +35,23 @@ function cellLabel(value: unknown): string {
 interface ParsedSpreadsheetSheet {
   data: unknown[][]
   sheet: string
+}
+
+async function parseSpreadsheet(bytes: Buffer): Promise<ParsedSpreadsheetSheet[]> {
+  try {
+    return await readXlsxFile(bufferArrayBuffer(bytes), { trim: false })
+  } catch (error) {
+    if (!isEmptyInlineStringParseFailure(error)) {
+      throw error
+    }
+    // Excel Craft 使用的 Openpyxl 会把带样式的空 inlineStr 单元格解释为空值。
+    // 仅在上游解析器命中同一兼容性缺口时规范化工作表 XML，保留正常文件的快速路径。
+    const normalized = await normalizeExcelCraftWorkbook(bytes)
+    if (!normalized) {
+      throw error
+    }
+    return readXlsxFile(bufferArrayBuffer(normalized), { trim: false })
+  }
 }
 
 function spreadsheetSheetPreview(sheet: ParsedSpreadsheetSheet): LocalArtifactSpreadsheetSheetPreview {
@@ -100,7 +118,7 @@ export async function spreadsheetPreview(
   ) {
     return { kind: "unsupported", mime, size, reason: "too_large" }
   }
-  const parsedSheets = await readXlsxFile(bufferArrayBuffer(bytes), { trim: false })
+  const parsedSheets = await parseSpreadsheet(bytes)
   const { preview, truncated } = spreadsheetWorkbookPreview(parsedSheets)
   return { kind: "spreadsheet", mime, size, spreadsheet: preview, truncated }
 }


### PR DESCRIPTION
## Summary

Wanta could not preview some valid `.xlsx` artifacts produced by the internal Excel Craft workflow. Instead of rendering the workbook, the artifact panel displayed an unavailable state and required the user to open the file in a system application.

The workbook itself was healthy. Openpyxl can emit styled blank cells as empty `inlineStr` elements, while the current `read-excel-file` parser rejects that OOXML shape before any worksheet can be rendered.

This change keeps the existing spreadsheet parser as the normal fast path. When parsing fails with the specific empty-inline-string compatibility error, Wanta normalizes only worksheet XML entries in memory by representing those cells as explicit empty inline strings, then retries parsing. Other parse failures continue to surface unchanged.

## Changes

- add a narrowly scoped Excel Craft/Openpyxl workbook compatibility adapter
- activate the adapter only for the known empty `inlineStr` parser failure
- preserve non-empty inline strings, numeric cells, workbook contents, and the normal parsing path
- add focused XML normalization tests and an end-to-end spreadsheet preview worker case

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` (222 files, 1492 tests)
- `npm run build`
- `git diff --check`
- manually opened the original failing workbook in the development app and verified all three worksheets render and switch correctly
