### PR TITLE
Fix team management feedback

### DIFF
--- a/src/components/app-shell/SidebarAccountControls.tsx
+++ b/src/components/app-shell/SidebarAccountControls.tsx
@@ -46,22 +46,44 @@ function WorkspaceAvatar({ className = "size-7", workspace }: { className?: stri
       </span>
     )
   }
+
+  return <TeamWorkspaceAvatar className={className} workspace={workspace} />
+}
+
+function TeamWorkspaceAvatar({
+  className,
+  workspace,
+}: {
+  className: string
+  workspace: WorkspaceSelection
+}) {
   const avatarUrl = workspace.avatarPreviewUrl ?? workspace.team?.avatar
   const fallback = teamInitials(workspace.team?.name ?? workspace.teamId)
   const fallbackStyle = teamAvatarStyle(workspace.teamId)
+  const [loadedAvatarUrl, setLoadedAvatarUrl] = React.useState<string | null>(null)
+  const avatarLoaded = Boolean(avatarUrl && loadedAvatarUrl === avatarUrl)
 
   return (
     <span
       className={cn(
-        "relative grid shrink-0 place-items-center overflow-hidden rounded-full border bg-background text-xs font-medium text-foreground",
+        "relative grid shrink-0 place-items-center overflow-hidden rounded-full text-xs font-medium",
+        avatarLoaded ? "bg-transparent text-transparent" : "border bg-background text-foreground",
         className,
       )}
-      style={fallbackStyle}
+      style={avatarLoaded ? undefined : fallbackStyle}
     >
-      <span aria-hidden="true" className="min-w-0">
-        {fallback}
-      </span>
-      <CachedAvatarImage src={avatarUrl} alt="" className="absolute inset-0 size-full object-cover" />
+      {avatarLoaded ? null : (
+        <span aria-hidden="true" className="min-w-0">
+          {fallback}
+        </span>
+      )}
+      <CachedAvatarImage
+        src={avatarUrl}
+        alt=""
+        className="absolute inset-0 size-full object-cover"
+        onLoad={() => setLoadedAvatarUrl(avatarUrl ?? null)}
+        onError={() => setLoadedAvatarUrl((current) => (current === avatarUrl ? null : current))}
+      />
     </span>
   )
 }

--- a/src/components/app-shell/SidebarAccountControls.tsx
+++ b/src/components/app-shell/SidebarAccountControls.tsx
@@ -50,13 +50,7 @@ function WorkspaceAvatar({ className = "size-7", workspace }: { className?: stri
   return <TeamWorkspaceAvatar className={className} workspace={workspace} />
 }
 
-function TeamWorkspaceAvatar({
-  className,
-  workspace,
-}: {
-  className: string
-  workspace: WorkspaceSelection
-}) {
+function TeamWorkspaceAvatar({ className, workspace }: { className: string; workspace: WorkspaceSelection }) {
   const avatarUrl = workspace.avatarPreviewUrl ?? workspace.team?.avatar
   const fallback = teamInitials(workspace.team?.name ?? workspace.teamId)
   const fallbackStyle = teamAvatarStyle(workspace.teamId)

--- a/src/i18n/skills-messages.ts
+++ b/src/i18n/skills-messages.ts
@@ -141,7 +141,7 @@ export const skillsMessages = {
     "teams.revokeProviderAccessConfirmTitle": "撤销连接器权限？",
     "teams.revokeProviderAccessConfirmDescription": "撤销后，该成员将不能继续使用这些团队连接器。",
     "teams.skillGuideTitle": "团队 Skill",
-    "teams.skillGuideDescription": "本团队配置的 Skill，以及根据已连接服务生成的系统推荐。",
+    "teams.skillGuideDescription": "团队推荐是团队共享配置，系统推荐来自已连接服务；安装状态仅表示当前设备是否已安装。",
     "teams.skillGuideLoading": "加载中",
     "teams.skillGuideLoadFailed": "加载失败",
     "teams.skillGuideUnavailableBadge": "未启用",
@@ -153,7 +153,7 @@ export const skillsMessages = {
     "teams.skillGuideSystemLoading": "正在匹配系统推荐",
     "teams.skillGuideReadOnlyBadge": "仅可查看团队配置",
     "teams.skillGuideReadOnlyDescription":
-      "本团队配置的 Skill，以及根据已连接服务生成的系统推荐；你仍可安装和管理本机 Skill，只有团队管理员可以修改团队推荐。",
+      "团队推荐是团队共享配置，系统推荐来自已连接服务；安装状态仅表示当前设备是否已安装，只有团队管理员可以修改团队推荐。",
     "teams.skillGuideEmptyTitle": "暂无团队 Skill",
     "teams.skillGuideEmptyDescription": "团队创建者配置后，成员在这个团队工作区中会默认获得对应指导。",
     "teams.skillGuideEmptyCreatorDescription": "添加适合团队工作流的 Skill，让成员切换到这个团队后默认使用同一套指导。",
@@ -250,7 +250,7 @@ export const skillsMessages = {
     "skills.teamAddEmpty": "暂无可添加的 Skill 包。",
     "skills.teamAddSearchEmpty": "没有匹配的 Skill 包。",
     "skills.teamAddRowAction": "添加",
-    "skills.teamAdded": "已添加",
+    "skills.teamAdded": "团队推荐",
     "skills.teamAddValidation": "请输入 package 和 skill 名称。",
     "skills.teamPackageSkillCount": "{{count}} Skills",
     "skills.teamPrivate": "私有",
@@ -579,7 +579,7 @@ export const skillsMessages = {
       "After revocation, this member will no longer be able to use these team connections.",
     "teams.skillGuideTitle": "Team Skills",
     "teams.skillGuideDescription":
-      "Skills configured by this team, plus system recommendations based on connected services.",
+      "Team recommendations are shared team settings; system recommendations come from connected services; install status applies only to this device.",
     "teams.skillGuideLoading": "Loading",
     "teams.skillGuideLoadFailed": "Load failed",
     "teams.skillGuideUnavailableBadge": "Not enabled",
@@ -591,7 +591,7 @@ export const skillsMessages = {
     "teams.skillGuideSystemLoading": "Matching system recommendations",
     "teams.skillGuideReadOnlyBadge": "Team settings view only",
     "teams.skillGuideReadOnlyDescription":
-      "Skills configured by this team, plus system recommendations based on connected services; you can still install and manage local Skills, but only team admins can change team recommendations.",
+      "Team recommendations are shared team settings; system recommendations come from connected services; install status applies only to this device, and only team admins can change team recommendations.",
     "teams.skillGuideEmptyTitle": "No team Skills yet",
     "teams.skillGuideEmptyDescription":
       "After the team creator configures Skills, members will get the matching guidance in this workspace.",
@@ -700,7 +700,7 @@ export const skillsMessages = {
     "skills.teamAddEmpty": "No Skill packages are available.",
     "skills.teamAddSearchEmpty": "No matching Skill packages.",
     "skills.teamAddRowAction": "Add",
-    "skills.teamAdded": "Added",
+    "skills.teamAdded": "Team recommendation",
     "skills.teamAddValidation": "Enter both package and Skill name.",
     "skills.teamPackageSkillCount": "{{count}} Skills",
     "skills.teamPrivate": "Private",

--- a/src/routes/Skills/TeamManagement.tsx
+++ b/src/routes/Skills/TeamManagement.tsx
@@ -527,7 +527,6 @@ export function TeamManagementRoute({
         }}
         onMoveActiveUser={moveActiveSearchUser}
         onSearchSelect={(user) => {
-          setMemberInput(user.username)
           setActiveSearchUserId(user.userId)
           setSelectedSearchUserId(user.userId)
           setAddMemberError(null)

--- a/src/routes/Skills/TeamSkillManageRows.tsx
+++ b/src/routes/Skills/TeamSkillManageRows.tsx
@@ -246,9 +246,10 @@ export function TeamSkillMarketRow({
       title={pkg.displayName}
       description={skillDescription}
       badges={
-        <Badge variant={linked ? "secondary" : "outline"}>
-          {linked ? t("skills.teamAdded") : getPublicSkillInstallStateLabel(installState, t)}
-        </Badge>
+        <>
+          {linked ? <Badge variant="secondary">{t("teams.skillManageConfigured")}</Badge> : null}
+          <Badge variant="outline">{getPublicSkillInstallStateLabel(installState, t)}</Badge>
+        </>
       }
       meta={
         <div className="min-w-0 truncate" title={skillLine}>
@@ -540,6 +541,9 @@ export function TeamSkillRecommendationRow({
         <>
           <Badge variant="secondary" className="shrink-0">
             {t("teams.skillManageRecommended")}
+          </Badge>
+          <Badge variant="outline" className="shrink-0">
+            {getPublicSkillInstallStateLabel(recommendation.installState, t)}
           </Badge>
         </>
       }

--- a/src/routes/Skills/TeamSkillsPane.tsx
+++ b/src/routes/Skills/TeamSkillsPane.tsx
@@ -24,7 +24,6 @@ import {
   teamRuntimeStatusTone,
   providerRecommendationSkillDescription,
   shouldOpenTeamSkillManagement,
-  shouldShowTeamRuntimeStatusOnCard,
 } from "./team-skill-manage-helpers.ts"
 import { TeamPackageRemoveConfirmDialog } from "./TeamSkillManageRows.tsx"
 import { useTeamSkillRemoval } from "./use-team-skill-removal.ts"
@@ -362,11 +361,9 @@ function TeamConfiguredSkillCard({
       badges={
         <>
           <Badge variant="secondary">{t("teams.skillManageConfigured")}</Badge>
-          {shouldShowTeamRuntimeStatusOnCard(runtimeStatus.state) ? (
-            <Badge className={cn("shrink-0", getSkillRowStatusBadgeClassName(runtimeTone))} variant="outline">
-              {teamRuntimeStatusLabel(runtimeStatus.state, t)}
-            </Badge>
-          ) : null}
+          <Badge className={cn("shrink-0", getSkillRowStatusBadgeClassName(runtimeTone))} variant="outline">
+            {teamRuntimeStatusLabel(runtimeStatus.state, t)}
+          </Badge>
         </>
       }
       meta={
@@ -438,9 +435,7 @@ function TeamRecommendedSkillCard({
       badges={
         <>
           <Badge variant="secondary">{t("teams.skillManageRecommended")}</Badge>
-          {recommendation.installState === "name-conflict" || recommendation.installState === "unavailable" ? (
-            <Badge variant="outline">{getPublicSkillInstallStateLabel(recommendation.installState, t)}</Badge>
-          ) : null}
+          <Badge variant="outline">{getPublicSkillInstallStateLabel(recommendation.installState, t)}</Badge>
         </>
       }
       meta={
@@ -565,11 +560,9 @@ function TeamConfiguredSkillDetail({
         <CardContent className="grid gap-2 px-3">
           <div className="flex min-w-0 flex-wrap items-center gap-1">
             <Badge variant="secondary">{t("teams.skillManageConfigured")}</Badge>
-            {shouldShowTeamRuntimeStatusOnCard(runtimeStatus.state) ? (
-              <Badge className={cn("shrink-0", getSkillRowStatusBadgeClassName(runtimeTone))} variant="outline">
-                {teamRuntimeStatusLabel(runtimeStatus.state, t)}
-              </Badge>
-            ) : null}
+            <Badge className={cn("shrink-0", getSkillRowStatusBadgeClassName(runtimeTone))} variant="outline">
+              {teamRuntimeStatusLabel(runtimeStatus.state, t)}
+            </Badge>
             {skill.version ? <Badge variant="outline">{skill.version}</Badge> : null}
           </div>
           {skill.description ? (
@@ -660,9 +653,7 @@ function TeamRecommendedSkillDetail({
         <CardContent className="grid gap-2 px-3">
           <div className="flex min-w-0 flex-wrap items-center gap-1">
             <Badge variant="secondary">{t("teams.skillManageRecommended")}</Badge>
-            {recommendation.installState === "name-conflict" || recommendation.installState === "unavailable" ? (
-              <Badge variant="outline">{getPublicSkillInstallStateLabel(recommendation.installState, t)}</Badge>
-            ) : null}
+            <Badge variant="outline">{getPublicSkillInstallStateLabel(recommendation.installState, t)}</Badge>
             <Badge variant="outline">{recommendation.package.version}</Badge>
           </div>
           {skillDescription ? (

--- a/src/routes/Skills/team-skill-manage-helpers.ts
+++ b/src/routes/Skills/team-skill-manage-helpers.ts
@@ -170,10 +170,6 @@ export function teamRuntimeStatusTone(state: TeamSkillRuntimeState): "attention"
       : "attention"
 }
 
-export function shouldShowTeamRuntimeStatusOnCard(state: TeamSkillRuntimeState): boolean {
-  return state !== "installed-same" && state !== "missing" && state !== "external-only"
-}
-
 export function canOpenManagedTeamSkill(state: TeamSkillRuntimeState): boolean {
   return (
     state === "installed-same" ||


### PR DESCRIPTION
## Summary

This PR addresses several related pieces of team-management feedback.

- Hide fallback initials and generated colors after a transparent team avatar successfully loads.
- Let the first click on a member-search result select that user without replacing the query and triggering a second search.
- Show team/system recommendation provenance independently from the current device's Skill installation state.
- Replace the ambiguous market state with explicit `Team recommendation` and installation-status badges.
- Explain that team recommendations are shared configuration while installation status applies only to the current device.

## User impact and root causes

Transparent team avatars were rendered over the fallback initials and palette color in the workspace switcher, so transparent pixels exposed text and color that should only have appeared while the image was unavailable. The avatar now tracks the URL that has actually loaded and removes the fallback presentation only after that image succeeds, while preserving the fallback on load failure.

Selecting a member-search result previously copied the username into the search field. That input change immediately started another search and cleared the newly selected user, making users click the result a second time. Selection now records the result's user ID without rewriting the active query.

Team Skill rows previously collapsed two independent dimensions into one badge. A package linked as a team recommendation hid its local install status, while installed system recommendations omitted the normal installed badge altogether. Team provenance and device installation state now render separately and consistently in list rows and detail views.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm run format`
- `corepack pnpm test` — 265 test files and 1,933 tests passed
- `git diff --check origin/main...HEAD`
