### PR TITLE
fix(dev): isolate Electron user data in repo worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ resources/agent-tool-runtime
 # Local dev scratch
 .wanta-dev/
 .playwright-mcp/
+
+# Local dev Electron userData
+wanta/

--- a/docs/ai/bootstrap.md
+++ b/docs/ai/bootstrap.md
@@ -13,13 +13,13 @@ machine-level prerequisites.
 ## Steps
 
 1. Run `corepack pnpm run bootstrap`.
-2. For ordinary product work, restore the machine-level signed-in snapshot:
-   `corepack pnpm run auth:restore`.
-3. For login, sign-in, sign-out, auth persistence, or first-run work, use a clean signed-out
-   worktree profile instead: `corepack pnpm run auth:clean`.
-4. If the checkout is partially initialized, rerun `corepack pnpm run bootstrap`; it is
-   idempotent. Re-run `auth:restore` or `auth:clean` after bootstrap if you need to reset the
-   current worktree profile.
+2. Run `corepack pnpm run dev:worktree` for worktree-aware development. If the current worktree's
+   `./wanta` userData is missing or empty, it is initialized once from the canonical repo's
+   `./wanta` when that source exists and is non-empty.
+3. For login, sign-in, sign-out, auth persistence, or first-run work, run
+   `corepack pnpm run auth:clean` to start with a clean signed-out dev profile. Delete `./wanta`
+   when you want `dev:worktree` to initialize from the canonical repo again.
+4. If the checkout is partially initialized, rerun `corepack pnpm run bootstrap`; it is idempotent.
 5. Run the quality gate when needed:
    - `corepack pnpm run ts-check`
    - `corepack pnpm run lint`
@@ -27,25 +27,24 @@ machine-level prerequisites.
    - `corepack pnpm test`
    - `corepack pnpm run build`
 
-## Machine-level login snapshot
+## Dev userData
 
-Use this only when `auth:restore` reports that the machine login snapshot is missing or incomplete.
-It is a machine setup step, not a normal worktree task.
+- Source `corepack pnpm run dev` uses `<repo>/wanta` as the complete Electron userData directory.
+- `corepack pnpm run dev:worktree` uses `<worktree>/wanta` as the complete Electron userData
+  directory, never the canonical repo's directory directly.
+- `dev:worktree` copies the canonical repo's `./wanta` only when the target `./wanta` is missing or
+  empty. Existing worktree state is never overwritten.
+- The old `~/wanta-dev/login-state` and `~/wanta-dev/login-user-data` auth snapshot flow is retired;
+  new development commands do not create, read, or depend on `~/wanta-dev`.
 
-1. Run `corepack pnpm run auth:capture`.
-2. Sign in through the Electron window.
-3. Wait for the script to detect the login, stop the dev app, and save the snapshot.
-4. Check it with `corepack pnpm run auth:status`.
-
-The snapshot is stored outside the repo at `~/wanta-dev/login-state`. The temporary capture profile
-is `~/wanta-dev/login-user-data`. These directories contain Electron session data and must not be
-committed, copied into a worktree, or printed in logs. The script only checks for the
-`oomol-token` cookie name marker; it never prints the token value.
+`corepack pnpm run auth:status` now reports only the current checkout's `./wanta`. `auth:clean`
+removes and recreates that directory with a small marker so `dev:worktree` preserves the intentionally
+signed-out profile. `auth:capture`, `auth:save`, and `auth:restore` are deprecated.
 
 ## Dev launch
 
 - Worktree-aware default: `corepack pnpm run dev:worktree`
-- Raw dev server only: `corepack pnpm run dev`
+- Source-checkout dev: `corepack pnpm run dev`
 - Headless renderer startup only: `corepack pnpm run dev:no-electron`
 - Disable Electron auto-start when you want the Vite process without an app window:
   `WANTA_ELECTRON_AUTO_START=0 corepack pnpm run dev`
@@ -61,9 +60,9 @@ committed, copied into a worktree, or printed in logs. The script only checks fo
 - `resources/agent-tool-runtime/`
 - `.wanta-dev/bootstrap.json`
 - `.wanta-dev/env.sh`
-- `.wanta-dev/user-data`
+- `wanta/`
 
-The generated env isolates the dev session by setting:
+The generated worktree env isolates the dev session by setting:
 
 - `WANTA_DEV_SERVER_PORT`
 - `WANTA_SKIP_PROTOCOL_REGISTRATION=1`

--- a/docs/ai/dev-debugging.md
+++ b/docs/ai/dev-debugging.md
@@ -13,26 +13,25 @@ screen sharing.
 
 ## Auth state modes
 
-- Normal product work: `corepack pnpm run auth:restore`, then launch with `dev:worktree`.
+- Normal product work: launch with `dev:worktree`; an empty worktree `./wanta` initializes once from
+  the canonical repo's `./wanta` when available.
 - Login/auth work: `corepack pnpm run auth:clean`, then launch with `dev:worktree`.
-- Machine setup or expired snapshot: `corepack pnpm run auth:capture`, sign in, wait for the script
-  to save the snapshot, then check `corepack pnpm run auth:status`.
+- There is no machine-level `~/wanta-dev` auth snapshot. If no canonical `./wanta` exists or its
+  login has expired, sign in in the current checkout's own `./wanta` profile.
 
 Do not ask the user to describe a logged-in screen before checking whether the current worktree has
 the intended auth mode. `auth:status` reports profile and cookie-marker presence without printing
 credentials.
 
-When login state is suspect, run `corepack pnpm run auth:status` first. It reports the machine
-snapshot and current worktree profile, cookie marker, and cookie expiry. If the snapshot is missing,
-expired, or close to expiry, run `corepack pnpm run auth:capture` on the prepared machine and then
-restore again with `corepack pnpm run auth:restore`.
+When login state is suspect, run `corepack pnpm run auth:status` first. It reports the current
+checkout's `./wanta` profile, cookie marker, and cookie expiry without printing credentials.
 
 ## What to inspect
 
 - The Vite terminal output
 - Electron main-process logs
-- `.wanta-dev/user-data/logs/diagnostics.jsonl` when using `dev:worktree`
-- `~/Library/Application Support/wanta/logs/diagnostics.jsonl` only for raw dev or packaged app runs
+- `wanta/logs/diagnostics.jsonl` when using `dev` or `dev:worktree`
+- `~/Library/Application Support/wanta/logs/diagnostics.jsonl` only for packaged app runs
 - the live app window
 
 ## macOS inspection helpers
@@ -46,7 +45,7 @@ restore again with `corepack pnpm run auth:restore`.
 ## Common failure modes
 
 - Electron window never appears
-- app stays on the login gate because `auth:restore` was not run, the machine snapshot is missing or
+- app stays on the login gate because the canonical/current `./wanta` is missing, signed out, or
   expired, or the task intentionally started from `auth:clean`
 - the worktree port is already taken
 - a stale Electron process is still alive after a stopped session

--- a/docs/ai/worktree.md
+++ b/docs/ai/worktree.md
@@ -38,7 +38,7 @@ Use this when the repo is opened in a fresh worktree and multiple agents may run
 - Port collisions
 - Shared user data
 - Shared protocol registration
-- Expired machine login snapshots
+- Missing, signed-out, or expired canonical/current `./wanta` profiles
 - Any background process that survives a stopped dev session
 
 ## Worktree-safe startup

--- a/docs/ai/worktree.md
+++ b/docs/ai/worktree.md
@@ -4,28 +4,30 @@ Use this when the repo is opened in a fresh worktree and multiple agents may run
 
 ## Current state
 
-- `corepack pnpm run bootstrap` derives a per-worktree Vite port and Electron user-data directory.
+- `corepack pnpm run bootstrap` derives a per-worktree Vite port and records the worktree Electron
+  userData directory.
 - `corepack pnpm run dev:worktree` reads `.wanta-dev/bootstrap.json` and launches with that isolated
   environment.
-- Ordinary product work can restore a machine-level signed-in snapshot with
-  `corepack pnpm run auth:restore`.
+- Ordinary product work starts from the worktree's `./wanta`. If it is missing or empty,
+  `dev:worktree` initializes it once from the canonical repo's `./wanta` when available.
 - Login/auth work can reset the current worktree to a clean signed-out profile with
-  `corepack pnpm run auth:clean`.
+  `corepack pnpm run auth:clean`, which clears `./wanta` and leaves a marker so startup does not
+  re-initialize it from the canonical repo.
 
 ## Current shared resources
 
-- Raw `corepack pnpm run dev` still uses the default Vite port and the platform default Electron user-data
-  path.
+- Raw `corepack pnpm run dev` still uses the default Vite port, but its Electron userData path is
+  `<repo>/wanta` instead of the platform default.
 - Raw `corepack pnpm run dev` may register the `wanta-local` protocol handler.
-- The machine-level login snapshot at `~/wanta-dev/login-state` is shared read-only input for
-  worktrees; each worktree restores it into its own `.wanta-dev/user-data`.
+- The canonical repo's `./wanta` is a one-time initialization source for empty worktree `./wanta`
+  directories; it is never used as a shared runtime profile.
 - Only one session per machine should enable protocol registration for login callback work.
 
 ## Current safe assumptions
 
 - One active `corepack pnpm run dev` per machine is the default safe mode.
 - `corepack pnpm run dev:worktree` is the safer default for parallel agent work.
-- `corepack pnpm run auth:restore` replaces only the current worktree's generated user-data directory.
+- Existing worktree `./wanta` data is never overwritten by startup.
 - `corepack pnpm run auth:clean` is the right starting point for login, logout, callback, and first-run
   behavior.
 - `WANTA_ELECTRON_AUTO_START=0` is useful when you want the build/watch loop without auto-launch.
@@ -42,9 +44,7 @@ Use this when the repo is opened in a fresh worktree and multiple agents may run
 ## Worktree-safe startup
 
 1. Run `corepack pnpm run bootstrap`.
-2. Run `corepack pnpm run auth:restore` for normal work, or `corepack pnpm run auth:clean` for auth
-   work.
+2. Run `corepack pnpm run auth:clean` only when you intentionally need a signed-out profile.
 3. Run `corepack pnpm run dev:worktree`.
 
-If `auth:restore` fails, the machine has not been prepared or the saved session expired. Run
-`corepack pnpm run auth:capture` once with human sign-in, then restore again in the worktree.
+If no canonical `./wanta` exists, the worktree still starts normally and shows the login page.

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,7 @@ cp .env.example .env.local   # .env.local is gitignored
 ```bash
 corepack pnpm run dev    # predev runs scripts/check-oo.ts first (three checks, see below)
                # vite dev server on port 5273; vite-plugin-electron starts the main process too
+               # Electron userData is the repo-local ./wanta directory
 corepack pnpm run dev:no-electron
                # only starts vite + the electron bundle watch, without auto-launching Electron;
                # for code-side debugging that needs no UI window
@@ -82,9 +83,15 @@ corepack pnpm run dev:no-electron
 - When `.electron-dist` exists, vite automatically sets `ELECTRON_OVERRIDE_DIST_PATH`, so dev uses
   the Electron copy with the `wanta-local` scheme (the menu bar shows the dev identity) — required
   for the browser-login round trip to hit the dev instance.
-- dev userData lives at `~/Library/Application Support/wanta` (macOS); agent data under its
-  `agent/` (workspace / isolation / oo-store). Link runtime selection and encrypted OpenConnector
-  token metadata live in `link-runtime.json` at the userData root.
+- Dev userData lives at `./wanta` in the current checkout; agent data under its `agent/` (workspace /
+  isolation / oo-store). Link runtime selection and encrypted OpenConnector token metadata live in
+  `link-runtime.json` at the userData root. Packaged production builds keep Electron's default
+  platform userData path such as `~/Library/Application Support/wanta` on macOS.
+- `corepack pnpm run dev:worktree` keeps the same `./wanta` userData rule for each worktree while
+  adding per-worktree port and protocol-registration isolation. When the target `./wanta` is missing
+  or empty, it copies the canonical main repo's `./wanta` once as an initialization source; it never
+  shares or overwrites an existing worktree userData directory. `WANTA_DEV_AUTH_SOURCE_DIR=/abs/path`
+  can override that initialization source.
 - Code changes must go through a temporary branch + PR: first align local `main` with
   `origin/main`, then cut a one-off branch from `main` (e.g. `codex/<task>`, `ci/<task>`,
   `fix/<task>`). Once the change is done and passes the quality gate, push the temporary branch
@@ -267,6 +274,7 @@ corepack pnpm run build:mac     # = build:app + prepare:binaries + electron-buil
 | `resources/skills/`             | bundled oo skills export (→ extraResources; re-ensured by predev and prepare-binaries) | postinstall `scripts/download-skills.ts` (`scripts/skills.ts`)       |
 | `resources/agent-tool-runtime/` | self-contained runtime for custom tools (→ extraResources)                             | `scripts/build-agent-tool-runtime.ts`                                |
 | `.wanta-dev/`                   | manual smoke / experiment scripts, outside every toolchain                             | handwritten                                                          |
+| `wanta/`                        | dev Electron userData for this checkout                                                | `pnpm run dev` / `pnpm run dev:worktree`                             |
 | `dist/` `dist-electron/`        | vite build output (renderer / main+preload)                                            | `pnpm run build`                                                     |
 | `release/`                      | electron-builder output                                                                | `pnpm run build:*`                                                   |
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "auth:status": "node --experimental-strip-types ./scripts/dev-auth-state.ts status",
     "postinstall": "node --experimental-strip-types ./scripts/download-electron.ts && node --experimental-strip-types ./scripts/download-oo.ts && node --experimental-strip-types ./scripts/download-skills.ts && node --experimental-strip-types ./scripts/download-ripgrep.ts && node --experimental-strip-types ./scripts/build-agent-tool-runtime.ts",
     "predev": "node --experimental-strip-types ./scripts/check-oo.ts",
-    "dev": "vite",
+    "dev": "node --experimental-strip-types ./scripts/dev.ts",
     "dev:worktree": "node --experimental-strip-types ./scripts/dev-worktree.ts",
     "dev:no-electron": "vite --mode no-electron",
     "build": "pnpm run build:app",

--- a/scripts/bootstrap.test.ts
+++ b/scripts/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { describe, test } from "vitest"
-import { preferredWorktreePort, renderEnvScript, shellQuote } from "./bootstrap.ts"
+import { createBootstrapConfig, preferredWorktreePort, renderEnvScript, shellQuote } from "./bootstrap.ts"
 
 describe("bootstrap helpers", () => {
   test("preferredWorktreePort is stable and bounded", () => {
@@ -30,5 +30,13 @@ describe("bootstrap helpers", () => {
     assert.match(script, /export WANTA_DEV_SERVER_PORT='6000'/)
     assert.match(script, /export WANTA_SKIP_PROTOCOL_REGISTRATION='1'/)
     assert.match(script, /export WANTA_USER_DATA_DIR='\/tmp\/wanta'/)
+  })
+
+  test("bootstrap config uses repo-local dev userData", async () => {
+    const config = await createBootstrapConfig()
+
+    assert.match(config.userDataDir, /\/wanta$/)
+    assert.equal(config.env["WANTA_USER_DATA_DIR"], config.userDataDir)
+    assert.doesNotMatch(config.userDataDir, /\.wanta-dev\/user-data$/)
   })
 })

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -9,7 +9,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 const stateDir = path.join(repoRoot, ".wanta-dev")
-const userDataDir = path.join(stateDir, "user-data")
+const userDataDir = path.join(repoRoot, "wanta")
 const bootstrapJsonPath = path.join(stateDir, "bootstrap.json")
 const envShPath = path.join(stateDir, "env.sh")
 const defaultPort = 5273
@@ -58,7 +58,7 @@ async function main(args: string[]): Promise<void> {
     await run(commandName("corepack"), ["pnpm", "install", "--frozen-lockfile"], {})
   }
   await run(commandName("corepack"), ["pnpm", "run", "predev"], config.env)
-  await assertBootstrapOutputs(config)
+  await assertBootstrapOutputs()
 
   console.log("[wanta] bootstrap complete")
   console.log(`[wanta] dev server port: ${config.devServerPort}`)
@@ -104,7 +104,6 @@ function canListenOnPort(port: number): Promise<boolean> {
 
 export async function writeBootstrapFiles(config: BootstrapConfig): Promise<void> {
   await mkdir(stateDir, { recursive: true })
-  await mkdir(config.userDataDir, { recursive: true })
   await writeFile(bootstrapJsonPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8")
   await writeFile(envShPath, renderEnvScript(config.env), { encoding: "utf-8", mode: 0o600 })
 }
@@ -131,13 +130,12 @@ function commandName(command: string): string {
   return process.platform === "win32" ? `${command}.cmd` : command
 }
 
-async function assertBootstrapOutputs(config: BootstrapConfig): Promise<void> {
+async function assertBootstrapOutputs(): Promise<void> {
   await Promise.all([
     assertPath(path.join(repoRoot, ".oo-bin")),
     assertPath(path.join(repoRoot, ".electron-dist")),
     assertPath(path.join(repoRoot, "resources", "skills")),
     assertPath(path.join(repoRoot, "resources", "agent-tool-runtime", "tool.js")),
-    assertPath(config.userDataDir),
     assertPath(bootstrapJsonPath),
     assertPath(envShPath),
   ])

--- a/scripts/dev-auth-state.test.ts
+++ b/scripts/dev-auth-state.test.ts
@@ -3,34 +3,25 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { describe, test } from "vitest"
-import { chromiumTimeToUnixMs, formatExpiry, inspectAuthState, resolveDevAuthPaths } from "./dev-auth-state.ts"
+import { chromiumTimeToUnixMs, formatExpiry, inspectAuthState, resolveDevUserDataDir } from "./dev-auth-state.ts"
 
 describe("dev auth state helpers", () => {
-  test("resolveDevAuthPaths uses bootstrap userData and machine root", () => {
-    const paths = resolveDevAuthPaths(
-      {
-        userDataDir: ".wanta-dev/user-data",
-      },
-      "/tmp/home",
-    )
+  test("resolveDevUserDataDir uses bootstrap userData", async () => {
+    const userDataDir = await resolveDevUserDataDir({
+      userDataDir: "/tmp/repo/wanta",
+    })
 
-    assert.equal(paths.machineRoot, "/tmp/home/wanta-dev")
-    assert.equal(paths.captureUserDataDir, "/tmp/home/wanta-dev/login-user-data")
-    assert.equal(paths.snapshotDir, "/tmp/home/wanta-dev/login-state")
-    assert.match(paths.worktreeUserDataDir, /\/\.wanta-dev\/user-data$/)
+    assert.equal(userDataDir, "/tmp/repo/wanta")
   })
 
-  test("resolveDevAuthPaths accepts env-only bootstrap config", () => {
-    const paths = resolveDevAuthPaths(
-      {
-        env: {
-          WANTA_USER_DATA_DIR: "/tmp/worktree-user-data",
-        },
+  test("resolveDevUserDataDir accepts env-only bootstrap config", async () => {
+    const userDataDir = await resolveDevUserDataDir({
+      env: {
+        WANTA_USER_DATA_DIR: "/tmp/worktree-user-data",
       },
-      "/tmp/home",
-    )
+    })
 
-    assert.equal(paths.worktreeUserDataDir, "/tmp/worktree-user-data")
+    assert.equal(userDataDir, "/tmp/worktree-user-data")
   })
 
   test("inspectAuthState requires both profile and oomol-token cookie marker", async () => {

--- a/scripts/dev-auth-state.ts
+++ b/scripts/dev-auth-state.ts
@@ -1,17 +1,17 @@
-import type { ChildProcess } from "node:child_process"
 import type { Dirent } from "node:fs"
 
-import { spawn, spawnSync } from "node:child_process"
-import { constants as fsConstants } from "node:fs"
-import { access, chmod, cp, mkdir, readFile, readdir, rename, rm, stat } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-interface BootstrapConfig {
-  env?: Record<string, string>
-  userDataDir?: string
-}
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(dirname, "..")
+const authJsonName = "auth.json"
+const cleanProfileMarkerName = ".wanta-clean-profile"
+const oomolCookieName = "oomol-token"
+const sqlite3Binary = process.platform === "darwin" ? "/usr/bin/sqlite3" : "sqlite3"
 
 export interface AuthState {
   hasOomolCookie: boolean
@@ -20,19 +20,10 @@ export interface AuthState {
   oomolCookieExpiresAtMs?: number
 }
 
-export interface DevAuthPaths {
-  captureUserDataDir: string
-  machineRoot: string
-  snapshotDir: string
-  worktreeUserDataDir: string
+interface BootstrapConfig {
+  env?: Record<string, string>
+  userDataDir?: string
 }
-
-const dirname = path.dirname(fileURLToPath(import.meta.url))
-const repoRoot = path.join(dirname, "..")
-const bootstrapJsonPath = path.join(repoRoot, ".wanta-dev", "bootstrap.json")
-const authJsonName = "auth.json"
-const oomolCookieName = "oomol-token"
-const sqlite3Binary = process.platform === "darwin" ? "/usr/bin/sqlite3" : "sqlite3"
 
 export function isMainModule(): boolean {
   return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
@@ -47,43 +38,30 @@ if (isMainModule()) {
 
 async function main(args: string[]): Promise<void> {
   const command = args[0] ?? "status"
-  const config = await readBootstrapConfig()
-  const paths = resolveDevAuthPaths(config)
+  const userDataDir = await resolveDevUserDataDir()
 
   switch (command) {
-    case "capture":
-      await captureLoggedInState(config, paths)
-      return
-    case "save":
-      await saveCapturedState(paths)
-      return
-    case "restore":
-      await restoreSnapshot(paths)
+    case "status":
+      await printStatus(userDataDir)
       return
     case "clean":
-      await cleanWorktreeUserData(paths)
+      await cleanDevUserData(userDataDir)
       return
-    case "status":
-      await printStatus(paths)
-      return
+    case "capture":
+    case "save":
+    case "restore":
+      throw new Error(
+        `auth:${command} is deprecated. Dev Electron userData now lives at ./wanta, and dev:worktree initializes from the canonical repo ./wanta when the target is empty. This command no longer reads or writes ~/wanta-dev.`,
+      )
     default:
-      throw new Error(`unknown auth command "${command}"; expected capture, save, restore, clean, or status`)
+      throw new Error(`unknown auth command "${command}"; expected status or clean`)
   }
 }
 
-export function resolveDevAuthPaths(config: BootstrapConfig, homeDir = os.homedir()): DevAuthPaths {
-  const machineRoot = path.resolve(process.env["WANTA_MACHINE_DEV_DIR"]?.trim() || path.join(homeDir, "wanta-dev"))
-  const configuredUserData = config.userDataDir ?? config.env?.["WANTA_USER_DATA_DIR"]
-  if (!configuredUserData) {
-    throw new Error("bootstrap config does not define WANTA_USER_DATA_DIR; run `corepack pnpm run bootstrap` first")
-  }
-
-  return {
-    captureUserDataDir: path.join(machineRoot, "login-user-data"),
-    machineRoot,
-    snapshotDir: path.join(machineRoot, "login-state"),
-    worktreeUserDataDir: path.resolve(repoRoot, configuredUserData),
-  }
+export async function resolveDevUserDataDir(config?: BootstrapConfig): Promise<string> {
+  const loadedConfig = config ?? (await readBootstrapConfig().catch(() => undefined))
+  const configuredUserData = loadedConfig?.userDataDir ?? loadedConfig?.env?.["WANTA_USER_DATA_DIR"]
+  return path.resolve(repoRoot, configuredUserData?.trim() || "wanta")
 }
 
 export async function inspectAuthState(userDataDir: string): Promise<AuthState> {
@@ -101,144 +79,24 @@ export async function inspectAuthState(userDataDir: string): Promise<AuthState> 
 }
 
 async function readBootstrapConfig(): Promise<BootstrapConfig> {
-  try {
-    return JSON.parse(await readFile(bootstrapJsonPath, "utf-8")) as BootstrapConfig
-  } catch (error) {
-    throw new Error(`bootstrap config missing or invalid; run \`corepack pnpm run bootstrap\` first: ${error}`)
-  }
+  const bootstrapJsonPath = path.join(repoRoot, ".wanta-dev", "bootstrap.json")
+  return JSON.parse(await readFile(bootstrapJsonPath, "utf-8")) as BootstrapConfig
 }
 
-async function captureLoggedInState(config: BootstrapConfig, paths: DevAuthPaths): Promise<void> {
-  await prepareMachineRoot(paths)
-  await rm(paths.captureUserDataDir, { force: true, recursive: true })
-  await mkdir(paths.captureUserDataDir, { mode: 0o700, recursive: true })
-  await chmod(paths.captureUserDataDir, 0o700).catch(() => undefined)
-
-  console.log("[wanta] starting dev app with a machine-level login capture userData dir")
-  console.log(`[wanta] capture user data: ${paths.captureUserDataDir}`)
-  console.log("[wanta] sign in in the Electron window; the script will save the snapshot after login is detected")
-
-  await runDevUntilLoggedIn(paths.captureUserDataDir, {
-    ...config.env,
-    WANTA_USER_DATA_DIR: paths.captureUserDataDir,
-    WANTA_SKIP_PROTOCOL_REGISTRATION: "0",
-  })
-
-  await saveCapturedState(paths)
+async function cleanDevUserData(userDataDir: string): Promise<void> {
+  await rm(userDataDir, { force: true, recursive: true })
+  await mkdir(userDataDir, { mode: 0o700, recursive: true })
+  await writeFile(
+    path.join(userDataDir, cleanProfileMarkerName),
+    "This marker keeps dev:worktree from initializing this intentionally clean signed-out profile.\n",
+    "utf-8",
+  )
+  console.log(`[wanta] reset dev userData to a clean signed-out state: ${userDataDir}`)
 }
 
-async function runDevUntilLoggedIn(userDataDir: string, env: Record<string, string> = {}): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(commandName("corepack"), ["pnpm", "run", "dev"], {
-      cwd: repoRoot,
-      detached: process.platform !== "win32",
-      env: { ...process.env, ...env },
-      stdio: "inherit",
-    })
-    let finalized = false
-    let loginDetected = false
-
-    const finish = (error?: Error): void => {
-      if (finalized) return
-      finalized = true
-      clearInterval(authCheckInterval)
-      process.off("SIGINT", onSignal)
-      process.off("SIGTERM", onSignal)
-      if (error) {
-        reject(error)
-        return
-      }
-      resolve()
-    }
-
-    const onSignal = (): void => {
-      stopChild(child)
-    }
-
-    const authCheckInterval = setInterval(() => {
-      void inspectAuthState(userDataDir)
-        .then((state) => {
-          if (!state.isLoggedIn || loginDetected) return
-          loginDetected = true
-          console.log("[wanta] login detected; stopping dev app before saving snapshot")
-          stopChild(child)
-        })
-        .catch(() => undefined)
-    }, 2_000)
-
-    process.once("SIGINT", onSignal)
-    process.once("SIGTERM", onSignal)
-    child.once("error", finish)
-    child.once("exit", (code, signal) => {
-      if (loginDetected || code === 0 || code === 130 || signal === "SIGINT" || signal === "SIGTERM") {
-        finish()
-        return
-      }
-      finish(new Error(`dev app exited with ${signal ?? `exit code ${code}`}`))
-    })
-  })
-}
-
-function stopChild(child: ChildProcess): void {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return
-  }
-  if (process.platform !== "win32" && child.pid !== undefined) {
-    try {
-      process.kill(-child.pid, "SIGINT")
-      return
-    } catch {
-      // Fall back to the direct child if the process group is already gone.
-    }
-  }
-  try {
-    child.kill("SIGINT")
-  } catch {
-    // The process may have exited between the state check and the signal.
-  }
-}
-
-async function saveCapturedState(paths: DevAuthPaths): Promise<void> {
-  const state = await inspectAuthState(paths.captureUserDataDir)
-  if (!state.isLoggedIn) {
-    throw new Error(
-      authStateFailureMessage("captured login userData is not logged in", paths.captureUserDataDir, state),
-    )
-  }
-
-  await prepareMachineRoot(paths)
-  await replaceDirectory(paths.captureUserDataDir, paths.snapshotDir)
-  await chmod(paths.snapshotDir, 0o700).catch(() => undefined)
-  console.log(`[wanta] saved logged-in snapshot: ${paths.snapshotDir}`)
-}
-
-async function restoreSnapshot(paths: DevAuthPaths): Promise<void> {
-  const state = await inspectAuthState(paths.snapshotDir)
-  if (!state.isLoggedIn) {
-    throw new Error(authStateFailureMessage("machine login snapshot is not ready", paths.snapshotDir, state))
-  }
-
-  await replaceDirectory(paths.snapshotDir, paths.worktreeUserDataDir)
-  await chmod(paths.worktreeUserDataDir, 0o700).catch(() => undefined)
-  console.log(`[wanta] restored logged-in userData to: ${paths.worktreeUserDataDir}`)
-}
-
-async function cleanWorktreeUserData(paths: DevAuthPaths): Promise<void> {
-  await rm(paths.worktreeUserDataDir, { force: true, recursive: true })
-  await mkdir(paths.worktreeUserDataDir, { mode: 0o700, recursive: true })
-  await chmod(paths.worktreeUserDataDir, 0o700).catch(() => undefined)
-  console.log(`[wanta] reset worktree userData to a clean signed-out state: ${paths.worktreeUserDataDir}`)
-}
-
-async function printStatus(paths: DevAuthPaths): Promise<void> {
-  const [snapshot, worktree] = await Promise.all([
-    inspectAuthState(paths.snapshotDir),
-    inspectAuthState(paths.worktreeUserDataDir),
-  ])
-
-  console.log(`[wanta] machine root: ${paths.machineRoot}`)
-  printAuthState("machine login snapshot", paths.snapshotDir, snapshot)
-  printAuthState("worktree userData", paths.worktreeUserDataDir, worktree)
+async function printStatus(userDataDir: string): Promise<void> {
+  console.log("[wanta] auth snapshot commands are deprecated; dev userData now lives in ./wanta")
+  printAuthState("dev userData", userDataDir, await inspectAuthState(userDataDir))
 }
 
 function printAuthState(label: string, dir: string, state: AuthState): void {
@@ -248,37 +106,6 @@ function printAuthState(label: string, dir: string, state: AuthState): void {
   console.log(`[wanta]   profile: ${state.hasProfile ? "present" : "missing"}`)
   console.log(`[wanta]   oomol-token cookie marker: ${state.hasOomolCookie ? "present" : "missing"}`)
   console.log(`[wanta]   oomol-token expires: ${formatExpiry(state.oomolCookieExpiresAtMs)}`)
-}
-
-function authStateFailureMessage(prefix: string, dir: string, state: AuthState): string {
-  return [
-    `${prefix}: ${dir}`,
-    `profile=${state.hasProfile ? "present" : "missing"}`,
-    `oomol-token cookie marker=${state.hasOomolCookie ? "present" : "missing"}`,
-    "Run `corepack pnpm run auth:capture` on this machine, or use `corepack pnpm run auth:clean` for login/auth work.",
-  ].join("; ")
-}
-
-async function prepareMachineRoot(paths: DevAuthPaths): Promise<void> {
-  await mkdir(paths.machineRoot, { mode: 0o700, recursive: true })
-  await chmod(paths.machineRoot, 0o700).catch(() => undefined)
-}
-
-async function replaceDirectory(source: string, target: string): Promise<void> {
-  await assertDirectory(source)
-  await mkdir(path.dirname(target), { recursive: true })
-  const temp = path.join(path.dirname(target), `.${path.basename(target)}.tmp-${process.pid}-${Date.now()}`)
-  await rm(temp, { force: true, recursive: true })
-  await cp(source, temp, { recursive: true })
-  await rm(target, { force: true, recursive: true })
-  await rename(temp, target)
-}
-
-async function assertDirectory(target: string): Promise<void> {
-  const info = await stat(target)
-  if (!info.isDirectory()) {
-    throw new Error(`${target} is not a directory`)
-  }
 }
 
 async function hasPersistedProfile(authJsonPath: string): Promise<boolean> {
@@ -359,61 +186,77 @@ function readCookieExpiry(cookieDbPath: string): number | undefined {
   return chromiumTimeToUnixMs(chromiumTime)
 }
 
-export function chromiumTimeToUnixMs(chromiumTime: bigint | number | string): number {
-  return Number((BigInt(chromiumTime) - 11_644_473_600_000_000n) / 1_000n)
+export function chromiumTimeToUnixMs(chromiumTime: bigint | string): number {
+  const value = typeof chromiumTime === "bigint" ? chromiumTime : BigInt(chromiumTime)
+  const unixMicroseconds = value - 11_644_473_600_000_000n
+  return Number(unixMicroseconds / 1000n)
 }
 
-function isExpired(expiresAtMs: number | undefined): boolean {
-  return expiresAtMs !== undefined && expiresAtMs <= Date.now()
+function isExpired(expiresAtMs: number | undefined, now = Date.now()): boolean {
+  return expiresAtMs !== undefined && expiresAtMs <= now
 }
 
-export function formatExpiry(expiresAtMs: number | undefined, nowMs = Date.now()): string {
+export function formatExpiry(expiresAtMs: number | undefined, now = Date.now()): string {
   if (expiresAtMs === undefined) {
     return "unknown"
   }
-  const remainingDays = (expiresAtMs - nowMs) / 86_400_000
-  const remaining =
-    remainingDays >= 0 ? `${remainingDays.toFixed(1)} days remaining` : `${Math.abs(remainingDays).toFixed(1)} days ago`
-  return `${new Date(expiresAtMs).toISOString()} (${remaining})`
+  const days = (expiresAtMs - now) / 86_400_000
+  return `${new Date(expiresAtMs).toISOString()} (${days.toFixed(1)} days remaining)`
 }
 
-async function* walkFiles(dir: string): AsyncGenerator<string> {
-  let entries: Array<Dirent<string>>
+async function pathExists(target: string): Promise<boolean> {
   try {
-    entries = await readdir(dir, { withFileTypes: true })
-  } catch {
-    return
-  }
-
-  for (const entry of entries) {
-    const next = path.join(dir, entry.name)
-    if (entry.isDirectory()) {
-      yield* walkFiles(next)
-      continue
+    await stat(target)
+    return true
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false
     }
-    if (entry.isFile()) {
-      yield next
-    }
+    throw error
   }
 }
 
 async function fileContains(filePath: string, needle: string): Promise<boolean> {
   try {
-    return (await readFile(filePath)).includes(Buffer.from(needle, "utf-8"))
+    return (await readFile(filePath, "utf-8")).includes(needle)
   } catch {
     return false
   }
 }
 
-async function pathExists(target: string): Promise<boolean> {
+async function* walkFiles(root: string): AsyncGenerator<string> {
+  let entries: Dirent[]
   try {
-    await access(target, fsConstants.F_OK)
-    return true
+    entries = await readdir(root, { withFileTypes: true })
   } catch {
-    return false
+    return
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name)
+    if (entry.isDirectory()) {
+      yield* walkFiles(entryPath)
+    } else if (entry.isFile()) {
+      yield entryPath
+    }
   }
 }
 
-function commandName(command: string): string {
-  return process.platform === "win32" ? `${command}.cmd` : command
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error
+}
+
+export async function createAuthFixture(root: string): Promise<string> {
+  const dir = await mkdir(path.join(root, "wanta-auth-fixture"), { recursive: true })
+  const userDataDir = dir ?? path.join(root, "wanta-auth-fixture")
+  await writeFile(
+    path.join(userDataDir, authJsonName),
+    `${JSON.stringify({ accounts: [{ id: "u1", name: "User" }], currentId: "u1" })}\n`,
+  )
+  await mkdir(path.join(userDataDir, "Default", "Network"), { recursive: true })
+  await writeFile(path.join(userDataDir, "Default", "Network", "Cookies"), "sqlite bytes oomol-token redacted")
+  return userDataDir
+}
+
+export function tempAuthRoot(): string {
+  return path.join(os.tmpdir(), `wanta-auth-${process.pid}`)
 }

--- a/scripts/dev-worktree.test.ts
+++ b/scripts/dev-worktree.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, test } from "vitest"
+import { initializeWorktreeUserData, resolveCanonicalUserDataDir } from "./dev-worktree.ts"
+
+const originalSourceDir = process.env["WANTA_DEV_AUTH_SOURCE_DIR"]
+
+afterEach(() => {
+  if (originalSourceDir === undefined) {
+    delete process.env["WANTA_DEV_AUTH_SOURCE_DIR"]
+  } else {
+    process.env["WANTA_DEV_AUTH_SOURCE_DIR"] = originalSourceDir
+  }
+})
+
+describe("dev worktree userData initialization", () => {
+  test("uses explicit canonical source override", async () => {
+    process.env["WANTA_DEV_AUTH_SOURCE_DIR"] = "/tmp/canonical-wanta"
+
+    assert.equal(await resolveCanonicalUserDataDir("/tmp/worktree"), "/tmp/canonical-wanta")
+  })
+
+  test("copies canonical userData only when target is missing or empty", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wanta-worktree-init-"))
+    const source = path.join(root, "repo", "wanta")
+    const target = path.join(root, "worktree", "wanta")
+    process.env["WANTA_DEV_AUTH_SOURCE_DIR"] = source
+    await mkdir(source, { recursive: true })
+    await writeFile(path.join(source, "settings.json"), "source-settings")
+
+    assert.equal(await initializeWorktreeUserData(configFor(target)), "copied")
+    assert.equal(await readFile(path.join(target, "settings.json"), "utf-8"), "source-settings")
+
+    await writeFile(path.join(target, "settings.json"), "target-settings")
+    assert.equal(await initializeWorktreeUserData(configFor(target)), "kept")
+    assert.equal(await readFile(path.join(target, "settings.json"), "utf-8"), "target-settings")
+
+    await rm(root, { force: true, recursive: true })
+  })
+
+  test("starts clean when canonical source is missing or empty", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wanta-worktree-empty-"))
+    const source = path.join(root, "repo", "wanta")
+    const target = path.join(root, "worktree", "wanta")
+    process.env["WANTA_DEV_AUTH_SOURCE_DIR"] = source
+
+    assert.equal(await initializeWorktreeUserData(configFor(target)), "empty-source")
+    await mkdir(source, { recursive: true })
+    assert.equal(await initializeWorktreeUserData(configFor(target)), "empty-source")
+
+    await rm(root, { force: true, recursive: true })
+  })
+})
+
+function configFor(userDataDir: string) {
+  return {
+    devServerPort: 6000,
+    env: {
+      WANTA_DEV_SERVER_PORT: "6000",
+      WANTA_SKIP_PROTOCOL_REGISTRATION: "1",
+      WANTA_USER_DATA_DIR: userDataDir,
+    },
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    repoRoot: path.dirname(userDataDir),
+    userDataDir,
+  }
+}

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -1,9 +1,9 @@
 import type { BootstrapConfig } from "./bootstrap.ts"
 
 import { spawn } from "node:child_process"
-import { readFile } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, stat } from "node:fs/promises"
 import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { createBootstrapConfig, writeBootstrapFiles } from "./bootstrap.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -11,10 +11,17 @@ const repoRoot = path.join(dirname, "..")
 const bootstrapJsonPath = path.join(repoRoot, ".wanta-dev", "bootstrap.json")
 const requiredEnvKeys = ["WANTA_DEV_SERVER_PORT", "WANTA_SKIP_PROTOCOL_REGISTRATION", "WANTA_USER_DATA_DIR"]
 
-await main()
+export function isMainModule(): boolean {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+}
+
+if (isMainModule()) {
+  await main()
+}
 
 async function main(): Promise<void> {
   let config = await readBootstrapConfig()
+  await initializeWorktreeUserData(config)
   let result = await run(commandName("corepack"), ["pnpm", "run", "dev"], config.env)
   if (result.ok) {
     return
@@ -26,6 +33,7 @@ async function main(): Promise<void> {
   console.warn("[wanta] configured dev server port is already in use; selecting another worktree port")
   config = await createBootstrapConfig()
   await writeBootstrapFiles(config)
+  await initializeWorktreeUserData(config)
   result = await run(commandName("corepack"), ["pnpm", "run", "dev"], config.env)
   if (!result.ok) {
     throw new Error(result.message)
@@ -76,6 +84,114 @@ function parseBootstrapConfig(value: unknown): BootstrapConfig {
   }
 }
 
+export async function initializeWorktreeUserData(
+  config: BootstrapConfig,
+): Promise<"copied" | "empty-source" | "self" | "kept"> {
+  const target = path.resolve(config.userDataDir)
+  if (!(await isDirectoryMissingOrEmpty(target))) {
+    console.log(`[wanta] keeping existing worktree userData: ${target}`)
+    return "kept"
+  }
+
+  const source = await resolveCanonicalUserDataDir(repoRoot)
+  if (source === undefined) {
+    console.log("[wanta] canonical dev userData not found; starting with a clean worktree profile")
+    return "empty-source"
+  }
+  if (await isSamePath(source, target)) {
+    console.log(`[wanta] current checkout is the canonical dev userData source: ${target}`)
+    return "self"
+  }
+  if (await isDirectoryMissingOrEmpty(source)) {
+    console.log(`[wanta] canonical dev userData is empty: ${source}; starting with a clean worktree profile`)
+    return "empty-source"
+  }
+
+  await copyDirectoryOnce(source, target)
+  console.log(`[wanta] initialized worktree userData from canonical source: ${source} -> ${target}`)
+  return "copied"
+}
+
+export async function resolveCanonicalUserDataDir(currentRepoRoot: string): Promise<string | undefined> {
+  const configured = process.env["WANTA_DEV_AUTH_SOURCE_DIR"]?.trim()
+  if (configured) {
+    return path.resolve(configured)
+  }
+
+  const worktrees = await listGitWorktrees(currentRepoRoot)
+  const mainWorktree = worktrees.find((worktree) => worktree.branch === "refs/heads/main")
+  const canonicalRoot = mainWorktree?.path ?? worktrees[0]?.path
+  return canonicalRoot === undefined ? undefined : path.join(canonicalRoot, "wanta")
+}
+
+interface GitWorktreeInfo {
+  branch?: string
+  path: string
+}
+
+async function listGitWorktrees(cwd: string): Promise<GitWorktreeInfo[]> {
+  const result = await run(commandName("git"), ["worktree", "list", "--porcelain"], {}, cwd)
+  if (!result.ok) {
+    return []
+  }
+  const worktrees: GitWorktreeInfo[] = []
+  let current: Partial<GitWorktreeInfo> = {}
+  for (const line of result.output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (current.path) worktrees.push(current as GitWorktreeInfo)
+      current = { path: line.slice("worktree ".length) }
+    } else if (line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length)
+    }
+  }
+  if (current.path) worktrees.push(current as GitWorktreeInfo)
+  return worktrees.filter((worktree) => path.isAbsolute(worktree.path))
+}
+
+async function isDirectoryMissingOrEmpty(target: string): Promise<boolean> {
+  try {
+    const info = await stat(target)
+    if (!info.isDirectory()) {
+      return false
+    }
+    return (await readdir(target)).length === 0
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return true
+    }
+    throw error
+  }
+}
+
+async function isSamePath(left: string, right: string): Promise<boolean> {
+  const [leftReal, rightReal] = await Promise.all([safeRealpath(left), safeRealpath(right)])
+  return (leftReal ?? path.resolve(left)) === (rightReal ?? path.resolve(right))
+}
+
+async function safeRealpath(target: string): Promise<string | undefined> {
+  try {
+    return await realpath(target)
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined
+    }
+    throw error
+  }
+}
+
+async function copyDirectoryOnce(source: string, target: string): Promise<void> {
+  await mkdir(path.dirname(target), { recursive: true })
+  const temp = await mkdtemp(path.join(path.dirname(target), `.${path.basename(target)}.tmp-`))
+  try {
+    await cp(source, temp, { recursive: true })
+    await rm(target, { force: true, recursive: true })
+    await rename(temp, target)
+  } catch (error) {
+    await rm(temp, { force: true, recursive: true }).catch(() => undefined)
+    throw error
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -85,17 +201,21 @@ function isStringRecord(value: unknown): value is Record<string, string> {
   return Object.values(value).every((entry) => typeof entry === "string")
 }
 
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error
+}
+
 interface RunResult {
   message: string
   ok: boolean
   output: string
 }
 
-async function run(command: string, args: string[], env: Record<string, string>): Promise<RunResult> {
+async function run(command: string, args: string[], env: Record<string, string>, cwd = repoRoot): Promise<RunResult> {
   return await new Promise<RunResult>((resolve, reject) => {
     let output = ""
     const child = spawn(command, args, {
-      cwd: repoRoot,
+      cwd,
       env: { ...process.env, ...env },
       stdio: ["inherit", "pipe", "pipe"],
     })

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -119,8 +119,7 @@ export async function resolveCanonicalUserDataDir(currentRepoRoot: string): Prom
   }
 
   const worktrees = await listGitWorktrees(currentRepoRoot)
-  const mainWorktree = worktrees.find((worktree) => worktree.branch === "refs/heads/main")
-  const canonicalRoot = mainWorktree?.path ?? worktrees[0]?.path
+  const canonicalRoot = worktrees[0]?.path
   return canonicalRoot === undefined ? undefined : path.join(canonicalRoot, "wanta")
 }
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,40 @@
+import { spawn } from "node:child_process"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(dirname, "..")
+const repoUserDataDir = path.join(repoRoot, "wanta")
+
+export function isMainModule(): boolean {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+}
+
+if (isMainModule()) {
+  await runDev(process.argv.slice(2))
+}
+
+export async function runDev(args: string[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(commandName("vite"), args, {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        WANTA_USER_DATA_DIR: repoUserDataDir,
+      },
+      stdio: "inherit",
+    })
+    child.once("error", reject)
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error(`vite ${args.join(" ")} failed with ${signal ?? `exit code ${code}`}`))
+    })
+  })
+}
+
+function commandName(command: string): string {
+  return process.platform === "win32" ? `${command}.cmd` : command
+}


### PR DESCRIPTION
## Summary
- Route `pnpm run dev` through a dev wrapper that sets `WANTA_USER_DATA_DIR` to the checkout-local `./wanta` directory.
- Move worktree bootstrap userData metadata to `<worktree>/wanta` and initialize empty worktree profiles by copying the canonical repo `./wanta` once.
- Retire the old `~/wanta-dev` auth snapshot flow in commands/docs, keep `auth:status` and `auth:clean` scoped to the current checkout, and ignore `wanta/` in git.

Closes #244

## Acceptance evidence
- `pnpm run dev` uses `<repo>/wanta`: covered by `scripts/dev.ts`, `package.json`, and `scripts/bootstrap.test.ts`; `electron/main.ts` still ignores `WANTA_USER_DATA_DIR` when `app.isPackaged`.
- `pnpm run dev:worktree` uses `<worktree>/wanta`: covered by `scripts/bootstrap.ts`, `.wanta-dev/bootstrap.json` verification, and `scripts/dev-worktree.test.ts`.
- Empty or missing worktree `./wanta` initializes once from canonical repo `./wanta`: covered by `scripts/dev-worktree.test.ts`.
- Existing non-empty worktree `./wanta` is not overwritten: covered by `scripts/dev-worktree.test.ts`.
- Worktree runtime does not share canonical `./wanta`: implementation copies into a same-filesystem temp dir and renames to the target; tests assert copied target data is independent and later preserved.
- Packaged/production app remains on Electron default userData: `electron/main.ts` continues to ignore `WANTA_USER_DATA_DIR` under `app.isPackaged`; this change only injects the env var from dev scripts.
- New flow does not create/read/depend on `~/wanta-dev`: `dev-auth-state.ts` now scopes status/clean to `./wanta`; `auth:capture`, `auth:save`, and `auth:restore` fail with an explicit deprecated message.

## Verification
- `corepack pnpm test scripts/bootstrap.test.ts scripts/dev-worktree.test.ts scripts/dev-auth-state.test.ts` — passed, 13 tests.
- `corepack pnpm run ts-check && corepack pnpm run lint && corepack pnpm run format && corepack pnpm test` — passed; full suite 263 files / 1949 tests.
- `corepack pnpm run build` — passed; Vite build succeeded with the existing chunk-size warning.
- `rm -rf wanta .wanta-dev && corepack pnpm run bootstrap -- --skip-install && test ! -e wanta && ...` — passed; bootstrap records absolute `<worktree>/wanta` and does not create `wanta/`.
- `corepack pnpm run auth:status` — reports only current checkout `./wanta`.
- `corepack pnpm run auth:restore` — exits with the expected deprecated message and does not read/write `~/wanta-dev`.
- `corepack pnpm run auth:clean` plus direct `initializeWorktreeUserData(...)` check — passed; clean signed-out marker makes `dev:worktree` keep the intentionally clean profile instead of copying canonical state.

## Review note
Blind reviewer attempt `deleg_fb68ffc8` failed before review because the model API returned HTTP 503 after 3 retries (`所有供应商暂时不可用`). Per task fallback rules, I performed a non-blind fallback review.

Non-blind fallback review verdict: pass.
- Issue acceptance items: all automated/script-level items above are covered by code and verification; manual regression items are supported by the new directory model and documented, with production behavior bounded to unchanged packaged `app.isPackaged` behavior.
- Extra focus points: no issue found for dev-only wrapper scope, target non-overwrite behavior, `~/wanta-dev` retirement, or `.wanta-dev` metadata-only role.
- Uncovered risks: copying a live Chromium profile can still capture a point-in-time snapshot of an active source profile, but it does not share the runtime profile and is acceptable for this dev initialization scope; no blocker recommended.
