### PR TITLE
fix(window): preserve native Windows frame

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,7 +68,7 @@ import { UpdateServiceImpl } from "./update/node.ts"
 import { buildApplicationMenuTemplate } from "./window/application-menu.ts"
 import {
   buildWindowsTitleBarOverlay,
-  nativeFramelessWindowFrameForPlatform,
+  nativeWindowFrameForPlatform,
   nativeWindowMaterialForPlatform,
   resolveWindowsTitleBarTheme,
   windowBackgroundColorForMaterial,
@@ -805,9 +805,7 @@ function createMainWindow(): void {
     ...(isMac
       ? {}
       : {
-          ...nativeFramelessWindowFrameForPlatform(process.platform),
-          ...(nativeMaterial === "windows-mica" ? { backgroundMaterial: "mica" } : {}),
-          frame: false,
+          ...nativeWindowFrameForPlatform(process.platform),
           titleBarOverlay: buildWindowsTitleBarOverlay(titleBarTheme),
         }),
     webPreferences: {

--- a/electron/settings/node.ts
+++ b/electron/settings/node.ts
@@ -155,9 +155,6 @@ export class SettingsServiceImpl
     const backgroundColor = windowBackgroundColorForMaterial(nextTheme, material)
     for (const window of windows) {
       window.setBackgroundColor(backgroundColor)
-      if (material === "windows-mica") {
-        window.setBackgroundMaterial("mica")
-      }
       window.setTitleBarOverlay(overlay)
     }
     this.lastAppliedWindowsTitleBarTheme = nextTheme

--- a/electron/window/title-bar-overlay.test.ts
+++ b/electron/window/title-bar-overlay.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildWindowsTitleBarOverlay,
-  nativeFramelessWindowFrameForPlatform,
+  nativeWindowFrameForPlatform,
   nativeWindowMaterialForPlatform,
   resolveWindowsTitleBarTheme,
   shouldApplyWindowsTitleBarTheme,
@@ -37,24 +37,22 @@ describe("windowBackgroundColorForTheme", () => {
 })
 
 describe("nativeWindowMaterialForPlatform", () => {
-  it("uses native materials only where Electron supports them", () => {
+  it("keeps Windows opaque while retaining macOS vibrancy", () => {
     expect(nativeWindowMaterialForPlatform("darwin")).toBe("macos-vibrancy")
-    expect(nativeWindowMaterialForPlatform("win32")).toBe("windows-mica")
+    expect(nativeWindowMaterialForPlatform("win32")).toBe("none")
     expect(nativeWindowMaterialForPlatform("linux")).toBe("none")
   })
 })
 
-describe("nativeFramelessWindowFrameForPlatform", () => {
-  it("keeps the native Windows frame and rounded corners enabled", () => {
-    expect(nativeFramelessWindowFrameForPlatform("win32")).toEqual({
-      roundedCorners: true,
-      thickFrame: true,
-    })
+describe("nativeWindowFrameForPlatform", () => {
+  it("keeps the native Windows frame so DWM owns the window outline", () => {
+    expect(nativeWindowFrameForPlatform("win32")).toEqual({})
   })
 
-  it("does not override native frame behavior on other platforms", () => {
-    expect(nativeFramelessWindowFrameForPlatform("darwin")).toEqual({})
-    expect(nativeFramelessWindowFrameForPlatform("linux")).toEqual({})
+  it("preserves the existing platform behavior elsewhere", () => {
+    expect(nativeWindowFrameForPlatform("darwin")).toEqual({})
+    expect(nativeWindowFrameForPlatform("linux")).toEqual({ frame: false })
+    expect(nativeWindowFrameForPlatform("freebsd")).toEqual({ frame: false })
   })
 })
 
@@ -64,9 +62,8 @@ describe("windowBackgroundColorForMaterial", () => {
     expect(windowBackgroundColorForMaterial("dark", "none")).toBe("#111113")
   })
 
-  it("uses a transparent window background when native material is active", () => {
+  it("uses a transparent window background only when macOS vibrancy is active", () => {
     expect(windowBackgroundColorForMaterial("light", "macos-vibrancy")).toBe(transparentWindowBackgroundColor)
-    expect(windowBackgroundColorForMaterial("dark", "windows-mica")).toBe(transparentWindowBackgroundColor)
   })
 })
 

--- a/electron/window/title-bar-overlay.ts
+++ b/electron/window/title-bar-overlay.ts
@@ -1,8 +1,8 @@
 import type { BrowserWindowConstructorOptions, TitleBarOverlayOptions } from "electron"
 
 export type WindowsTitleBarTheme = "light" | "dark"
-export type NativeWindowMaterial = "macos-vibrancy" | "windows-mica" | "none"
-export type NativeFramelessWindowFrame = Pick<BrowserWindowConstructorOptions, "roundedCorners" | "thickFrame">
+export type NativeWindowMaterial = "macos-vibrancy" | "none"
+export type NativeWindowFrame = Pick<BrowserWindowConstructorOptions, "frame">
 
 export const windowsTitleBarOverlayHeight = 47
 export const transparentWindowBackgroundColor = "#00000000"
@@ -38,21 +38,15 @@ export function nativeWindowMaterialForPlatform(platform: NodeJS.Platform): Nati
   if (platform === "darwin") {
     return "macos-vibrancy"
   }
-  if (platform === "win32") {
-    return "windows-mica"
-  }
   return "none"
 }
 
-export function nativeFramelessWindowFrameForPlatform(platform: NodeJS.Platform): NativeFramelessWindowFrame {
-  if (platform !== "win32") {
+export function nativeWindowFrameForPlatform(platform: NodeJS.Platform): NativeWindowFrame {
+  if (platform === "darwin" || platform === "win32") {
+    // Windows 只隐藏标题栏并保留原生 frame，由 DWM 绘制 Windows 11 圆角、阴影和缩放边框。
     return {}
   }
-  return {
-    // 显式保留 DWM 框架与圆角，让普通窗口使用 Windows 11 原生轮廓；最大化和贴靠时由系统恢复直角。
-    roundedCorners: true,
-    thickFrame: true,
-  }
+  return { frame: false }
 }
 
 export function windowBackgroundColorForMaterial(theme: WindowsTitleBarTheme, material: NativeWindowMaterial): string {


### PR DESCRIPTION
## Issue

Wanta's Windows window could remain visually square even after explicitly enabling Electron's `roundedCorners` and `thickFrame` options. This made the app chrome inconsistent with native Windows 11 windows and left the previous fix without a meaningful runtime behavior change.

## Root cause

Both `roundedCorners` and `thickFrame` already default to `true` in Electron. Wanta still created the Windows window with `frame: false`, `transparent: true`, and Mica background material, so explicitly restating those defaults did not move the window onto the native framed-window path used by the working OOMOL Chat Desktop implementation.

## Fix

This change keeps the native Windows frame while retaining `titleBarStyle: "hidden"` and the Window Controls Overlay. Windows 11 DWM can now own the window outline, shadow, resize frame, maximize behavior, and Snap integration. The Windows-specific transparent Mica path is removed so the window uses an opaque theme-matched background. macOS keeps its vibrancy configuration, while Linux and other non-native targets preserve the existing frameless behavior.

Theme changes continue to update the Windows window background and title bar overlay colors, but no longer re-enable Mica. Unit tests now verify that Windows keeps the native frame and opaque background, while other platform behavior remains unchanged.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 241 test files and 1,672 tests passed
- Vite production build for renderer, main process, and preload
- `npm run dev` — Electron main process and preload built successfully and the application started
- `git diff --check`

Final visual confirmation should be performed on a physical Windows 11 environment, including restored, maximized, Snap, light/dark theme, and mixed-DPI scenarios.
