### PR TITLE
Refine sidebar account controls

### DIFF
--- a/src/components/app-shell/SidebarAccountControls.tsx
+++ b/src/components/app-shell/SidebarAccountControls.tsx
@@ -346,7 +346,7 @@ export function SidebarFooterControls({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="oo-sidebar-nav-item oo-sidebar-workspace-trigger flex h-10 min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 text-left disabled:cursor-default disabled:opacity-80"
+                className="oo-sidebar-nav-item oo-sidebar-workspace-trigger flex h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 text-left disabled:cursor-default disabled:opacity-80"
                 aria-busy={workspaceSwitching}
                 aria-label={workspaceSwitching ? t("sidebar.switchingAccount") : t("teams.workspaceSwitcher")}
                 aria-expanded={workspaceMenuOpen}
@@ -392,10 +392,11 @@ export function SidebarFooterControls({
               <button
                 type="button"
                 className={cn(
-                  "oo-sidebar-nav-item flex size-10 shrink-0 items-center justify-center rounded-md",
+                  "oo-sidebar-account-trigger oo-sidebar-nav-item flex size-9 shrink-0 items-center justify-center rounded-md",
                   (accountMenuOpen || activeRoute === "settings" || activeRoute === "archived") &&
                     "bg-sidebar-accent text-sidebar-accent-foreground",
                 )}
+                data-active={activeRoute === "settings" || activeRoute === "archived" ? "true" : undefined}
                 aria-label={t("sidebar.accountMenu")}
                 title={t("settings.title")}
               >

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -192,6 +192,15 @@
     color: var(--sidebar-accent-foreground);
   }
 
+  .oo-sidebar-account-trigger:focus-visible {
+    box-shadow: none;
+  }
+
+  .oo-sidebar-account-trigger:focus-visible:not(:hover):not([data-state="open"]):not([data-active="true"]) {
+    background: transparent;
+    color: var(--sidebar-foreground);
+  }
+
   .oo-sidebar-local-menu-trigger:hover {
     background: color-mix(in oklab, var(--sidebar-accent) 45%, var(--sidebar));
     color: var(--sidebar-accent-foreground);


### PR DESCRIPTION
## Summary

Refine the signed-in sidebar footer so it matches the more compact signed-out treatment and does not retain a dark focus border after the account menu closes or the window loses focus.

## Problem

The signed-in workspace and settings controls were 40px tall while the signed-out local workspace control was 36px tall. This made the signed-in footer feel visually heavier and caused a noticeable difference between authentication states.

The settings trigger also inherited the generic sidebar `focus-visible` inset shadow. After opening the account menu or moving focus away from the window, the trigger could retain an active-looking background with a dark border even though the menu was closed.

## Root cause

The signed-in controls used `h-10` and `size-10`, while the signed-out trigger already used `h-9`. The settings trigger also had no state-specific focus override, unlike the signed-out local menu trigger and workspace trigger.

## Changes

- Reduce the signed-in workspace trigger from 40px to 36px.
- Reduce the settings trigger from 40px square to 36px square.
- Remove the retained inset focus border from the settings trigger.
- Restore the normal transparent resting surface when focus remains after the menu closes.
- Preserve hover, open-menu, Settings-route, and Archived-route active states.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 257 test files and 1,826 tests passed
- Started the Electron development build and verified successful renderer HMR after the style update.
