### PR TITLE
Hide self-managed settings when signed in

### DIFF
--- a/src/routes/Settings/index.tsx
+++ b/src/routes/Settings/index.tsx
@@ -33,6 +33,7 @@ import * as React from "react"
 import { toast } from "sonner"
 import { branding } from "../../../electron/branding.ts"
 import { notificationPresentation } from "./notification-presentation.ts"
+import { shouldShowSelfManagedRuntimeSettings } from "./settings-presentation.ts"
 import { CachedAvatarImage } from "@/components/CachedAvatarImage"
 import { ErrorNotice } from "@/components/ErrorNotice"
 import { OpenConnectorEndpointFields } from "@/components/OpenConnectorEndpointFields"
@@ -98,7 +99,7 @@ export function SettingsRoute({
   const auth = useAuth()
   const appSettings = useAppSettings()
   const attention = useAttention()
-  const models = useModelCatalog()
+  const showSelfManagedRuntimeSettings = shouldShowSelfManagedRuntimeSettings(auth.state?.status)
 
   return (
     <PageRouteShell
@@ -110,14 +111,9 @@ export function SettingsRoute({
       <h1 className="oo-text-page-title">{t("settings.title")}</h1>
 
       <div className="grid gap-5">
-        <SettingsSection title={t("settings.groupRuntime")}>
-          <RuntimeProfileSummary
-            authenticated={auth.state?.status === "authenticated"}
-            mode={appSettings.settings.operatingMode}
-          />
-          <ModelSettings connectorsEnabled={auth.state?.status === "authenticated"} models={models} />
-          <LinkRuntimeSettings runtime={linkRuntime} />
-        </SettingsSection>
+        {showSelfManagedRuntimeSettings ? (
+          <SelfManagedRuntimeSettings mode={appSettings.settings.operatingMode} runtime={linkRuntime} />
+        ) : null}
 
         <SettingsSection title={t("settings.groupAccount")}>
           <AccountSettings
@@ -167,21 +163,27 @@ export function SettingsRoute({
   )
 }
 
-function RuntimeProfileSummary({ authenticated, mode }: { authenticated: boolean; mode: OperatingMode | null }) {
+function SelfManagedRuntimeSettings({ mode, runtime }: { mode: OperatingMode | null; runtime: UseLinkRuntime }) {
   const { t } = useI18n()
-  const resolvedMode = authenticated ? "oomol" : mode
+  const models = useModelCatalog()
+
+  return (
+    <SettingsSection title={t("settings.groupRuntime")}>
+      <RuntimeProfileSummary mode={mode} />
+      <ModelSettings connectorsEnabled={false} models={models} />
+      <LinkRuntimeSettings runtime={runtime} />
+    </SettingsSection>
+  )
+}
+
+function RuntimeProfileSummary({ mode }: { mode: OperatingMode | null }) {
+  const { t } = useI18n()
   const description =
-    resolvedMode === "oomol"
-      ? t("settings.runtimeProfileOomolDescription")
-      : resolvedMode === "self-managed"
-        ? t("settings.runtimeProfileSelfDescription")
-        : t("settings.runtimeProfileUnselectedDescription")
+    mode === "self-managed"
+      ? t("settings.runtimeProfileSelfDescription")
+      : t("settings.runtimeProfileUnselectedDescription")
   const label =
-    resolvedMode === "oomol"
-      ? "Wanta"
-      : resolvedMode === "self-managed"
-        ? t("settings.runtimeProfileSelfManaged")
-        : t("settings.runtimeProfileUnselected")
+    mode === "self-managed" ? t("settings.runtimeProfileSelfManaged") : t("settings.runtimeProfileUnselected")
   return (
     <SettingsItem title={t("settings.runtimeProfile")} description={description}>
       <span className="oo-text-caption rounded-full border bg-background px-2.5 py-1 font-medium text-foreground">

--- a/src/routes/Settings/settings-presentation.test.ts
+++ b/src/routes/Settings/settings-presentation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { shouldShowSelfManagedRuntimeSettings } from "./settings-presentation.ts"
+
+describe("shouldShowSelfManagedRuntimeSettings", () => {
+  it("shows local model and OpenConnector settings only when signed out", () => {
+    expect(shouldShowSelfManagedRuntimeSettings("unauthenticated")).toBe(true)
+    expect(shouldShowSelfManagedRuntimeSettings("authenticated")).toBe(false)
+  })
+
+  it("keeps self-managed settings hidden while authentication is loading", () => {
+    expect(shouldShowSelfManagedRuntimeSettings(undefined)).toBe(false)
+  })
+})

--- a/src/routes/Settings/settings-presentation.ts
+++ b/src/routes/Settings/settings-presentation.ts
@@ -1,0 +1,5 @@
+import type { AuthStatus } from "../../../electron/auth/common.ts"
+
+export function shouldShowSelfManagedRuntimeSettings(status: AuthStatus | undefined): boolean {
+  return status === "unauthenticated"
+}


### PR DESCRIPTION
## Issue

The Settings page exposed self-managed runtime configuration while a user was signed in to Wanta. Signed-in users do not need custom model selection or OpenConnector deployment controls because their runtime is provided by Wanta.

This mixed two different operating modes in one view, made cloud accounts appear to require local configuration, and allowed self-managed controls to flash briefly while authentication was still loading.

## Root cause

The runtime section was rendered unconditionally. Authentication only changed which model options and profile label appeared inside the section, while the custom-model and OpenConnector controls remained mounted.

## Fix

- Render the complete runtime configuration section only for an explicitly unauthenticated session.
- Keep the section hidden while authentication state is loading to prevent a signed-in startup flash.
- Move the model catalog hook into the signed-out-only subtree so signed-in Settings pages do not load or mount self-managed model controls.
- Preserve saved custom model and OpenConnector configuration so it is available again after signing out.
- Add focused presentation tests for authenticated, unauthenticated, and loading states.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` — 257 test files and 1,826 tests passed
- Started the Electron development build and manually verified the signed-in Settings view.
