### PR TITLE
fix(connections): restore member connection status

### DIFF
--- a/src/routes/Connections/connection-route-model.test.ts
+++ b/src/routes/Connections/connection-route-model.test.ts
@@ -124,11 +124,11 @@ test("connection catalog filter rejects click events and malformed categories", 
   })
 })
 
-test("organization connection state is private to managers with a confirmed response", () => {
-  assert.equal(shouldShowConnectionState(false, "ready"), false)
-  assert.equal(shouldShowConnectionState(true, "unavailable"), false)
-  assert.equal(shouldShowConnectionState(true, "forbidden"), false)
-  assert.equal(shouldShowConnectionState(true, "ready"), true)
+test("organization members can view connection state after a confirmed response", () => {
+  assert.equal(shouldShowConnectionState("unavailable"), false)
+  assert.equal(shouldShowConnectionState("forbidden"), false)
+  assert.equal(shouldShowConnectionState(undefined), false)
+  assert.equal(shouldShowConnectionState("ready"), true)
 })
 
 test("available tools filter combines connected and directly available providers", () => {

--- a/src/routes/Connections/connection-route-model.ts
+++ b/src/routes/Connections/connection-route-model.ts
@@ -72,12 +72,9 @@ export interface ConnectionAuthIntent {
   source: "chat"
 }
 
-/** 组织连接状态只向可管理当前工作区、且服务端已确认读取成功的用户展示。 */
-export function shouldShowConnectionState(
-  canManageConnections: boolean,
-  appsStatus: ConnectionAppsStatus | undefined,
-): boolean {
-  return canManageConnections && appsStatus === "ready"
+/** 组织成员可只读查看连接状态；只有连接管理动作受 canManageConnections 限制。 */
+export function shouldShowConnectionState(appsStatus: ConnectionAppsStatus | undefined): boolean {
+  return appsStatus === "ready"
 }
 
 export function connectionDetailCacheKey(workspaceKey: string, service: string): string {

--- a/src/routes/Connections/index.tsx
+++ b/src/routes/Connections/index.tsx
@@ -118,7 +118,7 @@ export function ConnectionsPanel({
   )
   const directlyAvailableCount = React.useMemo(() => providers.filter(isDirectlyAvailableProvider).length, [providers])
   const availableToolsCount = connectedCount + directlyAvailableCount
-  const showConnectionState = shouldShowConnectionState(canManageConnections, summary?.appsStatus)
+  const showConnectionState = shouldShowConnectionState(summary?.appsStatus)
   const catalogProviders = React.useMemo(
     () => providers.filter((provider) => matchesProviderFilter(provider, activeFilter)),
     [activeFilter, providers],
@@ -499,7 +499,7 @@ export function ConnectionsPanel({
       >
         <SplitViewListPane ref={listPaneRef} narrowPane={narrowPane} className="pt-3">
           <div className="grid gap-3">
-            {canManageConnections && summary?.appsStatus && summary.appsStatus !== "ready" ? (
+            {summary?.appsStatus && summary.appsStatus !== "ready" ? (
               <ConnectionStateNotice status={summary.appsStatus} />
             ) : null}
             {listErrorNotice ? (


### PR DESCRIPTION
## Summary

Restore organization Connector status visibility for invited members while preserving the existing owner-only mutation boundary.

## Problem and user impact

Members invited to an organization could open the Connections catalog, but the UI hid the connected state of Connectors configured by the organization owner. The connected count, connected and attention filters, and per-provider status labels were all suppressed, making the shared organization workspace look as if none of its Connectors were connected.

This also removed the reliable connection-state input consumed by downstream product surfaces, but this PR intentionally fixes the Connector experience first.

## Root cause

The connection-state presentation gate incorrectly required both a successful `/v1/apps` response and `canManageConnections`. That coupled read visibility to mutation permission. Invited members correctly have `canManageConnections = false`, so a confirmed organization connection response was still hidden from them.

The read-only provider label logic already distinguished member-facing statuses such as Connected and Not connected from owner-facing actions such as Connect and Manage, but the presentation gate prevented that logic from running.

## Changes

- Show organization connection state whenever the scoped Apps response is confirmed as ready, regardless of management permission.
- Keep connect, reconnect, credential, and disconnect operations gated by `canManageConnections`.
- Show unavailable or forbidden connection-state notices to members as well as owners instead of silently presenting an unverified empty state.
- Update regression coverage to assert that a confirmed response is visible to organization members.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 237 test files, 1,615 tests passed
- `npm run build`
- `npm run dev` — Electron renderer, main process, preload, and Agent sidecar started successfully

Runtime account diagnostics still report a separate upstream `/v1/apps` 502 (`relation-control response is invalid`) for the affected joined organization. This PR makes that unavailable state visible to members and fixes the client-side permission regression; the upstream response requires separate backend follow-up.

The branch was rebased onto `main` at `798a137c` after #184 merged, then the complete validation suite above was rerun successfully.
