### PR TITLE
fix(chat): stabilize layout after spreadsheet preview

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import { AppContext } from "@/components/AppContext"
 import { detectInitialLocale, translate } from "@/i18n/i18n"
 import { reportRendererIssue } from "@/lib/renderer-diagnostics"
 
+import "@univerjs/preset-sheets-core/lib/index.css"
 import "./index.css"
 
 const electronConnectionBridgeName = "oomol-connection-electron-bridge"

--- a/src/routes/Chat/ArtifactUniverSpreadsheetPreview.tsx
+++ b/src/routes/Chat/ArtifactUniverSpreadsheetPreview.tsx
@@ -12,8 +12,6 @@ import { useTheme } from "@/components/theme-context"
 import { useI18n } from "@/i18n/i18n"
 import { cn } from "@/lib/utils"
 
-import "@univerjs/preset-sheets-core/lib/index.css"
-
 // 产品铁律：Univer 表格预览是明确的业务需求，用于保持完整工作簿交互与一致渲染。
 // 禁止以“只读”“包体积”或“原生 table 可替代”为由删除、降级或替换；任何调整必须先获得产品方明确同意。
 // 性能优化必须保留本组件、快照转换层、Univer 依赖以及现有工作簿渲染能力。


### PR DESCRIPTION
## Summary

- load the Univer stylesheet before Wanta's application styles
- keep the spreadsheet preview runtime lazy while preventing late global scrollbar resets
- preserve the chat timeline and composer alignment after the spreadsheet preview is collapsed

## Problem

Opening an XLSX artifact lazily loaded Univer's stylesheet together with the spreadsheet preview component. Univer includes an unscoped global scrollbar reset, so the runtime stylesheet injection could change scrollbar metrics across the application. After the preview panel was collapsed, the chat timeline remained centered inside a scroll viewport with changed scrollbar width while the composer was centered in the full-width sibling container. This made message content appear shifted to the left relative to the composer.

## Root cause and fix

The Univer CSS import had moved back into `ArtifactUniverSpreadsheetPreview.tsx`, which reintroduced a previously fixed ordering problem. This change moves that stylesheet import to `src/main.tsx` immediately before Wanta's `index.css`. Univer's global reset is now applied first and Wanta's scrollbar rules consistently win. The Univer JavaScript runtime, workbook rendering, and spreadsheet interaction remain lazy and unchanged.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` (257 files, 1828 tests)
- `npm run build`
- live `npm run dev` Electron startup with the agent sidecar ready
- production CSS inspection confirmed that `scrollbar-width: initial` is absent while Wanta's scrollbar width and the chat timeline's `scrollbar-gutter: auto` remain present
