### PR TITLE
Use WikiGraph SDK for app-side knowledge access

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,15 +87,16 @@ missing or not exactly `true` counts as off. The renderer reads and subscribes t
 Settings service; when off it hides the knowledge-base navigation, loads no knowledge-base list,
 injects no existing knowledge-base references into chat, and bounces any direct navigation to a
 knowledge-base route back to chat. The flag is saved to the local `userData/settings.json` and
-survives restart. Knowledge bases use the local WikiGraph 0.4 `wg` command against Wanta's private
-`<userData>/wikigraph-state` default library; Wanta does not keep a parallel archive registry, and
-imports are always copied into that managed library folder. Cover imports are converged to a
-thumbnail with a longest edge of 320 px and at most 512 KiB encoded; oversized legacy Data URLs never cross IPC. Before each turn is sent, the main
-process writes that turn's selected knowledge-base IDs into the agent-scope session state, and the
-per-turn system prompt exposes only `wikg://lib/arc/<id>` archive URIs. Agent-side WikiGraph access is
-through a Wanta-owned `wg` command placed at the front of the sidecar `PATH`; it binds Wanta's private
-WikiGraph state internally and passes stdin/stdout/stderr/exit code through without wrapping
-WikiGraph business output.
+survives restart. App-side knowledge-base management uses the `wiki-graph-core` SDK against Wanta's
+private `<userData>/wikigraph-state` default library; Wanta does not keep a parallel archive
+registry, and imports are always copied into that managed library folder. Cover imports are converged
+to a thumbnail with a longest edge of 320 px and at most 512 KiB encoded; oversized legacy Data URLs
+never cross IPC. Before each turn is sent, the main process writes that turn's selected
+knowledge-base IDs into the agent-scope session state, and the per-turn system prompt exposes only
+`wikg://lib/arc/<id>` archive URIs. Agent-side WikiGraph access remains through a Wanta-owned `wg`
+command placed at the front of the sidecar `PATH`; it binds Wanta's private WikiGraph state
+internally and passes stdin/stdout/stderr/exit code through without wrapping WikiGraph business
+output.
 
 ### Link runtime boundary
 

--- a/electron/knowledge/node.test.ts
+++ b/electron/knowledge/node.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const runner = vi.hoisted(() => ({
+  addWikiGraphLibraryArchive: vi.fn(),
+  inspectWikiGraph: vi.fn(),
+  listWikiGraphLibraryArchives: vi.fn(),
+  readWikiGraphCover: vi.fn(),
+  readWikiGraphIndex: vi.fn(),
+  readWikiGraphMetadata: vi.fn(),
+  removeWikiGraphLibraryArchive: vi.fn(),
+}))
+
+vi.mock("electron", () => ({
+  dialog: { showOpenDialog: vi.fn() },
+  nativeImage: { createFromBuffer: vi.fn() },
+  shell: { showItemInFolder: vi.fn() },
+}))
+
+vi.mock("./runner.ts", () => ({
+  ...runner,
+  wikiGraphCoverageReady: (coverage: { coveredWords?: number; totalWords?: number } | undefined) => {
+    return Boolean(coverage && (coverage.coveredWords ?? 0) > 0 && (coverage.totalWords ?? 0) > 0)
+  },
+}))
+
+const { KnowledgeServiceImpl } = await import("./node.ts")
+
+describe("KnowledgeServiceImpl", () => {
+  beforeEach(() => {
+    runner.addWikiGraphLibraryArchive.mockReset()
+    runner.inspectWikiGraph.mockReset()
+    runner.listWikiGraphLibraryArchives.mockReset()
+    runner.readWikiGraphCover.mockReset()
+    runner.readWikiGraphIndex.mockReset()
+    runner.readWikiGraphMetadata.mockReset()
+    runner.removeWikiGraphLibraryArchive.mockReset()
+  })
+
+  it("downgrades inspect and index SDK failures while preserving metadata summary", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    runner.listWikiGraphLibraryArchives.mockResolvedValue([
+      {
+        id: "public-id",
+        uri: "wikg://lib/arc/public-id",
+        relativePath: "book.wikg",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        exists: true,
+        lastSeenSize: 123,
+        status: "present",
+      },
+    ])
+    runner.readWikiGraphMetadata.mockResolvedValue({
+      authors: ["Author"],
+      language: "zh",
+      title: "Book Title",
+    })
+    runner.inspectWikiGraph.mockRejectedValue(new Error("inspect failed"))
+    runner.readWikiGraphIndex.mockRejectedValue(new Error("index failed"))
+    runner.readWikiGraphCover.mockResolvedValue(null)
+    const service = new KnowledgeServiceImpl({
+      runtime: { managedLibraryDir: "/tmp/wanta/library", stateDir: "/tmp/wanta/state" },
+    })
+
+    try {
+      await expect(service.list()).resolves.toEqual([
+        {
+          authors: ["Author"],
+          capabilities: {
+            fullTextSearch: false,
+            knowledgeGraph: false,
+            readingGraph: false,
+            summary: false,
+          },
+          id: "public-id",
+          importedAt: Date.parse("2026-01-02T00:00:00.000Z"),
+          language: "zh",
+          size: 123,
+          sourceFileName: "book.wikg",
+          statistics: {},
+          title: "Book Title",
+        },
+      ])
+      expect(warn).toHaveBeenCalledWith("[wanta] failed to inspect knowledge base:", expect.any(Error))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/electron/knowledge/runner.test.ts
+++ b/electron/knowledge/runner.test.ts
@@ -227,7 +227,7 @@ describe("WikiGraph SDK adapter", () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
     const rt = runtime(dir)
 
-    await prepareWikiGraphDefaultLibrary(rt)
+    await Promise.all([prepareWikiGraphDefaultLibrary(rt), prepareWikiGraphDefaultLibrary(rt)])
 
     expect(sdk.calls.runtimeStateDirs).toEqual([rt.stateDir])
     expect(sdk.calls.rebind).toEqual([
@@ -335,6 +335,13 @@ describe("WikiGraph SDK adapter", () => {
     sdk.failCover = true
 
     await expect(readWikiGraphCover(runtime(dir), "public-archive")).resolves.toBeNull()
+  })
+
+  it("propagates archive resolution failures when reading covers", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+    sdk.failGetArchive = new Error("archive missing")
+
+    await expect(readWikiGraphCover(runtime(dir), "public-archive")).rejects.toThrow("archive missing")
   })
 
   it("redacts managed storage paths and archive handles from SDK errors", async () => {

--- a/electron/knowledge/runner.test.ts
+++ b/electron/knowledge/runner.test.ts
@@ -1,20 +1,152 @@
-import type { WikiGraphCLIRunner, WikiGraphRuntime } from "./runner.ts"
-import type { RunWikiGraphCLIInput } from "wiki-graph"
+import type { WikiGraphRuntime } from "./runner.ts"
 
 import { mkdtemp, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi, beforeEach } from "vitest"
 import {
   addWikiGraphLibraryArchive,
+  inspectWikiGraph,
   listWikiGraphLibraryArchives,
+  prepareWikiGraphDefaultLibrary,
   readWikiGraphCover,
   readWikiGraphIndex,
   readWikiGraphMetadata,
   removeWikiGraphLibraryArchive,
-  runWikiGraphJson,
   wikiGraphCoverageReady,
 } from "./runner.ts"
+
+const sdk = vi.hoisted(() => {
+  return {
+    addRecord: undefined as MockArchiveRecord | undefined,
+    archives: [] as MockArchiveRecord[],
+    calls: {
+      add: [] as unknown[],
+      archiveFiles: [] as string[],
+      getArchive: [] as unknown[],
+      list: [] as unknown[],
+      rebind: [] as unknown[],
+      remove: [] as unknown[],
+      runtimeStateDirs: [] as (string | undefined)[],
+    },
+    chapters: [] as MockChapter[],
+    cover: undefined as { data: Uint8Array; mediaType: string; path: string } | undefined,
+    failCover: false,
+    failGetArchive: undefined as Error | undefined,
+    ftsCurrent: false,
+    indexSettings: { ftsEmbedded: false },
+    meta: undefined as MockBookMeta | undefined,
+    serials: new Map<number, { knowledgeGraphReady?: boolean; topologyReady?: boolean }>(),
+  }
+})
+
+interface MockArchiveRecord {
+  id: number
+  publicId: string
+  uri: string
+  libraryId: number
+  libraryUri: string
+  relativePath: string
+  path: string
+  exists: boolean
+  status: "conflict" | "missing" | "present"
+  createdAt: string
+  updatedAt: string
+  lastSeenSize?: number
+}
+
+interface MockBookMeta {
+  version: 1
+  sourceFormat: "epub" | "pdf" | "txt" | "markdown"
+  title: string | null
+  authors: string[]
+  language: string | null
+  identifier: string | null
+  publisher: string | null
+  publishedAt: string | null
+  description: string | null
+}
+
+interface MockChapter {
+  chapterId: number
+  childCount: number
+  depth: number
+  documentOrder: number
+  fragmentCount: number
+  key: string
+  path: string
+  stage: "planned" | "sourced" | "graphed" | "summarized"
+  title: string | null
+  tocPath: readonly string[]
+  uri: string
+  words: number
+}
+
+vi.mock("wiki-graph-core", () => {
+  return {
+    WikiGraphArchiveFile: class {
+      private readonly path: string
+
+      public constructor(filePath: string) {
+        this.path = filePath
+        sdk.calls.archiveFiles.push(filePath)
+      }
+
+      public async read<T>(operation: (archive: unknown) => Promise<T> | T): Promise<T> {
+        return await operation({
+          readCover: async () => {
+            if (sdk.failCover) throw new Error("cover failed")
+            return sdk.cover
+          },
+          readMeta: async () => sdk.meta,
+        })
+      }
+
+      public async readDocument<T>(operation: (document: unknown) => Promise<T> | T): Promise<T> {
+        return await operation({
+          serials: {
+            getById: async (id: number) => sdk.serials.get(id),
+          },
+        })
+      }
+    },
+    addWikiGraphLibraryArchive: async (input: unknown) => {
+      sdk.calls.add.push(input)
+      if (!sdk.addRecord) throw new Error("missing add record")
+      return sdk.addRecord
+    },
+    getWikiGraphLibraryArchive: async (target: { uri?: string }) => {
+      sdk.calls.getArchive.push(target)
+      if (sdk.failGetArchive) throw sdk.failGetArchive
+      const record = sdk.archives.find((item) => item.uri === target.uri) ?? sdk.addRecord
+      if (!record) throw new Error(`missing archive ${target.uri}`)
+      return record
+    },
+    isArchiveSearchIndexCurrent: async () => sdk.ftsCurrent,
+    listChapters: async () => sdk.chapters,
+    listWikiGraphLibraryArchives: async (target: unknown) => {
+      sdk.calls.list.push(target)
+      return sdk.archives
+    },
+    parseWikiGraphLibraryUri: (uri: string) => (uri.startsWith("wikg://lib") ? { kind: "mock", uri } : undefined),
+    readArchiveIndexSettings: async () => sdk.indexSettings,
+    rebindWikiGraphLibrary: async (input: unknown) => {
+      sdk.calls.rebind.push(input)
+      return { archives: sdk.archives, library: {} }
+    },
+    removeWikiGraphLibraryArchive: async (input: unknown) => {
+      sdk.calls.remove.push(input)
+      return sdk.archives[0]
+    },
+    withWikiGraphRuntimeStateDirectoryPath: async <T>(
+      stateDir: string | undefined,
+      operation: () => Promise<T> | T,
+    ) => {
+      sdk.calls.runtimeStateDirs.push(stateDir)
+      return await operation()
+    },
+  }
+})
 
 function runtime(dir: string): WikiGraphRuntime {
   return {
@@ -23,199 +155,203 @@ function runtime(dir: string): WikiGraphRuntime {
   }
 }
 
+function archiveRecord(overrides: Partial<MockArchiveRecord> = {}): MockArchiveRecord {
+  return {
+    id: 123,
+    publicId: "public-archive",
+    uri: "wikg://lib/arc/public-archive",
+    libraryId: 1,
+    libraryUri: "wikg://lib",
+    relativePath: "copy.wikg",
+    path: "/managed/library/copy.wikg",
+    exists: true,
+    status: "present",
+    createdAt: "2026-01-02T00:00:00.000Z",
+    updatedAt: "2026-01-03T00:00:00.000Z",
+    lastSeenSize: 42,
+    ...overrides,
+  }
+}
+
+function bookMeta(overrides: Partial<MockBookMeta> = {}): MockBookMeta {
+  return {
+    version: 1,
+    sourceFormat: "epub",
+    title: "Three Kingdoms",
+    authors: ["Luo Guanzhong"],
+    language: "zh-CN",
+    identifier: null,
+    publisher: "Publisher",
+    publishedAt: "1500",
+    description: null,
+    ...overrides,
+  }
+}
+
+function chapter(chapterId: number, stage: MockChapter["stage"], words: number): MockChapter {
+  return {
+    chapterId,
+    childCount: 0,
+    depth: 0,
+    documentOrder: chapterId,
+    fragmentCount: 1,
+    key: `chapter-${chapterId}`,
+    path: `${chapterId}`,
+    stage,
+    title: `Chapter ${chapterId}`,
+    tocPath: [],
+    uri: `wikg://chapter/${chapterId}`,
+    words,
+  }
+}
+
+beforeEach(() => {
+  sdk.addRecord = archiveRecord()
+  sdk.archives = [
+    archiveRecord({ publicId: "public-archive", uri: "wikg://lib/arc/public-archive" }),
+    archiveRecord({ exists: false, publicId: "missing", status: "missing", uri: "wikg://lib/arc/missing" }),
+  ]
+  sdk.calls = { add: [], archiveFiles: [], getArchive: [], list: [], rebind: [], remove: [], runtimeStateDirs: [] }
+  sdk.chapters = []
+  sdk.cover = undefined
+  sdk.failCover = false
+  sdk.failGetArchive = undefined
+  sdk.ftsCurrent = false
+  sdk.indexSettings = { ftsEmbedded: false }
+  sdk.meta = undefined
+  sdk.serials = new Map()
+})
+
 describe("WikiGraph SDK adapter", () => {
-  it("uses SDK stateDir and strips dangerous WikiGraph runtime env overrides", async () => {
+  it("uses SDK stateDir and binds the default library to Wanta managed storage", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const previousStateDir = process.env.WIKIGRAPH_STATE_DIR
-    const previousDev = process.env.WIKIGRAPH_DEV
-    process.env.WIKIGRAPH_STATE_DIR = "/unsafe/state"
-    process.env.WIKIGRAPH_DEV = "/unsafe/dev"
-    const calls: RunWikiGraphCLIInput[] = []
-    const runCLI: WikiGraphCLIRunner = vi.fn(async (input) => {
-      calls.push(input)
-      input.stdout?.write('{"items":[]}')
-      return { exitCode: 0 }
-    })
+    const rt = runtime(dir)
 
-    try {
-      await runWikiGraphJson(
-        runtime(dir),
-        ["wikg://lib/path", "set", path.join(dir, "library"), "--json"],
-        1000,
-        runCLI,
-      )
-    } finally {
-      if (previousStateDir === undefined) delete process.env.WIKIGRAPH_STATE_DIR
-      else process.env.WIKIGRAPH_STATE_DIR = previousStateDir
-      if (previousDev === undefined) delete process.env.WIKIGRAPH_DEV
-      else process.env.WIKIGRAPH_DEV = previousDev
-    }
+    await prepareWikiGraphDefaultLibrary(rt)
 
-    expect(calls).toEqual([
+    expect(sdk.calls.runtimeStateDirs).toEqual([rt.stateDir])
+    expect(sdk.calls.rebind).toEqual([
+      {
+        folderPath: rt.managedLibraryDir,
+        target: { kind: "mock", uri: "wikg://lib" },
+      },
+    ])
+  })
+
+  it("lists default library archives using SDK publicId as the Wanta-facing id", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+
+    const archives = await listWikiGraphLibraryArchives(runtime(dir))
+
+    expect(archives).toEqual([
       expect.objectContaining({
-        argv: ["wikg://lib/path", "set", path.join(dir, "library"), "--json"],
-        env: expect.objectContaining({
-          NO_COLOR: "1",
-          WIKIGRAPH_DEV: undefined,
-          WIKIGRAPH_ENV_POLICY: undefined,
-          WIKIGRAPH_QUEUE_DISABLE_AUTOSTART: undefined,
-          WIKIGRAPH_STATE_DIR: undefined,
-        }),
-        stateDir: path.join(dir, "wikigraph-state"),
+        id: "public-archive",
+        path: "/managed/library/copy.wikg",
+        uri: "wikg://lib/arc/public-archive",
       }),
     ])
+    expect(archives[0]?.id).not.toBe("123")
+    expect(sdk.calls.list).toEqual([{ kind: "mock", uri: "wikg://lib/arc" }])
   })
 
-  it("lists default lib archives and filters missing members", async () => {
+  it("copy-imports archives into the managed library and returns SDK publicId", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const commands: string[][] = []
-    const runCLI: WikiGraphCLIRunner = vi.fn(async (input) => {
-      const command = [...(input.argv ?? [])]
-      commands.push(command)
-      if (command[0] === "wikg://lib/path") {
-        input.stdout?.write('{"items":[]}')
-      } else if (command[0] === "wikg://lib/arc/tree") {
-        input.stdout?.write(
-          JSON.stringify({
-            items: [
-              { children: [], name: "present.wikg", path: "present.wikg", uri: "wikg://lib/arc/present" },
-              {
-                children: [
-                  { children: [], name: "missing.wikg", path: "old/missing.wikg", uri: "wikg://lib/arc/missing" },
-                ],
-                name: "old",
-                path: "old",
-              },
-            ],
-          }),
-        )
-      } else if (command[0] === "wikg://lib/arc/present") {
-        input.stdout?.write(JSON.stringify({ exists: true, id: "present", uri: "wikg://lib/arc/present" }))
-      } else if (command[0] === "wikg://lib/arc/missing") {
-        input.stdout?.write(JSON.stringify({ exists: false, id: "missing", uri: "wikg://lib/arc/missing" }))
-      } else {
-        input.stdout?.write("{}")
-      }
-      return { exitCode: 0 }
-    })
-
-    const archives = await listWikiGraphLibraryArchives(runtime(dir), runCLI)
-
-    expect(archives.map((item) => item.id)).toEqual(["present"])
-    expect(commands).toContainEqual(["wikg://lib/arc/tree", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/present", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/missing", "--json"])
-    expect(commands).not.toContainEqual(["wikg://lib/arc", "scan", "--json"])
-  })
-
-  it("copy-imports archives without saving the original source path as the source of truth", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const source = path.join(dir, "original.wikg")
+    const source = path.join(dir, "Original Book.wikg")
     await writeFile(source, "archive")
-    const commands: string[][] = []
-    const runCLI: WikiGraphCLIRunner = vi.fn(async (input) => {
-      commands.push([...(input.argv ?? [])])
-      input.stdout?.write(
-        commands.length === 1
-          ? '{"items":[]}'
-          : JSON.stringify({
-              id: "imported",
-              path: path.join(dir, "wikigraph-state", "library", "copy.wikg"),
-              relativePath: "copy.wikg",
-              uri: "wikg://lib/arc/imported",
-            }),
-      )
-      return { exitCode: 0 }
+    sdk.addRecord = archiveRecord({
+      id: 99,
+      publicId: "imported-public-id",
+      relativePath: "Original-Book-copy.wikg",
+      uri: "wikg://lib/arc/imported-public-id",
     })
 
-    const imported = await addWikiGraphLibraryArchive(runtime(dir), source, runCLI)
+    const imported = await addWikiGraphLibraryArchive(runtime(dir), source)
 
-    expect(imported).toMatchObject({ id: "imported", relativePath: "copy.wikg", uri: "wikg://lib/arc/imported" })
-    expect(imported.path).not.toBe(source)
-    expect(commands[1]).toEqual([
-      "wikg://lib/arc",
-      "add",
-      "--input",
-      source,
-      "--to",
-      expect.stringMatching(/original-.+\.wikg/u),
-      "--json",
+    expect(imported).toMatchObject({ id: "imported-public-id", uri: "wikg://lib/arc/imported-public-id" })
+    expect(imported.id).not.toBe("99")
+    expect(sdk.calls.add).toEqual([
+      {
+        inputPath: source,
+        target: { kind: "mock", uri: "wikg://lib/arc" },
+        to: expect.stringMatching(/^Original-Book-.+\.wikg$/u),
+      },
     ])
   })
 
-  it("builds remove, inspect, index, query, and cover SDK arguments", async () => {
+  it("removes archives by the public archive URI", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const commands: string[][] = []
-    const runCLIJson: WikiGraphCLIRunner = vi.fn(async (input) => {
-      commands.push([...(input.argv ?? [])])
-      input.stdout?.write("{}")
-      return { exitCode: 0 }
-    })
-    const runCLI: WikiGraphCLIRunner = vi.fn(async (input) => {
-      commands.push([...(input.argv ?? [])])
-      input.stdout?.write(Buffer.from([0, 159, 255, 10]))
-      return { exitCode: 0 }
-    })
 
-    await runWikiGraphJson(runtime(dir), ["wikg://lib/arc/archive", "inspect", "--json"], 1000, runCLIJson)
-    await readWikiGraphMetadata(runtime(dir), "archive", runCLIJson)
-    await readWikiGraphIndex(runtime(dir), "archive", runCLIJson)
-    await runWikiGraphJson(
-      runtime(dir),
-      ["wikg://lib/arc/archive/chapter", "--query", "term", "--json"],
-      1000,
-      runCLIJson,
+    await removeWikiGraphLibraryArchive(runtime(dir), "public-archive")
+
+    expect(sdk.calls.remove).toEqual([{ target: { kind: "mock", uri: "wikg://lib/arc/public-archive" } }])
+  })
+
+  it("reads metadata, cover, inspect capabilities, statistics, and index state through SDK APIs", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+    sdk.meta = bookMeta()
+    sdk.cover = { data: Uint8Array.from([1, 2, 3]), mediaType: "image/png", path: "cover.png" }
+    sdk.chapters = [
+      chapter(1, "planned", 100),
+      chapter(2, "sourced", 10),
+      chapter(3, "graphed", 20),
+      chapter(4, "summarized", 30),
+    ]
+    sdk.serials = new Map([
+      [2, { topologyReady: true }],
+      [3, { knowledgeGraphReady: true }],
+      [4, { knowledgeGraphReady: true, topologyReady: true }],
+    ])
+    sdk.ftsCurrent = true
+    sdk.indexSettings = { ftsEmbedded: true }
+    const rt = runtime(dir)
+
+    await expect(readWikiGraphMetadata(rt, "public-archive")).resolves.toEqual({
+      authors: ["Luo Guanzhong"],
+      language: "zh-CN",
+      publishedAt: "1500",
+      publisher: "Publisher",
+      title: "Three Kingdoms",
+    })
+    await expect(readWikiGraphCover(rt, "public-archive")).resolves.toEqual(Buffer.from([1, 2, 3]))
+    await expect(inspectWikiGraph(rt, "public-archive")).resolves.toEqual({
+      content: { chapters: { content: 3, total: 4 }, sourceWords: 60 },
+      coverage: {
+        knowledgeGraph: { coveredWords: 50, totalWords: 60 },
+        readingGraph: { coveredWords: 40, totalWords: 60 },
+        summary: { coveredWords: 30, totalWords: 60 },
+      },
+      index: { current: true, querySupport: true },
+    })
+    await expect(readWikiGraphIndex(rt, "public-archive")).resolves.toEqual({
+      current: true,
+      ftsCurrent: true,
+      querySupport: true,
+      status: "current",
+    })
+  })
+
+  it("downgrades missing or failed cover reads to null", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+    sdk.failCover = true
+
+    await expect(readWikiGraphCover(runtime(dir), "public-archive")).resolves.toBeNull()
+  })
+
+  it("redacts managed storage paths and archive handles from SDK errors", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+    const rt = runtime(dir)
+    sdk.failGetArchive = new Error(
+      `failed at ${path.join(rt.stateDir, "cache")} and ${path.join(rt.managedLibraryDir, "book.wikg")} for wikg://lib/arc/book`,
     )
-    await removeWikiGraphLibraryArchive(runtime(dir), "archive", runCLIJson)
-    const cover = await readWikiGraphCover(runtime(dir), "archive", runCLI)
 
-    expect(commands).toContainEqual(["wikg://lib/arc/archive", "inspect", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/archive/meta", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/archive/chapter", "--query", "term", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/archive", "remove", "--confirm", "--json"])
-    expect(commands).toContainEqual(["wikg://lib/arc/archive/cover"])
-    expect(cover).toEqual(Buffer.from([0, 159, 255, 10]))
+    await expect(readWikiGraphMetadata(rt, "book")).rejects.toThrow("[WikiGraph managed storage]")
+    await expect(readWikiGraphMetadata(rt, "book")).rejects.not.toThrow(dir)
+    await expect(readWikiGraphMetadata(rt, "book")).rejects.not.toThrow("wikg://lib/arc/book")
   })
 
   it("requires non-zero covered and total words", () => {
     expect(wikiGraphCoverageReady({ coveredWords: 12, totalWords: 20 })).toBe(true)
     expect(wikiGraphCoverageReady({ coveredWords: 0, totalWords: 20 })).toBe(false)
     expect(wikiGraphCoverageReady(undefined)).toBe(false)
-  })
-
-  it("redacts managed storage paths and archive URIs from SDK errors", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const runCLI: WikiGraphCLIRunner = vi.fn(async () => {
-      throw new Error(
-        `failed at ${path.join(dir, "wikigraph-state", "cache")} and ${path.join(dir, "wikigraph-state", "library", "book.wikg")} for wikg://lib/arc/book`,
-      )
-    })
-
-    await expect(
-      runWikiGraphJson(runtime(dir), ["wikg://lib/arc/book", "inspect", "--json"], 1000, runCLI),
-    ).rejects.toThrow("[WikiGraph managed storage]")
-    await expect(
-      runWikiGraphJson(runtime(dir), ["wikg://lib/arc/book", "inspect", "--json"], 1000, runCLI),
-    ).rejects.not.toThrow(dir)
-    await expect(
-      runWikiGraphJson(runtime(dir), ["wikg://lib/arc/book", "inspect", "--json"], 1000, runCLI),
-    ).rejects.not.toThrow("wikg://lib/arc/book")
-  })
-
-  it("rejects oversized JSON output while the SDK runner is still writing stdout", async () => {
-    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
-    const runCLI: WikiGraphCLIRunner = vi.fn(async (input) => {
-      await new Promise<void>((resolve, reject) => {
-        input.stdout?.write(Buffer.alloc(8 * 1024 * 1024 + 1, "{"), (error: Error | null | undefined) => {
-          if (error) reject(error)
-          else resolve()
-        })
-      })
-      return { exitCode: 0 }
-    })
-
-    await expect(
-      runWikiGraphJson(runtime(dir), ["wikg://lib/arc/book", "inspect", "--json"], 1000, runCLI),
-    ).rejects.toThrow("WikiGraph output exceeded the buffer limit")
   })
 })

--- a/electron/knowledge/runner.ts
+++ b/electron/knowledge/runner.ts
@@ -1,21 +1,22 @@
-import type { RunWikiGraphCLIInput } from "wiki-graph"
+import type { BookMeta, ReadonlyDocument, WikiGraphLibraryArchiveRecord } from "wiki-graph-core"
 
 import { mkdir, stat } from "node:fs/promises"
 import path from "node:path"
-import { Writable } from "node:stream"
-import { runWikiGraphCLI } from "wiki-graph"
+import {
+  addWikiGraphLibraryArchive as addWikiGraphLibraryArchiveWithSDK,
+  getWikiGraphLibraryArchive,
+  isArchiveSearchIndexCurrent,
+  listChapters,
+  listWikiGraphLibraryArchives as listWikiGraphLibraryArchivesWithSDK,
+  parseWikiGraphLibraryUri,
+  readArchiveIndexSettings,
+  rebindWikiGraphLibrary,
+  removeWikiGraphLibraryArchive as removeWikiGraphLibraryArchiveWithSDK,
+  WikiGraphArchiveFile,
+  withWikiGraphRuntimeStateDirectoryPath,
+} from "wiki-graph-core"
 
-const metadataTimeoutMs = 30_000
-const queryTimeoutMs = 60_000
-const maxJsonBytes = 8 * 1024 * 1024
-const maxCoverBytes = 4 * 1024 * 1024
 const defaultLibraryUri = "wikg://lib"
-const dangerousWikiGraphEnvNames = [
-  "WIKIGRAPH_DEV",
-  "WIKIGRAPH_ENV_POLICY",
-  "WIKIGRAPH_QUEUE_DISABLE_AUTOSTART",
-  "WIKIGRAPH_STATE_DIR",
-] as const
 
 export interface WikiGraphRuntime {
   managedLibraryDir: string
@@ -32,11 +33,6 @@ export interface WikiGraphLibraryArchive {
   exists?: boolean
   status?: string
   lastSeenSize?: number
-}
-
-interface WikiGraphArchiveTreeNode {
-  uri?: string
-  children?: unknown[]
 }
 
 export interface WikiGraphMetadata {
@@ -67,20 +63,12 @@ export interface WikiGraphIndexState {
   status?: string
 }
 
-export type WikiGraphCLIRunner = (input: RunWikiGraphCLIInput) => Promise<{ exitCode: number }>
-
-function runtimeEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: "1" }
-  for (const name of dangerousWikiGraphEnvNames) env[name] = undefined
-  return env
-}
-
-function parseJson<T>(stdout: string, label: string): T {
-  try {
-    return JSON.parse(stdout) as T
-  } catch (error) {
-    throw new Error(`WikiGraph returned invalid ${label} JSON`, { cause: error })
-  }
+interface InspectChapter {
+  knowledgeGraphReady: boolean
+  readingGraphReady: boolean
+  stage: string
+  summaryReady: boolean
+  words: number
 }
 
 function redactWikiGraphRuntimePaths(runtime: WikiGraphRuntime, value: string): string {
@@ -101,46 +89,38 @@ function wikiGraphError(runtime: WikiGraphRuntime, fallback: string, error: unkn
 }
 
 function archiveUri(id: string): string {
-  return `${defaultLibraryUri}/arc/${id}`
+  return `${defaultLibraryUri}/arc/${encodeURIComponent(id)}`
 }
 
-function isArchive(value: unknown): value is WikiGraphLibraryArchive {
-  if (!value || typeof value !== "object") return false
-  const item = value as Partial<WikiGraphLibraryArchive>
-  return typeof item.id === "string" && item.id.trim() !== "" && typeof item.uri === "string" && item.uri.trim() !== ""
+function requireLibraryTarget(uri: string) {
+  const target = parseWikiGraphLibraryUri(uri)
+  if (!target) throw new Error(`Invalid WikiGraph library URI: ${uri}`)
+  return target
 }
 
-function archiveIdFromUri(uri: string): string | null {
-  const match = /^wikg:\/\/lib\/arc\/([^/]+)\/?$/u.exec(uri.trim())
-  return match ? decodeURIComponent(match[1]) : null
+function archiveFromRecord(record: WikiGraphLibraryArchiveRecord): WikiGraphLibraryArchive {
+  return {
+    id: record.publicId,
+    uri: record.uri,
+    path: record.path,
+    relativePath: record.relativePath,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    exists: record.exists,
+    status: record.status,
+    lastSeenSize: record.lastSeenSize,
+  }
 }
 
-function parseArchiveTreeIds(value: unknown): string[] {
-  const ids = new Set<string>()
-  const visit = (node: unknown): void => {
-    if (!node || typeof node !== "object") return
-    const item = node as WikiGraphArchiveTreeNode
-    if (typeof item.uri === "string") {
-      const id = archiveIdFromUri(item.uri)
-      if (id) ids.add(id)
-    }
-    if (Array.isArray(item.children)) {
-      for (const child of item.children) visit(child)
-    }
+function metadataFromBookMeta(meta: BookMeta | undefined): WikiGraphMetadata {
+  if (!meta) return {}
+  return {
+    ...(meta.title ? { title: meta.title } : {}),
+    authors: meta.authors,
+    ...(meta.publisher ? { publisher: meta.publisher } : {}),
+    ...(meta.publishedAt ? { publishedAt: meta.publishedAt } : {}),
+    ...(meta.language ? { language: meta.language } : {}),
   }
-
-  if (Array.isArray(value)) {
-    for (const item of value) visit(item)
-    return [...ids]
-  }
-
-  const items = value && typeof value === "object" ? (value as { items?: unknown }).items : undefined
-  if (Array.isArray(items)) {
-    for (const item of items) visit(item)
-  } else {
-    visit(value)
-  }
-  return [...ids]
 }
 
 function safeImportTarget(sourcePath: string): string {
@@ -153,77 +133,40 @@ function safeImportTarget(sourcePath: string): string {
   return `${base || "archive"}-${Date.now().toString(36)}.wikg`
 }
 
-export async function prepareWikiGraphDefaultLibrary(
-  runtime: WikiGraphRuntime,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<void> {
-  await mkdir(runtime.stateDir, { recursive: true })
-  await mkdir(runtime.managedLibraryDir, { recursive: true })
-  await runWikiGraphJson<unknown>(
-    runtime,
-    ["wikg://lib/path", "set", runtime.managedLibraryDir, "--json"],
-    metadataTimeoutMs,
-    runCLI,
-  )
-}
-
-export async function runWikiGraphJson<T>(
-  runtime: WikiGraphRuntime,
-  args: string[],
-  timeout = queryTimeoutMs,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<T> {
+async function withRuntime<T>(runtime: WikiGraphRuntime, fallback: string, operation: () => Promise<T>): Promise<T> {
   try {
-    const stdout = new LimitedBufferWritable(maxJsonBytes)
-    const stderr = new LimitedBufferWritable(maxJsonBytes)
-    const result = await runWithTimeout(timeout, (signal) => {
-      return runCLI({
-        argv: args,
-        env: runtimeEnv(),
-        signal,
-        stateDir: runtime.stateDir,
-        stderr,
-        stdout,
-      })
-    })
-    const stdoutText = stdout.text
-    const stderrText = stderr.text
-    if (result.exitCode !== 0) throw new Error(stderrText.trim() || stdoutText.trim() || "WikiGraph command failed")
-    return parseJson<T>(stdoutText, args.join(" "))
+    return await withWikiGraphRuntimeStateDirectoryPath(runtime.stateDir, operation)
   } catch (error) {
-    throw wikiGraphError(runtime, "WikiGraph command failed", error)
+    throw wikiGraphError(runtime, fallback, error)
   }
 }
 
-export async function listWikiGraphLibraryArchives(
-  runtime: WikiGraphRuntime,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<WikiGraphLibraryArchive[]> {
-  await prepareWikiGraphDefaultLibrary(runtime, runCLI)
-  const tree = await runWikiGraphJson<unknown>(
-    runtime,
-    [`${defaultLibraryUri}/arc/tree`, "--json"],
-    metadataTimeoutMs,
-    runCLI,
-  )
-  const archives = await Promise.all(
-    parseArchiveTreeIds(tree).map((id) => {
-      return runWikiGraphJson<unknown>(runtime, [archiveUri(id), "--json"], metadataTimeoutMs, runCLI)
-    }),
-  )
-  return archives
-    .flatMap((item) => (isArchive(item) ? [item] : []))
-    .filter((item) => {
-      return item.exists !== false && item.status !== "missing"
+export async function prepareWikiGraphDefaultLibrary(runtime: WikiGraphRuntime): Promise<void> {
+  await mkdir(runtime.stateDir, { recursive: true })
+  await mkdir(runtime.managedLibraryDir, { recursive: true })
+  await withRuntime(runtime, "Failed to prepare WikiGraph library", async () => {
+    await rebindWikiGraphLibrary({
+      folderPath: runtime.managedLibraryDir,
+      target: requireLibraryTarget(defaultLibraryUri),
     })
+  })
+}
+
+export async function listWikiGraphLibraryArchives(runtime: WikiGraphRuntime): Promise<WikiGraphLibraryArchive[]> {
+  await prepareWikiGraphDefaultLibrary(runtime)
+  return await withRuntime(runtime, "Failed to list WikiGraph library archives", async () => {
+    const records = await listWikiGraphLibraryArchivesWithSDK(requireLibraryTarget(`${defaultLibraryUri}/arc`))
+    return records
+      .filter((item) => item.exists !== false && item.status !== "missing")
+      .map((item) => archiveFromRecord(item))
+  })
 }
 
 export async function addWikiGraphLibraryArchive(
   runtime: WikiGraphRuntime,
   sourcePath: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
 ): Promise<WikiGraphLibraryArchive> {
-  await prepareWikiGraphDefaultLibrary(runtime, runCLI)
+  await prepareWikiGraphDefaultLibrary(runtime)
   let source
   try {
     source = await stat(sourcePath)
@@ -231,126 +174,122 @@ export async function addWikiGraphLibraryArchive(
     throw new Error("Knowledge base file is unavailable", { cause: error })
   }
   if (!source.isFile()) throw new Error("Knowledge base must be a regular file")
-  const imported = await runWikiGraphJson<unknown>(
-    runtime,
-    [`${defaultLibraryUri}/arc`, "add", "--input", sourcePath, "--to", safeImportTarget(sourcePath), "--json"],
-    metadataTimeoutMs,
-    runCLI,
-  )
-  if (!isArchive(imported)) throw new Error("WikiGraph did not return an imported archive")
-  return imported
+  return await withRuntime(runtime, "Failed to import WikiGraph archive", async () => {
+    const imported = await addWikiGraphLibraryArchiveWithSDK({
+      inputPath: sourcePath,
+      target: requireLibraryTarget(`${defaultLibraryUri}/arc`),
+      to: safeImportTarget(sourcePath),
+    })
+    return archiveFromRecord(imported)
+  })
 }
 
-export async function removeWikiGraphLibraryArchive(
-  runtime: WikiGraphRuntime,
-  id: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<void> {
+export async function removeWikiGraphLibraryArchive(runtime: WikiGraphRuntime, id: string): Promise<void> {
   const normalizedId = id.trim()
   if (!normalizedId) return
-  await prepareWikiGraphDefaultLibrary(runtime, runCLI)
-  await runWikiGraphJson<unknown>(
-    runtime,
-    [archiveUri(normalizedId), "remove", "--confirm", "--json"],
-    metadataTimeoutMs,
-    runCLI,
-  )
+  await prepareWikiGraphDefaultLibrary(runtime)
+  await withRuntime(runtime, "Failed to remove WikiGraph archive", async () => {
+    await removeWikiGraphLibraryArchiveWithSDK({ target: requireLibraryTarget(archiveUri(normalizedId)) })
+  })
 }
 
-export async function readWikiGraphMetadata(
-  runtime: WikiGraphRuntime,
-  id: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<WikiGraphMetadata> {
-  return runWikiGraphJson<WikiGraphMetadata>(runtime, [`${archiveUri(id)}/meta`, "--json"], metadataTimeoutMs, runCLI)
+export async function readWikiGraphMetadata(runtime: WikiGraphRuntime, id: string): Promise<WikiGraphMetadata> {
+  const file = await archiveFile(runtime, id)
+  return await withRuntime(runtime, "Failed to read WikiGraph metadata", async () => {
+    return await file.read(async (archive) => metadataFromBookMeta(await archive.readMeta()))
+  })
 }
 
-export async function inspectWikiGraph(
-  runtime: WikiGraphRuntime,
-  id: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<WikiGraphInspect> {
-  return runWikiGraphJson<WikiGraphInspect>(runtime, [archiveUri(id), "inspect", "--json"], metadataTimeoutMs, runCLI)
+export async function inspectWikiGraph(runtime: WikiGraphRuntime, id: string): Promise<WikiGraphInspect> {
+  const file = await archiveFile(runtime, id)
+  return await withRuntime(runtime, "Failed to inspect WikiGraph archive", async () => {
+    return await file.readDocument(async (document) => {
+      const [chapters, ftsCurrent] = await Promise.all([
+        readInspectChapters(document),
+        isArchiveSearchIndexCurrent(document),
+      ])
+      const contentChapters = chapters.filter((chapter) => chapter.stage !== "planned")
+      const readingGraphCovered = contentChapters.filter((chapter) => chapter.readingGraphReady)
+      const knowledgeGraphCovered = contentChapters.filter((chapter) => chapter.knowledgeGraphReady)
+      const summaryCovered = contentChapters.filter((chapter) => chapter.summaryReady)
+      return {
+        content: {
+          chapters: { content: contentChapters.length, total: chapters.length },
+          sourceWords: sumWords(contentChapters),
+        },
+        index: { current: ftsCurrent, querySupport: ftsCurrent },
+        coverage: {
+          knowledgeGraph: inspectCoverage(knowledgeGraphCovered, contentChapters),
+          readingGraph: inspectCoverage(readingGraphCovered, contentChapters),
+          summary: inspectCoverage(summaryCovered, contentChapters),
+        },
+      }
+    })
+  })
 }
 
-export async function readWikiGraphIndex(
-  runtime: WikiGraphRuntime,
-  id: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<WikiGraphIndexState> {
-  return runWikiGraphJson<WikiGraphIndexState>(
-    runtime,
-    [`${archiveUri(id)}/index`, "--json"],
-    metadataTimeoutMs,
-    runCLI,
-  )
+export async function readWikiGraphIndex(runtime: WikiGraphRuntime, id: string): Promise<WikiGraphIndexState> {
+  const file = await archiveFile(runtime, id)
+  return await withRuntime(runtime, "Failed to read WikiGraph index state", async () => {
+    return await file.readDocument(async (document) => {
+      await readArchiveIndexSettings(document)
+      const ftsCurrent = await isArchiveSearchIndexCurrent(document)
+      return {
+        current: ftsCurrent,
+        ftsCurrent,
+        querySupport: ftsCurrent,
+        status: ftsCurrent ? "current" : "missing-or-outdated",
+      }
+    })
+  })
 }
 
-export async function readWikiGraphCover(
-  runtime: WikiGraphRuntime,
-  id: string,
-  runCLI: WikiGraphCLIRunner = runWikiGraphCLI,
-): Promise<Buffer | null> {
+export async function readWikiGraphCover(runtime: WikiGraphRuntime, id: string): Promise<Buffer | null> {
   try {
-    const stdout = new LimitedBufferWritable(maxCoverBytes)
-    const result = await runWithTimeout(metadataTimeoutMs, (signal) => {
-      return runCLI({
-        argv: [`${archiveUri(id)}/cover`],
-        env: runtimeEnv(),
-        signal,
-        stateDir: runtime.stateDir,
-        stdout,
+    const file = await archiveFile(runtime, id)
+    return await withRuntime(runtime, "Failed to read WikiGraph cover", async () => {
+      return await file.read(async (archive) => {
+        const cover = await archive.readCover()
+        return cover ? Buffer.from(cover.data) : null
       })
     })
-    const buffer = stdout.buffer
-    return result.exitCode === 0 && buffer.length > 0 ? buffer : null
   } catch {
     return null
   }
 }
 
-async function runWithTimeout<T>(timeout: number, run: (signal: AbortSignal) => Promise<T>): Promise<T> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(new Error("WikiGraph command timed out")), timeout)
-  try {
-    return await run(controller.signal)
-  } finally {
-    clearTimeout(timer)
-  }
+async function archiveFile(runtime: WikiGraphRuntime, id: string): Promise<WikiGraphArchiveFile> {
+  await prepareWikiGraphDefaultLibrary(runtime)
+  return await withRuntime(runtime, "Failed to resolve WikiGraph archive", async () => {
+    const archive = await getWikiGraphLibraryArchive(requireLibraryTarget(archiveUri(id.trim())))
+    return new WikiGraphArchiveFile(archive.path)
+  })
 }
 
-class LimitedBufferWritable extends Writable {
-  private readonly maxBytes: number
-  readonly #chunks: Buffer[] = []
-  #size = 0
+async function readInspectChapters(document: ReadonlyDocument): Promise<InspectChapter[]> {
+  return await Promise.all(
+    (await listChapters(document)).map(async (chapter) => {
+      const serial = await document.serials.getById(chapter.chapterId)
+      return {
+        knowledgeGraphReady: serial?.knowledgeGraphReady === true,
+        readingGraphReady: serial?.topologyReady === true,
+        stage: chapter.stage,
+        summaryReady: chapter.stage === "summarized",
+        words: chapter.words,
+      }
+    }),
+  )
+}
 
-  public constructor(maxBytes: number) {
-    super()
-    this.maxBytes = maxBytes
-  }
+function inspectCoverage(
+  covered: InspectChapter[],
+  total: InspectChapter[],
+): { coveredWords: number; totalWords: number } {
+  return { coveredWords: sumWords(covered), totalWords: sumWords(total) }
+}
 
-  public get buffer(): Buffer {
-    return Buffer.concat(this.#chunks, this.#size)
-  }
-
-  public get text(): string {
-    return this.buffer.toString("utf8")
-  }
-
-  public override _write(
-    chunk: Buffer | string,
-    encoding: BufferEncoding,
-    callback: (error?: Error | null) => void,
-  ): void {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
-    this.#size += buffer.length
-    if (this.#size > this.maxBytes) {
-      callback(new Error("WikiGraph output exceeded the buffer limit"))
-      return
-    }
-    this.#chunks.push(buffer)
-    callback()
-  }
+function sumWords(chapters: InspectChapter[]): number {
+  return chapters.reduce((sum, chapter) => sum + chapter.words, 0)
 }
 
 export function wikiGraphCoverageReady(coverage: { coveredWords?: number; totalWords?: number } | undefined): boolean {

--- a/electron/knowledge/runner.ts
+++ b/electron/knowledge/runner.ts
@@ -17,6 +17,7 @@ import {
 } from "wiki-graph-core"
 
 const defaultLibraryUri = "wikg://lib"
+const defaultLibraryPreparationByStateDir = new Map<string, Promise<void>>()
 
 export interface WikiGraphRuntime {
   managedLibraryDir: string
@@ -142,14 +143,22 @@ async function withRuntime<T>(runtime: WikiGraphRuntime, fallback: string, opera
 }
 
 export async function prepareWikiGraphDefaultLibrary(runtime: WikiGraphRuntime): Promise<void> {
-  await mkdir(runtime.stateDir, { recursive: true })
-  await mkdir(runtime.managedLibraryDir, { recursive: true })
-  await withRuntime(runtime, "Failed to prepare WikiGraph library", async () => {
+  const cached = defaultLibraryPreparationByStateDir.get(runtime.stateDir)
+  if (cached) return await cached
+
+  const preparation = withRuntime(runtime, "Failed to prepare WikiGraph library", async () => {
+    await mkdir(runtime.stateDir, { recursive: true })
+    await mkdir(runtime.managedLibraryDir, { recursive: true })
     await rebindWikiGraphLibrary({
       folderPath: runtime.managedLibraryDir,
       target: requireLibraryTarget(defaultLibraryUri),
     })
+  }).catch((error: unknown) => {
+    defaultLibraryPreparationByStateDir.delete(runtime.stateDir)
+    throw error
   })
+  defaultLibraryPreparationByStateDir.set(runtime.stateDir, preparation)
+  return await preparation
 }
 
 export async function listWikiGraphLibraryArchives(runtime: WikiGraphRuntime): Promise<WikiGraphLibraryArchive[]> {
@@ -245,8 +254,8 @@ export async function readWikiGraphIndex(runtime: WikiGraphRuntime, id: string):
 }
 
 export async function readWikiGraphCover(runtime: WikiGraphRuntime, id: string): Promise<Buffer | null> {
+  const file = await archiveFile(runtime, id)
   try {
-    const file = await archiveFile(runtime, id)
     return await withRuntime(runtime, "Failed to read WikiGraph cover", async () => {
       return await file.read(async (archive) => {
         const cover = await archive.readCover()


### PR DESCRIPTION
## Summary
- Replaces the app-side Knowledge WikiGraph adapter with direct `wiki-graph-core` SDK calls for library binding, archive membership, metadata, cover, inspect/statistics, and index state.
- Keeps the Agent-facing managed `wg` shim untouched; `wiki-graph` / `runWikiGraphCLI` remains only in `electron/knowledge/wg.ts` for sidecar CLI access.
- Adds SDK adapter tests plus KnowledgeService degradation coverage for inspect/index failures, and updates architecture docs to clarify App SDK vs Agent `wg` boundaries.

Closes #250

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run electron/knowledge/node.test.ts electron/knowledge/runner.test.ts electron/knowledge/thumbnail.test.ts electron/agent/wikigraph-bin.test.ts electron/agent/agent.test.ts` → 5 files / 40 tests passed
- `corepack pnpm run ts-check` → passed
- `corepack pnpm run lint` → passed
- `corepack pnpm run format` → passed
- `corepack pnpm run test` → 265 files / 1950 tests passed (run with `CODEX_HOME=` locally because this machine exports `CODEX_HOME=/Users/taozeyu/.codex` without a `skills` directory, which trips an unrelated agent-discovery fixture)
- `pnpm run build` → passed
- Static added-line security scan for hardcoded secret/eval/exec/shell/SQL patterns → 0 findings

## CodeRabbit follow-up
- Addressed all 3 actionable CodeRabbit comments from the post-evidence review:
  - `prepareWikiGraphDefaultLibrary` now wraps directory creation in the same WikiGraph error/redaction path.
  - preparation is cached per `runtime.stateDir` for concurrent/subsequent SDK operations and resets on failure.
  - `readWikiGraphCover` now only downgrades cover-read failures to `null`; archive resolution failures propagate.
- Added/updated tests for concurrent preparation reuse and cover archive-resolution propagation.

## Runtime / regression evidence
- SDK smoke, independent of global WikiGraph home: `WIKIGRAPH_STATE_DIR=/tmp/unsafe-global node --experimental-strip-types /tmp/wanta-sdk-smoke.ts`
  - Imported `/Users/taozeyu/Library/Mobile Documents/com~apple~CloudDocs/Documents/WIKG/三国演义.wikg` into a temp managed library.
  - Verified import/list/metadata/cover/inspect/remove; sample result: title `三国演义...`, 122 chapters, 426923 source words, cover bytes 122648, remove left 0 archives.
- Managed `wg` smoke: `node --experimental-strip-types /tmp/wanta-agent-wg-smoke.ts`
  - Ran `dist-electron/wanta-wg.js --wanta-state-dir <temp-state> -- wikg://lib/arc/<publicId> inspect --json` through Electron Node mode.
  - Verified managed CLI entrypoint still works and reported 122 chapters / 426923 source words.
- Electron dev startup / UI regression:
  - Started the renderer with `corepack pnpm run dev:no-electron`, then launched Electron with `WANTA_USER_DATA_DIR=<worktree>/wanta WANTA_SKIP_PROTOCOL_REGISTRATION=1 VITE_DEV_SERVER_URL=http://localhost:5273/ VITE_WANTA_ROUTE=knowledge VITE_WANTA_LOCALE=en ./.electron-dist/Electron.app/Contents/MacOS/Electron . --no-sandbox --remote-debugging-port=9222`.
  - Diagnostics log path: `<worktree>/wanta/logs/diagnostics.jsonl`; Electron main started and the agent sidecar reached `ready at http://127.0.0.1:4096`.
  - Knowledge beta was enabled in the dev profile. The Knowledge page rendered the imported `/Users/taozeyu/Library/Mobile Documents/com~apple~CloudDocs/Documents/WIKG/三国演义.wikg` archive with title/author/publisher, cover image data URL, `关系图已就绪`, and `122 个内容章节 · 426,923 字`.
  - Invoked the existing refresh (`重新检查`) and reveal (`显示文件`) actions from the Knowledge detail view; refresh preserved the same summary.
  - Captured Knowledge detail screenshot locally at `/tmp/wanta-regression-250/knowledge-detail.png`; the captured DOM/log summary above records the visible regression evidence for this PR.
- Chat pin / Agent `wg` boundary:
  - Clicking `使用此知识库新建对话` created a new chat with the pinned `当前知识库` bar showing the same 三国演义 knowledge base.
  - A new model turn in this headless CDP run failed before tool execution because the copied dev cookie could not be decrypted by macOS Keychain in the background launch (`errKCInteractionNotAllowed`) and OpenCode logged `Failed to fetch models.dev`; this is an environment/auth limitation of the headless run, not a KnowledgeService SDK regression.
  - The same dev profile contains prior pinned-knowledge chat evidence where the system prompt exposed only `wikg://lib/arc/90fbeceeb5c9` and tool records executed `wg "wikg://lib/arc/90fbeceeb5c9/..." ...`; in this run `<worktree>/wanta/agent/bin/wg` resolves to this worktree's `dist-electron/wanta-wg.js --wanta-state-dir <worktree>/wanta/wikigraph-state`, confirming the managed `wg` boundary remains intact.

## Notes / limitations
- Independent blind-review subagents were attempted and failed twice earlier because the provider returned HTTP 503. A fallback review plus static scans and all automated test/build verification passed; a fresh independent review was requested again after adding the CDP UI evidence.
- The current headless CDP chat send could not complete a fresh model/tool turn due the Keychain/model-fetch environment issue described above, but Knowledge page rendering, refresh/reveal, chat pin UI, SDK smoke, and managed `wg` smoke were verified.
