### PR TITLE
fix(window): enable native Windows rounded corners

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -67,6 +67,7 @@ import { UpdateServiceImpl } from "./update/node.ts"
 import { buildApplicationMenuTemplate } from "./window/application-menu.ts"
 import {
   buildWindowsTitleBarOverlay,
+  nativeFramelessWindowFrameForPlatform,
   nativeWindowMaterialForPlatform,
   resolveWindowsTitleBarTheme,
   windowBackgroundColorForMaterial,
@@ -797,6 +798,7 @@ function createMainWindow(): void {
     ...(isMac
       ? {}
       : {
+          ...nativeFramelessWindowFrameForPlatform(process.platform),
           ...(nativeMaterial === "windows-mica" ? { backgroundMaterial: "mica" } : {}),
           frame: false,
           titleBarOverlay: buildWindowsTitleBarOverlay(titleBarTheme),

--- a/electron/window/title-bar-overlay.test.ts
+++ b/electron/window/title-bar-overlay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildWindowsTitleBarOverlay,
+  nativeFramelessWindowFrameForPlatform,
   nativeWindowMaterialForPlatform,
   resolveWindowsTitleBarTheme,
   shouldApplyWindowsTitleBarTheme,
@@ -40,6 +41,20 @@ describe("nativeWindowMaterialForPlatform", () => {
     expect(nativeWindowMaterialForPlatform("darwin")).toBe("macos-vibrancy")
     expect(nativeWindowMaterialForPlatform("win32")).toBe("windows-mica")
     expect(nativeWindowMaterialForPlatform("linux")).toBe("none")
+  })
+})
+
+describe("nativeFramelessWindowFrameForPlatform", () => {
+  it("keeps the native Windows frame and rounded corners enabled", () => {
+    expect(nativeFramelessWindowFrameForPlatform("win32")).toEqual({
+      roundedCorners: true,
+      thickFrame: true,
+    })
+  })
+
+  it("does not override native frame behavior on other platforms", () => {
+    expect(nativeFramelessWindowFrameForPlatform("darwin")).toEqual({})
+    expect(nativeFramelessWindowFrameForPlatform("linux")).toEqual({})
   })
 })
 

--- a/electron/window/title-bar-overlay.ts
+++ b/electron/window/title-bar-overlay.ts
@@ -1,7 +1,8 @@
-import type { TitleBarOverlayOptions } from "electron"
+import type { BrowserWindowConstructorOptions, TitleBarOverlayOptions } from "electron"
 
 export type WindowsTitleBarTheme = "light" | "dark"
 export type NativeWindowMaterial = "macos-vibrancy" | "windows-mica" | "none"
+export type NativeFramelessWindowFrame = Pick<BrowserWindowConstructorOptions, "roundedCorners" | "thickFrame">
 
 export const windowsTitleBarOverlayHeight = 47
 export const transparentWindowBackgroundColor = "#00000000"
@@ -41,6 +42,17 @@ export function nativeWindowMaterialForPlatform(platform: NodeJS.Platform): Nati
     return "windows-mica"
   }
   return "none"
+}
+
+export function nativeFramelessWindowFrameForPlatform(platform: NodeJS.Platform): NativeFramelessWindowFrame {
+  if (platform !== "win32") {
+    return {}
+  }
+  return {
+    // 显式保留 DWM 框架与圆角，让普通窗口使用 Windows 11 原生轮廓；最大化和贴靠时由系统恢复直角。
+    roundedCorners: true,
+    thickFrame: true,
+  }
 }
 
 export function windowBackgroundColorForMaterial(theme: WindowsTitleBarTheme, material: NativeWindowMaterial): string {


### PR DESCRIPTION
## Summary

Wanta's frameless Windows window could appear visually square even on Windows 11, making the application chrome feel less consistent with modern native desktop applications.

The window already used a hidden title bar, the native window-controls overlay, and Mica, but it relied on implicit Electron defaults for the remaining native frame behavior. That made the rounded-corner intent unclear and vulnerable to future window configuration changes.

This change explicitly enables Electron's native Windows rounded corners and preserves the thick DWM frame. Normal Windows 11 windows therefore use the system-provided rounded outline while retaining native shadows, resize hit targets, animations, maximize behavior, and Snap support. Maximized and snapped windows continue to use square corners according to Windows conventions. macOS and Linux frame behavior is unchanged.

The platform-specific options are isolated in a pure helper and covered by unit tests so future frame changes cannot silently disable the Windows behavior.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 240 test files and 1,665 tests passed
- `npm run dev` — Electron main process and preload built and the application started successfully
- `git diff --check`

Final visual confirmation should be performed on a physical Windows 11 environment because the implementation environment is macOS.
