### PR TITLE
fix(chat): stabilize timeline width while scrolling

### DIFF
--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -528,6 +528,7 @@ export const ChatTimeline = React.memo(function ChatTimeline({
       <ConversationContent
         data-selectable="true"
         className={cn("mx-auto min-h-full w-full gap-4 px-4 pt-7 pb-9", CHAT_CONTENT_MAX_WIDTH_CLASS)}
+        scrollClassName="oo-scrollbar-gutter-auto"
       >
         {turns.map((turn, index) => {
           const turnArtifactGroups = artifactGroupsByTurnId.get(turn.id) ?? EMPTY_ARTIFACT_GROUPS


### PR DESCRIPTION
## Summary

- override the chat timeline dependency's forced `scrollbar-gutter: stable both-edges`
- keep the message viewport width stable when the transient scrolling scrollbar appears
- preserve the existing global scrollbar visibility behavior

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` (257 files, 1828 tests)
- live Electron 42 check: computed `scrollbar-gutter` is `auto`, and content width remains 700 px before, during, and after `.is-scrolling`