### PR TITLE
fix artifacts persistence warning semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -400,10 +400,12 @@ multiple files browse only that turn's set, and the whole session's history is n
 merged into one card; the top result entry follows the most recent turn that has results. The copy
 button copies message text only and takes no part in the artifact lifecycle. If a reply already
 shows a generated image but the turn ends with no reopenable local file, it registers
-`failed/generated_preview_not_persisted`; if only some images landed it registers `partial`. The UI
-states "artifact save failed" or "some artifacts not saved" explicitly and must not vanish silently
-or pass a remote URL off as a saved artifact. The in-body image preview and artifact persistence are
-independent, but for a final generated image both must produce output. At turn end the main process
+`failed/generated_preview_not_persisted`, and the UI states "artifact save failed" rather than
+silently hiding the failure or passing a remote URL off as a saved artifact. When at least one saved
+output exists but preview sources cannot all be attributed to saved files, the bundle records
+`partial/generated_preview_persistence_unverified` for diagnostics without presenting the mismatch
+as confirmed user data loss. The in-body image preview and artifact persistence are independent, but
+for a final generated image both must produce output. At turn end the main process
 materializes the assistant's local image attachments, Markdown data images, and public HTTPS image
 previews into the turn's managed directory before building the bundle, so a preview source need not
 be a native local file. Remote materialization is allowed only for a public HTTPS address carrying no

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -238,11 +238,14 @@
   Markdown image nodes, but must not guess paths from ordinary copy; remote materialization must
   restrict protocol, private-network addresses, redirects, MIME, size, and timeout. Failing to
   persist, or to publish to the project, must yield an explicit failure state — never dodge failure
-  by hiding the preview or the managed copy. At the start of each turn, record a file baseline of
-  the current session's older artifact directories under this turn's actual storage location; if an
-  old script mistakenly writes into an old directory, recover at turn end only the regular files
-  added or changed after the baseline into the current turn — never rewrite old bundles, scan across
-  sessions, or follow symlinks, and never recover when the baseline is incomplete.
+  by hiding the preview or the managed copy. A preview-count mismatch beside a reopenable saved
+  output is only incomplete source attribution, not proof that a distinct user deliverable was lost;
+  keep that diagnostic state without showing a data-loss warning. At the start of each turn, record
+  a file baseline of the current session's older artifact directories under this turn's actual
+  storage location; if an old script mistakenly writes into an old directory, recover at turn end
+  only the regular files added or changed after the baseline into the current turn — never rewrite
+  old bundles, scan across sessions, or follow symlinks, and never recover when the baseline is
+  incomplete.
 - **User attachments are separated from model representations**: when an ordinary file is selected
   it is first copied into a Wanta-private 0400 read-only snapshot; preview, parsing, and agent
   tools read only the snapshot — never modify the user's source path or the attachment snapshot.

--- a/electron/chat/artifact-bundles.test.ts
+++ b/electron/chat/artifact-bundles.test.ts
@@ -266,7 +266,7 @@ test("generatedImagePreviewCount includes assistant image attachments without do
   )
 })
 
-test("buildArtifactBundle marks an incompletely persisted image set as partial", async () => {
+test("buildArtifactBundle marks incomplete preview attribution as unverified", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-bundle-partial-"))
   try {
     await writeFile(path.join(root, "001.png"), "one")
@@ -281,7 +281,7 @@ test("buildArtifactBundle marks an incompletely persisted image set as partial",
     })
 
     assert.equal(bundle?.status, "partial")
-    assert.equal(bundle?.failure, "generated_preview_not_persisted")
+    assert.equal(bundle?.failure, "generated_preview_persistence_unverified")
     assert.deepEqual(
       bundle?.items.map((item) => item.name),
       ["001.png"],
@@ -306,7 +306,7 @@ test("buildArtifactBundle does not let an unrelated image mask a failed generate
     })
 
     assert.equal(bundle?.status, "partial")
-    assert.equal(bundle?.failure, "generated_preview_not_persisted")
+    assert.equal(bundle?.failure, "generated_preview_persistence_unverified")
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/electron/chat/artifact-bundles.ts
+++ b/electron/chat/artifact-bundles.ts
@@ -106,6 +106,7 @@ function validBundle(value: unknown): value is ArtifactBundle {
     typeof bundle.truncated === "boolean" &&
     (bundle.failure === undefined ||
       bundle.failure === "generated_preview_not_persisted" ||
+      bundle.failure === "generated_preview_persistence_unverified" ||
       bundle.failure === "project_output_publish_failed" ||
       bundle.failure === "project_output_publish_partial") &&
     Array.isArray(bundle.items) &&
@@ -750,7 +751,7 @@ export function buildArtifactBundleFromGroup(input: {
     truncated: group.truncated,
     createdAt,
     completedAt,
-    ...(isPartial ? { failure: "generated_preview_not_persisted" as const } : {}),
+    ...(isPartial ? { failure: "generated_preview_persistence_unverified" as const } : {}),
   }
 }
 

--- a/electron/chat/common.ts
+++ b/electron/chat/common.ts
@@ -543,6 +543,7 @@ export type ArtifactBundleDisplay = LocalArtifactDisplayMode
 export type ArtifactBundleStatus = "ready" | "partial" | "failed"
 export type ArtifactBundleFailure =
   | "generated_preview_not_persisted"
+  | "generated_preview_persistence_unverified"
   | "project_output_publish_failed"
   | "project_output_publish_partial"
 export type ArtifactItemStatus = "ready"

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -926,9 +926,6 @@ export const enMessages = {
   "artifacts.persistenceFailedTitle": "Artifact not saved",
   "artifacts.persistenceFailedDescription":
     "The generated result was shown in the response but was not saved as a local file that can be reopened.",
-  "artifacts.persistencePartialTitle": "Some artifacts were not saved",
-  "artifacts.persistencePartialDescription":
-    "Some generated results were not saved as local files. Only successfully saved items are listed below.",
   "artifacts.projectPublishFailedTitle": "Output not saved to the project",
   "artifacts.projectPublishFailedDescription":
     "The output remains available in Wanta, but it could not be copied into the project folder.",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -883,8 +883,6 @@ export const zhCNMessages = {
   "artifacts.emptyDescription": "当前对话还没有可查看的成果。Markdown、图片、视频、音频等文件会显示在这里。",
   "artifacts.persistenceFailedTitle": "制成品保存失败",
   "artifacts.persistenceFailedDescription": "生成结果已显示在回复中，但没有保存为可重新打开的本地文件。",
-  "artifacts.persistencePartialTitle": "部分制成品未保存",
-  "artifacts.persistencePartialDescription": "部分生成结果没有保存为本地文件；下方仅列出已成功保存的内容。",
   "artifacts.projectPublishFailedTitle": "制成品未保存到项目",
   "artifacts.projectPublishFailedDescription": "制成品仍可在 Wanta 中查看，但未能复制到项目文件夹。",
   "artifacts.projectPublishPartialTitle": "部分制成品未保存到项目",

--- a/src/routes/Chat/GeneratedArtifacts.test.ts
+++ b/src/routes/Chat/GeneratedArtifacts.test.ts
@@ -209,7 +209,7 @@ describe("GeneratedArtifactsShelf", () => {
     expect(html).toContain("没有保存为可重新打开的本地文件")
   })
 
-  it("keeps persisted items visible while warning about a partial image set", () => {
+  it("does not alarm users when a saved image only has incomplete preview attribution", () => {
     const image = artifactItem("001.png", "image/png")
     const html = renderArtifactShelf([
       {
@@ -220,7 +220,24 @@ describe("GeneratedArtifactsShelf", () => {
       },
     ])
 
-    expect(html).toContain("部分制成品未保存")
+    expect(html).not.toContain("部分制成品未保存")
+    expect(html).not.toContain("制成品保存失败")
+    expect(html).toContain("001")
+  })
+
+  it("does not alarm users for newly recorded unverified preview attribution", () => {
+    const image = artifactItem("001.png", "image/png")
+    const html = renderArtifactShelf([
+      {
+        messageId: "assistant-1",
+        group: { root: artifactFolder("generated-images"), items: [image], totalItems: 1, truncated: false },
+        status: "partial",
+        failure: "generated_preview_persistence_unverified",
+      },
+    ])
+
+    expect(html).not.toContain("部分制成品未保存")
+    expect(html).not.toContain("制成品保存失败")
     expect(html).toContain("001")
   })
 

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -134,13 +134,7 @@ function selectionWithContext(
   return { messageId, group, groups, ...(pack ? { pack } : {}), selectedPath }
 }
 
-function ArtifactPersistenceWarning({
-  failure,
-  partial = false,
-}: {
-  failure?: ArtifactBundleFailure
-  partial?: boolean
-}) {
+function ArtifactPersistenceWarning({ failure }: { failure?: ArtifactBundleFailure }) {
   const t = useT()
   const projectPublishFailure = failure === "project_output_publish_failed"
   const projectPublishPartial = failure === "project_output_publish_partial"
@@ -148,16 +142,12 @@ function ArtifactPersistenceWarning({
     ? "artifacts.projectPublishFailedTitle"
     : projectPublishPartial
       ? "artifacts.projectPublishPartialTitle"
-      : partial
-        ? "artifacts.persistencePartialTitle"
-        : "artifacts.persistenceFailedTitle"
+      : "artifacts.persistenceFailedTitle"
   const descriptionKey = projectPublishFailure
     ? "artifacts.projectPublishFailedDescription"
     : projectPublishPartial
       ? "artifacts.projectPublishPartialDescription"
-      : partial
-        ? "artifacts.persistencePartialDescription"
-        : "artifacts.persistenceFailedDescription"
+      : "artifacts.persistenceFailedDescription"
   return (
     <div className="rounded-lg border border-amber-500/30 bg-amber-500/8 px-3 py-2.5">
       <div className="flex min-w-0 items-start gap-2.5">
@@ -243,8 +233,10 @@ export function GeneratedArtifactsShelf({
     <section className="not-prose mt-0 grid gap-1.5">
       {newest?.status === "failed" ? (
         <ArtifactPersistenceWarning failure={newest.failure} />
-      ) : primary.status === "partial" ? (
-        <ArtifactPersistenceWarning failure={primary.failure} partial />
+      ) : primary.status === "partial" &&
+        (primary.failure === "project_output_publish_failed" ||
+          primary.failure === "project_output_publish_partial") ? (
+        <ArtifactPersistenceWarning failure={primary.failure} />
       ) : null}
       <OutputShelfCard
         title={title}


### PR DESCRIPTION
## Problem

Generated-image turns can finish with a reopenable local artifact while Wanta cannot prove that every inline preview source maps to that saved file. The artifact shelf currently presents this attribution mismatch as “Some artifacts were not saved.”

For users, that warning contradicts the visible saved artifact and suggests confirmed data loss even when the requested output is available. The warning is prominent but cannot identify a missing deliverable or offer a recovery action.

## Root cause

Artifact finalization compares the number of distinct assistant image preview sources with the number of saved images traced through `materializedOrigins`. A mismatch is useful diagnostic evidence, but it does not prove that a distinct user deliverable was lost: the same image can have different temporary, remote, Markdown, attachment, and managed-file representations.

The renderer treated this low-confidence partial state the same as a confirmed persistence failure.

## Changes

- Add `generated_preview_persistence_unverified` for turns that have reopenable saved output but incomplete preview-to-file attribution.
- Keep `generated_preview_not_persisted` for confirmed cases where a visible generated image has no reopenable local file.
- Stop showing a data-loss warning for new and legacy partial preview-attribution states while continuing to show the saved artifact card.
- Preserve warnings for complete artifact persistence failures and project publication failures.
- Remove the now-unused partial-persistence warning copy.
- Document the distinction between diagnostic attribution gaps and confirmed user data loss.
- Add regression coverage for both the new state and legacy stored partial bundles.

## Validation

- `npm run lint`
- `npm run ts-check`
- `npm run format`
- `npm test` — 257 files, 1834 tests passed
- `npm run build`
- Focused artifact tests — 2 files, 38 tests passed
- Existing development Vite instance responded successfully after reload
