### PR TITLE
ci: migrate CI/CD and dependencies from oomol to oomol-lab org

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   check:
@@ -26,14 +25,10 @@ jobs:
           node-version: "24"
           cache: npm
           cache-dependency-path: package-lock.json
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@oomol"
 
       - name: Install dependencies
         run: npm ci
         env:
-          # 私有 @oomol/* 包来自 GitHub Packages；CI 用仓库 token 读取。
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # 跳过 Electron 二进制下载（download-electron postinstall 也据此短路）。
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
           # 本 job 只做 lint/test/build:app，不打包，故无需下载 oo 二进制。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         id: aliyun_credentials
         uses: aliyun/configure-aliyun-credentials-action@v1.1.0
         with:
-          role-to-assume: ${{ vars.ALIYUN_INTERNAL_ROLE }}
+          role-to-assume: ${{ vars.ALIYUN_OOMOL_WANTA_ROLE }}
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
@@ -243,7 +243,7 @@ jobs:
         if: steps.aliyun_credentials.outcome == 'failure'
         uses: aliyun/configure-aliyun-credentials-action@v1.1.0
         with:
-          role-to-assume: ${{ vars.ALIYUN_INTERNAL_ROLE }}
+          role-to-assume: ${{ vars.ALIYUN_OOMOL_WANTA_ROLE }}
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
@@ -421,7 +421,7 @@ jobs:
         id: aliyun_credentials
         uses: aliyun/configure-aliyun-credentials-action@v1.1.0
         with:
-          role-to-assume: ${{ vars.ALIYUN_INTERNAL_ROLE }}
+          role-to-assume: ${{ vars.ALIYUN_OOMOL_WANTA_ROLE }}
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
@@ -433,7 +433,7 @@ jobs:
         if: steps.aliyun_credentials.outcome == 'failure'
         uses: aliyun/configure-aliyun-credentials-action@v1.1.0
         with:
-          role-to-assume: ${{ vars.ALIYUN_INTERNAL_ROLE }}
+          role-to-assume: ${{ vars.ALIYUN_OOMOL_WANTA_ROLE }}
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ on:
 permissions:
   contents: write
   id-token: write
-  packages: read
 
 # 串行化发布：并发 dispatch 会算出同一版本号并竞写同一批 OSS 对象/渠道指针。
 concurrency:
@@ -127,8 +126,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@oomol"
       - name: Set env + version
         run: |
           echo "VERSION=${{ needs.compute-version.outputs.version }}" >> $GITHUB_ENV
@@ -157,7 +154,6 @@ jobs:
         env:
           npm_config_audit: "false"
           npm_config_fund: "false"
-          NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_PACKAGE_PAT_READ }}
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
           # oo 二进制由后续 build:* 里的 prepare:binaries 在构建时下载，无需 postinstall 重复拉取。
           OO_SKIP_BINARY_DOWNLOAD: "1"
@@ -165,12 +161,10 @@ jobs:
       - name: Build (sign + notarize)
         run: npm run build:mac
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_PACKAGE_PAT_READ }}
           CSC_IDENTITY_AUTO_DISCOVERY: "true"
           APPLE_ID: ${{ secrets.APPLEID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLEID_PASS }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          GH_TOKEN: ${{ secrets.ACCESS_REPO }}
 
       # 对齐 win 侧的产物硬校验：mac 自动更新器消费 <channel>-mac.yml + zip + zip.blockmap。
       # stable 构建经 generateUpdatesFilesForAllChannels 同时产出 beta-mac.yml，两个指针都校验；
@@ -241,7 +235,7 @@ jobs:
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
-          audience: https://github.com/oomol
+          audience: https://github.com/oomol-lab
         continue-on-error: true
 
       - name: Configure Alibaba Cloud CLI (retry)
@@ -253,7 +247,7 @@ jobs:
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
-          audience: https://github.com/oomol
+          audience: https://github.com/oomol-lab
 
       - name: Cache rclone
         uses: actions/cache@v5
@@ -326,8 +320,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@oomol"
       - name: Set env + version
         shell: bash
         run: |
@@ -347,16 +339,12 @@ jobs:
         env:
           npm_config_audit: "false"
           npm_config_fund: "false"
-          NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_PACKAGE_PAT_READ }}
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
           # oo 二进制由后续 build:* 里的 prepare:binaries 在构建时下载，无需 postinstall 重复拉取。
           OO_SKIP_BINARY_DOWNLOAD: "1"
 
       - name: Build (signtool via electron-builder certificateSha1)
         run: npm run build:win
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PRIVATE_PACKAGE_PAT_READ }}
-          GH_TOKEN: ${{ secrets.ACCESS_REPO }}
 
       # 硬防 electron-builder 未来行为漂移。NSIS 自动更新器消费 <channel>.yml + Setup.exe
       # + Setup.exe.blockmap；任一不变量回归即让 release 大声失败。
@@ -437,7 +425,7 @@ jobs:
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
-          audience: https://github.com/oomol
+          audience: https://github.com/oomol-lab
         continue-on-error: true
 
       - name: Configure Alibaba Cloud CLI (retry)
@@ -449,7 +437,7 @@ jobs:
           oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
           role-session-name: github-action-session
           role-session-expiration: 1800
-          audience: https://github.com/oomol
+          audience: https://github.com/oomol-lab
 
       - name: Setup rclone
         shell: bash
@@ -524,7 +512,7 @@ jobs:
 
       - name: Create tag and release
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_REPO }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.compute-version.outputs.version }}"
@@ -609,19 +597,123 @@ jobs:
           fi
 
   # Release 发布后刷新 release 目录的 DCDN 缓存，使自动更新客户端无需等 CDN TTL 过期即可
-  # 看到新的 latest-mac.yml / latest.yml。复用 oomol/workflows 共享 workflow——
-  # 见 https://github.com/oomol/workflows 的入参定义。
+  # 看到新的 latest-mac.yml / latest.yml。
+  #
+  # 本 job 曾复用 oomol/workflows 的共享 workflow，仓库迁到 oomol-lab 后必须内联：
+  # oomol/workflows 是 private 且 Actions access 为 organization 级，跨 org 调用不被允许，
+  # 且两个 org 不在同一 enterprise 下（oomol=team / oomol-lab=free），无法通过放宽 access 解决。
+  # 实现照搬 oomol-lab/oo-cli 的 .github/workflows/refresh-cdn-cache.yaml（同 org 内已验证可用）。
   refresh-cdn-cache:
     needs: [compute-version, create-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
-    uses: oomol/workflows/.github/workflows/refresh-cdn-cache.yml@main
-    with:
-      domain: static.oomol.com
+    env:
+      PINNED_ALIYUN_CLI_VERSION: 3.0.286
+      ALIYUN_REGION: cn-hangzhou
+      CDN_DOMAIN: static.oomol.com
       # 只刷自动更新渠道指针文件（清单由 compute-version 按渠道计算：stable 刷
       # latest*+beta* 共 4 个，beta 只刷 beta* 两个）。版本化产物（Wanta-${VERSION}.dmg /
       # -Setup.exe 及其 .blockmap）住在每次 release 不可变的版本戳 URL 上，永不陈旧。
-      files: ${{ needs.compute-version.outputs.cdn_files }}
-      # Wanta 用标准 GitHub runner；共享 workflow 默认即 ubuntu-latest，这里显式指定。
-      runs-on: ubuntu-latest
+      CDN_FILES: ${{ needs.compute-version.outputs.cdn_files }}
+    steps:
+      - name: Cache Aliyun CLI
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/bin/aliyun
+          key: aliyun-cli-${{ runner.os }}-${{ runner.arch }}-${{ env.PINNED_ALIYUN_CLI_VERSION }}
+
+      - name: Install Aliyun CLI
+        run: |
+          set -euo pipefail
+          if [ ! -x "$HOME/.local/bin/aliyun" ]; then
+            mkdir -p "$HOME/.local/bin"
+            curl -fsSL "https://aliyuncli.alicdn.com/aliyun-cli-linux-${PINNED_ALIYUN_CLI_VERSION}-amd64.tgz" -o /tmp/aliyun-cli.tgz
+            mkdir -p /tmp/aliyun-cli
+            tar -xzf /tmp/aliyun-cli.tgz -C /tmp/aliyun-cli
+            ALIYUN_BIN="$(find /tmp/aliyun-cli -type f -name aliyun | head -n 1)"
+            if [ -z "$ALIYUN_BIN" ]; then
+              echo "::error::Unable to find aliyun binary in downloaded archive"; exit 1
+            fi
+            install "$ALIYUN_BIN" "$HOME/.local/bin/aliyun"
+          fi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/aliyun" version
+
+      - name: Configure Alibaba Cloud credentials
+        id: aliyun_credentials
+        uses: aliyun/configure-aliyun-credentials-action@v1.1.0
+        with:
+          role-to-assume: ${{ vars.ALIYUN_CDN_CACHE_REFRESH_ROLE }}
+          oidc-provider-arn: ${{ vars.ALIYUN_OIDC_PROVIDER }}
+          role-session-name: github-action-cdn-cache-refresh
+          role-session-expiration: 1800
+          audience: https://github.com/oomol-lab
+
+      - name: Configure Aliyun CLI
+        env:
+          ALICLOUD_ACCESS_KEY_ID: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-id }}
+          ALICLOUD_ACCESS_KEY_SECRET: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-secret }}
+          ALICLOUD_SECURITY_TOKEN: ${{ steps.aliyun_credentials.outputs.aliyun-security-token }}
+        run: |
+          set -euo pipefail
+          aliyun configure set \
+            --mode StsToken \
+            --region "$ALIYUN_REGION" \
+            --access-key-id "$ALICLOUD_ACCESS_KEY_ID" \
+            --access-key-secret "$ALICLOUD_ACCESS_KEY_SECRET" \
+            --sts-token "$ALICLOUD_SECURITY_TOKEN"
+
+      - name: Refresh CDN cache
+        run: |
+          set -euo pipefail
+
+          # CDN_FILES 是 compute-version 产出的多行绝对路径清单；拼上域名成完整 URL。
+          # 空清单说明 outputs plumbing 回归（拼错输出名→空串），必须大声失败而不是静默跳过刷新。
+          URLS=""
+          COUNT=0
+          while IFS= read -r FILE; do
+            [ -n "$FILE" ] || continue
+            URLS="${URLS}https://${CDN_DOMAIN}${FILE}"$'\n'
+            COUNT=$((COUNT + 1))
+          done <<< "$CDN_FILES"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::CDN_FILES is empty — nothing to refresh (channel pointer plumbing regression?)"
+            exit 1
+          fi
+
+          aliyun dcdn DescribeDcdnRefreshQuota --region "$ALIYUN_REGION" > quota.json
+          cat quota.json
+
+          URL_REMAIN="$(jq -r '.UrlRemain // empty' quota.json)"
+          if [ -n "$URL_REMAIN" ] && [ "$URL_REMAIN" -lt "$COUNT" ]; then
+            echo "::error::DCDN URL refresh quota insufficient (UrlRemain=$URL_REMAIN, need=$COUNT). Retry tomorrow or raise the daily quota via an Aliyun ticket."
+            exit 1
+          fi
+
+          echo "::notice title=Refresh target::${COUNT} channel pointer file(s)"
+          printf '%s' "$URLS"
+
+          # RefreshDcdnObjectCaches 的 ObjectPath 支持换行分隔的多 URL，一次提交即可。
+          aliyun dcdn RefreshDcdnObjectCaches \
+            --ObjectType File \
+            --ObjectPath "$(printf '%s' "$URLS")" \
+            --region "$ALIYUN_REGION" > refresh-result.json
+          cat refresh-result.json
+
+          REFRESH_TASK_ID="$(jq -r '.RefreshTaskId // ""' refresh-result.json)"
+          REQUEST_ID="$(jq -r '.RequestId // ""' refresh-result.json)"
+
+          {
+            echo "## CDN cache refresh"
+            echo ""
+            echo "- Refreshed ${COUNT} file(s):"
+            printf '%s' "$URLS" | sed 's/^/  - `/; s/$/`/'
+            echo "- Refresh task id: \`${REFRESH_TASK_ID:-unknown}\`"
+            echo "- Request id: \`${REQUEST_ID:-unknown}\`"
+            echo ""
+            echo "_DCDN refresh tasks typically take 5-6 minutes to take effect at every edge node._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@oomol:registry=https://npm.pkg.github.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ docs/            本仓库文档（见下方索引）
 ## 常用命令（精确脚本名，见 package.json）
 
 ```bash
-npm install          # 需 @oomol 私有包 PAT（docs/development.md §1）；postinstall 自动下载 .electron-dist 与 .oo-bin/oo
+npm install          # 依赖全公开（@oomol/* 已在公共 npm），无需 token/.npmrc；postinstall 自动下载 .electron-dist 与 .oo-bin/oo
 npm run dev          # Vite dev（端口 5273）+ 主进程；predev 守卫检查 .oo-bin/oo
 npm run build        # = build:app = ts-check + vite build
 npm run ts-check     # tsgo -p tsconfig.json

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@
 ## 1. 环境准备
 
 - **Node >= 22.22.2**（与钉死的 OpenCode 依赖链最低版本一致；PR CI 钉 Node 24，release CI 用 `lts/*`——当前解析为 24）。npm + package-lock.json。
-- **私有包鉴权**：`@oomol/connection*` 来自 GitHub Packages（`.npmrc`：`@oomol:registry=https://npm.pkg.github.com`），本地需要带 `read:packages` 的 PAT（一般配在全局 `~/.npmrc`），否则 `npm install` 401。注意两种失败的严重性不同：私有包 401 发生在依赖解析阶段、**致命**；下面两个 postinstall 下载脚本才是 best-effort（仅 warn）——PAT 缺失时哪怕只看到一堆 warn 也不能继续，`@oomol/connection` 没装上 dev 起不来。
+- **依赖来源全部公开**：`@oomol/connection` / `@oomol/connection-electron-adapter` 已发布到公共 registry（`registry.npmjs.org`），`npm install` **无需任何 token 或 `.npmrc`**——本仓库开源后 fresh clone 与外部 fork CI 都能直接安装（历史上曾走 GitHub Packages 私有 registry + `read:packages` PAT，仓库转公开、包同步发到公共 npm 后已移除该鉴权链）。若本机全局 `~/.npmrc` 仍把 `@oomol` scope 指向 `npm.pkg.github.com`，会覆盖默认公共 registry——删掉那行即可。注意：postinstall 的二进制/skill 下载脚本是 best-effort（仅 warn），但 `@oomol/connection` 装不上 dev 起不来，安装失败不能忽略。
 - `npm install` 的 postinstall 串联二进制/skill 下载脚本，并在最后构建自定义工具 runtime：
   - `scripts/download-electron.ts` → 下载 dev 专用 Electron 副本到 `.electron-dist/` 并改写 macOS Info.plist 为 `com.oomol.wanta-local` / `wanta-local` scheme（dev deep-link 用）。`ELECTRON_SKIP_BINARY_DOWNLOAD=1` 跳过。
   - `scripts/download-oo.ts` → 下载 oo 二进制到 `.oo-bin/`（版本锁定见 `scripts/oo-cli.ts` 的 `OO_CLI_VERSION`；含 sha512 integrity 校验与 `chmod 0o755`）。oo / ripgrep 下载统一使用 30 秒单次超时与最多 3 次请求尝试（最多重试 2 次），确定性的 4xx 不重试。`OO_SKIP_BINARY_DOWNLOAD=1` 跳过。
@@ -32,7 +32,7 @@ npm run dev:no-electron
 - vite dev server 固定端口 `5273` 且 `strictPort=true`：如果已有 `npm run dev` 占用端口，新的 dev 进程会直接失败，避免悄悄切到 `5274+` 后再拉起第二个 Electron。需要临时禁用 Electron 自动启动时，也可用 `WANTA_ELECTRON_AUTO_START=0 npm run dev`。
 - `.electron-dist` 存在时 vite 自动设 `ELECTRON_OVERRIDE_DIST_PATH`，dev 用带 `wanta-local` scheme 的 Electron（菜单栏显示 dev 身份），浏览器登录回跳才能命中 dev 实例。
 - dev 的 userData 在 `~/Library/Application Support/wanta`（macOS）；agent 数据在其下 `agent/`（workspace / isolation / oo-store）。
-- 提代码必须走临时分支 + PR：先把本地 `main` 对齐 `origin/main`，再从 `main` 拉一次性分支（如 `codex/<task>`、`ci/<task>`、`fix/<task>`）。改动完成并通过质量门后推送临时分支，开 PR 到 `oomol/lumo:main`，由 PR 合并回 `main`。不要直接在 `main` 上提交或推送。PR 合并后同步最新 `main`，删除本地临时分支，并删除 fork/远端上的同名临时分支。所有 Git 操作中的人类可读文本必须用英文，包括 commit message、branch name、PR title、PR description、PR review/comment、tag/release note。
+- 提代码必须走临时分支 + PR：先把本地 `main` 对齐 `origin/main`，再从 `main` 拉一次性分支（如 `codex/<task>`、`ci/<task>`、`fix/<task>`）。改动完成并通过质量门后推送临时分支，开 PR 到 `oomol-lab/wanta:main`，由 PR 合并回 `main`。不要直接在 `main` 上提交或推送。PR 合并后同步最新 `main`，删除本地临时分支，并删除 fork/远端上的同名临时分支。所有 Git 操作中的人类可读文本必须用英文，包括 commit message、branch name、PR title、PR description、PR review/comment、tag/release note。
 - 改动后质量门四件套：`npm run ts-check && npm run lint && npm run format && npm test`。
 
 ## 4. 测试

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,8 +1342,8 @@
     },
     "node_modules/@oomol/connection": {
       "version": "0.2.28",
-      "resolved": "https://npm.pkg.github.com/download/@oomol/connection/0.2.28/386e614cd61f2944b9726510b76ad8d09d0e1a06",
-      "integrity": "sha512-ea3tDDCTYqFyW4k3fmR5qZYtsO6iO6xu8xdKm/cH9aeBBKFxyDZI65esp9mWGUWxRc7MYXXdFpEgvUJc1cjn/w==",
+      "resolved": "https://registry.npmjs.org/@oomol/connection/-/connection-0.2.28.tgz",
+      "integrity": "sha512-g3UFgNgZgmNMPjgvbYCXEU7bRziaKil9Jkr4F0dFxBDQX9XZqem1CPad8kRA35Oa6xl3ptxOxDBgHJWBsStOlw==",
       "dev": true,
       "dependencies": {
         "remitter": "^0.4.4"
@@ -1351,8 +1351,8 @@
     },
     "node_modules/@oomol/connection-electron-adapter": {
       "version": "0.2.12",
-      "resolved": "https://npm.pkg.github.com/download/@oomol/connection-electron-adapter/0.2.12/7253f61ef708ccdb49f5e5018aa6488d338ab482",
-      "integrity": "sha512-Bo/OV93qigB2JPioZgYVxYxNfLorXe/5lPbth2xlrD2AbT8FjfHOjIZd84PsHLlgKYGKLfXfQSFhaeClSwD1GQ==",
+      "resolved": "https://registry.npmjs.org/@oomol/connection-electron-adapter/-/connection-electron-adapter-0.2.12.tgz",
+      "integrity": "sha512-Y01k7jJ+rJ4A4WRnmR7zSWLihZqlsW6itRQT2B1cDD1pT1vHbHz2XARXkKrLwIy/ZuO/BbzGB8kscHp+sCcuvA==",
       "dev": true,
       "peerDependencies": {
         "@oomol/connection": "0"


### PR DESCRIPTION
## Why

The repo moved `oomol/wanta` → `oomol-lab/wanta` and is now open source. The transfer broke CI: PR checks fail on `npm ci` (`403 permission_denied: read_package`) and the release workflow references several resources that only exist in the old `oomol` org. This PR fixes everything fixable in code and lists the ops actions that must accompany it.

## What changed (code)

### Dependencies — root cause of red PR checks
- `@oomol/connection@0.2.28` and `@oomol/connection-electron-adapter@0.2.12` are now on **public npm**. Dropped the private GitHub Packages auth chain entirely:
  - deleted `.npmrc`
  - removed `registry-url` / `scope` / `NODE_AUTH_TOKEN` / `packages:` from both workflows
  - repointed the two `package-lock.json` entries at `registry.npmjs.org` (`resolved` + `integrity`) — surgical 4-field diff, deps declarations verified identical to the GitHub Packages build
- ✅ Verified `npm ci` installs from public npm with **no token** in a clean env → external fork PRs can now build.

### Release workflow
- **Inlined the CDN refresh job.** It called the private, org-scoped reusable workflow `oomol/workflows/.github/workflows/refresh-cdn-cache.yml`, which `oomol-lab` repos cannot access (the two orgs aren't in a shared enterprise, so relaxing access isn't an option). Reimplemented inline, mirroring `oomol-lab/oo-cli`'s proven pattern (pinned aliyun CLI 3.0.286, DCDN `RefreshDcdnObjectCaches`, `audience: .../oomol-lab`, `vars.ALIYUN_CDN_CACHE_REFRESH_ROLE`).
- Switched OIDC **audience** `https://github.com/oomol` → `.../oomol-lab` (5 places).
- Replaced `secrets.ACCESS_REPO` with the built-in `GITHUB_TOKEN` for tag/release creation (`contents: write` is sufficient in-repo), and dropped the now-dead `GH_TOKEN` from the build steps (`electron-builder` always runs `--publish never`).

### Docs
- `development.md` / `AGENTS.md`: deps are fully public, no PAT needed; fixed the stale PR target (`oomol/lumo` → `oomol-lab/wanta`).

## Verified locally
`format` ✅ · `lint` ✅ · `ts-check` ✅ · `test` ✅ (241 files / 1672 tests) · clean-room `npm ci` from public npm ✅

## ⚠️ Ops actions required before a release can publish
These are outside the repo and block a real `Release Build` dispatch (they do **not** block PR checks):

- [x] **github-ops** — grant `oomol-lab/wanta` the macOS signing/notarization secrets: add `wanta` to the selected-repos list for `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `APPLE_TEAM_ID`, `MACOS_NOTARIZATION_ISSUER_ID`, and add `APPLEID` + `APPLEID_PASS` to oomol-lab (currently oomol-only).
- [x] **github-ops** — provide a self-hosted **Windows x64** runner for `oomol-lab` (the `release-win` job needs `[self-hosted, Windows, x64]`; oomol-lab has none). The Windows code-signing cert SHA1 stays hardcoded in `electron-builder.ts` as before, so that runner must hold the matching certificate.

## Out of scope (separate follow-ups)
Open-source hygiene surfaced by the audit but not part of the org move: `LICENSE` + third-party notices, `README`, `SECURITY.md` + private vuln reporting, repo description/topics. Happy to do these in a follow-up PR.