### PR TITLE
feat(chat): merge wikigraph knowledge activity rows

### DIFF
--- a/src/routes/Chat/AssistantTurnRenderer.tsx
+++ b/src/routes/Chat/AssistantTurnRenderer.tsx
@@ -29,6 +29,7 @@ import { formatWholeSecondDuration } from "./tool-activity.ts"
 import { toolActionSummary, toolServiceSlug } from "./tool-display.ts"
 import { isActiveToolPart } from "./tool-state.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
+import { groupedToolActivityParts } from "./wikigraph-tool-grouping.ts"
 import { MessageResponse } from "@/components/ai-elements/message"
 import { MarkdownImage } from "@/components/ai-elements/message-image"
 import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task"
@@ -361,7 +362,7 @@ export function AssistantBlock({
         ) : null
       ) : (
         <div className="space-y-0.5">
-          {block.parts.map((part) => {
+          {groupedToolActivityParts(block.parts).map((part) => {
             const service = toolServiceSlug(part)
             return (
               <ToolActivityStep

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { I18nContext, translate } from "../../i18n/i18n.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
+import { groupedToolActivityParts } from "./wikigraph-tool-grouping.ts"
 
 function renderToolActivityStep(
   part: ChatMessagePart,
@@ -98,9 +99,9 @@ describe("ToolActivityStep", () => {
     expect(html).not.toContain("lucide-chevron-right")
   })
 
-  it("renders consecutive WG Bash knowledge calls as compact knowledge rows", () => {
-    const html = [
-      renderToolActivityStep({
+  it("renders consecutive WG Bash knowledge calls as one compact knowledge row", () => {
+    const parts = groupedToolActivityParts([
+      {
         kind: "tool",
         partId: "tool-wg-1",
         callId: "call-wg-1",
@@ -108,8 +109,8 @@ describe("ToolActivityStep", () => {
         status: "completed",
         input: { command: 'wg wikg://lib/entity --query "唐僧" --json | jq .' },
         output: "{}",
-      }),
-      renderToolActivityStep({
+      },
+      {
         kind: "tool",
         partId: "tool-wg-2",
         callId: "call-wg-2",
@@ -117,13 +118,133 @@ describe("ToolActivityStep", () => {
         status: "completed",
         input: { command: 'wg wikg://lib/evidence --query "孙悟空" --json | jq .' },
         output: "{}",
-      }),
-    ].join("\n")
+      },
+    ])
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
-    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(2)
+    expect(parts).toHaveLength(1)
+    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(1)
     expect(html).not.toContain("wg wikg://lib")
     expect(html).not.toContain("jq .")
     expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("coalesces WikiGraph skill loads with WG Bash calls in both orders", () => {
+    const skillPart: ChatMessagePart = {
+      kind: "tool",
+      partId: "tool-skill",
+      callId: "call-skill",
+      tool: "skill",
+      status: "completed",
+      title: "Loaded skill: wikigraph-knowledge",
+      output: "# WikiGraph Knowledge",
+    }
+    const wgPart: ChatMessagePart = {
+      kind: "tool",
+      partId: "tool-wg",
+      callId: "call-wg",
+      tool: "bash",
+      status: "completed",
+      input: { command: 'wg wikg://lib/search --query "唐僧" --json' },
+      output: "{}",
+    }
+
+    for (const order of [
+      [skillPart, wgPart],
+      [wgPart, skillPart],
+      [skillPart, { ...skillPart, partId: "tool-skill-2", callId: "call-skill-2" }],
+    ]) {
+      const parts = groupedToolActivityParts(order)
+      const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+      expect(parts).toHaveLength(1)
+      expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(1)
+      expect(html).not.toContain("wikigraph-knowledge")
+      expect(html).not.toContain("Loaded skill")
+      expect(html).not.toContain("wg wikg://lib")
+      expect(html).not.toContain("工具参数")
+      expect(html).not.toContain("工具结果")
+      expect(html).not.toContain("lucide-chevron-right")
+    }
+  })
+
+  it("keeps ordinary tools as boundaries between knowledge groups", () => {
+    const parts = groupedToolActivityParts([
+      {
+        kind: "tool",
+        partId: "tool-wg-1",
+        callId: "call-wg-1",
+        tool: "bash",
+        status: "completed",
+        input: { command: 'wg wikg://lib/search --query "唐僧" --json' },
+      },
+      {
+        kind: "tool",
+        partId: "tool-jq",
+        callId: "call-jq",
+        tool: "bash",
+        status: "completed",
+        input: { command: "jq . /tmp/result.json" },
+      },
+      {
+        kind: "tool",
+        partId: "tool-wg-2",
+        callId: "call-wg-2",
+        tool: "bash",
+        status: "completed",
+        input: { command: 'wg wikg://lib/evidence --query "孙悟空" --json' },
+      },
+    ])
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(3)
+    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(2)
+    expect(html).toContain("jq . /tmp/result.json")
+  })
+
+  it("keeps the merged knowledge row in the failed state", () => {
+    const parts = groupedToolActivityParts([
+      {
+        kind: "tool",
+        partId: "tool-skill",
+        callId: "call-skill",
+        tool: "skill",
+        status: "completed",
+        title: "Loaded skill: wikigraph-knowledge",
+      },
+      {
+        kind: "tool",
+        partId: "tool-wg-failed",
+        callId: "call-wg-failed",
+        tool: "bash",
+        status: "error",
+        input: { command: 'wg wikg://lib/entity --query "猪八戒" --json' },
+        error: "exit code 1",
+      },
+    ])
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(1)
+    expect(html).toContain("正在查询知识库...")
+    expect(html).toContain("未完成")
+    expect(html).not.toContain("wg wikg://lib/entity")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("keeps ordinary skill loads visible and expandable", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-skill",
+      callId: "call-skill",
+      tool: "skill",
+      status: "completed",
+      title: "Loaded skill: pdf",
+      output: "# PDF",
+    })
+
+    expect(html).not.toContain("正在查询知识库...")
+    expect(html).toContain("Loaded skill: pdf")
+    expect(html).toContain("lucide-chevron-right")
   })
 
   it("keeps the failed WG Bash status while hiding command details", () => {

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -30,7 +30,7 @@ import * as React from "react"
 import { LoadingShimmerText } from "./LoadingShimmerText.tsx"
 import { shouldShowRunningNoOutput } from "./tool-activity.ts"
 import { shouldHideToolDetailsImmediately } from "./tool-details-visibility.ts"
-import { isWgKnowledgeBashPart, parseToolAuthorization, toolDisplayLine } from "./tool-display.ts"
+import { isWikigraphKnowledgeActivityPart, parseToolAuthorization, toolDisplayLine } from "./tool-display.ts"
 import { formatToolOutputPreview, toolOutputPreviewLimitChars } from "./tool-output-preview.ts"
 import { isActiveToolPart, isToolCancellation } from "./tool-state.ts"
 import { Button } from "@/components/ui/button"
@@ -182,6 +182,9 @@ function ToolStepIcon({
   provider?: ConnectionProvider
   stopped?: boolean
 }) {
+  if (isWikigraphKnowledgeActivityPart(part) && part.status !== "error" && !stopped) {
+    return <LibraryBig className="size-3.5 text-muted-foreground" />
+  }
   if (provider && part.status !== "error" && !stopped) {
     return <ProviderIcon iconUrl={provider.iconUrl} displayName={provider.displayName} size="compact" />
   }
@@ -255,7 +258,7 @@ export function ToolActivityStep({
   const activePart = isActiveToolPart(part)
   const stopped = isToolCancellation(part) || (!live && activePart)
   const answerSummary = questionAnswerSummary(part)
-  const hideDetails = isWgKnowledgeBashPart(part)
+  const hideDetails = isWikigraphKnowledgeActivityPart(part)
   const details = !hideDetails && hasToolDetails(part, auth, answerSummary, stopped)
   const [open, setOpen] = React.useState(false)
   const [detailsVisible, setDetailsVisible] = React.useState(false)

--- a/src/routes/Chat/tool-display.test.ts
+++ b/src/routes/Chat/tool-display.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import {
   isWgKnowledgeBashPart,
+  isWikigraphKnowledgeActivityPart,
+  isWikigraphKnowledgeSkillPart,
   normalizeServiceSlug,
   parseToolAuthorization,
   toolActionSummary,
@@ -82,6 +84,36 @@ describe("tool display", () => {
     expect(isWgKnowledgeBashPart(part)).toBe(true)
     expect(toolDisplayLine(t, part)).toEqual({ title: "chat.toolBashQueryKnowledge:" })
     expect(toolActionSummary(t, part)).toBe("chat.toolBashQueryKnowledge:")
+  })
+
+  it("renders the wikigraph-knowledge skill load as a hidden knowledge activity", () => {
+    const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "skill",
+      status: "completed" as const,
+      title: "  Loaded  skill :  wikigraph-knowledge  ",
+      output: "# WikiGraph Knowledge",
+    }
+
+    expect(isWikigraphKnowledgeSkillPart(part)).toBe(true)
+    expect(isWikigraphKnowledgeActivityPart(part)).toBe(true)
+    expect(toolDisplayLine(t, part)).toEqual({ title: "chat.toolBashQueryKnowledge:" })
+    expect(toolActionSummary(t, part)).toBe("chat.toolBashQueryKnowledge:")
+  })
+
+  it("does not treat ordinary skill loads as wikigraph knowledge activity", () => {
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "skill",
+      status: "completed" as const,
+      title: "Loaded skill: pdf",
+    }
+
+    expect(isWikigraphKnowledgeSkillPart(part)).toBe(false)
+    expect(isWikigraphKnowledgeActivityPart(part)).toBe(false)
   })
 
   it("keeps ordinary Bash calls in the existing command display path", () => {

--- a/src/routes/Chat/tool-display.ts
+++ b/src/routes/Chat/tool-display.ts
@@ -174,9 +174,20 @@ export function isWgKnowledgeBashPart(part: ChatMessagePart): boolean {
   return isWgKnowledgeShellCommand(str(part.input?.command))
 }
 
+export function isWikigraphKnowledgeSkillPart(part: ChatMessagePart): boolean {
+  return Boolean(part.title?.match(/^\s*Loaded\s+skill\s*:\s*wikigraph-knowledge\s*$/iu))
+}
+
+export function isWikigraphKnowledgeActivityPart(part: ChatMessagePart): boolean {
+  return isWgKnowledgeBashPart(part) || isWikigraphKnowledgeSkillPart(part)
+}
+
 export function toolDisplayLine(t: TranslateFn, part: ChatMessagePart): ToolDisplayLine {
   const input = part.input ?? {}
   const fallbackDetail = part.title || part.tool || "tool"
+  if (isWikigraphKnowledgeActivityPart(part)) {
+    return { title: t("chat.toolBashQueryKnowledge") }
+  }
   switch (part.tool) {
     case "list_apps": {
       const service = str(input.service)
@@ -215,9 +226,6 @@ export function toolDisplayLine(t: TranslateFn, part: ChatMessagePart): ToolDisp
     }
     case "bash": {
       const command = str(input.command).split("\n")[0]
-      if (isWgKnowledgeShellCommand(str(input.command))) {
-        return { title: t("chat.toolBashQueryKnowledge") }
-      }
       return {
         title: command ? bashActionSummary(t, command) : t("chat.toolRunGeneric"),
         ...(command ? { detail: compactToolDetail(command, 96), detailKind: "code" } : {}),
@@ -299,6 +307,9 @@ export function toolActionSummary(t: TranslateFn, part: ChatMessagePart): string
   const input = part.input ?? {}
   const target = connectorTarget(input)
   const fallbackDetail = part.title || part.tool || "tool"
+  if (isWikigraphKnowledgeActivityPart(part)) {
+    return t("chat.toolBashQueryKnowledge")
+  }
   switch (part.tool) {
     case "list_apps": {
       const service = str(input.service)
@@ -316,9 +327,6 @@ export function toolActionSummary(t: TranslateFn, part: ChatMessagePart): string
       return knowledgeOperationSummary(t, input)
     case "bash": {
       const command = str(input.command).split("\n")[0]
-      if (isWgKnowledgeShellCommand(str(input.command))) {
-        return t("chat.toolBashQueryKnowledge")
-      }
       return command ? bashActionSummary(t, command) : t("chat.toolRunGeneric")
     }
     case "read": {

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -1,0 +1,77 @@
+import type { ChatMessagePart, ToolStatus } from "../../../electron/chat/common.ts"
+
+import { isWikigraphKnowledgeActivityPart } from "./tool-display.ts"
+import { isToolCancellation } from "./tool-state.ts"
+
+function mergedStatus(parts: ChatMessagePart[]): ToolStatus | undefined {
+  if (parts.some((part) => part.status === "error")) {
+    return "error"
+  }
+  if (parts.some((part) => part.status === "running")) {
+    return "running"
+  }
+  if (parts.some((part) => part.status === "pending")) {
+    return "pending"
+  }
+  if (parts.some((part) => part.status === "completed")) {
+    return "completed"
+  }
+  return parts[0]?.status
+}
+
+function mergedTiming(parts: ChatMessagePart[]): ChatMessagePart["timing"] {
+  let start: number | undefined
+  let end: number | undefined
+  for (const part of parts) {
+    if (typeof part.timing?.start === "number") {
+      start = start === undefined ? part.timing.start : Math.min(start, part.timing.start)
+    }
+    if (typeof part.timing?.end === "number") {
+      end = end === undefined ? part.timing.end : Math.max(end, part.timing.end)
+    }
+  }
+  return start === undefined && end === undefined ? undefined : { start, end }
+}
+
+function mergeWikigraphKnowledgeParts(parts: ChatMessagePart[]): ChatMessagePart {
+  const first = parts[0]
+  const errorPart = parts.find((part) => part.status === "error" || part.error)
+  return {
+    ...first,
+    partId: first.partId,
+    callId: first.callId ?? first.partId,
+    title: "Loaded skill: wikigraph-knowledge",
+    status: mergedStatus(parts),
+    error: errorPart?.error,
+    output: undefined,
+    input: {},
+    metadata: undefined,
+    attachmentsCount: undefined,
+    authorization: undefined,
+    cancelled: parts.some((part) => isToolCancellation(part)) || undefined,
+    timing: mergedTiming(parts),
+  }
+}
+
+export function groupedToolActivityParts(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const grouped: ChatMessagePart[] = []
+  let pendingKnowledge: ChatMessagePart[] = []
+  const flushKnowledge = () => {
+    if (pendingKnowledge.length === 0) {
+      return
+    }
+    grouped.push(mergeWikigraphKnowledgeParts(pendingKnowledge))
+    pendingKnowledge = []
+  }
+
+  for (const part of parts) {
+    if (isWikigraphKnowledgeActivityPart(part)) {
+      pendingKnowledge.push(part)
+      continue
+    }
+    flushKnowledge()
+    grouped.push(part)
+  }
+  flushKnowledge()
+  return grouped
+}


### PR DESCRIPTION
## Summary
- Merge consecutive `wikigraph-knowledge` Skill loads and WG Bash queries into a single non-expandable knowledge row.
- Preserve the merged row's error/incomplete state while keeping ordinary bash and ordinary skill rows visible.
- Added unit coverage plus a real Electron renderer smoke verification.

## Verification
- corepack pnpm vitest run src/routes/Chat/tool-display.test.ts src/routes/Chat/ToolActivityStep.test.ts src/routes/Chat/render-blocks.test.ts
- corepack pnpm run lint
- corepack pnpm run build
- corepack pnpm run format
- Real Electron smoke via CDP: grouped rows 4; knowledge rows 2; screenshot verified one knowledge row, one ordinary jq row, one failed knowledge row marked 未完成, and one ordinary skill row.

Closes #259
