### PR TITLE
docs: add project README and Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+<div align="center">
+
+<img src="resources/branding/logo.png" width="112" alt="Wanta logo" />
+
+# Wanta
+
+**A desktop AI agent that works across your apps and local files.**
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
+![Electron 42](https://img.shields.io/badge/Electron-42-47848F?logo=electron)
+![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
+
+[Website](https://wanta.ai/) · [OpenConnector](https://github.com/oomol-lab/open-connector) · [Documentation](docs/project-overview.md)
+
+</div>
+
+Wanta is an open-source desktop AI agent built by [OOMOL](https://oomol.com/). Describe what you
+want to accomplish, and Wanta can plan the work, use connected SaaS services and local tools, and
+return the result in a streaming conversation.
+
+Wanta is designed for practical work across email, documents, analytics, project tools, files, and
+other systems. It uses the same shared connector ecosystem as
+[OpenConnector](https://github.com/oomol-lab/open-connector), while adding a desktop agent,
+permission controls, conversation history, and artifact handling.
+
+## What It Does
+
+- Work across connected services using natural language instead of manually moving data between
+  apps.
+- Search, inspect, and run connector Actions while keeping service credentials outside the agent
+  process.
+- Read and write local files, run shell commands, and execute scripts with confirmation for
+  high-risk operations.
+- Stream responses and tool activity so the execution process remains visible.
+- Preserve task outputs as artifacts that can be opened, reviewed, and reused.
+- Run as a desktop application on macOS, Windows, and Linux.
+
+## Where It Fits
+
+Wanta is intended for people who regularly collect, compare, transform, or publish information
+across multiple tools. Typical tasks include:
+
+- Pulling analytics or operational data from several services and producing a summary.
+- Organizing email, project, support, or knowledge-base information.
+- Reading local documents and spreadsheets, then creating new files from the results.
+- Automating repeatable workflows that combine SaaS Actions with local scripts.
+
+## How It Works
+
+```mermaid
+flowchart LR
+  User["User request"] --> Wanta["Wanta desktop app"]
+  Wanta --> Agent["OpenCode agent"]
+  Agent --> Connector["OpenConnector / OOMOL Connector"]
+  Agent --> Local["Local files, shell, and scripts"]
+  Connector --> Apps["Connected SaaS services"]
+  Local --> Result["Task artifacts"]
+  Apps --> Result
+  Result --> Wanta
+```
+
+The Electron main process manages the local agent sidecar, authentication, permissions, sessions,
+and system integration. The React renderer provides the conversation, connection, settings, and
+artifact interfaces. See [docs/architecture.md](docs/architecture.md) for the full design.
+
+## Quick Start
+
+### Requirements
+
+- Node.js 22.22.2 or newer
+- npm
+
+### Run from Source
+
+```bash
+git clone https://github.com/oomol-lab/wanta.git
+cd wanta
+npm install
+npm run dev
+```
+
+`npm install` prepares the Electron development runtime, the pinned OpenCode dependency, the `oo`
+CLI, ripgrep, and bundled Skills. The Vite development server and Electron app start together with
+`npm run dev`.
+
+Hosted models and connected services currently require signing in to an OOMOL account from the
+application. Each external service must also be authorized before Wanta can use its Actions.
+
+## Development
+
+| Command               | Purpose                                     |
+| --------------------- | ------------------------------------------- |
+| `npm run dev`         | Start the Vite and Electron development app |
+| `npm run build`       | Type-check and build the application        |
+| `npm run ts-check`    | Run TypeScript type checking                |
+| `npm run lint`        | Check the code with oxlint                  |
+| `npm run format`      | Check formatting with oxfmt                 |
+| `npm test`            | Run the Vitest test suite                   |
+| `npm run build:mac`   | Build the macOS package                     |
+| `npm run build:win`   | Build the Windows package                   |
+| `npm run build:linux` | Build the Linux package                     |
+
+Before opening a pull request, run the complete quality gate:
+
+```bash
+npm run ts-check && npm run lint && npm run format && npm test
+```
+
+## Project Structure
+
+| Path                 | Purpose                                                     |
+| -------------------- | ----------------------------------------------------------- |
+| `electron/`          | Electron main process, preload, agent, and desktop services |
+| `src/`               | React renderer, routes, hooks, and UI components            |
+| `scripts/`           | Development, binary preparation, and packaging scripts      |
+| `resources/`         | Branding and resources bundled with the application         |
+| `docs/`              | Architecture, development, conventions, and decisions       |
+| `.github/workflows/` | Pull request and release automation                         |
+
+The primary stack is Electron 42, Vite 8, React 19, Tailwind CSS 4, OpenCode, TypeScript, Vitest,
+oxlint, and oxfmt.
+
+## Documentation
+
+- [Project overview](docs/project-overview.md)
+- [Architecture](docs/architecture.md)
+- [Development guide](docs/development.md)
+- [Code conventions](docs/conventions.md)
+- [Key technical decisions](docs/key-decisions.md)
+- [Network request caching](docs/network-request-caching.md)
+
+## Contributing
+
+Issues and pull requests are welcome. Before making changes, read the
+[development guide](docs/development.md) and [code conventions](docs/conventions.md). Create a
+short-lived branch from the latest `main`, keep the change focused, and include appropriate tests
+when behavior changes.
+
+By submitting a contribution, you agree that it is provided under the Apache License, Version 2.0,
+unless you clearly state otherwise in writing.
+
+## License Scope
+
+Unless otherwise noted, source code, scripts, tests, and documentation authored for this repository
+are licensed under the [Apache License, Version 2.0](LICENSE).
+
+This license does not grant rights to third-party products, services, APIs, trademarks, trade names,
+logos, icons, screenshots, or other materials owned by their respective holders. Third-party names
+and assets are used only for identification and interoperability; their inclusion does not imply
+endorsement, sponsorship, or partnership.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "wanta",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@opencode-ai/sdk": "1.17.13",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,17 @@
   "displayName": "Wanta",
   "version": "0.0.0",
   "private": true,
-  "description": "Wanta — AI agent chat client for non-coding analysis and automation over OOMOL connectors.",
+  "description": "Wanta — open-source desktop AI agent for connected apps, local files, and automation.",
+  "homepage": "https://wanta.ai/",
+  "bugs": {
+    "url": "https://github.com/oomol-lab/wanta/issues"
+  },
+  "license": "Apache-2.0",
   "author": "OOMOL",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oomol-lab/wanta.git"
+  },
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Wanta did not have a repository-level README or license file, so new visitors could not quickly understand the product, run it from source, find the internal documentation, or determine the repository's licensing terms from the GitHub landing page.

This change adds a concise public-facing README based on the current implementation and documentation. It introduces Wanta's purpose, its relationship with OpenConnector, representative use cases, the agent execution flow, source setup instructions, development commands, repository structure, contribution guidance, and license scope. The README uses the existing Wanta brand asset and links detailed technical material instead of duplicating it.

The repository now includes the standard Apache License 2.0 text. The root package metadata declares `Apache-2.0` and adds the project homepage, repository, and issue tracker so package-aware tooling exposes consistent project information. The package description is also updated to reflect Wanta's current connected-app and local-tool capabilities instead of describing it as non-coding only.

## User impact

Repository visitors now have a clear entry point for understanding and evaluating Wanta. Contributors can find the supported setup commands, quality gates, source layout, and deeper documentation without first reading internal project files. GitHub and package tooling can also detect the Apache 2.0 license and canonical project URLs.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 242 test files and 1,684 tests passed
- `git diff --check`
- Apache License text compared with the official Apache License 2.0 text
