### PR TITLE
Make archived chat restoration explicit

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1740,13 +1740,6 @@ export function AppShell({ auth }: { auth: UseAuth }) {
           <ArchivedRoute
             listArchived={listArchived}
             onBack={() => setRoute("chat")}
-            onOpenSession={(session) => {
-              setSelectedSessionId(session.id)
-              setIsDraftSession(false)
-              setPendingChatTransition(null)
-              setRoute("chat")
-              setSidebarSegment(session.projectId ? "projects" : "tasks")
-            }}
             refreshSessions={refreshSessions}
             removeSession={removeSessionWithRuntimeCleanup}
             ready={ready}

--- a/src/routes/Archived/index.tsx
+++ b/src/routes/Archived/index.tsx
@@ -30,13 +30,7 @@ import {
   ConfirmDialogTitle,
   ConfirmDialogTrigger,
 } from "@/components/ui/confirm-dialog"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useI18n } from "@/i18n/i18n"
@@ -47,7 +41,6 @@ import { cn } from "@/lib/utils"
 interface ArchivedRouteProps {
   listArchived: () => Promise<SessionInfo[]>
   onBack: () => void
-  onOpenSession: (session: SessionInfo) => void
   refreshSessions: () => Promise<void>
   removeSession: (id: string) => Promise<void>
   ready: boolean
@@ -68,7 +61,6 @@ const sortOptions = [
 export function ArchivedRoute({
   listArchived,
   onBack,
-  onOpenSession,
   refreshSessions,
   removeSession,
   ready,
@@ -156,13 +148,6 @@ export function ArchivedRoute({
       return null
     } finally {
       setPendingSessionId(null)
-    }
-  }
-
-  const handleOpen = async (session: SessionInfo): Promise<void> => {
-    const restored = await restoreSession(session)
-    if (restored) {
-      onOpenSession(restored)
     }
   }
 
@@ -280,7 +265,6 @@ export function ArchivedRoute({
                 pending={pendingSessionId === session.id}
                 session={session}
                 onDelete={handleDelete}
-                onOpen={handleOpen}
                 onRestore={handleRestore}
               />
             ))}
@@ -298,14 +282,12 @@ function ArchivedSessionRow({
   pending,
   session,
   onDelete,
-  onOpen,
   onRestore,
 }: {
   locale: string
   pending: boolean
   session: SessionInfo
   onDelete: (session: SessionInfo) => Promise<void>
-  onOpen: (session: SessionInfo) => Promise<void>
   onRestore: (session: SessionInfo) => Promise<void>
 }) {
   const { t } = useI18n()
@@ -316,12 +298,7 @@ function ArchivedSessionRow({
     <article
       className={cn("grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-5 py-4", pending && "opacity-60")}
     >
-      <button
-        type="button"
-        className="grid min-w-0 gap-2 text-left"
-        disabled={pending}
-        onClick={() => void onOpen(session)}
-      >
+      <div className="grid min-w-0 gap-2">
         <div className="oo-text-caption flex min-w-0 items-center gap-2 text-muted-foreground">
           <FolderIcon className="size-4 shrink-0" />
           <span className="min-w-0 truncate">{t("archived.listMeta", { date: archivedAt })}</span>
@@ -330,31 +307,32 @@ function ArchivedSessionRow({
           {session.title}
         </div>
         <div className="oo-text-caption text-muted-foreground">{t("archived.updatedAt", { date: updatedAt })}</div>
-      </button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="grid size-8 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label={t("archived.rowActions")}
-            title={t("archived.rowActions")}
-            disabled={pending}
-          >
-            <MoreHorizontalIcon className="size-4" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => void onRestore(session)}>
-            <RotateCcwIcon className="size-4" />
-            {t("archived.restore")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant="destructive" onSelect={() => void onDelete(session)}>
-            <Trash2Icon className="size-4" />
-            {t("archived.delete")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="outline" disabled={pending} onClick={() => void onRestore(session)}>
+          <RotateCcwIcon className="size-4" />
+          {t("archived.restore")}
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="grid size-8 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label={t("archived.rowActions")}
+              title={t("archived.rowActions")}
+              disabled={pending}
+            >
+              <MoreHorizontalIcon className="size-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem variant="destructive" onSelect={() => void onDelete(session)}>
+              <Trash2Icon className="size-4" />
+              {t("archived.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     </article>
   )
 }


### PR DESCRIPTION
## Problem

Clicking anywhere in an archived chat row immediately restored the chat and opened it. The large hidden click target made restoration easy to trigger accidentally while reviewing the archive.

## Root cause

The row's entire information area was implemented as a button whose click handler called `unarchiveSession` before navigating back to chat. Although the overflow menu also offered a Restore command, restoration was still bound to the much larger, unlabeled row target.

## Changes

- Render archived chat metadata as non-interactive content.
- Add a visible, dedicated Restore button to every archived row.
- Keep permanent deletion in the overflow menu.
- Remove the obsolete restore-and-open callback from the archived route boundary.

## Verification

- `npm run ts-check`
- `npm run lint`
- `npm run format`
- `npm test` — 262 files and 1,902 tests passed
- `npm run dev` — Vite, Electron main/preload bundles, and the agent sidecar started successfully without runtime errors
