### PR TITLE
fix(chat): show WG bash calls as knowledge queries

### DIFF
--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -759,6 +759,7 @@ export const enMessages = {
   "chat.toolBashRunPythonScript": "Running Python script",
   "chat.toolBashReadContent": "Reading file content",
   "chat.toolBashFindFiles": "Finding files",
+  "chat.toolBashQueryKnowledge": "Searching knowledge...",
   "chat.toolRead": "Reading file: {detail}",
   "chat.toolReadGeneric": "Reading file",
   "chat.toolWrite": "Writing file: {detail}",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -721,6 +721,7 @@ export const zhCNMessages = {
   "chat.toolBashRunPythonScript": "运行 Python 脚本",
   "chat.toolBashReadContent": "读取文件内容",
   "chat.toolBashFindFiles": "查找文件",
+  "chat.toolBashQueryKnowledge": "正在查询知识库...",
   "chat.toolRead": "读取文件：{detail}",
   "chat.toolReadGeneric": "读取文件",
   "chat.toolWrite": "写入文件：{detail}",

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -79,6 +79,71 @@ describe("ToolActivityStep", () => {
     expect(html).toContain("w-full max-w-full min-w-0 overflow-hidden rounded-md")
   })
 
+  it("renders WG Bash knowledge calls without command details or an expand affordance", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-wg",
+      callId: "call-wg",
+      tool: "bash",
+      status: "completed",
+      input: { command: 'wg wikg://lib --query "唐僧" --json | jq .' },
+      output: "{}",
+    })
+
+    expect(html).toContain("正在查询知识库...")
+    expect(html).not.toContain("wg wikg://lib")
+    expect(html).not.toContain("jq .")
+    expect(html).not.toContain("工具参数")
+    expect(html).not.toContain("工具结果")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("renders consecutive WG Bash knowledge calls as compact knowledge rows", () => {
+    const html = [
+      renderToolActivityStep({
+        kind: "tool",
+        partId: "tool-wg-1",
+        callId: "call-wg-1",
+        tool: "bash",
+        status: "completed",
+        input: { command: 'wg wikg://lib/entity --query "唐僧" --json | jq .' },
+        output: "{}",
+      }),
+      renderToolActivityStep({
+        kind: "tool",
+        partId: "tool-wg-2",
+        callId: "call-wg-2",
+        tool: "bash",
+        status: "completed",
+        input: { command: 'wg wikg://lib/evidence --query "孙悟空" --json | jq .' },
+        output: "{}",
+      }),
+    ].join("\n")
+
+    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(2)
+    expect(html).not.toContain("wg wikg://lib")
+    expect(html).not.toContain("jq .")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("keeps the failed WG Bash status while hiding command details", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-wg-failed",
+      callId: "call-wg-failed",
+      tool: "bash",
+      status: "error",
+      input: { command: 'wg wikg://lib/entity --query "唐僧" --json | jq .' },
+      error: "exit code 1",
+    })
+
+    expect(html).toContain("正在查询知识库...")
+    expect(html).toContain("未完成")
+    expect(html).not.toContain("wg wikg://lib")
+    expect(html).not.toContain("jq .")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
   it("shimmers only the active web fetch title when the URL is shown inline", () => {
     const html = renderToolActivityStep({
       kind: "tool",

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -30,7 +30,7 @@ import * as React from "react"
 import { LoadingShimmerText } from "./LoadingShimmerText.tsx"
 import { shouldShowRunningNoOutput } from "./tool-activity.ts"
 import { shouldHideToolDetailsImmediately } from "./tool-details-visibility.ts"
-import { parseToolAuthorization, toolDisplayLine } from "./tool-display.ts"
+import { isWgKnowledgeBashPart, parseToolAuthorization, toolDisplayLine } from "./tool-display.ts"
 import { formatToolOutputPreview, toolOutputPreviewLimitChars } from "./tool-output-preview.ts"
 import { isActiveToolPart, isToolCancellation } from "./tool-state.ts"
 import { Button } from "@/components/ui/button"
@@ -255,7 +255,8 @@ export function ToolActivityStep({
   const activePart = isActiveToolPart(part)
   const stopped = isToolCancellation(part) || (!live && activePart)
   const answerSummary = questionAnswerSummary(part)
-  const details = hasToolDetails(part, auth, answerSummary, stopped)
+  const hideDetails = isWgKnowledgeBashPart(part)
+  const details = !hideDetails && hasToolDetails(part, auth, answerSummary, stopped)
   const [open, setOpen] = React.useState(false)
   const [detailsVisible, setDetailsVisible] = React.useState(false)
   const outputPreviewRef = React.useRef<{ output: string; text: string; truncated: boolean } | null>(null)

--- a/src/routes/Chat/tool-display.test.ts
+++ b/src/routes/Chat/tool-display.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  isWgKnowledgeBashPart,
   normalizeServiceSlug,
   parseToolAuthorization,
   toolActionSummary,
@@ -66,6 +67,39 @@ describe("tool display", () => {
       detailKind: "text",
     })
     expect(toolActionSummary(t, part)).toBe("chat.toolKnowledgeSearch:唐僧师徒关系")
+  })
+
+  it("renders WG Bash knowledge calls without exposing command details", () => {
+    const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "bash",
+      status: "completed" as const,
+      input: { command: 'printf "%s\\n" "唐僧" | wg wikg://lib/entity --query - --json | jq .' },
+    }
+
+    expect(isWgKnowledgeBashPart(part)).toBe(true)
+    expect(toolDisplayLine(t, part)).toEqual({ title: "chat.toolBashQueryKnowledge:" })
+    expect(toolActionSummary(t, part)).toBe("chat.toolBashQueryKnowledge:")
+  })
+
+  it("keeps ordinary Bash calls in the existing command display path", () => {
+    const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "bash",
+      status: "completed" as const,
+      input: { command: 'echo "wikg://lib"' },
+    }
+
+    expect(isWgKnowledgeBashPart(part)).toBe(false)
+    expect(toolDisplayLine(t, part)).toEqual({
+      title: "chat.toolRunGeneric:",
+      detail: 'echo "wikg://lib"',
+      detailKind: "code",
+    })
   })
 
   it("uses operation-specific knowledge query labels", () => {

--- a/src/routes/Chat/tool-display.ts
+++ b/src/routes/Chat/tool-display.ts
@@ -3,6 +3,7 @@ import type { TranslateFn } from "@/i18n/i18n"
 
 import { parseAuthorizationSignal } from "../../../electron/chat/authorization-signal.ts"
 import { compactPathDetail, compactToolDetail } from "./tool-activity.ts"
+import { isWgKnowledgeShellCommand } from "./wg-shell-detection.ts"
 
 export type ToolDisplayDetailKind = "code" | "text"
 
@@ -166,6 +167,13 @@ function knowledgeOperationSummary(t: TranslateFn, input: Record<string, unknown
   }
 }
 
+export function isWgKnowledgeBashPart(part: ChatMessagePart): boolean {
+  if (part.tool !== "bash") {
+    return false
+  }
+  return isWgKnowledgeShellCommand(str(part.input?.command))
+}
+
 export function toolDisplayLine(t: TranslateFn, part: ChatMessagePart): ToolDisplayLine {
   const input = part.input ?? {}
   const fallbackDetail = part.title || part.tool || "tool"
@@ -207,6 +215,9 @@ export function toolDisplayLine(t: TranslateFn, part: ChatMessagePart): ToolDisp
     }
     case "bash": {
       const command = str(input.command).split("\n")[0]
+      if (isWgKnowledgeShellCommand(str(input.command))) {
+        return { title: t("chat.toolBashQueryKnowledge") }
+      }
       return {
         title: command ? bashActionSummary(t, command) : t("chat.toolRunGeneric"),
         ...(command ? { detail: compactToolDetail(command, 96), detailKind: "code" } : {}),
@@ -305,6 +316,9 @@ export function toolActionSummary(t: TranslateFn, part: ChatMessagePart): string
       return knowledgeOperationSummary(t, input)
     case "bash": {
       const command = str(input.command).split("\n")[0]
+      if (isWgKnowledgeShellCommand(str(input.command))) {
+        return t("chat.toolBashQueryKnowledge")
+      }
       return command ? bashActionSummary(t, command) : t("chat.toolRunGeneric")
     }
     case "read": {

--- a/src/routes/Chat/wg-shell-detection.test.ts
+++ b/src/routes/Chat/wg-shell-detection.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { isWgKnowledgeShellCommand } from "./wg-shell-detection.ts"
+
+const positiveCases = [
+  'wg wikg://lib --query "唐僧" --json',
+  'wg wikg://lib/arc/book-1/entity --query "孙悟空" --json',
+  "wikigraph wikg://lib inspect",
+  '/usr/local/bin/wg wikg://lib/chunk --query "取经"',
+  'NO_COLOR=1 WG_LOG=warn wg wikg://lib --query "佛教" --json',
+  'env NO_COLOR=1 PATH=/opt/bin:$PATH wg wikg://lib/entity --query "沙僧"',
+  'wg wikg://lib/entity --query "唐僧" --json | jq -r ".items[].title"',
+  'printf "%s\\n" "唐僧" | wg wikg://lib/entity --query - --json | jq .',
+  "cd /tmp && wg wikg://lib inspect",
+  'test -f cache.json || wg wikg://lib --query "缺失" --json',
+  '(wg wikg://lib --query "三藏" --json | jq .)',
+  'bash -lc "wg wikg://lib --query \\\"观音\\\" --json | jq ."',
+  'sh -c "NO_COLOR=1 wg wikg://lib inspect"',
+  "wg wikg://lib --query - <<'QUERY'\n唐僧 和 孙悟空\nQUERY",
+  "diff <(wg wikg://lib/entity --query 唐僧 --json) old.json",
+  'echo "$(wg wikg://lib/entity --query 唐僧 --json)" | jq .',
+]
+
+const negativeCases = [
+  "echo '$(wg wikg://lib/entity --query 唐僧 --json)'",
+  "echo wg wikg://lib/entity --query 唐僧",
+  'curl "https://example.com/?u=wikg://lib&cmd=wg"',
+  "wg --help",
+  "grep wg notes.txt",
+  'grep "wikg://lib" notes.txt',
+  'node -e "console.log(\\\"wg wikg://lib\\\")"',
+  "python -c \"print('wg wikg://lib')\"",
+  "cat <<'EOF'\nwg wikg://lib --query 唐僧\nEOF",
+  "cat <<EOF\nwg wikg://lib --query 唐僧\nEOF",
+]
+
+describe("WG shell detection", () => {
+  it.each(positiveCases)("recognizes WG knowledge command: %s", (command) => {
+    expect(isWgKnowledgeShellCommand(command)).toBe(true)
+  })
+
+  it.each(negativeCases)("does not recognize non-executed WG text: %s", (command) => {
+    expect(isWgKnowledgeShellCommand(command)).toBe(false)
+  })
+})

--- a/src/routes/Chat/wg-shell-detection.ts
+++ b/src/routes/Chat/wg-shell-detection.ts
@@ -1,0 +1,390 @@
+const shellRecursionLimit = 6
+
+interface ShellWordToken {
+  kind: "word"
+  value: string
+}
+
+interface ShellOperatorToken {
+  kind: "operator"
+  value: string
+}
+
+type ShellToken = ShellWordToken | ShellOperatorToken
+
+export function isWgKnowledgeShellCommand(command: string): boolean {
+  return scanShell(command, 0)
+}
+
+function scanShell(command: string, depth: number): boolean {
+  const shell = stripHeredocBodies(command)
+  if (depth > shellRecursionLimit || shell.trim() === "") {
+    return false
+  }
+  for (const substitution of executableSubstitutions(shell)) {
+    if (scanShell(substitution, depth + 1)) {
+      return true
+    }
+  }
+  const tokens = tokenizeShell(shell)
+  let words: string[] = []
+  for (const token of tokens) {
+    if (token.kind === "operator") {
+      if (matchesSimpleCommand(words, depth)) {
+        return true
+      }
+      words = []
+      continue
+    }
+    words.push(token.value)
+  }
+  return matchesSimpleCommand(words, depth)
+}
+
+function stripHeredocBodies(command: string): string {
+  const lines = command.split(/\r?\n/u)
+  const kept: string[] = []
+  let pendingDelimiter: string | null = null
+  for (const line of lines) {
+    if (pendingDelimiter !== null) {
+      if (line.trim() === pendingDelimiter) {
+        pendingDelimiter = null
+      }
+      continue
+    }
+    kept.push(line)
+    pendingDelimiter = heredocDelimiter(line)
+  }
+  return kept.join("\n")
+}
+
+function heredocDelimiter(line: string): string | null {
+  let quote: "single" | "double" | null = null
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if (quote === "single") {
+      if (char === "'") {
+        quote = null
+      }
+      continue
+    }
+    if (char === "\\") {
+      index += 1
+      continue
+    }
+    if (char === '"') {
+      quote = quote === "double" ? null : "double"
+      continue
+    }
+    if (char === "'") {
+      quote = "single"
+      continue
+    }
+    if (quote !== null || char !== "<" || line[index + 1] !== "<") {
+      continue
+    }
+    let cursor = index + 2
+    if (line[cursor] === "-") {
+      cursor += 1
+    }
+    while (/\s/u.test(line[cursor] ?? "")) {
+      cursor += 1
+    }
+    const delimiter = readHeredocDelimiter(line, cursor)
+    if (delimiter) {
+      return delimiter
+    }
+  }
+  return null
+}
+
+function readHeredocDelimiter(line: string, start: number): string | null {
+  const quote = line[start]
+  if (quote === "'" || quote === '"') {
+    const end = line.indexOf(quote, start + 1)
+    return end > start + 1 ? line.slice(start + 1, end) : null
+  }
+  const match = /^[^\s;&|()<>]+/u.exec(line.slice(start))
+  return match?.[0] ?? null
+}
+
+function executableSubstitutions(command: string): string[] {
+  const substitutions: string[] = []
+  let quote: "single" | "double" | null = null
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i]
+    if (quote === "single") {
+      if (char === "'") {
+        quote = null
+      }
+      continue
+    }
+    if (char === "\\") {
+      i += 1
+      continue
+    }
+    if (char === '"') {
+      quote = quote === "double" ? null : "double"
+      continue
+    }
+    if (char === "'") {
+      quote = "single"
+      continue
+    }
+    if (char === "$" && command[i + 1] === "(") {
+      const result = readBalanced(command, i + 1, "(", ")")
+      if (result) {
+        substitutions.push(result.content)
+        i = result.end
+      }
+      continue
+    }
+    if (quote === null && char === "<" && command[i + 1] === "(") {
+      const result = readBalanced(command, i + 1, "(", ")")
+      if (result) {
+        substitutions.push(result.content)
+        i = result.end
+      }
+      continue
+    }
+    if (quote === null && char === "`") {
+      const end = readBacktick(command, i)
+      if (end > i) {
+        substitutions.push(command.slice(i + 1, end))
+        i = end
+      }
+    }
+  }
+  return substitutions
+}
+
+function readBalanced(
+  input: string,
+  openIndex: number,
+  openChar: string,
+  closeChar: string,
+): { content: string; end: number } | null {
+  let quote: "single" | "double" | null = null
+  let depth = 0
+  for (let i = openIndex; i < input.length; i += 1) {
+    const char = input[i]
+    if (quote === "single") {
+      if (char === "'") {
+        quote = null
+      }
+      continue
+    }
+    if (char === "\\") {
+      i += 1
+      continue
+    }
+    if (char === '"') {
+      quote = quote === "double" ? null : "double"
+      continue
+    }
+    if (char === "'") {
+      quote = "single"
+      continue
+    }
+    if (char === openChar) {
+      depth += 1
+      continue
+    }
+    if (char === closeChar) {
+      depth -= 1
+      if (depth === 0) {
+        return { content: input.slice(openIndex + 1, i), end: i }
+      }
+    }
+  }
+  return null
+}
+
+function readBacktick(input: string, start: number): number {
+  for (let i = start + 1; i < input.length; i += 1) {
+    if (input[i] === "\\") {
+      i += 1
+      continue
+    }
+    if (input[i] === "`") {
+      return i
+    }
+  }
+  return -1
+}
+
+function tokenizeShell(command: string): ShellToken[] {
+  const tokens: ShellToken[] = []
+  let word = ""
+  const flushWord = () => {
+    if (word !== "") {
+      tokens.push({ kind: "word", value: word })
+      word = ""
+    }
+  }
+
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i]
+    if (/\s/.test(char)) {
+      flushWord()
+      if (char === "\n") {
+        tokens.push({ kind: "operator", value: ";" })
+      }
+      continue
+    }
+    if (char === "\\") {
+      if (i + 1 < command.length) {
+        word += command[i + 1]
+        i += 1
+      }
+      continue
+    }
+    if (char === "'" || char === '"') {
+      const result = readQuotedWord(command, i, char)
+      word += result.value
+      i = result.end
+      continue
+    }
+    if (char === "$" && command[i + 1] === "(") {
+      const result = readBalanced(command, i + 1, "(", ")")
+      if (result) {
+        word += command.slice(i, result.end + 1)
+        i = result.end
+        continue
+      }
+    }
+    if (char === "&" && command[i + 1] === "&") {
+      flushWord()
+      tokens.push({ kind: "operator", value: "&&" })
+      i += 1
+      continue
+    }
+    if (char === "|" && command[i + 1] === "|") {
+      flushWord()
+      tokens.push({ kind: "operator", value: "||" })
+      i += 1
+      continue
+    }
+    if (char === "|" || char === ";" || char === "(" || char === ")") {
+      flushWord()
+      tokens.push({ kind: "operator", value: char })
+      continue
+    }
+    word += char
+  }
+  flushWord()
+  return tokens
+}
+
+function readQuotedWord(input: string, start: number, quote: "'" | '"'): { value: string; end: number } {
+  let value = ""
+  for (let i = start + 1; i < input.length; i += 1) {
+    const char = input[i]
+    if (char === quote) {
+      return { value, end: i }
+    }
+    if (quote === '"' && char === "\\" && i + 1 < input.length) {
+      value += input[i + 1]
+      i += 1
+      continue
+    }
+    value += char
+  }
+  return { value, end: input.length - 1 }
+}
+
+function matchesSimpleCommand(words: string[], depth: number): boolean {
+  const commandWords = words.filter(Boolean)
+  let index = skipAssignmentPrefix(commandWords, 0)
+  if (index >= commandWords.length) {
+    return false
+  }
+  const executable = commandWords[index]
+  if (isEnvExecutable(executable)) {
+    index = skipEnvPrefix(commandWords, index + 1)
+    if (index >= commandWords.length) {
+      return false
+    }
+  }
+  const shellCommandIndex = shellCommandStringIndex(commandWords, index)
+  if (shellCommandIndex !== null) {
+    return scanShell(commandWords[shellCommandIndex] ?? "", depth + 1)
+  }
+  return (
+    isWgExecutable(executableName(commandWords[index] ?? "")) && commandWords.slice(index + 1).some(containsWikgUri)
+  )
+}
+
+function skipAssignmentPrefix(words: string[], start: number): number {
+  let index = start
+  while (index < words.length && isAssignment(words[index] ?? "")) {
+    index += 1
+  }
+  return index
+}
+
+function skipEnvPrefix(words: string[], start: number): number {
+  let index = start
+  while (index < words.length) {
+    const word = words[index] ?? ""
+    if (isAssignment(word)) {
+      index += 1
+      continue
+    }
+    if (word === "-" || word.startsWith("-i") || word.startsWith("--ignore-environment")) {
+      index += 1
+      continue
+    }
+    if ((word === "-u" || word === "--unset") && index + 1 < words.length) {
+      index += 2
+      continue
+    }
+    break
+  }
+  return index
+}
+
+function shellCommandStringIndex(words: string[], commandIndex: number): number | null {
+  const executable = executableName(words[commandIndex] ?? "")
+  if (executable !== "bash" && executable !== "sh" && executable !== "zsh") {
+    return null
+  }
+  for (let index = commandIndex + 1; index < words.length; index += 1) {
+    const word = words[index] ?? ""
+    if (word === "--") {
+      continue
+    }
+    if (word === "-c") {
+      return index + 1 < words.length ? index + 1 : null
+    }
+    if (/^-[A-Za-z]*c[A-Za-z]*$/.test(word)) {
+      return index + 1 < words.length ? index + 1 : null
+    }
+    if (!word.startsWith("-")) {
+      return null
+    }
+  }
+  return null
+}
+
+function executableName(word: string): string {
+  const withoutTrailingSlash = word.replace(/\/+$/, "")
+  const slash = withoutTrailingSlash.lastIndexOf("/")
+  return (slash >= 0 ? withoutTrailingSlash.slice(slash + 1) : withoutTrailingSlash).toLowerCase()
+}
+
+function isEnvExecutable(word: string): boolean {
+  return executableName(word) === "env"
+}
+
+function isWgExecutable(name: string): boolean {
+  return name === "wg" || name === "wikigraph"
+}
+
+function isAssignment(word: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(word)
+}
+
+function containsWikgUri(word: string): boolean {
+  return word.includes("wikg://")
+}


### PR DESCRIPTION
## Summary
- Detect Bash tool calls that execute `wg` / `wikigraph` against `wikg://...` archives and display them as knowledge queries instead of generic Bash commands.
- Hide raw command details and the expand affordance for WG knowledge Bash rows while preserving ordinary Bash display behavior and tool status labels.
- Add shell-structure fixture coverage for WG detection, including positive/negative cases from #254 plus heredoc body false positives.

Closes #254

## Verification
- `corepack pnpm vitest run src/routes/Chat/wg-shell-detection.test.ts src/routes/Chat/tool-display.test.ts src/routes/Chat/ToolActivityStep.test.ts` — passed, 3 files / 48 tests.
- `corepack pnpm run ts-check` — passed.
- `corepack pnpm run lint` — passed, 0 warnings / 0 errors.
- `corepack pnpm run format` — passed.
- `corepack pnpm run test` — passed, 266 files / 1979 tests. Existing tests emit expected stderr noise around mocked services/billing/update paths, but the command exits 0.
- `corepack pnpm run build` — passed.

## Electron App verification
Actual app startup used for the UI regression check:

```bash
VITE_WANTA_LOCALE=zh-CN \
VITE_WANTA_SMOKE='请依次运行两个本地 Bash 命令：第一条 echo normal-wanta-smoke；第二条 wg wikg://lib --query "唐僧" --json。只需要执行这两个命令。' \
WANTA_ELECTRON_AUTO_START=0 \
corepack pnpm run dev:worktree

VITE_DEV_SERVER_URL=http://localhost:5292 \
WANTA_USER_DATA_DIR=/Users/taozeyu/codes/github.com/oomol-lab/wanta/.worktrees/t_eaec4504/wanta \
WANTA_DEV_SERVER_PORT=5292 \
WANTA_SKIP_PROTOCOL_REGISTRATION=1 \
./.electron-dist/Electron.app/Contents/MacOS/Electron --remote-debugging-port=9235 . --no-sandbox
```

Trigger/simulation steps:
1. Started the real Electron app with the `VITE_WANTA_SMOKE` prompt above.
2. Used Chrome DevTools Protocol on port 9235 to inspect the actual renderer DOM.
3. Expanded the “处理过程” disclosure in the real app.

Inspectable DOM evidence from the real app:
- Ordinary Bash row rendered as an expandable button containing `运行命令 / echo normal-wanta-smoke / 已完成`, with `aria-expanded="false"` and a chevron.
- WG Bash row rendered as a compact non-button row containing `正在查询知识库... / 已完成`; it did not expose `wg wikg://lib`, `jq .`, or a chevron/secondary expand entry.

## Review notes
- Attempted an independent blind reviewer via Hermes delegation, but the subagent failed before reviewing due to provider HTTP 503 after retries. I then performed a local fallback review against the issue acceptance rubric and added missing UI tests for consecutive WG calls and failed WG call status before committing.
