### PR TITLE
fix(chat): coalesce WikiGraph probe activity

### DIFF
--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -208,56 +208,59 @@ describe("ToolActivityStep", () => {
   })
 
   it("coalesces an entire WikiGraph flow across skill load, WG probe, completed queries, and a running query", () => {
-    const parts = groupedToolActivityParts([
-      {
-        kind: "tool",
-        partId: "tool-skill",
-        callId: "call-skill",
-        tool: "skill",
-        status: "completed",
-        title: "Loaded skill: wikigraph-knowledge",
-        output: "# WikiGraph Knowledge",
-      },
-      {
-        kind: "tool",
-        partId: "tool-wg-help",
-        callId: "call-wg-help",
-        tool: "bash",
-        status: "completed",
-        input: { command: "wg --help 2>&1" },
-        output: "Usage: wg ...",
-      },
-      {
-        kind: "tool",
-        partId: "tool-wg-1",
-        callId: "call-wg-1",
-        tool: "bash",
-        status: "completed",
-        input: { command: 'wg wikg://lib/search --query "华容道" --json' },
-        output: "{}",
-      },
-      {
-        kind: "tool",
-        partId: "tool-wg-2",
-        callId: "call-wg-2",
-        tool: "bash",
-        status: "running",
-        input: { command: 'wg wikg://lib/evidence --query "关羽 曹操" --json' },
-      },
-    ])
-    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+    for (const probeCommand of ["wg --help 2>&1", 'bash -lc "wg --help 2>&1"', "sh -c 'wikigraph --version 2>&1'"]) {
+      const parts = groupedToolActivityParts([
+        {
+          kind: "tool",
+          partId: "tool-skill",
+          callId: "call-skill",
+          tool: "skill",
+          status: "completed",
+          title: "Loaded skill: wikigraph-knowledge",
+          output: "# WikiGraph Knowledge",
+        },
+        {
+          kind: "tool",
+          partId: "tool-wg-help",
+          callId: "call-wg-help",
+          tool: "bash",
+          status: "completed",
+          input: { command: probeCommand },
+          output: "Usage: wg ...",
+        },
+        {
+          kind: "tool",
+          partId: "tool-wg-1",
+          callId: "call-wg-1",
+          tool: "bash",
+          status: "completed",
+          input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+          output: "{}",
+        },
+        {
+          kind: "tool",
+          partId: "tool-wg-2",
+          callId: "call-wg-2",
+          tool: "bash",
+          status: "running",
+          input: { command: 'wg wikg://lib/evidence --query "关羽 曹操" --json' },
+        },
+      ])
+      const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
 
-    expect(parts).toHaveLength(1)
-    expect(html.match(/查询知识库/g)).toHaveLength(1)
-    expect(html).toContain("运行中")
-    expect(html).not.toContain("已完成")
-    expect(html).not.toContain("wg --help")
-    expect(html).not.toContain("wg wikg://")
-    expect(html).not.toContain("Loaded skill")
-    expect(html).not.toContain("wikigraph-knowledge")
-    expect(html).not.toContain("工具参数")
-    expect(html).not.toContain("工具结果")
-    expect(html).not.toContain("lucide-chevron-right")
+      expect(parts).toHaveLength(1)
+      expect(html.match(/查询知识库/g)).toHaveLength(1)
+      expect(html).toContain("运行中")
+      expect(html).not.toContain("已完成")
+      expect(html).not.toContain("wg --help")
+      expect(html).not.toContain("wikigraph --version")
+      expect(html).not.toContain("wg wikg://")
+      expect(html).not.toContain("Loaded skill")
+      expect(html).not.toContain("wikigraph-knowledge")
+      expect(html).not.toContain("工具参数")
+      expect(html).not.toContain("工具结果")
+      expect(html).not.toContain("lucide-chevron-right")
+    }
   })
 
   it("keeps WikiGraph probe commands visible when no knowledge flow surrounds them", () => {

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -207,6 +207,88 @@ describe("ToolActivityStep", () => {
     }
   })
 
+  it("coalesces an entire WikiGraph flow across skill load, WG probe, completed queries, and a running query", () => {
+    const parts = groupedToolActivityParts([
+      {
+        kind: "tool",
+        partId: "tool-skill",
+        callId: "call-skill",
+        tool: "skill",
+        status: "completed",
+        title: "Loaded skill: wikigraph-knowledge",
+        output: "# WikiGraph Knowledge",
+      },
+      {
+        kind: "tool",
+        partId: "tool-wg-help",
+        callId: "call-wg-help",
+        tool: "bash",
+        status: "completed",
+        input: { command: "wg --help 2>&1" },
+        output: "Usage: wg ...",
+      },
+      {
+        kind: "tool",
+        partId: "tool-wg-1",
+        callId: "call-wg-1",
+        tool: "bash",
+        status: "completed",
+        input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+        output: "{}",
+      },
+      {
+        kind: "tool",
+        partId: "tool-wg-2",
+        callId: "call-wg-2",
+        tool: "bash",
+        status: "running",
+        input: { command: 'wg wikg://lib/evidence --query "关羽 曹操" --json' },
+      },
+    ])
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(1)
+    expect(html.match(/查询知识库/g)).toHaveLength(1)
+    expect(html).toContain("运行中")
+    expect(html).not.toContain("已完成")
+    expect(html).not.toContain("wg --help")
+    expect(html).not.toContain("wg wikg://")
+    expect(html).not.toContain("Loaded skill")
+    expect(html).not.toContain("wikigraph-knowledge")
+    expect(html).not.toContain("工具参数")
+    expect(html).not.toContain("工具结果")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("keeps WikiGraph probe commands visible when no knowledge flow surrounds them", () => {
+    const parts = groupedToolActivityParts([
+      {
+        kind: "tool",
+        partId: "tool-wg-help",
+        callId: "call-wg-help",
+        tool: "bash",
+        status: "completed",
+        input: { command: "wg --help 2>&1" },
+        output: "Usage: wg ...",
+      },
+      {
+        kind: "tool",
+        partId: "tool-ordinary",
+        callId: "call-ordinary",
+        tool: "bash",
+        status: "completed",
+        input: { command: "echo ok" },
+        output: "ok",
+      },
+    ])
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(2)
+    expect(html).not.toContain("查询知识库")
+    expect(html).toContain("wg --help 2&gt;&amp;1")
+    expect(html).toContain("echo ok")
+  })
+
   it("keeps ordinary tools as boundaries between knowledge groups", () => {
     const parts = groupedToolActivityParts([
       {

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -7,9 +7,8 @@ function str(value: unknown): string {
   return typeof value === "string" ? value : ""
 }
 
-function shellWordPattern(word: string): string {
-  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  return String.raw`(?:${escaped}|['"]${escaped}['"])`
+function shellCommandPattern(commandPattern: string): string {
+  return String.raw`(?:${commandPattern}|['"]${commandPattern}['"])`
 }
 
 function isWikigraphProbeCommand(command: string): boolean {
@@ -20,13 +19,14 @@ function isWikigraphProbeCommand(command: string): boolean {
   const executable = String.raw`(?:wg|wikigraph|(?:\S+/)(?:wg|wikigraph))`
   const probeArg = String.raw`(?:--help|-h|help|--version|version)`
   const optionalRedirect = String.raw`(?:\s+\d*>[&]?\d+|\s+[<>]{1,2}\S+)*`
+  const probeCommand = String.raw`${executable}\s+${probeArg}${optionalRedirect}`
   const directProbe = new RegExp(String.raw`^${executable}\s+${probeArg}${optionalRedirect}$`, "iu")
   const envProbe = new RegExp(
     String.raw`^env(?:\s+-\S+|\s+\w+=\S+)*\s+${executable}\s+${probeArg}${optionalRedirect}$`,
     "iu",
   )
   const shellProbe = new RegExp(
-    String.raw`^(?:bash|sh|zsh)\s+(?:-[A-Za-z]*c[A-Za-z]*\s+)${shellWordPattern(`wg --help`)}${optionalRedirect}$`,
+    String.raw`^(?:bash|sh|zsh)\s+(?:-[A-Za-z]*c[A-Za-z]*\s+)${shellCommandPattern(probeCommand)}${optionalRedirect}$`,
     "iu",
   )
   return directProbe.test(normalized) || envProbe.test(normalized) || shellProbe.test(normalized)

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -3,6 +3,39 @@ import type { ChatMessagePart, ToolStatus } from "../../../electron/chat/common.
 import { isWikigraphKnowledgeActivityPart } from "./tool-display.ts"
 import { isToolCancellation } from "./tool-state.ts"
 
+function str(value: unknown): string {
+  return typeof value === "string" ? value : ""
+}
+
+function shellWordPattern(word: string): string {
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return String.raw`(?:${escaped}|['"]${escaped}['"])`
+}
+
+function isWikigraphProbeCommand(command: string): boolean {
+  const normalized = command.replace(/\s+/g, " ").trim()
+  if (!normalized) {
+    return false
+  }
+  const executable = String.raw`(?:wg|wikigraph|(?:\S+/)(?:wg|wikigraph))`
+  const probeArg = String.raw`(?:--help|-h|help|--version|version)`
+  const optionalRedirect = String.raw`(?:\s+\d*>[&]?\d+|\s+[<>]{1,2}\S+)*`
+  const directProbe = new RegExp(String.raw`^${executable}\s+${probeArg}${optionalRedirect}$`, "iu")
+  const envProbe = new RegExp(
+    String.raw`^env(?:\s+-\S+|\s+\w+=\S+)*\s+${executable}\s+${probeArg}${optionalRedirect}$`,
+    "iu",
+  )
+  const shellProbe = new RegExp(
+    String.raw`^(?:bash|sh|zsh)\s+(?:-[A-Za-z]*c[A-Za-z]*\s+)${shellWordPattern(`wg --help`)}${optionalRedirect}$`,
+    "iu",
+  )
+  return directProbe.test(normalized) || envProbe.test(normalized) || shellProbe.test(normalized)
+}
+
+function isWikigraphKnowledgeAuxiliaryPart(part: ChatMessagePart): boolean {
+  return part.tool === "bash" && isWikigraphProbeCommand(str(part.input?.command))
+}
+
 function mergedStatus(parts: ChatMessagePart[]): ToolStatus | undefined {
   if (parts.some((part) => part.status === "error")) {
     return "error"
@@ -56,6 +89,21 @@ function mergeWikigraphKnowledgeParts(parts: ChatMessagePart[]): ChatMessagePart
 export function groupedToolActivityParts(parts: ChatMessagePart[]): ChatMessagePart[] {
   const grouped: ChatMessagePart[] = []
   let pendingKnowledge: ChatMessagePart[] = []
+  const hasLaterKnowledgeActivity = (startIndex: number) => {
+    for (let index = startIndex; index < parts.length; index += 1) {
+      const candidate = parts[index]
+      if (!candidate) {
+        continue
+      }
+      if (isWikigraphKnowledgeActivityPart(candidate)) {
+        return true
+      }
+      if (!isWikigraphKnowledgeAuxiliaryPart(candidate)) {
+        return false
+      }
+    }
+    return false
+  }
   const flushKnowledge = () => {
     if (pendingKnowledge.length === 0) {
       return
@@ -64,8 +112,19 @@ export function groupedToolActivityParts(parts: ChatMessagePart[]): ChatMessageP
     pendingKnowledge = []
   }
 
-  for (const part of parts) {
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index]
+    if (!part) {
+      continue
+    }
     if (isWikigraphKnowledgeActivityPart(part)) {
+      pendingKnowledge.push(part)
+      continue
+    }
+    if (
+      isWikigraphKnowledgeAuxiliaryPart(part) &&
+      (pendingKnowledge.length > 0 || hasLaterKnowledgeActivity(index + 1))
+    ) {
       pendingKnowledge.push(part)
       continue
     }


### PR DESCRIPTION
## Summary
- Coalesce WikiGraph knowledge activity across skill loading, WG probe commands, completed WG queries, and a running WG query into one knowledge-query activity row.
- Treat standalone WG probe commands as ordinary Bash so unrelated commands are not hidden as knowledge activity.
- Add regression coverage for the issue sequence and for the non-knowledge Bash boundary.

Closes https://github.com/oomol-lab/wanta/issues/272

## Acceptance evidence
- Automated coverage added for: `Loaded skill: wikigraph-knowledge` → `wg --help 2>&1` → multiple `wg ... wikg://...` queries with a running query.
- Rendering assertion verifies only one `查询知识库` row, running state is preserved, and `wg --help`, `wg wikg://`, `Loaded skill`, `工具参数`, `工具结果`, and chevron details are absent.
- Standalone `wg --help 2>&1` plus ordinary `echo ok` remains visible as ordinary command activity.
- Electron real-app regression: launched Wanta Local with `VITE_WANTA_SMOKE` using the issue reproduction prompt and an authenticated worktree userData. The run produced real WikiGraph `wg wikg://...` tool calls and a final answer. Window screenshot `/tmp/wanta-smoke/wanta-window.png` was inspected: one knowledge-query activity row was visible; `wg --help`, `wg wikg://`, `Loaded skill`, `工具参数`, `工具结果`, and expandable entry were not visible.

## Verification
- `corepack pnpm exec vitest run src/routes/Chat/ToolActivityStep.test.ts` — 23 tests passed.
- `corepack pnpm run lint` — 0 warnings/errors.
- `corepack pnpm run format` — all matched files use correct format.
- `corepack pnpm run test` — passed.
- `corepack pnpm run build` — passed.

## Review note
Blind reviewer creation was attempted earlier in this Kanban task as required, but the reviewer run failed because the model provider returned HTTP 503 / all providers temporarily unavailable. I completed a non-blind fallback review against the issue acceptance criteria. The change is limited to renderer activity grouping and tests; it does not touch security, credentials, production data, migrations, or public compatibility boundaries.
