### PR TITLE
feat(chat): improve composer input and clean up legacy branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,5 @@ resources/skills
 resources/agent-tool-runtime
 
 # Local dev scratch
-.lumo-dev/
 .wanta-dev/
 .playwright-mcp/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -29,7 +29,6 @@
     "node_modules",
     "release",
     ".electron-dist",
-    ".lumo-dev",
     ".wanta-dev"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,5 +21,5 @@
       }
     }
   ],
-  "ignorePatterns": ["dist", "dist-electron", "node_modules", "release", ".electron-dist", ".lumo-dev", ".wanta-dev"]
+  "ignorePatterns": ["dist", "dist-electron", "node_modules", "release", ".electron-dist", ".wanta-dev"]
 }

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1846,6 +1846,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                       error={error}
                       emptyTitle={chatEmptyTitle}
                       generatedArtifacts={latestArtifactSelection}
+                      historyScope={billingCacheScope}
                       submitDisabled={!ready || chatBootstrapping || workspaceActivationBlocked || !sessionScope}
                       willQueueMessage={Boolean(
                         activeChatSessionId && (!chatTurnAllowsDirectSend(activeChatTurnState) || isSendInFlight()),

--- a/src/hooks/useTeamWorkspace.ts
+++ b/src/hooks/useTeamWorkspace.ts
@@ -63,7 +63,6 @@ interface PendingWorkspaceTeamPatch {
 }
 
 const selectedWorkspaceStorageKeyPrefix = `${branding.storageKeyPrefix}:active-workspace:`
-const legacySelectedWorkspaceStorageKeyPrefix = "lumo:active-workspace:"
 const workspaceOverviewCacheMs = 30_000
 const workspaceOverviewPatchTtlMs = 120_000
 let workspaceOverviewCache: WorkspaceOverviewCacheEntry | null = null
@@ -76,10 +75,6 @@ function workspaceTeamPatchKey(accountId: string, teamId: string): string {
 
 function selectedWorkspaceStorageKey(accountId: string): string {
   return `${selectedWorkspaceStorageKeyPrefix}${accountId}`
-}
-
-function legacySelectedWorkspaceStorageKey(accountId: string): string {
-  return `${legacySelectedWorkspaceStorageKeyPrefix}${accountId}`
 }
 
 export function storedTeamIdFromValue(value: unknown): string | null {
@@ -97,10 +92,7 @@ function readStoredTeamId(accountId: string | undefined): string | null {
   }
   try {
     const key = selectedWorkspaceStorageKey(accountId)
-    const legacyKey = legacySelectedWorkspaceStorageKey(accountId)
-    const currentRaw = window.localStorage.getItem(key)
-    const legacyRaw = currentRaw === null ? window.localStorage.getItem(legacyKey) : null
-    const raw = currentRaw ?? legacyRaw
+    const raw = window.localStorage.getItem(key)
     if (!raw) {
       return null
     }
@@ -112,9 +104,8 @@ function readStoredTeamId(accountId: string | undefined): string | null {
     if (!storedTeamId) {
       return null
     }
-    if (legacyRaw !== null || !("teamId" in parsed)) {
+    if (!("teamId" in parsed)) {
       window.localStorage.setItem(key, JSON.stringify({ teamId: storedTeamId }))
-      window.localStorage.removeItem(legacyKey)
     }
     return storedTeamId
   } catch {

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -19,6 +19,13 @@ import { Bug, X } from "lucide-react"
 import * as React from "react"
 import { AddCustomModelDialog } from "./AddCustomModelDialog.tsx"
 import { AttachmentList } from "./ChatAttachments.tsx"
+import {
+  appendStoredComposerHistory,
+  buildComposerHistory,
+  mergeComposerHistories,
+  navigateComposerHistory,
+  readStoredComposerHistory,
+} from "./composer-history.ts"
 import { composerPaletteItemElementId } from "./composer-palette-accessibility.ts"
 import {
   buildArtifactPaletteItems,
@@ -28,7 +35,12 @@ import {
   buildSkillPaletteItems,
   slashCommandItems,
 } from "./composer-palette-items.ts"
-import { composerReducer, composerSubmissionText, initialComposerState } from "./composer-state.ts"
+import {
+  composerReducer,
+  composerSubmissionText,
+  hasComposerDraftContent,
+  initialComposerState,
+} from "./composer-state.ts"
 import { ComposerAttachmentMenu } from "./ComposerAttachmentMenu.tsx"
 import { ComposerPalette } from "./ComposerPalette.tsx"
 import { ComposerTrailingControls } from "./ComposerTrailingControls.tsx"
@@ -62,6 +74,7 @@ interface ChatComposerProps {
   focusRequest: number
   generatedArtifacts?: ArtifactSelection | null
   hasMessages: boolean
+  historyScope: string
   initialComposerState?: ComposerState
   messages: ChatMessage[]
   knowledgeBaseIds: string[]
@@ -159,6 +172,7 @@ export function ChatComposer({
   focusRequest,
   generatedArtifacts = null,
   hasMessages,
+  historyScope,
   initialComposerState: initialComposerStateProp,
   messages,
   knowledgeBaseIds,
@@ -209,6 +223,10 @@ export function ChatComposer({
     [],
   )
   const [answeringQuestion, setAnsweringQuestion] = React.useState(false)
+  const [historyIndex, setHistoryIndex] = React.useState<number | null>(null)
+  const [storedComposerHistory, setStoredComposerHistory] = React.useState(() =>
+    readStoredComposerHistory(historyScope),
+  )
   const { agentMode, reasoningLevel, setAgentMode, setReasoningLevel } = useComposerPreferences()
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
   const appendVoiceTranscription = React.useCallback((text: string) => {
@@ -218,6 +236,19 @@ export function ChatComposer({
   const voiceInput = useVoiceComposerInput(appendVoiceTranscription)
   const paletteId = React.useId()
   const { attachments, command, contextMentions, dismissedTriggerKey, draft, draftSelection } = composer
+  React.useEffect(() => {
+    setStoredComposerHistory(readStoredComposerHistory(historyScope))
+    setHistoryIndex(null)
+  }, [historyScope])
+  const composerHistory = React.useMemo(() => {
+    const currentChatHistory = buildComposerHistory(messages, queuedMessages)
+    return mergeComposerHistories(currentChatHistory, storedComposerHistory)
+  }, [messages, queuedMessages, storedComposerHistory])
+  React.useEffect(() => {
+    if (historyIndex !== null && draft !== composerHistory[historyIndex]) {
+      setHistoryIndex(null)
+    }
+  }, [composerHistory, draft, historyIndex])
   const activePendingQuestion = pendingQuestions[0]
   const activePendingQuestionId = activePendingQuestion?.id
   const composerQuestionBlocked = Boolean(activePendingQuestion && !isSingleTextQuestion(activePendingQuestion))
@@ -396,6 +427,49 @@ export function ChatComposer({
     skillItems,
     slashItems,
   })
+  const resetHistoryNavigation = React.useCallback(() => setHistoryIndex(null), [])
+  const appendComposerHistory = React.useCallback(
+    (text: string): void => {
+      setStoredComposerHistory(appendStoredComposerHistory(historyScope, text))
+    },
+    [historyScope],
+  )
+  const handleComposerKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+      composerPalette.handleKeyDown(event)
+      if (
+        event.defaultPrevented ||
+        event.nativeEvent.isComposing ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown")
+      ) {
+        return
+      }
+
+      if (
+        historyIndex === null &&
+        (event.key !== "ArrowUp" || Boolean(activePendingQuestion) || hasComposerDraftContent(composer))
+      ) {
+        return
+      }
+
+      const navigation = navigateComposerHistory(
+        composerHistory,
+        historyIndex,
+        event.key === "ArrowUp" ? "older" : "newer",
+      )
+      if (!navigation) {
+        return
+      }
+      event.preventDefault()
+      setHistoryIndex(navigation.index)
+      dispatchComposer({ draft: navigation.text, type: "recall-history" })
+    },
+    [activePendingQuestion, composer, composerHistory, composerPalette, historyIndex],
+  )
 
   // 表单提交（含回车）始终走"发送"路径；"停止"只通过 ComposerTrailingControls
   // 的按钮点击触发，避免生成中按回车误中止流。
@@ -418,7 +492,9 @@ export function ChatComposer({
       setAnsweringQuestion(true)
       try {
         await onAnswerQuestion(activePendingQuestion.id, answerSingleTextQuestion(activePendingQuestion, text))
+        appendComposerHistory(text)
         composerAttachments.revokeCurrentPreviews()
+        resetHistoryNavigation()
         dispatchComposer({ type: "reset-after-submit" })
         clearInputError()
       } catch (err) {
@@ -441,6 +517,7 @@ export function ChatComposer({
       }
       clearedAfterSubmit = true
       composerAttachments.revokeCurrentPreviews()
+      resetHistoryNavigation()
       dispatchComposer({ type: "reset-after-submit" })
       clearInputError()
     }
@@ -468,6 +545,7 @@ export function ChatComposer({
       showTrustedInputError(t("chat.sendNotAccepted"))
       return
     }
+    appendComposerHistory(text)
     clearAfterOptimisticSubmit()
   }
 
@@ -588,6 +666,7 @@ export function ChatComposer({
               : undefined
           }
           onChange={(e) => {
+            resetHistoryNavigation()
             dispatchComposer({
               type: "set-draft",
               draft: e.target.value,
@@ -597,8 +676,11 @@ export function ChatComposer({
               },
             })
           }}
-          onClick={updateDraftSelection}
-          onKeyDown={composerPalette.handleKeyDown}
+          onClick={() => {
+            resetHistoryNavigation()
+            updateDraftSelection()
+          }}
+          onKeyDown={handleComposerKeyDown}
           onKeyUp={updateDraftSelection}
           onSelect={updateDraftSelection}
           onPaste={composerAttachments.handlePaste}

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -545,7 +545,10 @@ export function ChatComposer({
       showTrustedInputError(t("chat.sendNotAccepted"))
       return
     }
-    appendComposerHistory(text)
+    // 文本历史无法恢复命令 chip；排除命令，避免召回后把命令备注误发成普通消息。
+    if (command === null) {
+      appendComposerHistory(text)
+    }
     clearAfterOptimisticSubmit()
   }
 

--- a/src/routes/Chat/ChatErrorNotice.tsx
+++ b/src/routes/Chat/ChatErrorNotice.tsx
@@ -38,20 +38,10 @@ function autoPromptStorageKey(autoOpenKey: string): string {
   return `wanta-payment-dialog-opened:${autoOpenKey}`
 }
 
-function legacyAutoPromptStorageKey(autoOpenKey: string): string {
-  return `lumo-payment-dialog-opened:${autoOpenKey}`
-}
-
 function markAutoPromptOpened(autoOpenKey: string): boolean {
   const key = autoPromptStorageKey(autoOpenKey)
-  const legacyKey = legacyAutoPromptStorageKey(autoOpenKey)
   try {
     if (sessionStorage.getItem(key)) {
-      return false
-    }
-    if (sessionStorage.getItem(legacyKey)) {
-      sessionStorage.setItem(key, "1")
-      sessionStorage.removeItem(legacyKey)
       return false
     }
     sessionStorage.setItem(key, "1")

--- a/src/routes/Chat/composer-history.test.ts
+++ b/src/routes/Chat/composer-history.test.ts
@@ -51,6 +51,23 @@ describe("composer history", () => {
     ).toEqual(["describe it"])
   })
 
+  it("excludes command submissions from messages and the queue", () => {
+    expect(
+      buildComposerHistory(
+        [
+          message(10, "user", "before"),
+          message(20, "user", "/bug-report"),
+          message(30, "user", "/bug-report include diagnostics"),
+          message(40, "user", "after"),
+        ],
+        [
+          { createdAt: 50, text: "/bug-report queued note" },
+          { createdAt: 60, text: "queued message" },
+        ],
+      ),
+    ).toEqual(["before", "after", "queued message"])
+  })
+
   it("deduplicates consecutive prompts and keeps the newest limit", () => {
     expect(
       buildComposerHistory(
@@ -97,6 +114,7 @@ describe("composer history", () => {
 
     expect(appendStoredComposerHistory(scope, " same ", storage)).toEqual(["same"])
     expect(appendStoredComposerHistory(scope, "same", storage)).toEqual(["same"])
+    expect(appendStoredComposerHistory(scope, "/bug-report stored note", storage)).toEqual(["same"])
     storage.values.set(composerHistoryStorageKey(scope), "{broken")
     expect(readStoredComposerHistory(scope, storage)).toEqual([])
   })

--- a/src/routes/Chat/composer-history.test.ts
+++ b/src/routes/Chat/composer-history.test.ts
@@ -1,0 +1,126 @@
+import type { ChatMessage, ChatMessagePart } from "../../../electron/chat/common.ts"
+import type { ComposerHistoryStorage } from "./composer-history.ts"
+
+import { describe, expect, it } from "vitest"
+import {
+  appendStoredComposerHistory,
+  buildComposerHistory,
+  composerHistoryStorageKey,
+  mergeComposerHistories,
+  navigateComposerHistory,
+  readStoredComposerHistory,
+} from "./composer-history.ts"
+
+function createStorage(): ComposerHistoryStorage & { values: Map<string, string> } {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => void values.set(key, value),
+    values,
+  }
+}
+
+function message(
+  createdAt: number,
+  role: ChatMessage["role"],
+  text: string,
+): Pick<ChatMessage, "createdAt" | "parts" | "role"> {
+  const parts: ChatMessagePart[] = text ? [{ kind: "text", partId: `text-${createdAt}`, text }] : []
+  return { createdAt, parts, role }
+}
+
+describe("composer history", () => {
+  it("builds chronological history from visible user and queued text", () => {
+    expect(
+      buildComposerHistory(
+        [message(10, "user", "first"), message(20, "assistant", "ignored"), message(30, "user", "third")],
+        [{ createdAt: 20, text: "second" }],
+      ),
+    ).toEqual(["first", "second", "third"])
+  })
+
+  it("strips synthetic attachment prelude and ignores empty entries", () => {
+    expect(
+      buildComposerHistory(
+        [
+          message(10, "user", 'Called the Read tool with the following input: {"filePath":"/tmp/a.png"}  describe it'),
+          message(20, "user", 'Called the Read tool with the following input: {"filePath":"/tmp/b.png"}'),
+        ],
+        [{ createdAt: 30, text: "   " }],
+      ),
+    ).toEqual(["describe it"])
+  })
+
+  it("deduplicates consecutive prompts and keeps the newest limit", () => {
+    expect(
+      buildComposerHistory(
+        [
+          message(10, "user", "first"),
+          message(20, "user", "same"),
+          message(30, "user", "same"),
+          message(40, "user", "last"),
+        ],
+        [],
+        2,
+      ),
+    ).toEqual(["same", "last"])
+    expect(buildComposerHistory([message(10, "user", "first")], [], 0)).toEqual([])
+  })
+
+  it("keeps the newest 20 prompts by default", () => {
+    const messages = Array.from({ length: 25 }, (_, index) => message(index, "user", `prompt ${index + 1}`))
+
+    const history = buildComposerHistory(messages, [])
+
+    expect(history).toHaveLength(20)
+    expect(history[0]).toBe("prompt 6")
+    expect(history.at(-1)).toBe("prompt 25")
+  })
+
+  it("persists the newest 20 prompts within an account and workspace scope", () => {
+    const storage = createStorage()
+    const scope = "user-1:team:team-1"
+    for (let index = 1; index <= 25; index += 1) {
+      appendStoredComposerHistory(scope, `prompt ${index}`, storage)
+    }
+
+    expect(readStoredComposerHistory(scope, storage)).toEqual(
+      Array.from({ length: 20 }, (_, index) => `prompt ${index + 6}`),
+    )
+    expect(readStoredComposerHistory("user-1:team:team-2", storage)).toEqual([])
+    expect(readStoredComposerHistory("user-2:team:team-1", storage)).toEqual([])
+  })
+
+  it("deduplicates consecutive stored prompts and ignores invalid storage", () => {
+    const storage = createStorage()
+    const scope = "user-1:team:team-1"
+
+    expect(appendStoredComposerHistory(scope, " same ", storage)).toEqual(["same"])
+    expect(appendStoredComposerHistory(scope, "same", storage)).toEqual(["same"])
+    storage.values.set(composerHistoryStorageKey(scope), "{broken")
+    expect(readStoredComposerHistory(scope, storage)).toEqual([])
+  })
+
+  it("merges current-chat fallback with newer workspace history", () => {
+    expect(mergeComposerHistories(["old", "shared", "current"], ["shared", "latest"])).toEqual([
+      "old",
+      "current",
+      "shared",
+      "latest",
+    ])
+  })
+
+  it("wraps backward and navigates forward to an empty composer", () => {
+    const history = ["first", "second", "third"]
+    expect(navigateComposerHistory(history, null, "older")).toEqual({ index: 2, text: "third" })
+    expect(navigateComposerHistory(history, 2, "older")).toEqual({ index: 1, text: "second" })
+    expect(navigateComposerHistory(history, 0, "older")).toEqual({ index: 2, text: "third" })
+    expect(navigateComposerHistory(history, 1, "newer")).toEqual({ index: 2, text: "third" })
+    expect(navigateComposerHistory(history, 2, "newer")).toEqual({ index: null, text: "" })
+  })
+
+  it("does not navigate forward before history browsing starts", () => {
+    expect(navigateComposerHistory(["first"], null, "newer")).toBeNull()
+    expect(navigateComposerHistory([], null, "older")).toBeNull()
+  })
+})

--- a/src/routes/Chat/composer-history.ts
+++ b/src/routes/Chat/composer-history.ts
@@ -1,0 +1,157 @@
+import type { ChatMessage } from "../../../electron/chat/common.ts"
+import type { QueuedChatMessage } from "@/components/app-shell/chat-queue"
+
+import { storageKey } from "../../../electron/branding.ts"
+import { visibleUserText } from "./message-text.ts"
+
+const COMPOSER_HISTORY_LIMIT = 20
+const COMPOSER_HISTORY_STORAGE_VERSION = 1
+
+export interface ComposerHistoryStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+interface ComposerHistoryCandidate {
+  createdAt: number
+  order: number
+  text: string
+}
+
+export interface ComposerHistoryNavigation {
+  index: number | null
+  text: string
+}
+
+export function composerHistoryStorageKey(scope: string): string {
+  return storageKey(`composer-history.v${COMPOSER_HISTORY_STORAGE_VERSION}.${encodeURIComponent(scope)}`)
+}
+
+function normalizeHistory(values: unknown, limit = COMPOSER_HISTORY_LIMIT): string[] {
+  if (!Array.isArray(values) || limit <= 0) {
+    return []
+  }
+  const history: string[] = []
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue
+    }
+    const text = value.trim()
+    if (text && history.at(-1) !== text) {
+      history.push(text)
+    }
+  }
+  return history.slice(-limit)
+}
+
+export function readStoredComposerHistory(scope: string, storage: ComposerHistoryStorage = localStorage): string[] {
+  try {
+    const raw = storage.getItem(composerHistoryStorageKey(scope))
+    return raw === null ? [] : normalizeHistory(JSON.parse(raw))
+  } catch {
+    // localStorage 不可用或内容损坏时，仅退回当前聊天里的历史。
+    return []
+  }
+}
+
+export function appendStoredComposerHistory(
+  scope: string,
+  text: string,
+  storage: ComposerHistoryStorage = localStorage,
+): string[] {
+  const history = readStoredComposerHistory(scope, storage)
+  const next = normalizeHistory([...history, text])
+  if (next.length === history.length && next.every((value, index) => value === history[index])) {
+    return history
+  }
+  try {
+    storage.setItem(composerHistoryStorageKey(scope), JSON.stringify(next))
+  } catch {
+    // localStorage 不可用时保留本次渲染进程内的历史。
+  }
+  return next
+}
+
+export function mergeComposerHistories(older: string[], newer: string[]): string[] {
+  const seen = new Set<string>()
+  const merged: string[] = []
+  for (const text of [...older, ...newer].reverse()) {
+    if (!seen.has(text)) {
+      seen.add(text)
+      merged.push(text)
+    }
+  }
+  return merged.reverse().slice(-COMPOSER_HISTORY_LIMIT)
+}
+
+function messageText(message: Pick<ChatMessage, "parts">): string {
+  return visibleUserText(
+    message.parts
+      .filter((part) => part.kind === "text")
+      .map((part) => part.text ?? "")
+      .join(""),
+  ).trim()
+}
+
+export function buildComposerHistory(
+  messages: Array<Pick<ChatMessage, "createdAt" | "parts" | "role">>,
+  queuedMessages: Array<Pick<QueuedChatMessage, "createdAt" | "text">>,
+  limit = COMPOSER_HISTORY_LIMIT,
+): string[] {
+  if (limit <= 0) {
+    return []
+  }
+
+  let order = 0
+  const candidates: ComposerHistoryCandidate[] = []
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue
+    }
+    const text = messageText(message)
+    if (text) {
+      candidates.push({ createdAt: message.createdAt, order: order++, text })
+    }
+  }
+  for (const message of queuedMessages) {
+    const text = message.text.trim()
+    if (text) {
+      candidates.push({ createdAt: message.createdAt, order: order++, text })
+    }
+  }
+
+  candidates.sort((left, right) => left.createdAt - right.createdAt || left.order - right.order)
+  const history: string[] = []
+  for (const candidate of candidates) {
+    if (history.at(-1) !== candidate.text) {
+      history.push(candidate.text)
+    }
+  }
+  return normalizeHistory(history, limit)
+}
+
+export function navigateComposerHistory(
+  history: string[],
+  currentIndex: number | null,
+  direction: "newer" | "older",
+): ComposerHistoryNavigation | null {
+  if (history.length === 0 || (currentIndex === null && direction === "newer")) {
+    return null
+  }
+
+  if (currentIndex === null) {
+    const index = history.length - 1
+    return { index, text: history[index] ?? "" }
+  }
+
+  const boundedIndex = Math.min(Math.max(currentIndex, 0), history.length - 1)
+  if (direction === "older") {
+    const index = (boundedIndex - 1 + history.length) % history.length
+    return { index, text: history[index] ?? "" }
+  }
+  if (boundedIndex === history.length - 1) {
+    return { index: null, text: "" }
+  }
+  const index = boundedIndex + 1
+  return { index, text: history[index] ?? "" }
+}

--- a/src/routes/Chat/composer-history.ts
+++ b/src/routes/Chat/composer-history.ts
@@ -2,6 +2,7 @@ import type { ChatMessage } from "../../../electron/chat/common.ts"
 import type { QueuedChatMessage } from "@/components/app-shell/chat-queue"
 
 import { storageKey } from "../../../electron/branding.ts"
+import { BUG_REPORT_COMMAND } from "../../../electron/chat/common.ts"
 import { visibleUserText } from "./message-text.ts"
 
 const COMPOSER_HISTORY_LIMIT = 20
@@ -37,11 +38,15 @@ function normalizeHistory(values: unknown, limit = COMPOSER_HISTORY_LIMIT): stri
       continue
     }
     const text = value.trim()
-    if (text && history.at(-1) !== text) {
+    if (text && !isCommandSubmission(text) && history.at(-1) !== text) {
       history.push(text)
     }
   }
   return history.slice(-limit)
+}
+
+function isCommandSubmission(text: string): boolean {
+  return text === BUG_REPORT_COMMAND || text.startsWith(`${BUG_REPORT_COMMAND} `)
 }
 
 export function readStoredComposerHistory(scope: string, storage: ComposerHistoryStorage = localStorage): string[] {
@@ -109,13 +114,13 @@ export function buildComposerHistory(
       continue
     }
     const text = messageText(message)
-    if (text) {
+    if (text && !isCommandSubmission(text)) {
       candidates.push({ createdAt: message.createdAt, order: order++, text })
     }
   }
   for (const message of queuedMessages) {
     const text = message.text.trim()
-    if (text) {
+    if (text && !isCommandSubmission(text)) {
       candidates.push({ createdAt: message.createdAt, order: order++, text })
     }
   }

--- a/src/routes/Chat/composer-state.test.ts
+++ b/src/routes/Chat/composer-state.test.ts
@@ -153,6 +153,19 @@ describe("composer state", () => {
     })
   })
 
+  it("recalls history with the cursor at the end and clears palette suppression", () => {
+    const state = {
+      ...initialComposerState(),
+      dismissedTriggerKey: "slash:0:rev",
+    }
+
+    expect(composerReducer(state, { draft: "previous prompt", type: "recall-history" })).toMatchObject({
+      dismissedTriggerKey: null,
+      draft: "previous prompt",
+      draftSelection: { end: 15, start: 15 },
+    })
+  })
+
   it("preserves attachment draft metadata without preserving renderer preview URLs", () => {
     const empty = initialComposerState()
     const withAttachment = {

--- a/src/routes/Chat/composer-state.ts
+++ b/src/routes/Chat/composer-state.ts
@@ -24,6 +24,7 @@ export type ComposerAction =
   | { type: "remove-attachment"; id: string }
   | { type: "remove-command" }
   | { type: "remove-context-mention"; mention: ChatContextMention }
+  | { type: "recall-history"; draft: string }
   | { type: "replace-trigger"; replacement: string; trigger: ComposerTrigger }
   | { type: "reset-after-submit" }
   | { type: "select-bug-report"; trigger: ComposerTrigger }
@@ -149,6 +150,13 @@ export function composerReducer(state: ComposerState, action: ComposerAction): C
       return {
         ...state,
         contextMentions: state.contextMentions.filter((mention) => !sameContextMention(mention, action.mention)),
+      }
+    case "recall-history":
+      return {
+        ...state,
+        dismissedTriggerKey: null,
+        draft: action.draft,
+        draftSelection: { end: action.draft.length, start: action.draft.length },
       }
     case "replace-trigger":
       return {

--- a/src/routes/Chat/composer-triggers.test.ts
+++ b/src/routes/Chat/composer-triggers.test.ts
@@ -11,6 +11,21 @@ describe("detectComposerTrigger", () => {
     })
   })
 
+  it("detects a slash trigger after whitespace in existing text", () => {
+    expect(detectComposerTrigger("asdasd /", 8)).toEqual({
+      end: 8,
+      kind: "slash",
+      query: "",
+      start: 7,
+    })
+    expect(detectComposerTrigger("please /bug", 11)).toEqual({
+      end: 11,
+      kind: "slash",
+      query: "bug",
+      start: 7,
+    })
+  })
+
   it("detects a skill trigger after whitespace", () => {
     expect(detectComposerTrigger("use $ai-elements", 16)).toEqual({
       end: 16,
@@ -29,8 +44,8 @@ describe("detectComposerTrigger", () => {
     })
   })
 
-  it("does not detect slash inside a filesystem path", () => {
-    expect(detectComposerTrigger("open /Users/me/file.ts", 11)).toBeNull()
+  it("stops detecting slash when the query becomes a filesystem path", () => {
+    expect(detectComposerTrigger("open /Users/me/file.ts", 12)).toBeNull()
   })
 
   it("does not detect context trigger inside email or ordinary words", () => {

--- a/src/routes/Chat/composer-triggers.ts
+++ b/src/routes/Chat/composer-triggers.ts
@@ -47,14 +47,6 @@ export function detectComposerTrigger(
     return null
   }
 
-  if (marker === "/") {
-    // Slash 只在行首或行首空白后触发，避免把文件路径识别为命令。
-    const lineStart = text.lastIndexOf("\n", start - 1) + 1
-    if (text.slice(lineStart, start).trim()) {
-      return null
-    }
-  }
-
   if (marker === "@" && !isContextTriggerBoundary(start > 0 ? text[start - 1] : undefined)) {
     return null
   }

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -62,6 +62,7 @@ interface ChatAreaProps {
   error: string | null
   emptyTitle?: string
   generatedArtifacts?: ArtifactSelection | null
+  historyScope: string
   submitDisabled: boolean
   willQueueMessage: boolean
   initialComposerState?: ComposerState
@@ -260,6 +261,7 @@ export const ChatArea = React.memo(function ChatArea({
   error,
   emptyTitle,
   generatedArtifacts,
+  historyScope,
   submitDisabled,
   willQueueMessage,
   initialComposerState,
@@ -333,6 +335,7 @@ export const ChatArea = React.memo(function ChatArea({
       focusRequest={composerFocusRequest}
       generatedArtifacts={generatedArtifacts}
       hasMessages={hasMessages}
+      historyScope={historyScope}
       initialComposerState={initialComposerState}
       messages={messages}
       knowledgeBaseIds={knowledgeBaseIds}


### PR DESCRIPTION
## Summary

This PR cleans up remaining legacy brand-specific references and improves the chat composer input experience.

Users can now trigger the slash-command palette when `/` is typed after whitespace, instead of only at the beginning of the entire draft. The composer also supports recalling previous prompts with the Up and Down arrow keys. Prompt history keeps the 20 most recent distinct entries, wraps from the oldest entry back to the newest, and is persisted per account and team/workspace so it can be reused across tasks without leaking into another workspace.

## Root cause

Slash-command detection treated the whole draft as a single trigger location, so an inline slash after ordinary text was ignored. The composer also had no dedicated prompt-history state or scoped persistence layer, which meant keyboard history navigation was unavailable and prior inputs could only be recovered manually from the current conversation.

## Changes

- Remove obsolete brand-specific ignore and UI references.
- Recognize slash-command triggers at whitespace-delimited positions in the draft.
- Add Up/Down prompt-history navigation while preserving palette keyboard priority and IME/modifier behavior.
- Keep the newest 20 prompt entries, collapse consecutive duplicates, and wrap backward navigation from oldest to newest.
- Persist text-only prompt history using an account-and-team/workspace scope.
- Exclude command submissions from persisted, active-task, and queued history because text-only recall cannot restore command metadata safely.
- Fall back to visible user and queued messages from the active task for compatibility with existing conversations.
- Add focused tests for trigger detection, composer state restoration, history limits, persistence isolation, malformed storage, deduplication, merging, and navigation.

## Validation

- `npm run lint`
- `npm run format`
- `npm run ts-check`
- `npm test` — 242 test files and 1,684 tests passed
- Manual Electron development run with the agent sidecar ready
