### PR TITLE
fix(chat): hide internal attachment context

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -359,11 +359,12 @@ Ordinary file attachments are frozen at selection time into a 0400 read-only pri
 depending on the user's source file. The model-compatibility representation (currently including
 XLSX-extracted text and optimized images) is kept strictly separate from the public attachment
 identity: before sending, `UserAttachmentStore` atomically persists the original attachment manifest
-to `userData/user-attachments.json` keyed by the OpenCode user message ID, with `agentPath` as
-internal input only. OpenCode's expanded synthetic Read text and internal file parts are not
+and user-authored text to `userData/user-attachments.json` keyed by the OpenCode user message ID,
+with `agentPath` as internal input only. OpenCode's expanded synthetic Read text, Wanta's model-only
+attachment compatibility text, and internal file parts are not
 broadcast to the renderer; history loading likewise overrides OpenCode's model representation with
 the Wanta attachment manifest, so mid-send, on refresh, and after restart it always shows the file
-name, MIME, and snapshot path the user chose. If the user asks to modify an attachment, the agent
+name, MIME, snapshot path, and exact text the user chose. If the user asks to modify an attachment, the agent
 must first copy it into the turn's artifact directory and treat the copy as a new output; a directory
 attachment stays an explicit local reference and is not snapshotted recursively.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -252,10 +252,12 @@
   When the user asks for modifications, first copy into the current turn's artifact directory and
   make the copy the new output. Public message attachments are persisted by `UserAttachmentStore`
   keyed by user message ID and are the source of truth for chat history; `agentPath`
-  representations (XLSX text extraction, optimized image copies, OCR, etc.) are internal only —
-  they must not replace the attachment card, enter copied text, or impersonate the user's original
-  during history restore. OpenCode's synthetic file expansions must be filtered by structured
-  markers — never guessed from Read copy or free text. Directory attachments are local references
+  representations (XLSX text extraction, optimized image copies, OCR, fallback path instructions,
+  etc.) are internal only — they must not replace the attachment card, enter copied text, or
+  impersonate the user's original during history restore. Persist the exact user-authored text with
+  the public attachment record and use it as the display/copy/retry source of truth. OpenCode's and
+  Wanta's synthetic attachment context must be filtered by structured markers — never guessed from
+  Read copy or free text. Directory attachments are local references
   and do not get recursive snapshots.
 
 ## 8. Renderer / UI

--- a/electron/agent/attachment-input.test.ts
+++ b/electron/agent/attachment-input.test.ts
@@ -74,8 +74,12 @@ describe("planAttachmentInputs", () => {
   ])("turns unsupported binary %s into a safe path reference", async (name, mime) => {
     const [input] = await plan([attachment(name, mime)], mediaCapable)
 
-    expect(input).toMatchObject({ kind: "text", text: expect.stringContaining(`/tmp/${name}`) })
-    expect(input).toMatchObject({ kind: "text", text: expect.stringContaining("not safe to pass through") })
+    expect(input).toMatchObject({
+      kind: "internal-text",
+      purpose: "attachment-reference",
+      text: expect.stringContaining(`/tmp/${name}`),
+    })
+    expect(input).toMatchObject({ kind: "internal-text", text: expect.stringContaining("not safe to pass through") })
   })
 
   it("passes normalized image formats only to image-capable models", async () => {
@@ -83,7 +87,7 @@ describe("planAttachmentInputs", () => {
       { kind: "file", mime: "image/png", name: "photo.png", path: "/tmp/photo.png" },
     ])
     expect((await plan([attachment("photo.png", "image/png")], textOnly))[0]).toMatchObject({
-      kind: "text",
+      kind: "internal-text",
       text: expect.stringContaining("does not support image input"),
     })
   })
@@ -91,7 +95,7 @@ describe("planAttachmentInputs", () => {
   it("does not pass SVG and BMP through as model images", async () => {
     for (const item of [attachment("vector.svg", "image/svg+xml"), attachment("scan.bmp", "image/bmp")]) {
       expect((await plan([item], mediaCapable))[0]).toMatchObject({
-        kind: "text",
+        kind: "internal-text",
         text: expect.stringContaining("not in the normalized image allowlist"),
       })
     }
@@ -102,7 +106,7 @@ describe("planAttachmentInputs", () => {
       { kind: "file", mime: "application/pdf", name: "report.pdf", path: "/tmp/report.pdf" },
     ])
     expect((await plan([attachment("report.pdf", "application/pdf")], textOnly))[0]).toMatchObject({
-      kind: "text",
+      kind: "internal-text",
       text: expect.stringContaining("does not support direct PDF input"),
     })
   })
@@ -119,14 +123,17 @@ describe("planAttachmentInputs", () => {
     const item = attachment("grown.txt", "text/plain", 100)
     const [input] = await plan([item], mediaCapable, new Map([[item.path, maxDirectAttachmentBytes + 1]]))
 
-    expect(input).toMatchObject({ kind: "text", text: expect.stringContaining("size budget") })
+    expect(input).toMatchObject({ kind: "internal-text", text: expect.stringContaining("size budget") })
   })
 
   it("uses a path reference when the current file size cannot be verified", async () => {
     const item = attachment("missing.txt", "text/plain")
     const inputs = await planAttachmentInputs([item], mediaCapable, { fileSize: async () => null })
 
-    expect(inputs[0]).toMatchObject({ kind: "text", text: expect.stringContaining("could not be verified") })
+    expect(inputs[0]).toMatchObject({
+      kind: "internal-text",
+      text: expect.stringContaining("could not be verified"),
+    })
   })
 
   it("stops embedding files after the aggregate direct-size budget", async () => {
@@ -142,7 +149,7 @@ describe("planAttachmentInputs", () => {
     )
 
     expect(inputs.slice(0, 3).every((input) => input.kind === "file")).toBe(true)
-    expect(inputs[3]).toMatchObject({ kind: "text", text: expect.stringContaining("size budget") })
+    expect(inputs[3]).toMatchObject({ kind: "internal-text", text: expect.stringContaining("size budget") })
   })
 
   it("limits the number of attachments represented in one turn", async () => {
@@ -152,6 +159,10 @@ describe("planAttachmentInputs", () => {
     const inputs = await plan(attachments, textOnly)
 
     expect(inputs).toHaveLength(maxAttachmentsPerTurn + 1)
-    expect(inputs.at(-1)).toMatchObject({ kind: "text", text: expect.stringContaining("2 additional attachments") })
+    expect(inputs.at(-1)).toMatchObject({
+      kind: "internal-text",
+      purpose: "attachment-limit",
+      text: expect.stringContaining("2 additional attachments"),
+    })
   })
 })

--- a/electron/agent/attachment-input.ts
+++ b/electron/agent/attachment-input.ts
@@ -9,7 +9,11 @@ export interface AttachmentModelCapabilities {
 
 export type PlannedAttachmentInput =
   | { kind: "file"; mime: string; name: string; path: string }
-  | { kind: "text"; text: string }
+  | {
+      kind: "internal-text"
+      purpose: "attachment-limit" | "attachment-reference"
+      text: string
+    }
 
 export interface AttachmentInputDependencies {
   fileSize: (path: string) => Promise<number | null>
@@ -147,7 +151,8 @@ function pathReference(
   reason: string,
 ): PlannedAttachmentInput {
   return {
-    kind: "text",
+    kind: "internal-text",
+    purpose: "attachment-reference",
     text: [
       `Attached local file: ${attachment.name}`,
       `Path: ${attachment.path}`,
@@ -237,7 +242,8 @@ export async function planAttachmentInputs(
   const omitted = (attachments?.length ?? 0) - accepted.length
   if (omitted > 0) {
     inputs.push({
-      kind: "text",
+      kind: "internal-text",
+      purpose: "attachment-limit",
       text: `${omitted} additional attachment${omitted === 1 ? " was" : "s were"} not embedded because the per-turn limit is ${maxAttachmentsPerTurn}. Ask the user to split the files across multiple turns if they are required.`,
     })
   }

--- a/electron/agent/event-translator.test.ts
+++ b/electron/agent/event-translator.test.ts
@@ -116,6 +116,34 @@ test("text part.updated preserves the synthetic marker for visibility filtering"
   ])
 })
 
+test("text part.updated treats Wanta internal metadata as synthetic", () => {
+  const out = translateOpencodeEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "p1",
+        messageID: "m1",
+        metadata: { wantaVisibility: "internal" },
+        sessionID: "s1",
+        text: "internal attachment reference",
+        type: "text",
+      },
+    },
+  })
+  assert.deepEqual(out, [
+    {
+      event: "messageDelta",
+      data: {
+        messageId: "m1",
+        partId: "p1",
+        sessionId: "s1",
+        synthetic: true,
+        text: "internal attachment reference",
+      },
+    },
+  ])
+})
+
 test("reasoning part.updated → messageReasoningDelta", () => {
   const out = translateOpencodeEvent({
     type: "message.part.updated",
@@ -385,6 +413,29 @@ test("normalizeMessage hides synthetic OpenCode file expansion from user text", 
       createdAt: 1,
       id: "m1",
       parts: [{ kind: "text", partId: "user-1", text: "Analyze this workbook" }],
+      role: "user",
+    },
+  )
+})
+
+test("normalizeMessage hides Wanta internal attachment context from user history", () => {
+  assert.deepEqual(
+    normalizeMessage({
+      info: { id: "m1", role: "user", time: { created: 1 } },
+      parts: [
+        {
+          id: "internal-1",
+          metadata: { wantaVisibility: "internal" },
+          text: "Attached local file: photo.png",
+          type: "text",
+        },
+        { id: "user-1", type: "text", text: "Analyze this image" },
+      ],
+    }),
+    {
+      createdAt: 1,
+      id: "m1",
+      parts: [{ kind: "text", partId: "user-1", text: "Analyze this image" }],
       role: "user",
     },
   )

--- a/electron/agent/event-translator.ts
+++ b/electron/agent/event-translator.ts
@@ -409,6 +409,7 @@ interface OpencodePart {
   type: string
   text?: string
   synthetic?: boolean
+  metadata?: Record<string, unknown>
   mime?: string
   filename?: string
   url?: string
@@ -439,6 +440,10 @@ interface OpencodePart {
   time?: {
     created?: number
   }
+}
+
+function isInternalUserTextPart(part: OpencodePart): boolean {
+  return part.synthetic === true || part.metadata?.wantaVisibility === "internal"
 }
 
 function toolContext(state: NonNullable<OpencodePart["state"]>) {
@@ -490,13 +495,14 @@ function translatePart(part: OpencodePart, delta?: string): ChatEmit[] {
     ]
   }
   if (part.type === "text") {
+    const internal = isInternalUserTextPart(part)
     const data: MessageDeltaEvent = {
       sessionId: part.sessionID,
       messageId: part.messageID,
       partId: part.id,
       text: part.text ?? "",
       ...(delta === undefined ? {} : { delta }),
-      ...(part.synthetic ? { synthetic: true } : {}),
+      ...(internal ? { synthetic: true } : {}),
     }
     return [
       {
@@ -656,7 +662,7 @@ export function normalizeMessage(message: { info?: unknown; parts?: unknown }): 
   const parts: ChatMessagePart[] = []
   for (const part of rawParts) {
     if (part.type === "text") {
-      if (info.role === "user" && part.synthetic === true) {
+      if (info.role === "user" && isInternalUserTextPart(part)) {
         continue
       }
       const text = part.text ?? ""

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -578,7 +578,17 @@ describe("AgentManager", () => {
       })
 
       const calls = promptAsync.mock.calls as unknown as Array<
-        [{ parts: Array<{ mime?: string; text?: string; type: string }> }]
+        [
+          {
+            parts: Array<{
+              metadata?: Record<string, unknown>
+              mime?: string
+              synthetic?: boolean
+              text?: string
+              type: string
+            }>
+          },
+        ]
       >
       const call = calls[0]?.[0]
       expect(call).toBeDefined()
@@ -590,6 +600,8 @@ describe("AgentManager", () => {
         }),
       )
       expect(call.parts[0]).toMatchObject({
+        metadata: { wantaPurpose: "attachment-reference", wantaVisibility: "internal" },
+        synthetic: true,
         type: "text",
         text: expect.stringContaining("not safe to pass through"),
       })
@@ -641,10 +653,22 @@ describe("AgentManager", () => {
       })
 
       const calls = promptAsync.mock.calls as unknown as Array<
-        [{ parts: Array<{ mime?: string; text?: string; type: string }> }]
+        [
+          {
+            parts: Array<{
+              metadata?: Record<string, unknown>
+              mime?: string
+              synthetic?: boolean
+              text?: string
+              type: string
+            }>
+          },
+        ]
       >
       expect(calls[0]?.[0].parts[0]).toMatchObject({ mime: "text/plain", type: "file" })
       expect(calls[0]?.[0].parts[1]).toMatchObject({
+        metadata: { wantaPurpose: "attachment-reference", wantaVisibility: "internal" },
+        synthetic: true,
         type: "text",
         text: expect.stringContaining("does not support image input"),
       })
@@ -691,13 +715,20 @@ describe("AgentManager", () => {
       const call = promptAsync.mock.calls[0]?.[0] as
         | {
             model?: { modelID: string; providerID: string }
-            parts?: Array<{ text?: string; type: string }>
+            parts?: Array<{
+              metadata?: Record<string, unknown>
+              synthetic?: boolean
+              text?: string
+              type: string
+            }>
             variant?: string
           }
         | undefined
       expect(call?.model).toEqual({ modelID: "local-model", providerID: "wanta-custom-local-default" })
       expect(call).not.toHaveProperty("variant")
       expect(call?.parts?.[0]).toMatchObject({
+        metadata: { wantaPurpose: "attachment-reference", wantaVisibility: "internal" },
+        synthetic: true,
         type: "text",
         text: expect.stringContaining("does not support image input"),
       })

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -1173,10 +1173,15 @@ async function buildPromptParts(
 ): Promise<Array<TextPartInput | FilePartInput>> {
   const parts: Array<TextPartInput | FilePartInput> = []
   for (const input of await planAttachmentInputs(attachments, capabilities)) {
-    if (input.kind === "text") {
+    if (input.kind === "internal-text") {
       parts.push({
         type: "text",
         text: input.text,
+        synthetic: true,
+        metadata: {
+          wantaPurpose: input.purpose,
+          wantaVisibility: "internal",
+        },
       })
       continue
     }

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -336,6 +336,7 @@ test("sendMessage persists original attachments and hides internal spreadsheet p
     path: originalPath,
     size: 100,
   })
+  assert.equal((await store.read()).get("session-1")?.get(messageId ?? "")?.userText, "Analyze this workbook")
 
   bridge.emit({
     type: "message.updated",
@@ -395,6 +396,17 @@ test("sendMessage persists original attachments and hides internal spreadsheet p
           kind: "attachment",
           partId: "internal-file",
         },
+        {
+          kind: "text",
+          partId: "internal-attachment-reference",
+          text: [
+            `Attached local file: ${attachment.name}`,
+            `Path: ${attachment.path}`,
+            `Media type: ${attachment.mime}; size: 100 B`,
+            "The file was not embedded in the model request because its media type is not safe to pass through.",
+            `A prepared copy exists at ${attachment.agentPath}, but it was not embedded. Use local tools against the original or prepared path as appropriate.`,
+          ].join("\n"),
+        },
         { kind: "text", partId: "user-text", text: "Analyze this workbook" },
       ],
       role: "user",
@@ -406,6 +418,11 @@ test("sendMessage persists original attachments and hides internal spreadsheet p
     messages[0]?.parts.some((part) => part.attachment?.name === "inventory-extracted.txt"),
     false,
   )
+  assert.equal(
+    messages[0]?.parts.some((part) => part.text?.includes("Attached local file:")),
+    false,
+  )
+  assert.equal(messages[0]?.parts.find((part) => part.kind === "text")?.text, "Analyze this workbook")
 
   await rm(directory, { force: true, recursive: true })
 })

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1357,7 +1357,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     let submitted = false
     try {
       if (req.attachments?.length) {
-        await this.deps.userAttachmentStore?.record(req.sessionId, userMessageId, req.attachments)
+        await this.deps.userAttachmentStore?.record(req.sessionId, userMessageId, req.attachments, req.text)
         attachmentsRecorded = true
         this.managedUserMessageIds.add(userMessageId)
         const sessionMessageIds = this.managedUserMessageIdsBySession.get(req.sessionId) ?? new Set<string>()

--- a/electron/chat/user-attachments.test.ts
+++ b/electron/chat/user-attachments.test.ts
@@ -33,7 +33,7 @@ describe("UserAttachmentStore", () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-user-attachments-"))
     temporaryDirectories.push(directory)
     const store = new UserAttachmentStore(directory)
-    await store.record("session-1", "message-1", [workbook()])
+    await store.record("session-1", "message-1", [workbook()], "Analyze this workbook")
 
     const restarted = new UserAttachmentStore(directory)
     const record = (await restarted.read()).get("session-1")?.get("message-1")
@@ -48,9 +48,44 @@ describe("UserAttachmentStore", () => {
       },
     ])
     expect(record?.internalPaths).toEqual(["/managed/internal/inventory-extracted.txt"])
-    expect((await readFile(path.join(directory, "user-attachments.json"), "utf8")).toString()).not.toContain(
-      "agentName",
+    expect(record?.userText).toBe("Analyze this workbook")
+    const persisted = (await readFile(path.join(directory, "user-attachments.json"), "utf8")).toString()
+    expect(persisted).toContain('"version": 2')
+    expect(persisted).not.toContain("agentName")
+  })
+
+  it("loads version 1 records without public user text", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-user-attachments-v1-"))
+    temporaryDirectories.push(directory)
+    await writeFile(
+      path.join(directory, "user-attachments.json"),
+      JSON.stringify({
+        sessions: {
+          "session-1": {
+            "message-1": {
+              attachments: [
+                {
+                  id: "attachment-1",
+                  kind: "file",
+                  mime: "image/png",
+                  name: "photo.png",
+                  path: "/managed/original/photo.png",
+                  size: 100,
+                },
+              ],
+              internalPaths: [],
+              messageId: "message-1",
+              sessionId: "session-1",
+            },
+          },
+        },
+        version: 1,
+      }),
     )
+
+    const record = (await new UserAttachmentStore(directory).read()).get("session-1")?.get("message-1")
+    expect(record?.attachments[0]?.name).toBe("photo.png")
+    expect(record?.userText).toBeUndefined()
   })
 
   it("removes unreferenced managed snapshots with their session record", async () => {
@@ -231,6 +266,151 @@ describe("applyUserAttachmentRecords", () => {
         partId: "wanta-attachment-attachment-1",
       },
       { kind: "text", partId: "user-text", text: "Analyze this workbook" },
+    ])
+  })
+
+  it("reconstructs public user text without model-only attachment context", () => {
+    const message: ChatMessage = {
+      createdAt: 1,
+      id: "message-1",
+      parts: [
+        {
+          kind: "text",
+          partId: "internal-reference",
+          text: [
+            "Attached local file: photo.png",
+            "Path: /managed/original/photo.png",
+            "Media type: image/png; size: 100 B",
+            "The file was not embedded in the model request because the selected model does not support image input.",
+            "Use an appropriate local tool or script against the exact path when the task requires its contents. Do not use the Read tool on an unsupported binary file.",
+          ].join("\n"),
+        },
+        { kind: "text", partId: "user-text", text: "/bug-report Check the image failure" },
+      ],
+      role: "user",
+    }
+    const record = {
+      attachments: [
+        {
+          id: "attachment-1",
+          kind: "file" as const,
+          mime: "image/png",
+          name: "photo.png",
+          path: "/managed/original/photo.png",
+          size: 100,
+        },
+      ],
+      internalPaths: [],
+      messageId: "message-1",
+      sessionId: "session-1",
+      userText: "/bug-report Check the image failure",
+    }
+
+    expect(applyUserAttachmentRecords([message], new Map([["message-1", record]]))[0]?.parts).toEqual([
+      {
+        attachment: record.attachments[0],
+        kind: "attachment",
+        partId: "wanta-attachment-attachment-1",
+      },
+      { kind: "text", partId: "user-text", text: "/bug-report Check the image failure" },
+    ])
+  })
+
+  it("removes exact legacy attachment references while preserving user-authored text", () => {
+    const record = {
+      attachments: [
+        {
+          id: "attachment-1",
+          kind: "file" as const,
+          mime: "image/png",
+          name: "photo.png",
+          path: "/managed/original/photo.png",
+          size: 100,
+        },
+      ],
+      internalPaths: [],
+      messageId: "message-1",
+      sessionId: "session-1",
+    }
+    const legacyReference = [
+      "Attached local file: photo.png",
+      "Path: /managed/original/photo.png",
+      "Media type: image/png; size: 100 B",
+      "The file was not embedded in the model request because the selected model does not support image input.",
+      "Use an appropriate local tool or script against the exact path when the task requires its contents. Do not use the Read tool on an unsupported binary file.",
+    ].join("\n")
+    const message: ChatMessage = {
+      createdAt: 1,
+      id: "message-1",
+      parts: [
+        { kind: "text", partId: "legacy-reference", text: legacyReference },
+        { kind: "text", partId: "user-text", text: "Analyze this image" },
+        { kind: "text", partId: "similar-user-text", text: `${legacyReference}\nUser-authored detail` },
+      ],
+      role: "user",
+    }
+
+    expect(applyUserAttachmentRecords([message], new Map([["message-1", record]]))[0]?.parts).toEqual([
+      {
+        attachment: record.attachments[0],
+        kind: "attachment",
+        partId: "wanta-attachment-attachment-1",
+      },
+      { kind: "text", partId: "user-text", text: "Analyze this image" },
+      { kind: "text", partId: "similar-user-text", text: `${legacyReference}\nUser-authored detail` },
+    ])
+  })
+
+  it("removes legacy prepared-copy and attachment-limit context", () => {
+    const prepared = workbook()
+    const attachments = [
+      {
+        id: prepared.id,
+        kind: prepared.kind,
+        mime: prepared.mime,
+        name: prepared.name,
+        path: prepared.path,
+        size: prepared.size,
+      },
+      ...Array.from({ length: 21 }, (_, index) => ({
+        id: `attachment-${index + 2}`,
+        kind: "file" as const,
+        mime: "text/plain",
+        name: `note-${index + 2}.txt`,
+        path: `/managed/original/note-${index + 2}.txt`,
+        size: 10,
+      })),
+    ]
+    const record = {
+      attachments,
+      internalPaths: [prepared.agentPath!],
+      messageId: "message-1",
+      sessionId: "session-1",
+    }
+    const preparedReference = [
+      `Attached local file: ${prepared.name}`,
+      `Path: ${prepared.path}`,
+      `Media type: ${prepared.mime}; size: 100 B`,
+      "The file was not embedded in the model request because it exceeds the safe direct-attachment size budget.",
+      `A prepared copy exists at ${prepared.agentPath}, but it was not embedded. Use local tools against the original or prepared path as appropriate.`,
+    ].join("\n")
+    const omittedReference =
+      "2 additional attachments were not embedded because the per-turn limit is 20. Ask the user to split the files across multiple turns if they are required."
+    const message: ChatMessage = {
+      createdAt: 1,
+      id: "message-1",
+      parts: [
+        { kind: "text", partId: "legacy-prepared", text: preparedReference },
+        { kind: "text", partId: "legacy-limit", text: omittedReference },
+        { kind: "text", partId: "user-text", text: "Analyze the attachments" },
+      ],
+      role: "user",
+    }
+
+    const parts = applyUserAttachmentRecords([message], new Map([["message-1", record]]))[0]?.parts ?? []
+    expect(parts.filter((part) => part.kind === "attachment")).toHaveLength(22)
+    expect(parts.filter((part) => part.kind === "text")).toEqual([
+      { kind: "text", partId: "user-text", text: "Analyze the attachments" },
     ])
   })
 })

--- a/electron/chat/user-attachments.ts
+++ b/electron/chat/user-attachments.ts
@@ -11,6 +11,7 @@ export interface StoredUserAttachmentRecord {
   internalPaths: string[]
   messageId: string
   sessionId: string
+  userText?: string
 }
 
 interface PersistedUserAttachmentRecords {
@@ -57,7 +58,13 @@ function publicAttachment(attachment: ChatAttachment): ChatAttachment {
 function normalizeRecords(value: unknown): UserAttachmentRecords {
   const persisted = value && typeof value === "object" ? (value as PersistedUserAttachmentRecords) : undefined
   const records: UserAttachmentRecords = new Map()
-  if (persisted?.version !== 1 || !persisted.sessions || typeof persisted.sessions !== "object") return records
+  if (
+    (persisted?.version !== 1 && persisted?.version !== 2) ||
+    !persisted.sessions ||
+    typeof persisted.sessions !== "object"
+  ) {
+    return records
+  }
   for (const [sessionId, messages] of Object.entries(persisted.sessions)) {
     if (!validText(sessionId) || !messages || typeof messages !== "object") continue
     const sessionRecords = new Map<string, StoredUserAttachmentRecord>()
@@ -71,7 +78,8 @@ function normalizeRecords(value: unknown): UserAttachmentRecords {
         !Array.isArray(candidate.attachments) ||
         !candidate.attachments.every(validAttachment) ||
         !Array.isArray(candidate.internalPaths) ||
-        !candidate.internalPaths.every(validText)
+        !candidate.internalPaths.every(validText) ||
+        (candidate.userText !== undefined && typeof candidate.userText !== "string")
       ) {
         continue
       }
@@ -80,6 +88,7 @@ function normalizeRecords(value: unknown): UserAttachmentRecords {
         internalPaths: [...candidate.internalPaths],
         messageId,
         sessionId,
+        ...(typeof candidate.userText === "string" ? { userText: candidate.userText } : {}),
       })
     }
     if (sessionRecords.size > 0) records.set(sessionId, sessionRecords)
@@ -94,7 +103,7 @@ function serializeRecords(records: UserAttachmentRecords): PersistedUserAttachme
     for (const [messageId, record] of messages) serialized[messageId] = record
     if (Object.keys(serialized).length > 0) sessions[sessionId] = serialized
   }
-  return { version: 1, sessions }
+  return { version: 2, sessions }
 }
 
 function cloneRecords(records: UserAttachmentRecords): UserAttachmentRecords {
@@ -124,14 +133,78 @@ export function applyUserAttachmentRecords(
     if (message.role !== "user") return message
     const record = records.get(message.id)
     if (!record) return message
-    const nonAttachments = message.parts.filter((part) => part.kind !== "attachment")
     const attachments: ChatMessagePart[] = record.attachments.map((attachment) => ({
       attachment,
       kind: "attachment",
       partId: `wanta-attachment-${attachment.id}`,
     }))
-    return { ...message, parts: [...attachments, ...nonAttachments] }
+    if (record.userText !== undefined) {
+      const existingUserTextPart = message.parts.find((part) => part.kind === "text" && part.text === record.userText)
+      const userTextPart: ChatMessagePart[] = record.userText
+        ? [
+            existingUserTextPart ?? {
+              kind: "text",
+              partId: `wanta-user-text-${message.id}`,
+              text: record.userText,
+            },
+          ]
+        : []
+      const otherParts = message.parts.filter((part) => part.kind !== "attachment" && part.kind !== "text")
+      return { ...message, parts: [...attachments, ...userTextPart, ...otherParts] }
+    }
+    const legacyPublicParts = message.parts.filter(
+      (part) =>
+        part.kind !== "attachment" &&
+        !(part.kind === "text" && isLegacyInternalAttachmentText(part.text ?? "", record)),
+    )
+    return { ...message, parts: [...attachments, ...legacyPublicParts] }
   })
+}
+
+const legacyAttachmentLimit = 20
+
+function legacySizeLabel(size: number): string {
+  if (!Number.isFinite(size) || size <= 0) return "unknown size"
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / 1024 / 1024).toFixed(1)} MB`
+}
+
+function isLegacyAttachmentReferenceText(text: string, record: StoredUserAttachmentRecord): boolean {
+  const lines = text.split("\n")
+  if (lines.length !== 5) return false
+  const attachment = record.attachments.find(
+    (candidate) =>
+      lines[0] === `Attached local file: ${candidate.name}` &&
+      lines[1] === `Path: ${candidate.path}` &&
+      lines[2] ===
+        `Media type: ${candidate.mime || "application/octet-stream"}; size: ${legacySizeLabel(candidate.size)}`,
+  )
+  if (
+    !attachment ||
+    !lines[3]?.startsWith("The file was not embedded in the model request because ") ||
+    !lines[3].endsWith(".")
+  ) {
+    return false
+  }
+  const directPathInstruction =
+    "Use an appropriate local tool or script against the exact path when the task requires its contents. Do not use the Read tool on an unsupported binary file."
+  if (lines[4] === directPathInstruction) return true
+  return record.internalPaths.some(
+    (internalPath) =>
+      lines[4] ===
+      `A prepared copy exists at ${internalPath}, but it was not embedded. Use local tools against the original or prepared path as appropriate.`,
+  )
+}
+
+function isLegacyInternalAttachmentText(text: string, record: StoredUserAttachmentRecord): boolean {
+  if (isLegacyAttachmentReferenceText(text, record)) return true
+  const omitted = record.attachments.length - legacyAttachmentLimit
+  return (
+    omitted > 0 &&
+    text ===
+      `${omitted} additional attachment${omitted === 1 ? " was" : "s were"} not embedded because the per-turn limit is ${legacyAttachmentLimit}. Ask the user to split the files across multiple turns if they are required.`
+  )
 }
 
 export class UserAttachmentStore {
@@ -154,7 +227,12 @@ export class UserAttachmentStore {
     return cloneRecords(await this.loadRecords())
   }
 
-  public async record(sessionId: string, messageId: string, attachments: readonly ChatAttachment[]): Promise<void> {
+  public async record(
+    sessionId: string,
+    messageId: string,
+    attachments: readonly ChatAttachment[],
+    userText?: string,
+  ): Promise<void> {
     if (attachments.length === 0) return
     await this.enqueueMutation(async () => {
       const records = cloneRecords(await this.loadRecords())
@@ -166,6 +244,7 @@ export class UserAttachmentStore {
           .filter((value): value is string => Boolean(value)),
         messageId,
         sessionId,
+        ...(userText === undefined ? {} : { userText }),
       })
       records.set(sessionId, sessionRecords)
       await this.persist(records)

--- a/src/routes/Chat/ChatAttachments.tsx
+++ b/src/routes/Chat/ChatAttachments.tsx
@@ -101,7 +101,7 @@ function AttachmentImageCard({
     <div className="group relative size-20 shrink-0">
       <button
         type="button"
-        title={attachment.path}
+        title={attachment.name}
         className="size-full overflow-hidden rounded-xl border border-border/60 bg-background text-left shadow-xs hover:border-border hover:bg-accent/40 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
         onClick={() => onOpen(attachment, previewUrl)}
       >
@@ -233,7 +233,7 @@ export function AttachmentList({
             <div key={attachment.id} className="relative max-w-full min-w-0">
               <button
                 type="button"
-                title={attachment.path}
+                title={attachment.name}
                 className={cn(
                   "oo-border-divider flex h-14 max-w-full min-w-0 items-center gap-3 rounded-lg border bg-background/70 py-2 pl-2 text-left shadow-xs hover:border-border hover:bg-accent/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
                   onRemove ? "pr-8" : "pr-2",


### PR DESCRIPTION
## Summary

Hide model-only attachment compatibility context from user-facing chat messages while preserving the exact local paths the agent needs for local tool processing.

## Issue and user impact

When an attachment could not be sent directly to the selected model—for example, an image used with a non-vision model—Wanta converted it into a five-line local-path instruction. That instruction was submitted as an ordinary user text part, so the chat bubble displayed internal details such as `Attached local file`, the private snapshot path, MIME type, size, and provider compatibility reason.

The leaked representation polluted copied message text, composer history, retries, and command parsing. In particular, retrying `/bug-report` with a fallback attachment could place the internal path block before the command and prevent the retry from being recognized as a bug-report command. Attachment cards also exposed their absolute local paths through hover tooltips.

## Root cause

OpenCode synthetic file expansions were already filtered from live events and restored history, but Wanta's own attachment fallback text was created as an unmarked ordinary text part. The public attachment manifest replaced internal file parts during history restoration, but it did not provide an authoritative copy of the user-authored message text, so ordinary fallback text remained visible.

## Fix

- Represent attachment fallback and attachment-limit instructions as explicit internal attachment text.
- Send that model-only context with both `synthetic: true` and Wanta-owned visibility metadata.
- Treat either marker as internal in the event translator so live events and restored history remain filtered.
- Persist the exact user-authored text alongside the public attachment manifest and reconstruct public user messages from that source of truth.
- Upgrade the attachment record format to version 2 while continuing to load version 1 records.
- Precisely remove legacy five-line attachment references, prepared-copy instructions, and attachment-limit notices from old attachment messages without broad free-text matching.
- Replace absolute-path attachment tooltips with attachment names.
- Update architecture and convention documentation to preserve the public/internal attachment boundary.

## Validation

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 257 test files and 1,840 tests passed
- `npm run dev` — Vite, Electron main/preload, spreadsheet preview worker, and the OpenCode sidecar started successfully
- Manual verification with a JPEG attachment and DeepSeek V4 Flash confirmed that the attachment preview and user-authored message remain visible without the internal path block

