### PR TITLE
Unify AI Elements code blocks

### DIFF
--- a/src/components/ai-elements/code-block.tsx
+++ b/src/components/ai-elements/code-block.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, CopyIcon } from "lucide-react"
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { writeClipboardText } from "@/lib/clipboard"
 import { cn } from "@/lib/utils"
 
 const isItalic = (fontStyle: number | undefined) => fontStyle !== undefined && (fontStyle & 1) !== 0
@@ -538,14 +539,11 @@ export const CodeBlockCopyButton = ({
   const { code } = useContext(CodeBlockContext)
 
   const copyToClipboard = useCallback(async () => {
-    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
-      onError?.(new Error("Clipboard API not available"))
-      return
-    }
-
     try {
       if (!isCopied) {
-        await navigator.clipboard.writeText(code)
+        if (!(await writeClipboardText(code))) {
+          throw new Error("Failed to copy code to the clipboard")
+        }
         setIsCopied(true)
         onCopy?.()
         if (timeoutRef.current !== null) {

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -14,11 +14,13 @@ import {
   panImageViewerState,
   zoomImageViewerState,
 } from "./message-image.tsx"
+import { MessageStreamdown } from "./message-streamdown.tsx"
 import {
   compactLocalPath,
   markdownCodeLanguage,
   markdownCodeRendererLanguages,
   markdownCodeText,
+  messageResponseRenderers,
   messageClassName,
   messageResponseControls,
   nextSmoothedText,
@@ -27,6 +29,7 @@ import {
   smoothedTextRevealStep,
 } from "./message.tsx"
 import { AppContext } from "@/components/AppContext"
+import { ThemeContext } from "@/components/theme-context"
 import { I18nContext, translate } from "@/i18n/i18n"
 
 const mockService = {
@@ -85,6 +88,56 @@ describe("normalizeUnlabeledCodeFences", () => {
     const markdown = ["```mermaid", "flowchart LR", "A --> B", "```", "", "```ts", "const value = 1", "```"].join("\n")
 
     expect(normalizeUnlabeledCodeFences(markdown)).toBe(markdown)
+  })
+
+  it("labels an incomplete bare fence so streaming content uses the AI Elements renderer", () => {
+    expect(normalizeUnlabeledCodeFences(["```", "unfinished content"].join("\n"))).toBe(
+      ["```text", "unfinished content"].join("\n"),
+    )
+  })
+})
+
+describe("messageResponseRenderers", () => {
+  it("registers unknown fenced languages with the AI Elements renderer", () => {
+    const [renderer] = messageResponseRenderers(["```report", "content", "```"].join("\n"))
+
+    expect(renderer?.language).toContain("report")
+  })
+
+  it("registers incomplete fenced languages but leaves Mermaid to its dedicated renderer", () => {
+    const [renderer] = messageResponseRenderers(
+      ["```mermaid", "flowchart LR", "A --> B", "```", "", "```custom-log", "unfinished"].join("\n"),
+    )
+
+    expect(renderer?.language).toContain("custom-log")
+    expect(renderer?.language).not.toContain("mermaid")
+  })
+
+  it.each([
+    ["unknown language", ["```report", "content", "```"].join("\n"), "report"],
+    ["incomplete bare fence", normalizeUnlabeledCodeFences(["```", "content"].join("\n")), "text"],
+  ])("renders %s with the AI Elements code block", (_case, markdown, language) => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        ThemeContext.Provider,
+        { value: { effectiveTheme: "light", preference: "light", setPreference: () => undefined } },
+        React.createElement(
+          I18nContext.Provider,
+          {
+            value: {
+              locale: "zh-CN",
+              setLocale: () => undefined,
+              t: (key, vars) => translate("zh-CN", key, vars),
+            },
+          },
+          React.createElement(MessageStreamdown, { defaultRenderers: messageResponseRenderers(markdown) }, markdown),
+        ),
+      ),
+    )
+
+    expect(html).toContain(`data-language="${language}"`)
+    expect(html).toContain('aria-label="复制代码"')
+    expect(html).not.toContain('data-streamdown="code-block"')
   })
 })
 

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -3,7 +3,8 @@ import type { ComponentProps, HTMLAttributes, ReactNode } from "react"
 import type { CustomRenderer, CustomRendererProps, StreamdownProps } from "streamdown"
 
 import { CheckIcon, CopyIcon } from "lucide-react"
-import { isValidElement, lazy, memo, Suspense, useEffect, useRef, useState } from "react"
+import { isValidElement, lazy, memo, Suspense, useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
 import { extractLocalImagePaths, normalizeLocalImageMarkdown } from "../../../electron/chat/markdown-images.ts"
 import {
   CodeBlock,
@@ -13,7 +14,7 @@ import {
   CodeBlockHeader,
   CodeBlockTitle,
 } from "./code-block.tsx"
-import { normalizeMermaidMarkdown } from "./mermaid-policy.ts"
+import { incompleteMermaidLanguage, normalizeMermaidMarkdown } from "./mermaid-policy.ts"
 import { MarkdownImage } from "./message-image.tsx"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -280,7 +281,7 @@ function MarkdownCodeRenderer({ code, language }: CustomRendererProps) {
           <CodeBlockFilename>{normalizedLanguage}</CodeBlockFilename>
         </CodeBlockTitle>
         <CodeBlockActions>
-          <CodeBlockCopyButton aria-label={t("chat.copyCode")} />
+          <CodeBlockCopyButton aria-label={t("chat.copyCode")} onError={() => toast.error(t("error.copyFailed"))} />
         </CodeBlockActions>
       </CodeBlockHeader>
     </CodeBlock>
@@ -291,7 +292,7 @@ const messageResponseComponents = {
   img: MarkdownImage,
 } satisfies MessageResponseProps["components"]
 
-// Mermaid 由 Streamdown 的专用渲染器处理；其它常见代码语言继续复用 Wanta 的代码块。
+// Mermaid uses its dedicated renderer; ordinary fenced content uses Wanta's AI Elements code block.
 export const markdownCodeRendererLanguages = [
   "bash",
   "c",
@@ -335,12 +336,47 @@ export const markdownCodeRendererLanguages = [
   "yml",
 ] as const
 
-const messageResponseRenderers = [
-  {
-    language: [...markdownCodeRendererLanguages],
-    component: MarkdownCodeRenderer,
-  },
-] satisfies CustomRenderer[]
+function fencedCodeLanguages(markdown: string): string[] {
+  const languages = new Set<string>()
+  const lines = markdown.split(/\r?\n/)
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const opening = lines[index]?.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*([^\s]*)/)
+    if (!opening) {
+      continue
+    }
+
+    const openingFence = opening[1]
+    const language = opening[2]
+    if (language && language.toLowerCase() !== "mermaid" && language !== incompleteMermaidLanguage) {
+      languages.add(language)
+    }
+
+    let closingIndex = -1
+    for (let candidateIndex = index + 1; candidateIndex < lines.length; candidateIndex += 1) {
+      const closing = lines[candidateIndex]?.match(/^[ \t]{0,3}(`+|~+)[ \t]*$/)
+      if (closing && closing[1]?.[0] === openingFence?.[0] && closing[1].length >= openingFence.length) {
+        closingIndex = candidateIndex
+        break
+      }
+    }
+    if (closingIndex < 0) {
+      break
+    }
+    index = closingIndex
+  }
+
+  return [...languages]
+}
+
+export function messageResponseRenderers(markdown: string): CustomRenderer[] {
+  return [
+    {
+      language: [...new Set([...markdownCodeRendererLanguages, ...fencedCodeLanguages(markdown)])],
+      component: MarkdownCodeRenderer,
+    },
+  ]
+}
 
 interface LocalImagePreview {
   path: string
@@ -391,8 +427,8 @@ export function normalizeSingleLocalPathCodeFences(markdown: string): string {
 }
 
 /**
- * Streamdown 的自定义 renderer 不匹配空语言名；为无标签 fenced block 补上 text，
- * 使其继续使用 AI Elements 代码块，同时不拦截 Mermaid 专用 renderer。
+ * Streamdown does not match custom renderers against an empty language. Label both complete and
+ * incomplete bare fences as text so they consistently use the AI Elements code block.
  */
 export function normalizeUnlabeledCodeFences(markdown: string): string {
   const parts = markdown.split(/(\r?\n)/)
@@ -411,10 +447,10 @@ export function normalizeUnlabeledCodeFences(markdown: string): string {
       }
     }
 
-    if (closingIndex < 0) continue
     if (opening[3].trim().length === 0) {
       parts[index] = `${opening[1]}${openingFence}text`
     }
+    if (closingIndex < 0) break
     index = closingIndex
   }
 
@@ -538,6 +574,10 @@ export const MessageResponse = memo(
           )
         : sourceChildren
     const localImagePreviews = typeof responseChildren === "string" ? extractLocalImagePreviews(responseChildren) : []
+    const defaultRenderers = useMemo(
+      () => messageResponseRenderers(typeof responseChildren === "string" ? responseChildren : ""),
+      [responseChildren],
+    )
     return (
       // fallback 直接铺原始 markdown 文本：streamdown chunk 首次加载时内容即可见，加载完再升级为富渲染。
       <Suspense fallback={<div className={cn("size-full whitespace-pre-wrap", className)}>{responseChildren}</div>}>
@@ -550,7 +590,7 @@ export const MessageResponse = memo(
               ...components,
             }}
             controls={messageResponseControls(controls)}
-            defaultRenderers={messageResponseRenderers}
+            defaultRenderers={defaultRenderers}
             lineNumbers={lineNumbers ?? false}
             plugins={plugins}
             {...props}

--- a/src/routes/Chat/ArtifactPreviewPane.tsx
+++ b/src/routes/Chat/ArtifactPreviewPane.tsx
@@ -9,6 +9,7 @@ import type { TranslateFn } from "@/i18n/i18n"
 
 import { Code2, Copy, ExternalLink, File, FolderOpen, Info, Music, Package } from "lucide-react"
 import * as React from "react"
+import { toast } from "sonner"
 import { htmlPreviewSrcDoc } from "./artifact-html-preview.ts"
 import {
   artifactMetaLabel,
@@ -284,7 +285,10 @@ function ArtifactSourcePreview({
             <CodeBlockFilename>{item.name}</CodeBlockFilename>
           </CodeBlockTitle>
           <CodeBlockActions>
-            <CodeBlockCopyButton aria-label={t("chat.copyMessage")} />
+            <CodeBlockCopyButton
+              aria-label={t("chat.copyMessage")}
+              onError={() => toast.error(t("error.copyFailed"))}
+            />
           </CodeBlockActions>
         </CodeBlockHeader>
       </CodeBlock>


### PR DESCRIPTION
## Summary

Unify ordinary fenced Markdown content on Wanta's vendored AI Elements `CodeBlock` and make code copying reliable in Electron.

## Problem

Assistant responses could render visually and behaviorally different code cards depending on the fence language. Known languages used Wanta's AI Elements code block, while bare, incomplete, or unknown-language fences could fall back to Streamdown's native code card. Users therefore saw two different headers, borders, spacing systems, and copy buttons for the same kind of content.

The copy buttons in both the vendored code block and the Streamdown fallback relied directly on `navigator.clipboard.writeText`. When Chromium rejected that API in the Electron renderer, the action failed silently: the clipboard did not change, the success icon did not appear, and no error was shown.

## Root cause

Streamdown custom renderers are matched by exact language identifiers. Wanta registered a fixed list of common languages and normalized only closed bare fences to `text`. Unknown languages and incomplete bare fences therefore had no matching AI Elements renderer and used Streamdown's fallback. The vendored `CodeBlockCopyButton` also bypassed Wanta's existing clipboard helper, which already provides a DOM fallback.

## Changes

- Discover language identifiers from complete and incomplete fenced blocks and register them with Wanta's AI Elements renderer.
- Normalize incomplete bare fences to `text` as well as completed bare fences.
- Keep Mermaid on its dedicated validated diagram renderer.
- Route `CodeBlockCopyButton` through the shared clipboard helper so failed Clipboard API writes fall back to the hidden-textarea copy path.
- Show the existing localized copy-failure toast in chat code blocks and artifact source previews.
- Add regression coverage for unknown languages, incomplete bare and labeled fences, Mermaid separation, and rendered output that no longer contains Streamdown's native code card.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 257 files and 1,833 tests passed
- `npm run dev` — Vite, Electron main/preload builds, renderer startup, and agent sidecar startup completed successfully
- `git diff --check`
