### PR TITLE
fix(knowledge): validate WikiGraph imports after upgrade

### DIFF
--- a/electron/knowledge/runner.test.ts
+++ b/electron/knowledge/runner.test.ts
@@ -28,11 +28,13 @@ const sdk = vi.hoisted(() => {
       rebind: [] as unknown[],
       remove: [] as unknown[],
       runtimeStateDirs: [] as (string | undefined)[],
+      upgrade: [] as string[],
     },
     chapters: [] as MockChapter[],
     cover: undefined as { data: Uint8Array; mediaType: string; path: string } | undefined,
     failCover: false,
     failGetArchive: undefined as Error | undefined,
+    failListChapters: undefined as Error | undefined,
     ftsCurrent: false,
     indexSettings: { ftsEmbedded: false },
     meta: undefined as MockBookMeta | undefined,
@@ -123,7 +125,10 @@ vi.mock("wiki-graph-core", () => {
       return record
     },
     isArchiveSearchIndexCurrent: async () => sdk.ftsCurrent,
-    listChapters: async () => sdk.chapters,
+    listChapters: async () => {
+      if (sdk.failListChapters) throw sdk.failListChapters
+      return sdk.chapters
+    },
     listWikiGraphLibraryArchives: async (target: unknown) => {
       sdk.calls.list.push(target)
       return sdk.archives
@@ -137,6 +142,16 @@ vi.mock("wiki-graph-core", () => {
     removeWikiGraphLibraryArchive: async (input: unknown) => {
       sdk.calls.remove.push(input)
       return sdk.archives[0]
+    },
+    upgradeWikiGraphMaintenanceTarget: async (target: string) => {
+      sdk.calls.upgrade.push(target)
+      return {
+        kind: "archive",
+        path: target,
+        schemaVersionAfter: 2,
+        schemaVersionBefore: 1,
+        status: "upgraded",
+      }
     },
     withWikiGraphRuntimeStateDirectoryPath: async <T>(
       stateDir: string | undefined,
@@ -211,11 +226,21 @@ beforeEach(() => {
     archiveRecord({ publicId: "public-archive", uri: "wikg://lib/arc/public-archive" }),
     archiveRecord({ exists: false, publicId: "missing", status: "missing", uri: "wikg://lib/arc/missing" }),
   ]
-  sdk.calls = { add: [], archiveFiles: [], getArchive: [], list: [], rebind: [], remove: [], runtimeStateDirs: [] }
+  sdk.calls = {
+    add: [],
+    archiveFiles: [],
+    getArchive: [],
+    list: [],
+    rebind: [],
+    remove: [],
+    runtimeStateDirs: [],
+    upgrade: [],
+  }
   sdk.chapters = []
   sdk.cover = undefined
   sdk.failCover = false
   sdk.failGetArchive = undefined
+  sdk.failListChapters = undefined
   sdk.ftsCurrent = false
   sdk.indexSettings = { ftsEmbedded: false }
   sdk.meta = undefined
@@ -273,6 +298,8 @@ describe("WikiGraph SDK adapter", () => {
       uri: "wikg://lib/arc/imported-public-id",
     })
     expect(imported.id).not.toBe("99")
+    expect(sdk.calls.upgrade).toEqual(["/managed/library/copy.wikg"])
+    expect(sdk.calls.archiveFiles).toEqual(["/managed/library/copy.wikg"])
     expect(sdk.calls.add).toEqual([
       {
         inputPath: source,
@@ -280,6 +307,40 @@ describe("WikiGraph SDK adapter", () => {
         to: expect.stringMatching(/^research\/Original-Book-.+\.wikg$/u),
       },
     ])
+  })
+
+  it("fails and removes the managed copy when post-upgrade validation cannot read chapters", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-wg-adapter-"))
+    const source = path.join(dir, "Broken Book.wikg")
+    await writeFile(source, "archive")
+    sdk.addRecord = archiveRecord({
+      path: "/managed/library/broken-copy.wikg",
+      publicId: "broken-public-id",
+      uri: "wikg://lib/arc/broken-public-id",
+    })
+    sdk.failListChapters = new Error("Missing chapter key in TOC")
+
+    let importError: unknown
+    try {
+      await addWikiGraphLibraryArchive(runtime(dir), source)
+    } catch (error) {
+      importError = error
+    }
+
+    expect(importError).toBeInstanceOf(Error)
+    expect((importError as Error).message).toContain("WANTA_KNOWLEDGE_IMPORT_UNREADABLE")
+    expect((importError as Error).message).not.toContain("Missing chapter key in TOC")
+
+    expect(sdk.calls.add).toEqual([
+      expect.objectContaining({
+        inputPath: source,
+        target: { kind: "mock", uri: "wikg://lib/arc" },
+      }),
+    ])
+    expect(sdk.calls.upgrade).toEqual(["/managed/library/broken-copy.wikg"])
+    expect(sdk.calls.upgrade).not.toContain(source)
+    expect(sdk.calls.archiveFiles).toEqual(["/managed/library/broken-copy.wikg"])
+    expect(sdk.calls.remove).toEqual([{ target: { kind: "mock", uri: "wikg://lib/arc/broken-public-id" } }])
   })
 
   it("removes archives by the public archive URI", async () => {

--- a/electron/knowledge/runner.ts
+++ b/electron/knowledge/runner.ts
@@ -12,12 +12,15 @@ import {
   readArchiveIndexSettings,
   rebindWikiGraphLibrary,
   removeWikiGraphLibraryArchive as removeWikiGraphLibraryArchiveWithSDK,
+  upgradeWikiGraphMaintenanceTarget,
   WikiGraphArchiveFile,
   withWikiGraphRuntimeStateDirectoryPath,
 } from "wiki-graph-core"
 
 const defaultLibraryUri = "wikg://lib"
 const defaultLibraryPreparationByStateDir = new Map<string, Promise<void>>()
+const unreadableImportMessage =
+  "WANTA_KNOWLEDGE_IMPORT_UNREADABLE: The selected WikiGraph file could not be imported because Wanta cannot make the managed copy readable with the current WikiGraph SDK. The original file was not modified."
 
 export interface WikiGraphRuntime {
   managedLibraryDir: string
@@ -214,7 +217,37 @@ export async function addWikiGraphLibraryArchive(
       target: requireLibraryTarget(`${defaultLibraryUri}/arc`),
       to: safeImportRelativePath(sourcePath, targetDirectory),
     })
+    try {
+      await prepareImportedArchiveForUse(imported)
+    } catch (error) {
+      await removeWikiGraphLibraryArchiveWithSDK({ target: requireLibraryTarget(imported.uri) }).catch(
+        (cleanupError: unknown) => {
+          console.warn("[wanta] failed to clean unreadable WikiGraph import:", cleanupError)
+        },
+      )
+      throw new Error(unreadableImportMessage, { cause: error })
+    }
     return archiveFromRecord(imported)
+  })
+}
+
+async function prepareImportedArchiveForUse(record: WikiGraphLibraryArchiveRecord): Promise<void> {
+  await upgradeWikiGraphMaintenanceTarget(record.path)
+  // wiki-graph-core@0.4.0 has no separate repair API for current-schema archives whose TOC is still
+  // structurally unreadable. Keep this validation boundary explicit so a future SDK repair call can
+  // be inserted before the checks without treating a copied file as a completed product import.
+  await validateImportedArchive(record.path)
+}
+
+async function validateImportedArchive(archivePath: string): Promise<void> {
+  const file = new WikiGraphArchiveFile(archivePath)
+  await file.read(async (archive) => {
+    await archive.readMeta()
+  })
+  await file.readDocument(async (document) => {
+    await listChapters(document)
+    await readArchiveIndexSettings(document)
+    await isArchiveSearchIndexCurrent(document)
   })
 }
 

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -101,6 +101,9 @@ export const enMessages = {
   "error.knowledgeList.description": "The knowledge base list cannot be loaded right now. Try again later.",
   "error.knowledgeAction.title": "Knowledge base action not completed",
   "error.knowledgeAction.description": "The change was not applied. Existing knowledge bases are unaffected.",
+  "error.knowledgeImportUnreadable.title": "Knowledge base import failed",
+  "error.knowledgeImportUnreadable.description":
+    "Wanta copied the WikiGraph file into managed storage, but the managed copy could not be upgraded into a readable knowledge base. The original file was not modified, and no incomplete import was kept.",
   "error.update.title": "Update failed",
   "error.update.description": "The update operation could not be completed right now. Try again later.",
   "app.loadFailed": "Failed to load the interface",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -90,6 +90,9 @@ export const zhCNMessages = {
   "error.knowledgeList.description": "暂时无法读取知识库列表。请稍后重试。",
   "error.knowledgeAction.title": "知识库操作未完成",
   "error.knowledgeAction.description": "本次修改没有生效，现有知识库不会受影响。",
+  "error.knowledgeImportUnreadable.title": "知识库导入失败",
+  "error.knowledgeImportUnreadable.description":
+    "Wanta 已将 WikiGraph 文件复制到托管存储，但托管副本无法升级为可读取的知识库。原始文件没有被修改，也不会保留未完成的导入。",
   "error.update.title": "更新失败",
   "error.update.description": "暂时无法完成更新操作。请稍后重试。",
   "app.loadFailed": "界面加载失败",

--- a/src/lib/user-facing-error.test.ts
+++ b/src/lib/user-facing-error.test.ts
@@ -44,6 +44,17 @@ describe("resolveUserFacingError", () => {
     })
   })
 
+  it("maps unreadable WikiGraph imports to product copy without exposing SDK internals", () => {
+    expect(
+      resolveUserFacingError("WANTA_KNOWLEDGE_IMPORT_UNREADABLE: Missing chapter key in TOC", { area: "generic" }),
+    ).toMatchObject({
+      descriptionKey: "error.knowledgeImportUnreadable.description",
+      kind: "validation_error",
+      severity: "warning",
+      titleKey: "error.knowledgeImportUnreadable.title",
+    })
+  })
+
   it("keeps artifact file errors scoped to file operations", () => {
     expect(resolveUserFacingError("ENOENT: no such file or directory", { area: "artifact" })).toMatchObject({
       kind: "local_file_unavailable",

--- a/src/lib/user-facing-error.ts
+++ b/src/lib/user-facing-error.ts
@@ -248,6 +248,19 @@ export function resolveUserFacingError(
     )
   }
 
+  if (normalizedMessage.startsWith("wanta_knowledge_import_unreadable")) {
+    return buildError(
+      area,
+      "validation_error",
+      "warning",
+      "error.knowledgeImportUnreadable.title",
+      "error.knowledgeImportUnreadable.description",
+      diagnostics,
+      false,
+      message,
+    )
+  }
+
   if (status && status >= 500) {
     return buildError(
       area,


### PR DESCRIPTION
## Summary
- Runs WikiGraph SDK maintenance upgrade on the managed archive copy immediately after `.wikg` import.
- Validates the managed copy through the same SDK read paths Wanta later needs for metadata, chapters, and index state before treating import as successful.
- Cleans failed imports and maps unreadable WikiGraph archives to product-facing error copy instead of exposing raw TOC/stack internals.

Closes https://github.com/oomol-lab/wanta/issues/260

## Acceptance evidence
- Managed-copy upgrade/validation is covered by `electron/knowledge/runner.test.ts`; assertions verify `upgradeWikiGraphMaintenanceTarget()` and `WikiGraphArchiveFile` receive the SDK-created managed path, not the user's source path.
- Successful schema-upgrade path continues to return a normal `KnowledgeBaseSummary`-ready archive record.
- Post-upgrade unreadable archives fail import, remove the managed library archive, do not leak `Missing chapter key in TOC`, and leave no archive in the library list.
- Source `.wikg` is not modified; tests assert SDK calls target the managed copy, and the real-file smoke below compared mtime/size before/after.
- App-side import path still uses `wiki-graph-core` SDK only; no new `wg` CLI invocation or `.wikg` unzip/internal rewrite was added.

## Verification
- `corepack pnpm exec vitest run electron/knowledge/runner.test.ts src/lib/user-facing-error.test.ts` — passed, 2 files / 18 tests.
- `corepack pnpm run ts-check` — passed.
- `corepack pnpm run lint` — passed, 0 warnings / 0 errors.
- `corepack pnpm run format` — passed.
- `corepack pnpm run test` — passed. Existing tests emit expected stderr noise from mocked failure/broadcast paths.
- `corepack pnpm run build` — passed. Vite emitted existing chunk-size warnings only.

## Real Electron / SDK regression
- Started the worktree Electron dev app with `VITE_WANTA_ROUTE=knowledge VITE_WANTA_LOCALE=zh-CN corepack pnpm run dev:worktree` and confirmed it launched.
- Ran a temporary smoke script against the same Electron knowledge SDK layer:
  - Imported `/Users/taozeyu/Documents/WIKG/三国演义.wikg` into a temp managed library: import/list/inspect succeeded; remove left list count 0; original mtime/size unchanged.
  - Imported `/Users/taozeyu/Documents/WIKG/西游记.wikg`: import failed with product sentinel `WANTA_KNOWLEDGE_IMPORT_UNREADABLE`, raw `Missing chapter key in TOC` was not in the user-facing message, list count remained 0 after cleanup, original mtime/size unchanged.
- GUI click-based file-picker regression was not completed because the background computer-use click was denied by the environment; the dev app launch plus SDK-backed import path regression above covers the actual Electron knowledge layer behavior.

## Review note
- Blind reviewer creation was attempted via subagent, but the reviewer failed before review with `HTTP 503: 所有供应商暂时不可用` after 3 retries.
- Non-blind fallback review was completed against issue #260 acceptance criteria. Verdict: pass. High-risk boundary check: this change does not modify secrets, permissions, production data, public compatibility keys, or archive internals; it only changes import orchestration and cleanup through the existing SDK boundary.
- wiki-graph-core@0.4.0 still has no separate repair API for current-schema archives with broken TOC keys. The code leaves an explicit adapter point before validation and fails cleanly until upstream repair support exists.
