### PR TITLE
fix(chat): require WikiGraph for pinned knowledge context

### DIFF
--- a/electron/chat/context-system.test.ts
+++ b/electron/chat/context-system.test.ts
@@ -9,6 +9,10 @@ test("buildContextMentionsSystem describes a pinned knowledge base without expos
   assert.match(prompt, /kb-1/)
   assert.match(prompt, /西游记/)
   assert.match(prompt, /load and follow the `wikigraph-knowledge` Skill/)
+  assert.match(prompt, /before answering/)
+  assert.match(prompt, /people, events, relationships, causes\/processes\/results, summaries/)
+  assert.match(prompt, /citations, sources, quotations, or fact-checking/)
+  assert.match(prompt, /do not answer those requests from general model knowledge/)
   assert.doesNotMatch(prompt, /shell `wg` command/)
   assert.doesNotMatch(prompt, /Wanta provides a managed `wg` on PATH/)
   assert.doesNotMatch(prompt, /Never modify a knowledge base unless the user explicitly asks/)
@@ -24,6 +28,22 @@ test("buildContextMentionsSystem describes the global knowledge library", () => 
   assert.match(prompt, /library URI: "wikg:\/\/lib"/)
   assert.doesNotMatch(prompt, /wikg:\/\/lib\/arc\/wikg:\/\/lib/)
   assert.match(prompt, /Treat `wikg:\/\/lib` as the whole local WikiGraph library/)
+  assert.match(prompt, /Use `wikg:\/\/lib` directly for a selected knowledge library/)
+})
+
+test("buildContextMentionsSystem routes the Hua Rong Trail fixture through WikiGraph context", () => {
+  const userPrompt = "关羽在华容道放走曹操，前后涉及的故事起因经过结果和相关人物结局是什么？你帮我列出来。"
+  const contextPrompt =
+    buildContextMentionsSystem([
+      { id: "wikg://lib", kind: "knowledge", name: "Knowledge library", scope: "library" },
+    ]) ?? ""
+  const agentInput = `${contextPrompt}\n\nUser request:\n${userPrompt}`
+
+  assert.match(agentInput, /load and follow the `wikigraph-knowledge` Skill/)
+  assert.match(agentInput, /people, events, relationships, causes\/processes\/results, summaries/)
+  assert.match(agentInput, /do not answer those requests from general model knowledge/)
+  assert.match(agentInput, /wikg:\/\/lib/)
+  assert.doesNotMatch(agentInput, /wikg:\/\/lib\/arc\/wikg:\/\/lib/)
 })
 
 test("buildPermissionModeSystem describes default access", () => {

--- a/electron/chat/context-system.ts
+++ b/electron/chat/context-system.ts
@@ -57,7 +57,9 @@ export function buildContextMentionsSystem(mentions: ChatContextMention[] | unde
       lines.push(`- ${quoted(knowledgeBase.name)}; ${isLibrary ? "library" : "archive"} URI: ${quoted(uri)}`)
     }
     lines.push(
-      "When the user's request depends on these knowledge bases, load and follow the `wikigraph-knowledge` Skill with the listed library/archive URI. Treat `wikg://lib` as the whole local WikiGraph library and `wikg://lib/arc/<id>` as a focused archive.",
+      "For knowledge-base-related requests, load and follow the `wikigraph-knowledge` Skill with the listed library/archive URI before answering. This includes requests about knowledge, facts, people, events, relationships, causes/processes/results, summaries, citations, sources, quotations, or fact-checking; do not answer those requests from general model knowledge while this knowledge context is pinned.",
+      "Treat `wikg://lib` as the whole local WikiGraph library and `wikg://lib/arc/<id>` as a focused archive. Use `wikg://lib` directly for a selected knowledge library; never wrap the whole-library URI inside an archive URI.",
+      "If WikiGraph search fails, the index is unavailable, or no evidence is found, say that limitation explicitly instead of pretending the knowledge base was searched successfully.",
     )
   }
   return lines.join("\n")


### PR DESCRIPTION
## Summary
- Strengthen pinned knowledge-base turn context so knowledge/fact/person/event/relationship/cause-process-result/summary/source requests must load and follow `wikigraph-knowledge` before answering.
- Clarify that `wikg://lib` represents the whole local WikiGraph library and must not be wrapped as an archive URI.
- Add regression coverage for the global library URI and the Hua Rong Trail issue fixture from #269.

Closes #269

## Verification
- `corepack pnpm test -- electron/chat/context-system.test.ts`
- `corepack pnpm run ts-check`
- `corepack pnpm run lint`
- `corepack pnpm run format`
- `corepack pnpm test`
- `corepack pnpm run build`

## Review
- Local diff reviewed with Codex read-only review; no blocking issues found.
- Manual dev smoke launched with `corepack pnpm run dev:worktree` after `corepack pnpm run bootstrap`; the app and agent sidecar reached ready state. Interactive @ mention entry was not used as the primary verification because background desktop typing was unreliable in this session.
