### PR TITLE
Improve tool process activity UX

### DIFF
--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -764,7 +764,7 @@ export const enMessages = {
   "chat.toolBashRunPythonScript": "Running Python script",
   "chat.toolBashReadContent": "Reading file content",
   "chat.toolBashFindFiles": "Finding files",
-  "chat.toolBashQueryKnowledge": "Searching knowledge...",
+  "chat.toolBashQueryKnowledge": "Search knowledge",
   "chat.toolRead": "Reading file: {detail}",
   "chat.toolReadGeneric": "Reading file",
   "chat.toolWrite": "Writing file: {detail}",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -726,7 +726,7 @@ export const zhCNMessages = {
   "chat.toolBashRunPythonScript": "运行 Python 脚本",
   "chat.toolBashReadContent": "读取文件内容",
   "chat.toolBashFindFiles": "查找文件",
-  "chat.toolBashQueryKnowledge": "正在查询知识库...",
+  "chat.toolBashQueryKnowledge": "查询知识库",
   "chat.toolRead": "读取文件：{detail}",
   "chat.toolReadGeneric": "读取文件",
   "chat.toolWrite": "写入文件：{detail}",

--- a/src/routes/Chat/AssistantTurnRenderer.tsx
+++ b/src/routes/Chat/AssistantTurnRenderer.tsx
@@ -25,6 +25,7 @@ import {
 import { ChatErrorNotice } from "./ChatErrorNotice.tsx"
 import { LoadingShimmerText } from "./LoadingShimmerText.tsx"
 import { processOpenAfterStatusChange, processShouldOpenAutomatically } from "./process-activity-open.ts"
+import { ProcessActivityViewport } from "./ProcessActivityViewport.tsx"
 import { formatWholeSecondDuration } from "./tool-activity.ts"
 import { toolActionSummary, toolServiceSlug } from "./tool-display.ts"
 import { isActiveToolPart } from "./tool-state.ts"
@@ -102,6 +103,7 @@ export function TurnProcessActivity({
   onRecover,
   onRetryFresh,
   onViewBilling,
+  onBeforeDisclosure,
 }: {
   blocks: AssistantTimelineBlock[]
   process: ReturnType<typeof summarizeTurnProcess>
@@ -112,6 +114,7 @@ export function TurnProcessActivity({
   onRecover?: (kind: ChatErrorKind) => Promise<void> | void
   onRetryFresh?: () => Promise<void> | void
   onViewBilling?: () => void
+  onBeforeDisclosure?: (anchor: HTMLElement | null) => () => void
 }) {
   const t = useT()
   const status = chatTurnProcessStatus(process, live)
@@ -125,6 +128,8 @@ export function TurnProcessActivity({
   ].join(":")
   const [open, setOpen] = React.useState(shouldOpen)
   const [now, setNow] = React.useState(() => Date.now())
+  const triggerRef = React.useRef<HTMLButtonElement>(null)
+  const restoreScrollAnchorRef = React.useRef<(() => void) | null>(null)
   const duration = formatProcessDuration(process, now, live)
   const title = processTitle(t, status, duration)
   const renderBlocks = blocks.map((item) => item.block)
@@ -154,16 +159,26 @@ export function TurnProcessActivity({
     return () => window.clearInterval(timer)
   }, [status])
 
-  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
-    openPreferenceRef.current = nextOpen ? "user_open" : "user_closed"
-    setOpen(nextOpen)
-  }, [])
+  React.useLayoutEffect(() => {
+    restoreScrollAnchorRef.current?.()
+    restoreScrollAnchorRef.current = null
+  }, [open])
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      restoreScrollAnchorRef.current = onBeforeDisclosure?.(triggerRef.current) ?? null
+      openPreferenceRef.current = nextOpen ? "user_open" : "user_closed"
+      setOpen(nextOpen)
+    },
+    [onBeforeDisclosure],
+  )
 
   return (
     <Task open={open} onOpenChange={handleOpenChange} className="not-prose my-0 w-full">
       <div className="border-b border-border/60 py-1.5 pr-1.5">
         <TaskTrigger title={title}>
           <button
+            ref={triggerRef}
             type="button"
             className="group inline-flex max-w-full items-center gap-1.5 text-left font-medium text-[var(--oo-section-heading-foreground)] transition-colors select-none"
           >
@@ -176,7 +191,7 @@ export function TurnProcessActivity({
         </TaskTrigger>
       </div>
       <TaskContent className="[&>div]:mt-0">
-        <div className="space-y-2 pt-2">
+        <ProcessActivityViewport followKey={statusKey} label={title} live={isLiveTurnProcess(process, live)}>
           {blocks.map(({ message, block }, index) => (
             <AssistantBlock
               key={`${message.id}:${block.kind === "tools" ? block.key : block.part.partId}`}
@@ -195,7 +210,7 @@ export function TurnProcessActivity({
             />
           ))}
           {showLiveStatus ? <LiveStatusBar process={process} live={live} /> : null}
-        </div>
+        </ProcessActivityViewport>
       </TaskContent>
     </Task>
   )

--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -114,6 +114,7 @@ interface ChatTurnViewProps {
   onArtifactsAvailable: (selection: ArtifactSelection) => void
   onArtifactsOpen: (selection: ArtifactSelection) => void
   onTurnOutputOpen: (selection: TurnOutputSelection) => void
+  onBeforeDisclosure: (anchor: HTMLElement | null) => () => void
   onViewBilling?: () => void
 }
 
@@ -134,6 +135,7 @@ function chatTurnViewPropsEqual(previous: ChatTurnViewProps, next: ChatTurnViewP
     previous.onArtifactsAvailable === next.onArtifactsAvailable &&
     previous.onArtifactsOpen === next.onArtifactsOpen &&
     previous.onTurnOutputOpen === next.onTurnOutputOpen &&
+    previous.onBeforeDisclosure === next.onBeforeDisclosure &&
     previous.onViewBilling === next.onViewBilling
   )
 }
@@ -154,6 +156,7 @@ const ChatTurnView = React.memo(function ChatTurnView({
   onArtifactsAvailable,
   onArtifactsOpen,
   onTurnOutputOpen,
+  onBeforeDisclosure,
   onViewBilling,
 }: ChatTurnViewProps) {
   const timelineSegments = segmentAssistantTimeline(turn.assistants)
@@ -284,6 +287,7 @@ const ChatTurnView = React.memo(function ChatTurnView({
                     onRecover={retrySource ? handleRecover : undefined}
                     onRetryFresh={retrySource ? handleRetryFresh : undefined}
                     onViewBilling={onViewBilling}
+                    onBeforeDisclosure={onBeforeDisclosure}
                   />
                 </MessageContent>
                 {ownsTurnActions && (processActionsText || assistantCancelled) ? (
@@ -413,6 +417,21 @@ export const ChatTimeline = React.memo(function ChatTimeline({
   const artifactGroupsByMessageIdRef = React.useRef<Map<string, ResolvedArtifactGroup[]>>(new Map())
   const artifactGroupsByTurnIdRef = React.useRef<Map<string, ResolvedArtifactGroup[]>>(new Map())
   const latestAssistant = React.useMemo(() => latestAssistantMessage(messages), [messages])
+  const handleBeforeDisclosure = React.useCallback((anchor: HTMLElement | null) => {
+    const conversation = conversationRef.current
+    const scrollElement = conversation?.scrollRef.current
+    conversation?.stopScroll()
+    if (!anchor || !scrollElement) {
+      return () => undefined
+    }
+    const anchorTop = anchor.getBoundingClientRect().top
+    return () => {
+      const offset = anchor.getBoundingClientRect().top - anchorTop
+      if (Math.abs(offset) > 0.5) {
+        scrollElement.scrollTop += offset
+      }
+    }
+  }, [])
   const turnGrouping = React.useMemo(() => updateChatTurnGrouping(turnGroupingRef.current, messages), [messages])
   React.useLayoutEffect(() => {
     turnGroupingRef.current = turnGrouping
@@ -559,6 +578,7 @@ export const ChatTimeline = React.memo(function ChatTimeline({
                 onArtifactsOpen={onArtifactsOpen}
                 onArtifactsAvailable={publishArtifactAvailability ? onArtifactsAvailable : noopArtifactsAvailable}
                 onTurnOutputOpen={onTurnOutputOpen}
+                onBeforeDisclosure={handleBeforeDisclosure}
                 onViewBilling={onViewBilling}
               />
             </div>

--- a/src/routes/Chat/ProcessActivityViewport.test.ts
+++ b/src/routes/Chat/ProcessActivityViewport.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { processActivityScrollState } from "./process-activity-scroll.ts"
+
+describe("processActivityScrollState", () => {
+  it("treats short content as fully visible", () => {
+    expect(processActivityScrollState({ clientHeight: 320, scrollHeight: 240, scrollTop: 0 })).toEqual({
+      atBottom: true,
+      atTop: true,
+      hasOverflow: false,
+      remaining: 0,
+    })
+  })
+
+  it("shows only the bottom edge when an overflowing viewport is at the start", () => {
+    expect(processActivityScrollState({ clientHeight: 320, scrollHeight: 800, scrollTop: 0 })).toEqual({
+      atBottom: false,
+      atTop: true,
+      hasOverflow: true,
+      remaining: 480,
+    })
+  })
+
+  it("shows both edges while the viewport is in the middle", () => {
+    expect(processActivityScrollState({ clientHeight: 320, scrollHeight: 800, scrollTop: 200 })).toEqual({
+      atBottom: false,
+      atTop: false,
+      hasOverflow: true,
+      remaining: 280,
+    })
+  })
+
+  it("allows for subpixel rounding at the bottom edge", () => {
+    expect(processActivityScrollState({ clientHeight: 320, scrollHeight: 800, scrollTop: 479 })).toEqual({
+      atBottom: true,
+      atTop: false,
+      hasOverflow: true,
+      remaining: 1,
+    })
+  })
+})

--- a/src/routes/Chat/ProcessActivityViewport.tsx
+++ b/src/routes/Chat/ProcessActivityViewport.tsx
@@ -71,7 +71,7 @@ export function ProcessActivityViewport({
       <div
         ref={viewportRef}
         aria-label={label}
-        className="max-h-[min(20rem,40vh)] overflow-y-auto pr-1 focus-visible:outline-none"
+        className="max-h-[min(20rem,40vh)] overflow-y-auto rounded-sm pr-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         onScroll={handleScroll}
         role="region"
         tabIndex={scrollState.hasOverflow ? 0 : -1}

--- a/src/routes/Chat/ProcessActivityViewport.tsx
+++ b/src/routes/Chat/ProcessActivityViewport.tsx
@@ -1,0 +1,97 @@
+import type { ProcessActivityScrollState } from "./process-activity-scroll.ts"
+import type { ReactNode } from "react"
+
+import * as React from "react"
+import { processActivityScrollState } from "./process-activity-scroll.ts"
+import { cn } from "@/lib/utils"
+
+const followLatestTolerancePx = 24
+
+const initialScrollState: ProcessActivityScrollState = {
+  atBottom: true,
+  atTop: true,
+  hasOverflow: false,
+  remaining: 0,
+}
+
+export function ProcessActivityViewport({
+  children,
+  className,
+  followKey,
+  label,
+  live,
+}: {
+  children: ReactNode
+  className?: string
+  followKey: string
+  label: string
+  live: boolean
+}) {
+  const viewportRef = React.useRef<HTMLDivElement>(null)
+  const contentRef = React.useRef<HTMLDivElement>(null)
+  const followingLatestRef = React.useRef(true)
+  const [scrollState, setScrollState] = React.useState(initialScrollState)
+
+  const measure = React.useCallback(() => {
+    const viewport = viewportRef.current
+    if (!viewport) {
+      return
+    }
+    if (live && followingLatestRef.current) {
+      viewport.scrollTop = viewport.scrollHeight
+    }
+    setScrollState(processActivityScrollState(viewport))
+  }, [live])
+
+  React.useEffect(() => {
+    measure()
+    if (typeof ResizeObserver === "undefined") {
+      return
+    }
+    const observer = new ResizeObserver(measure)
+    const viewport = viewportRef.current
+    const content = contentRef.current
+    if (viewport) {
+      observer.observe(viewport)
+    }
+    if (content) {
+      observer.observe(content)
+    }
+    return () => observer.disconnect()
+  }, [followKey, measure])
+
+  const handleScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const next = processActivityScrollState(event.currentTarget)
+    followingLatestRef.current = next.remaining <= followLatestTolerancePx
+    setScrollState(next)
+  }, [])
+
+  return (
+    <div className={cn("relative min-w-0", className)}>
+      <div
+        ref={viewportRef}
+        aria-label={label}
+        className="max-h-[min(20rem,40vh)] overflow-y-auto pr-1 focus-visible:outline-none"
+        onScroll={handleScroll}
+        role="region"
+        tabIndex={scrollState.hasOverflow ? 0 : -1}
+      >
+        <div ref={contentRef} className="space-y-2 py-2">
+          {children}
+        </div>
+      </div>
+      {scrollState.hasOverflow && !scrollState.atTop ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-background to-transparent"
+        />
+      ) : null}
+      {scrollState.hasOverflow && !scrollState.atBottom ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-background to-transparent"
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -91,7 +91,10 @@ describe("ToolActivityStep", () => {
       output: "{}",
     })
 
-    expect(html).toContain("正在查询知识库...")
+    expect(html).toContain("查询知识库")
+    expect(html).toContain("已完成")
+    expect(html).not.toContain("正在查询知识库")
+    expect(html).not.toContain("opacity-0 group-hover/tool-step:opacity-100")
     expect(html).not.toContain("wg wikg://lib")
     expect(html).not.toContain("jq .")
     expect(html).not.toContain("工具参数")
@@ -123,7 +126,8 @@ describe("ToolActivityStep", () => {
     const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
     expect(parts).toHaveLength(1)
-    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(1)
+    expect(html.match(/查询知识库/g)).toHaveLength(1)
+    expect(html).toContain("已完成")
     expect(html).not.toContain("wg wikg://lib")
     expect(html).not.toContain("jq .")
     expect(html).not.toContain("lucide-chevron-right")
@@ -158,7 +162,8 @@ describe("ToolActivityStep", () => {
       const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
       expect(parts).toHaveLength(1)
-      expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(1)
+      expect(html.match(/查询知识库/g)).toHaveLength(1)
+      expect(html).toContain("已完成")
       expect(html).not.toContain("wikigraph-knowledge")
       expect(html).not.toContain("Loaded skill")
       expect(html).not.toContain("wg wikg://lib")
@@ -198,7 +203,7 @@ describe("ToolActivityStep", () => {
     const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
     expect(parts).toHaveLength(3)
-    expect(html.match(/正在查询知识库\.\.\./g)).toHaveLength(2)
+    expect(html.match(/查询知识库/g)).toHaveLength(2)
     expect(html).toContain("jq . /tmp/result.json")
   })
 
@@ -225,7 +230,7 @@ describe("ToolActivityStep", () => {
     const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
     expect(parts).toHaveLength(1)
-    expect(html).toContain("正在查询知识库...")
+    expect(html).toContain("查询知识库")
     expect(html).toContain("未完成")
     expect(html).not.toContain("wg wikg://lib/entity")
     expect(html).not.toContain("lucide-chevron-right")
@@ -242,7 +247,7 @@ describe("ToolActivityStep", () => {
       output: "# PDF",
     })
 
-    expect(html).not.toContain("正在查询知识库...")
+    expect(html).not.toContain("查询知识库")
     expect(html).toContain("Loaded skill: pdf")
     expect(html).toContain("lucide-chevron-right")
   })
@@ -258,11 +263,27 @@ describe("ToolActivityStep", () => {
       error: "exit code 1",
     })
 
-    expect(html).toContain("正在查询知识库...")
+    expect(html).toContain("查询知识库")
     expect(html).toContain("未完成")
     expect(html).not.toContain("wg wikg://lib")
     expect(html).not.toContain("jq .")
     expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("uses the live status and shimmer instead of loading punctuation for active knowledge queries", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-wg-running",
+      callId: "call-wg-running",
+      tool: "bash",
+      status: "running",
+      input: { command: 'wg wikg://lib/search --query "唐僧" --json' },
+    })
+
+    expect(html).toContain("查询知识库")
+    expect(html).toContain("运行中")
+    expect(html).toMatch(/class="[^"]*text-transparent[^"]*"[^>]*>查询知识库<\/span>/)
+    expect(html).not.toContain("查询知识库...")
   })
 
   it("shimmers only the active web fetch title when the URL is shown inline", () => {

--- a/src/routes/Chat/ToolActivityStep.tsx
+++ b/src/routes/Chat/ToolActivityStep.tsx
@@ -269,7 +269,7 @@ export function ToolActivityStep({
   const showShimmer = active || shimmer
   const displayLine = toolDisplayLine(t, part)
   const metaItems = [provider?.displayName, statusText].filter(Boolean)
-  const completedMeta = part.status === "completed" && !auth
+  const hideCompletedMeta = part.status === "completed" && !auth && !hideDetails
   const outputPreview = React.useMemo(() => {
     if (!detailsVisible || !part.output || auth) {
       return null
@@ -343,8 +343,8 @@ export function ToolActivityStep({
             <span
               className={cn(
                 "flex min-w-0 shrink-0 items-center gap-1 font-medium text-muted-foreground transition-opacity",
-                completedMeta && "opacity-0 group-hover/tool-step:opacity-100",
-                completedMeta &&
+                hideCompletedMeta && "opacity-0 group-hover/tool-step:opacity-100",
+                hideCompletedMeta &&
                   details &&
                   "group-focus-visible/tool-step:opacity-100 group-data-[state=open]/tool-step:opacity-100",
               )}

--- a/src/routes/Chat/process-activity-scroll.ts
+++ b/src/routes/Chat/process-activity-scroll.ts
@@ -1,0 +1,22 @@
+const edgeTolerancePx = 2
+
+export interface ProcessActivityScrollState {
+  atBottom: boolean
+  atTop: boolean
+  hasOverflow: boolean
+  remaining: number
+}
+
+export function processActivityScrollState(input: {
+  clientHeight: number
+  scrollHeight: number
+  scrollTop: number
+}): ProcessActivityScrollState {
+  const remaining = Math.max(0, input.scrollHeight - input.scrollTop - input.clientHeight)
+  return {
+    atBottom: remaining <= edgeTolerancePx,
+    atTop: input.scrollTop <= edgeTolerancePx,
+    hasOverflow: input.scrollHeight > input.clientHeight + edgeTolerancePx,
+    remaining,
+  }
+}


### PR DESCRIPTION
## Summary

Improve the chat tool-process timeline so long runs remain readable without taking over the conversation, disclosure interactions preserve the reader's position, and WikiGraph knowledge activity reports its real lifecycle state.

## Problem

Long tool sequences expanded without a height limit, which could push the assistant's answer and composer far down the page. Expanding or collapsing the process also changed the outer conversation height, causing the stick-to-bottom behavior to pull the entire chat toward the bottom instead of preserving the process header the user had clicked.

WikiGraph activity had a separate status-copy issue: every knowledge row used the fixed label `Searching knowledge...`, including completed and failed calls. The underlying tool status was already correct, but the stale progressive label made historical activity look unfinished.

## Root cause

The process content rendered directly in the assistant timeline with no bounded viewport. The outer conversation's resize observer could not distinguish model-generated growth from a user-triggered disclosure.

WikiGraph rows used one status-independent translation key. Completed status metadata was also hidden until hover, so the misleading title was usually the only visible state.

## Changes

- Bound expanded process activity to `min(20rem, 40vh)` and enable internal scrolling only when content overflows.
- Add conditional top and bottom fades that reflect the current scroll edges.
- Follow new live tool activity only while the user remains near the inner viewport bottom.
- Stop outer stick-to-bottom behavior for user-triggered process disclosure and restore the clicked header's visual position after layout.
- Replace the fixed WikiGraph loading copy with the neutral action label `查询知识库` / `Search knowledge`.
- Keep the real completed status visible for compact WikiGraph rows while retaining running shimmer and the existing pending, error, and stopped states.
- Preserve the existing WikiGraph grouping and internal-command redaction behavior.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run src/routes/Chat/ProcessActivityViewport.test.ts src/routes/Chat/ToolActivityStep.test.ts src/routes/Chat/tool-display.test.ts src/routes/Chat/tool-activity.test.ts src/routes/Chat/process-activity-open.test.ts`

All five test files passed with 60 tests.
