### PR TITLE
ci(release): disable setup-node npm cache on self-hosted Windows runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,15 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          # This self-hosted runner cannot authenticate to the GitHub Actions
+          # cache service, so setup-node@v5's default package-manager cache
+          # (package-manager-cache: true) hangs ~10 min on a failed restore
+          # ("Server failed to authenticate the request") before giving up —
+          # setup-node took 20 min while the actual `npm ci` took 34 s (run
+          # 29923188224). The runner's disk already persists npm's cache dir
+          # across runs, so the GitHub-side cache is pure overhead here.
+          # Disable it. Hosted runners (release-mac, pr.yml) keep it enabled.
+          package-manager-cache: false
       - name: Set env + version
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

`release-win` runs on a **self-hosted Windows runner** that cannot authenticate to the GitHub Actions cache service. `actions/setup-node@v5` enables its package-manager cache by default (`package-manager-cache: true`), so every run wastes ~20 min on a cache operation that can never succeed.

Timeline from run [29923188224](https://github.com/oomol-lab/wanta/actions/runs/29923188224/job/88933615515) (`release-win`, total 23m55s):

| Time | Event | Duration |
|------|-------|----------|
| 13:17:24 | `Cache hit for: node-cache-Windows-x64-npm-...` | |
| 13:17:24 → 13:27:33 | restore attempt → `Failed to restore: Server failed to authenticate the request` | **~10 min** |
| 13:27:33 | `npm cache is not found` (gives up) | |
| 13:27:33 → 13:37:33 | still stalled → `runner received a shutdown signal` | **~10 min** |
| 13:37:33 → 13:38:07 | actual `npm ci` | **34 s** |

The `setup-node` step alone took **20m10s**; the real `npm ci` took **34 s**. For comparison `release-mac` (hosted runner) finished the whole job in 4m52s. A post-job `Failed to save: Unable to reserve cache` warning also appears.

## Fix

Set `package-manager-cache: false` on the `release-win` `setup-node` step only. This disables both restore and save, so the failed restore stall and the failed save warning both go away.

Why this is correct:
- Root cause is auth failure to the cache service (`Server failed to authenticate the request`), not a slow cache — restore only ever stalls to timeout.
- The self-hosted runner's disk already persists npm's cache dir (`AppData\Local\npm-cache`) across runs, so the GitHub-side cache is pure overhead. `npm ci` is 34 s regardless.
- Hosted runners (`release-mac` on `macos-latest`, `pr.yml` on `ubuntu-latest`) keep the cache — there it authenticates fine, and clean-environment runs make it worthwhile. **Unchanged.**

## Expected impact

`release-win` drops from ~24 min to ~4 min. No functional change to build/sign/publish.