### PR TITLE
feat(models): add GPT 5.6 models without selection restarts

### DIFF
--- a/electron/agent/agent.test.ts
+++ b/electron/agent/agent.test.ts
@@ -157,26 +157,44 @@ test("buildOpencodeConfig covers every registered built-in model runtime", () =>
   }
 })
 
-test("GPT 5.5 resolves through the OpenAI provider for Responses API semantics", () => {
-  const gpt55 = resolveBuiltinModel("gpt-5.5")
-  assert.deepEqual(gpt55.runtime, { providerID: "openai", modelID: "gpt-5.5" })
+test("GPT models resolve through the OpenAI provider for Responses API semantics", () => {
   const config = buildOpencodeConfig({
     linkRuntime: { kind: "oomol", sessionToken: "api-test" },
     modelAccess: { kind: "oomol", sessionToken: "api-test" },
   })
-  const provider = config.provider?.[gpt55.runtime.providerID]
-  const model = provider?.models?.[gpt55.runtime.modelID]
+
+  const expectedModels = [
+    { id: "gpt-5.6-sol", displayName: "GPT 5.6 Sol" },
+    { id: "gpt-5.6-terra", displayName: "GPT 5.6 Terra" },
+    { id: "gpt-5.6-luna", displayName: "GPT 5.6 Luna" },
+    { id: "gpt-5.5", displayName: "GPT 5.5" },
+  ] as const
+
+  const provider = config.provider?.openai
   assert.ok(provider)
   assert.equal(provider.npm, undefined)
   assert.equal(provider.options?.baseURL, `https://llm.${ooEndpoint}/v1`)
   assert.equal(provider.options?.apiKey, "api-test")
-  assert.ok(model)
-  assert.equal(model.name, "GPT 5.5")
-  assert.deepEqual(modelLimit(model), { context: 400_000, input: 258_400, output: 128_000 })
-  assert.equal(model.reasoning, true)
-  assert.equal(modelVariantReasoningEffort(model, "max"), "xhigh")
-  assert.equal(model.attachment, true)
-  assert.deepEqual(model.modalities, { input: ["text", "image"], output: ["text"] })
+
+  for (const expected of expectedModels) {
+    const definition = resolveBuiltinModel(expected.id)
+    assert.deepEqual(definition.runtime, { providerID: "openai", modelID: expected.id })
+    const configuredModel:
+      | {
+          name?: string
+          reasoning?: boolean
+          attachment?: boolean
+          modalities?: unknown
+        }
+      | undefined = provider.models?.[expected.id]
+    assert.ok(configuredModel)
+    assert.equal(configuredModel.name, expected.displayName)
+    assert.deepEqual(modelLimit(configuredModel), { context: 400_000, input: 258_400, output: 128_000 })
+    assert.equal(configuredModel.reasoning, true)
+    assert.equal(modelVariantReasoningEffort(configuredModel, "max"), "xhigh")
+    assert.equal(configuredModel.attachment, true)
+    assert.deepEqual(configuredModel.modalities, { input: ["text", "image"], output: ["text"] })
+  }
 })
 
 test("buildOpencodeConfig wires text-only custom openai-compatible providers without changing the default model", () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -239,7 +239,7 @@ const sessionService = new SessionServiceImpl(null, {
 })
 const modelsService = new ModelsServiceImpl({
   store: modelsStore,
-  onCustomModelsChanged: restartAgentForModelConfig,
+  onModelDefinitionsChanged: restartAgentForModelConfig,
 })
 // 凭证逻辑在未注册的 AuthManager；注册给渲染层的 AuthServiceImpl 只是薄门面（防 RPC 凭证泄露）。
 const authManager = new AuthManager({

--- a/electron/models/builtin.test.ts
+++ b/electron/models/builtin.test.ts
@@ -44,6 +44,36 @@ test("built-in model registry has unique ids and matching summaries", () => {
         maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
       },
       {
+        id: "gpt-5.6-sol",
+        supportsImages: true,
+        supportsPdf: true,
+        toolCall: true,
+        runtimeKind: "openai-responses",
+        contextWindow: 400_000,
+        inputTokenLimit: 258_400,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: "gpt-5.6-terra",
+        supportsImages: true,
+        supportsPdf: true,
+        toolCall: true,
+        runtimeKind: "openai-responses",
+        contextWindow: 400_000,
+        inputTokenLimit: 258_400,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: "gpt-5.6-luna",
+        supportsImages: true,
+        supportsPdf: true,
+        toolCall: true,
+        runtimeKind: "openai-responses",
+        contextWindow: 400_000,
+        inputTokenLimit: 258_400,
+        maxOutputTokens: 128_000,
+      },
+      {
         id: "gpt-5.5",
         supportsImages: true,
         supportsPdf: true,
@@ -131,15 +161,26 @@ test("Auto built-in model remains on the OOMOL compatible runtime", () => {
   assert.deepEqual(model.runtime, { providerID: "oomol", modelID: "oopilot" })
 })
 
-test("GPT 5.5 uses OpenAI Responses runtime routing", () => {
-  const model = resolveBuiltinModel("gpt-5.5")
+test("GPT models use OpenAI Responses runtime routing", () => {
+  const expectedModels = [
+    { id: "gpt-5.6-sol", displayName: "GPT 5.6 Sol" },
+    { id: "gpt-5.6-terra", displayName: "GPT 5.6 Terra" },
+    { id: "gpt-5.6-luna", displayName: "GPT 5.6 Luna" },
+    { id: "gpt-5.5", displayName: "GPT 5.5" },
+  ] as const
 
-  assert.equal(model.displayName, "GPT 5.5")
-  assert.deepEqual(model.runtime, { providerID: "openai", modelID: "gpt-5.5" })
+  for (const expected of expectedModels) {
+    const model = resolveBuiltinModel(expected.id)
+    assert.equal(model.displayName, expected.displayName)
+    assert.deepEqual(model.runtime, { providerID: "openai", modelID: expected.id })
+  }
 })
 
 test("isBuiltinModelId accepts only registered built-in ids", () => {
   assert.equal(isBuiltinModelId("oopilot"), true)
+  assert.equal(isBuiltinModelId("gpt-5.6-sol"), true)
+  assert.equal(isBuiltinModelId("gpt-5.6-terra"), true)
+  assert.equal(isBuiltinModelId("gpt-5.6-luna"), true)
   assert.equal(isBuiltinModelId("gpt-5.5"), true)
   assert.equal(isBuiltinModelId("qwen3.7-max"), true)
   assert.equal(isBuiltinModelId("kimi/kimi-k2.7-code"), false)

--- a/electron/models/builtin.ts
+++ b/electron/models/builtin.ts
@@ -38,15 +38,18 @@ export interface BuiltinModelDefinition {
 
 // UI 展示用的内置模型上下文窗口；网关别名实际窗口调整时只改这里。
 const autoContextWindow = 200_000
-const gpt55ContextWindow = 400_000
-const gpt55InputTokenLimit = 258_400
-const gpt55MaxOutputTokens = 128_000
+const gptContextWindow = 400_000
+const gptInputTokenLimit = 258_400
+const gptMaxOutputTokens = 128_000
 const millionTokenContextWindow = 1_000_000
 const deepSeekV4ReasoningVariants = ["low", "high", "max"] as const satisfies readonly WantaReasoningVariant[]
 const qwen37ReasoningVariants = ["low", "high"] as const satisfies readonly WantaReasoningVariant[]
 
 export const BUILTIN_MODEL_IDS = [
   "oopilot",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
   "gpt-5.5",
   "deepseek-v4-flash",
   "deepseek-v4-pro",
@@ -91,6 +94,60 @@ export const BUILTIN_MODEL_DEFINITIONS: BuiltinModelDefinition[] = [
     maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
   },
   {
+    id: "gpt-5.6-sol",
+    displayName: "GPT 5.6 Sol",
+    providerName: "OpenAI",
+    runtime: {
+      providerID: "openai",
+      modelID: "gpt-5.6-sol",
+    },
+    capabilities: {
+      reasoningVariants: WANTA_REASONING_VARIANT_LEVELS,
+      supportsImages: true,
+      supportsPdf: true,
+      toolCall: true,
+    },
+    contextWindow: gptContextWindow,
+    inputTokenLimit: gptInputTokenLimit,
+    maxOutputTokens: gptMaxOutputTokens,
+  },
+  {
+    id: "gpt-5.6-terra",
+    displayName: "GPT 5.6 Terra",
+    providerName: "OpenAI",
+    runtime: {
+      providerID: "openai",
+      modelID: "gpt-5.6-terra",
+    },
+    capabilities: {
+      reasoningVariants: WANTA_REASONING_VARIANT_LEVELS,
+      supportsImages: true,
+      supportsPdf: true,
+      toolCall: true,
+    },
+    contextWindow: gptContextWindow,
+    inputTokenLimit: gptInputTokenLimit,
+    maxOutputTokens: gptMaxOutputTokens,
+  },
+  {
+    id: "gpt-5.6-luna",
+    displayName: "GPT 5.6 Luna",
+    providerName: "OpenAI",
+    runtime: {
+      providerID: "openai",
+      modelID: "gpt-5.6-luna",
+    },
+    capabilities: {
+      reasoningVariants: WANTA_REASONING_VARIANT_LEVELS,
+      supportsImages: true,
+      supportsPdf: true,
+      toolCall: true,
+    },
+    contextWindow: gptContextWindow,
+    inputTokenLimit: gptInputTokenLimit,
+    maxOutputTokens: gptMaxOutputTokens,
+  },
+  {
     id: "gpt-5.5",
     displayName: "GPT 5.5",
     providerName: "OpenAI",
@@ -104,9 +161,9 @@ export const BUILTIN_MODEL_DEFINITIONS: BuiltinModelDefinition[] = [
       supportsPdf: true,
       toolCall: true,
     },
-    contextWindow: gpt55ContextWindow,
-    inputTokenLimit: gpt55InputTokenLimit,
-    maxOutputTokens: gpt55MaxOutputTokens,
+    contextWindow: gptContextWindow,
+    inputTokenLimit: gptInputTokenLimit,
+    maxOutputTokens: gptMaxOutputTokens,
   },
   {
     id: "deepseek-v4-flash",

--- a/electron/models/node.test.ts
+++ b/electron/models/node.test.ts
@@ -148,10 +148,10 @@ test("ModelsServiceImpl serializes concurrent model mutations", async () => {
   ])
 })
 
-test("ModelsServiceImpl requests runtime refresh for save, selection, and deletion", async () => {
+test("ModelsServiceImpl refreshes runtime only when model definitions change", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "wanta-models-service-"))
-  const onCustomModelsChanged = vi.fn()
-  const service = new ModelsServiceImpl({ store: createStore(dir), onCustomModelsChanged })
+  const onModelDefinitionsChanged = vi.fn()
+  const service = new ModelsServiceImpl({ store: createStore(dir), onModelDefinitionsChanged })
 
   const catalog = await service.saveCustomModel({
     providerId: "openrouter",
@@ -161,10 +161,14 @@ test("ModelsServiceImpl requests runtime refresh for save, selection, and deleti
   })
   const customModel = catalog.customModels[0]
   assert.ok(customModel)
-  await service.setSelectedModel({ kind: "custom", id: customModel.id })
+  assert.equal(onModelDefinitionsChanged.mock.calls.length, 1)
+
+  await service.setSelectedModel({ kind: "builtin", id: "oopilot" })
+  assert.equal(onModelDefinitionsChanged.mock.calls.length, 1)
+
   await service.deleteCustomModel(customModel.id)
 
-  assert.equal(onCustomModelsChanged.mock.calls.length, 3)
+  assert.equal(onModelDefinitionsChanged.mock.calls.length, 2)
 })
 
 test("ModelsServiceImpl removes a newly stored credential when metadata save fails", async () => {

--- a/electron/models/node.ts
+++ b/electron/models/node.ts
@@ -22,7 +22,7 @@ import {
 
 export interface ModelsServiceDeps {
   store: ModelsStore
-  onCustomModelsChanged?: () => void
+  onModelDefinitionsChanged?: () => void
 }
 
 type OptionalTokenLimitField = "contextWindow" | "inputTokenLimit" | "maxOutputTokens"
@@ -45,7 +45,6 @@ export class ModelsServiceImpl extends ConnectionService<ModelsService> implemen
       const models = await this.deps.store.read()
       const selected = isKnownModelChoice(models, choice) ? choice : defaultModelChoice()
       await this.deps.store.write({ ...models, selected })
-      this.deps.onCustomModelsChanged?.()
       return this.emitCatalog()
     })
   }
@@ -130,7 +129,7 @@ export class ModelsServiceImpl extends ConnectionService<ModelsService> implemen
         }
         throw error
       }
-      this.deps.onCustomModelsChanged?.()
+      this.deps.onModelDefinitionsChanged?.()
       return this.emitCatalog()
     })
   }
@@ -158,7 +157,7 @@ export class ModelsServiceImpl extends ConnectionService<ModelsService> implemen
         }
         throw error
       }
-      this.deps.onCustomModelsChanged?.()
+      this.deps.onModelDefinitionsChanged?.()
       return this.emitCatalog()
     })
   }

--- a/electron/models/store.test.ts
+++ b/electron/models/store.test.ts
@@ -29,7 +29,17 @@ test("ModelsStore returns default catalog on missing file", async () => {
   assert.deepEqual(catalog.selected, defaultModelChoice())
   assert.deepEqual(
     catalog.builtins.map((model) => model.id),
-    ["oopilot", "gpt-5.5", "deepseek-v4-flash", "deepseek-v4-pro", "qwen3.7-plus", "qwen3.7-max"],
+    [
+      "oopilot",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+      "qwen3.7-plus",
+      "qwen3.7-max",
+    ],
   )
   assert.equal(catalog.customModels.length, 0)
   assert.ok(catalog.providers.some((provider) => provider.id === "deepseek"))


### PR DESCRIPTION
## Summary

Add the GPT 5.6 Sol, Terra, and Luna built-in models to the OpenAI Responses runtime and make their product-facing names explicitly identify the GPT family. Model selection now updates the persisted preference without restarting the Agent.

## Problem

The model picker showed Sol, Terra, and Luna without a GPT prefix, so users could not easily tell which model family or provider they belonged to. Selecting any model also invoked the same callback used for custom model definition changes. That callback restarted the Agent sidecar, temporarily replaced the chat with a loading skeleton, disabled the composer, and caused a visible layout jump.

## Root cause

The built-in registry did not include the GPT 5.6 aliases. In the models service, `setSelectedModel` called `onCustomModelsChanged` even though selecting an already configured model does not change the provider configuration. The main process wired that callback directly to the Agent refresh scheduler.

## Changes

- Register GPT 5.6 Sol, Terra, and Luna as OpenAI Responses built-in models.
- Use the explicit display names `GPT 5.6 Sol`, `GPT 5.6 Terra`, and `GPT 5.6 Luna`.
- Reuse the GPT context, input, output, reasoning, image, PDF, and tool-call capabilities.
- Rename the refresh callback to `onModelDefinitionsChanged`.
- Stop refreshing the Agent for a persisted selection-only change.
- Continue refreshing the Agent when custom model definitions are saved or deleted.
- Expand registry, store, runtime routing, and OpenAI provider configuration coverage.

## User impact

Users can identify the GPT 5.6 models immediately in the picker. Switching among existing models no longer tears down and restarts the Agent, so the chat remains stable and the transient full-page loading state is avoided. The newly selected model continues to be passed explicitly with the next turn.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- 49 model registry/store/configuration tests passed.
- 137 models service, Agent manager, and chat service tests passed.
- Formatting checks passed for the changed files.
- `git diff --check` passed.
