### PR TITLE
fix(chat): detect WG substitutions in env assignments

### DIFF
--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -99,6 +99,40 @@ describe("ToolActivityStep", () => {
     expect(html).not.toContain("lucide-chevron-right")
   })
 
+  it("renders assignment-prefix WG Bash substitutions as knowledge activity", () => {
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-wg-assignment",
+      callId: "call-wg-assignment",
+      tool: "bash",
+      status: "completed",
+      input: { command: "env FOO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1" },
+      output: "{}",
+    })
+
+    expect(html).toContain("知识库")
+    expect(html).not.toContain("env FOO=")
+    expect(html).not.toContain("wg wikg://lib")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("keeps quoted assignment WG Bash text visible as an ordinary command", () => {
+    const command = "env FOO='$(wg wikg://lib/entity --query 唐僧 --json)' node -e 1"
+    const html = renderToolActivityStep({
+      kind: "tool",
+      partId: "tool-wg-quoted-assignment",
+      callId: "call-wg-quoted-assignment",
+      tool: "bash",
+      status: "completed",
+      input: { command },
+      output: "{}",
+    })
+
+    expect(html).not.toContain("正在查询知识库...")
+    expect(html).toContain("env FOO=&#x27;$(wg wikg://lib/entity --query 唐僧 --json)&#x27; node -e 1")
+    expect(html).toContain("lucide-chevron-right")
+  })
+
   it("renders consecutive WG Bash knowledge calls as one compact knowledge row", () => {
     const parts = groupedToolActivityParts([
       {

--- a/src/routes/Chat/tool-display.test.ts
+++ b/src/routes/Chat/tool-display.test.ts
@@ -86,6 +86,40 @@ describe("tool display", () => {
     expect(toolActionSummary(t, part)).toBe("chat.toolBashQueryKnowledge:")
   })
 
+  it("renders assignment-prefix WG substitutions as hidden knowledge Bash calls", () => {
+    const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "bash",
+      status: "completed" as const,
+      input: { command: "OO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1" },
+    }
+
+    expect(isWgKnowledgeBashPart(part)).toBe(true)
+    expect(toolDisplayLine(t, part)).toEqual({ title: "chat.toolBashQueryKnowledge:" })
+    expect(toolActionSummary(t, part)).toBe("chat.toolBashQueryKnowledge:")
+  })
+
+  it("keeps quoted assignment WG text in the ordinary Bash display path", () => {
+    const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
+    const command = "env FOO='$(wg wikg://lib/entity --query 唐僧 --json)' node -e 1"
+    const part = {
+      kind: "tool" as const,
+      partId: "p1",
+      tool: "bash",
+      status: "completed" as const,
+      input: { command },
+    }
+
+    expect(isWgKnowledgeBashPart(part)).toBe(false)
+    expect(toolDisplayLine(t, part)).toEqual({
+      title: "chat.toolRunGeneric:",
+      detail: command,
+      detailKind: "code",
+    })
+  })
+
   it("renders the wikigraph-knowledge skill load as a hidden knowledge activity", () => {
     const t = (key: string, vars?: Record<string, string | number>) => `${key}:${vars?.detail ?? ""}`
     const part = {

--- a/src/routes/Chat/wg-shell-detection.test.ts
+++ b/src/routes/Chat/wg-shell-detection.test.ts
@@ -18,6 +18,11 @@ const positiveCases = [
   "wg wikg://lib --query - <<'QUERY'\n唐僧 和 孙悟空\nQUERY",
   "diff <(wg wikg://lib/entity --query 唐僧 --json) old.json",
   'echo "$(wg wikg://lib/entity --query 唐僧 --json)" | jq .',
+  "OO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1",
+  "env FOO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1",
+  "FOO=$(wikigraph wikg://lib inspect) node -e 1",
+  "env -i FOO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1",
+  "env --unset PATH FOO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1",
 ]
 
 const negativeCases = [
@@ -32,6 +37,10 @@ const negativeCases = [
   "python -c \"print('wg wikg://lib')\"",
   "cat <<'EOF'\nwg wikg://lib --query 唐僧\nEOF",
   "cat <<EOF\nwg wikg://lib --query 唐僧\nEOF",
+  "OO='$(wg wikg://lib/entity --query 唐僧 --json)' node -e 1",
+  "env FOO='$(wg wikg://lib/entity --query 唐僧 --json)' node -e 1",
+  'OO="wg wikg://lib/entity --query 唐僧 --json" node -e 1',
+  'env FOO="wg wikg://lib/entity --query 唐僧 --json" node -e 1',
 ]
 
 const unbashBoundaryCases = [

--- a/src/routes/Chat/wg-shell-detection.ts
+++ b/src/routes/Chat/wg-shell-detection.ts
@@ -34,8 +34,11 @@ function scanAstValue(value: unknown, source: string, depth: number): boolean {
   if (Array.isArray(value)) {
     return value.some((item) => scanAstValue(item, source, depth))
   }
+  if (isAssignmentNode(value)) {
+    return scanWord(value.value, depth)
+  }
   if (isWord(value)) {
-    return scanWord(value, source, depth)
+    return scanWord(value, depth)
   }
   if (isCommand(value)) {
     return scanCommand(value, source, depth)
@@ -57,18 +60,21 @@ function scanAstValue(value: unknown, source: string, depth: number): boolean {
 
 function scanCommand(command: Command, source: string, depth: number): boolean {
   const words = command.name ? [command.name, ...command.suffix] : [...command.suffix]
-  return scanCommandWords(words, command.redirects, source, depth)
+  return scanAstValue(command.prefix, source, depth) || scanCommandWords(words, command.redirects, source, depth)
 }
 
 function scanCommandWords(words: Word[], redirects: Redirect[], source: string, depth: number): boolean {
   const commandIndex = firstCommandWordIndex(words, 0)
   if (commandIndex >= words.length) {
-    return scanNestedWords(words, source, depth) || scanAstValue(redirects, source, depth)
+    return scanNestedWords(words, depth) || scanAstValue(redirects, source, depth)
   }
 
   const executable = executableName(wordValue(words[commandIndex]))
   if (executable === "env") {
     const envCommandIndex = skipEnvPrefix(words, commandIndex + 1)
+    if (scanNestedWords(words.slice(commandIndex + 1, envCommandIndex), depth)) {
+      return true
+    }
     if (envCommandIndex < words.length) {
       return scanCommandWords(words.slice(envCommandIndex), redirects, source, depth)
     }
@@ -86,18 +92,18 @@ function scanCommandWords(words: Word[], redirects: Redirect[], source: string, 
     return true
   }
 
-  return scanNestedWords(words, source, depth) || scanAstValue(redirects, source, depth)
+  return scanNestedWords(words, depth) || scanAstValue(redirects, source, depth)
 }
 
-function scanNestedWords(words: Word[], source: string, depth: number): boolean {
-  return words.some((word) => scanWord(word, source, depth))
+function scanNestedWords(words: Word[], depth: number): boolean {
+  return words.some((word) => scanWord(word, depth))
 }
 
-function scanWord(word: Word, source: string, depth: number): boolean {
+function scanWord(word: Word, depth: number): boolean {
   // unbash exposes the command structure as AST, but its public package exports do not include the
   // word-part helper that materializes command/process substitutions. Keep this small scanner bounded
   // to unbash-provided Word nodes so the main detection path remains AST-based.
-  for (const substitution of executableSubstitutionsInWord(source.slice(word.pos, word.end))) {
+  for (const substitution of executableSubstitutionsInWord(word.text)) {
     if (scanShell(substitution, depth + 1)) {
       return true
     }
@@ -291,6 +297,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isCommand(value: unknown): value is Command {
   return isRecord(value) && value.type === "Command"
+}
+
+function isAssignmentNode(value: unknown): value is { type: "Assignment"; value: Word } {
+  return isRecord(value) && value.type === "Assignment" && isWord(value.value)
 }
 
 function isWord(value: unknown): value is Word {


### PR DESCRIPTION
## Summary
- Detect executable WG substitutions inside `Command.prefix` assignment values from the unbash AST.
- Scan `env` wrapper assignment/option words before recursing into the real wrapped command.
- Use unbash `Word.text` for nested substitution scanning so non-ASCII command text is not affected by position offset differences across environments.
- Add coverage for assignment/env positive cases, quoted/plain assignment negatives, tool display, and ToolActivityStep UI behavior.

Closes #267

## Verification
- `corepack pnpm vitest run src/routes/Chat/wg-shell-detection.test.ts src/routes/Chat/tool-display.test.ts src/routes/Chat/ToolActivityStep.test.ts` — passed (3 files, 73 tests).
- `corepack pnpm run ts-check` — passed.
- `corepack pnpm run lint` — passed (0 warnings/errors).
- `corepack pnpm run format` — passed.
- `corepack pnpm test` — passed (266 files, 2021 tests; existing service-broadcast stderr noise only).
- `corepack pnpm run build` — passed.
- Manual issue sample check via `node --input-type=module` — all 5 positive samples returned `true`; all 4 negative samples returned `false`.

## Electron App regression
- Launch command used for real app verification: `VITE_WANTA_WG_TOOL_SMOKE=1 VITE_WANTA_LOCALE=zh-CN corepack pnpm run dev:worktree`.
- A temporary dev-only smoke entry was used locally and was not retained in this PR.
- Evidence from the live Wanta Local window: `env FOO=$(wg wikg://lib/entity --query 唐僧 --json) node -e 1` displayed as `正在查询知识库...` with command details hidden; `env FOO='$(wg wikg://lib/entity --query 唐僧 --json)' node -e 1` remained an ordinary Bash row (`运行命令`) with command details visible.

## Review note
- Blind reviewer was attempted through delegation `deleg_89f95e45`, but the reviewer API failed after 3 retries with HTTP 503 (`所有供应商暂时不可用，请稍后重试`).
- Per task rules, I completed a non-blind fallback review against issue #267's acceptance rubric.
- Fallback verdict: pass. This change is UI classification only, does not alter WG/wikigraph CLI behavior, does not change the unbash dependency, and does not affect security/permission/production-data boundaries.

## CI follow-up
- The first PR run exposed a Linux-only test failure caused by scanning source slices with unbash offsets around non-ASCII text.
- The latest commit switches nested substitution scanning to `Word.text`; local full test/build pass after that fix.
