### PR TITLE
Fix knowledge archive preparation

### DIFF
--- a/electron/knowledge/node.test.ts
+++ b/electron/knowledge/node.test.ts
@@ -7,6 +7,7 @@ const runner = vi.hoisted(() => ({
   listWikiGraphLibraryArchives: vi.fn(),
   listWikiGraphLibraryFolders: vi.fn(),
   moveWikiGraphLibraryArchive: vi.fn(),
+  prepareWikiGraphArchive: vi.fn(),
   readWikiGraphCover: vi.fn(),
   readWikiGraphIndex: vi.fn(),
   readWikiGraphMetadata: vi.fn(),
@@ -34,6 +35,7 @@ describe("KnowledgeServiceImpl", () => {
     runner.addWikiGraphLibraryArchive.mockReset()
     runner.inspectWikiGraph.mockReset()
     runner.listWikiGraphLibraryArchives.mockReset()
+    runner.prepareWikiGraphArchive.mockReset()
     runner.readWikiGraphCover.mockReset()
     runner.readWikiGraphIndex.mockReset()
     runner.readWikiGraphMetadata.mockReset()
@@ -86,6 +88,87 @@ describe("KnowledgeServiceImpl", () => {
         },
       ])
       expect(warn).toHaveBeenCalledWith("[wanta] failed to inspect knowledge base:", expect.any(Error))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it("prepares the archive before reading summary details", async () => {
+    runner.listWikiGraphLibraryArchives.mockResolvedValue([
+      {
+        id: "public-id",
+        uri: "wikg://lib/arc/public-id",
+        relativePath: "book.wikg",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        exists: true,
+        lastSeenSize: 123,
+        status: "present",
+      },
+    ])
+    runner.prepareWikiGraphArchive.mockResolvedValue(undefined)
+    runner.readWikiGraphMetadata.mockResolvedValue({ title: "Book Title" })
+    runner.inspectWikiGraph.mockResolvedValue({})
+    runner.readWikiGraphIndex.mockResolvedValue({})
+    runner.readWikiGraphCover.mockResolvedValue(null)
+    const service = new KnowledgeServiceImpl({
+      runtime: { managedLibraryDir: "/tmp/wanta/library", stateDir: "/tmp/wanta/state" },
+    })
+
+    await service.list()
+
+    expect(runner.prepareWikiGraphArchive).toHaveBeenCalledWith(
+      { managedLibraryDir: "/tmp/wanta/library", stateDir: "/tmp/wanta/state" },
+      "public-id",
+    )
+    expect(runner.prepareWikiGraphArchive.mock.invocationCallOrder[0]).toBeLessThan(
+      runner.readWikiGraphMetadata.mock.invocationCallOrder[0],
+    )
+    expect(runner.prepareWikiGraphArchive.mock.invocationCallOrder[0]).toBeLessThan(
+      runner.inspectWikiGraph.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("keeps listing other knowledge bases when one archive cannot be prepared", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    runner.listWikiGraphLibraryArchives.mockResolvedValue([
+      {
+        id: "broken-id",
+        uri: "wikg://lib/arc/broken-id",
+        relativePath: "broken.wikg",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        exists: true,
+        lastSeenSize: 1,
+        status: "present",
+      },
+      {
+        id: "good-id",
+        uri: "wikg://lib/arc/good-id",
+        relativePath: "good.wikg",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        exists: true,
+        lastSeenSize: 2,
+        status: "present",
+      },
+    ])
+    runner.prepareWikiGraphArchive.mockImplementation(async (_runtime: unknown, id: string) => {
+      if (id === "broken-id") throw new Error("prepare failed")
+    })
+    runner.readWikiGraphMetadata.mockResolvedValue({ title: "Good Book" })
+    runner.inspectWikiGraph.mockResolvedValue({})
+    runner.readWikiGraphIndex.mockResolvedValue({})
+    runner.readWikiGraphCover.mockResolvedValue(null)
+    const service = new KnowledgeServiceImpl({
+      runtime: { managedLibraryDir: "/tmp/wanta/library", stateDir: "/tmp/wanta/state" },
+    })
+
+    try {
+      await expect(service.list()).resolves.toMatchObject([
+        { id: "good-id", title: "Good Book" },
+        { id: "broken-id", title: "broken" },
+      ])
+      expect(runner.readWikiGraphMetadata).toHaveBeenCalledTimes(1)
+      expect(runner.readWikiGraphMetadata).toHaveBeenCalledWith(expect.anything(), "good-id")
+      expect(warn).toHaveBeenCalledWith("[wanta] failed to prepare knowledge base:", expect.any(Error))
     } finally {
       warn.mockRestore()
     }

--- a/electron/knowledge/node.ts
+++ b/electron/knowledge/node.ts
@@ -21,6 +21,7 @@ import {
   listWikiGraphLibraryArchives,
   listWikiGraphLibraryFolders,
   moveWikiGraphLibraryArchive,
+  prepareWikiGraphArchive,
   readWikiGraphCover,
   readWikiGraphIndex,
   readWikiGraphMetadata,
@@ -208,8 +209,17 @@ export class KnowledgeServiceImpl
   }
 
   private async summary(archive: WikiGraphLibraryArchive): Promise<KnowledgeBaseSummary> {
+    try {
+      await prepareWikiGraphArchive(this.deps.runtime, archive.id)
+    } catch (error: unknown) {
+      console.warn("[wanta] failed to prepare knowledge base:", error)
+      return summaryFromInspection(archive, {}, {}, null)
+    }
     const [metadata, inspect, _index, cover] = await Promise.all([
-      readWikiGraphMetadata(this.deps.runtime, archive.id),
+      readWikiGraphMetadata(this.deps.runtime, archive.id).catch((error: unknown) => {
+        console.warn("[wanta] failed to read knowledge base metadata:", error)
+        return {}
+      }),
       inspectWikiGraph(this.deps.runtime, archive.id).catch((error: unknown) => {
         console.warn("[wanta] failed to inspect knowledge base:", error)
         return {}

--- a/electron/knowledge/runner.ts
+++ b/electron/knowledge/runner.ts
@@ -342,9 +342,6 @@ export async function addWikiGraphLibraryArchive(
 
 async function prepareImportedArchiveForUse(record: WikiGraphLibraryArchiveRecord): Promise<void> {
   await prepareArchivePathForUse(record.path)
-  // wiki-graph-core@0.4.0 has no separate repair API for current-schema archives whose TOC is still
-  // structurally unreadable. Keep this validation boundary explicit so a future SDK repair call can
-  // be inserted before the checks without treating a copied file as a completed product import.
   await validateImportedArchive(record.path)
 }
 
@@ -491,6 +488,10 @@ export async function readWikiGraphCover(runtime: WikiGraphRuntime, id: string):
   } catch {
     return null
   }
+}
+
+export async function prepareWikiGraphArchive(runtime: WikiGraphRuntime, id: string): Promise<void> {
+  await preparedDocumentArchiveFile(runtime, id)
 }
 
 async function archiveFile(runtime: WikiGraphRuntime, id: string): Promise<WikiGraphArchiveFile> {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "electron-updater": "6.8.9",
     "react-diff-view": "3.3.3",
     "unbash": "4.0.4",
-    "wiki-graph": "0.4.0",
-    "wiki-graph-core": "0.4.0"
+    "wiki-graph": "0.4.1",
+    "wiki-graph-core": "0.4.1"
   },
   "devDependencies": {
     "@electron-internal/extract-zip": "1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
         specifier: 4.0.4
         version: 4.0.4
       wiki-graph:
-        specifier: 0.4.0
-        version: 0.4.0(wiki-graph-core@0.4.0)
+        specifier: 0.4.1
+        version: 0.4.1(wiki-graph-core@0.4.1)
       wiki-graph-core:
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.4.1
+        version: 0.4.1
     devDependencies:
       '@electron-internal/extract-zip':
         specifier: 1.0.2
@@ -4572,16 +4572,16 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wiki-graph-core@0.4.0:
-    resolution: {integrity: sha512-Kfbrs53FjeKP8jlXsQTelM1MLIU/tKzMpzjBD6suZ9Tf7CWtHZrvAAcviIciYcE8hIylBaL+/IKF8rtfR8JTwA==}
+  wiki-graph-core@0.4.1:
+    resolution: {integrity: sha512-CuN9X3gopFIuzso5LHW2TYJxiG+4d6Cd/AOMvniLaoo4gtcbU10QQriLJP70sy+zMlNUhmfxbIeRf10RDkQFBw==}
     engines: {node: '>=22.12.0'}
 
-  wiki-graph@0.4.0:
-    resolution: {integrity: sha512-LoApbkJI9Ge6eOie9E/AVmGB2+kSr/HvshcEfRJuXuy006ATwj4fqMGQ7UpGkc5y0DdYiI5PY0JsQDs5qoIeHQ==}
+  wiki-graph@0.4.1:
+    resolution: {integrity: sha512-+Y9ENYYmQ4DdnTBgCQG0eaZ8I4zenFf24ZLatuiWGYrawOl2k52YuQRYJ1udOvNl3KJIiptRzm/cPUHHbYaj+A==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
-      wiki-graph-core: ^0.4.0
+      wiki-graph-core: ^0.4.1
     peerDependenciesMeta:
       wiki-graph-core:
         optional: true
@@ -9539,7 +9539,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wiki-graph-core@0.4.0:
+  wiki-graph-core@0.4.1:
     dependencies:
       '@ai-sdk/anthropic': 3.0.103(zod@4.4.3)
       '@ai-sdk/google': 3.0.101(zod@4.4.3)
@@ -9560,7 +9560,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  wiki-graph@0.4.0(wiki-graph-core@0.4.0):
+  wiki-graph@0.4.1(wiki-graph-core@0.4.1):
     dependencies:
       '@ai-sdk/anthropic': 3.0.103(zod@4.4.3)
       '@ai-sdk/google': 3.0.101(zod@4.4.3)
@@ -9579,7 +9579,7 @@ snapshots:
       yazl: 3.3.1
       zod: 4.4.3
     optionalDependencies:
-      wiki-graph-core: 0.4.0
+      wiki-graph-core: 0.4.1
     transitivePeerDependencies:
       - chokidar
 


### PR DESCRIPTION
## Summary
- upgrade wiki-graph and wiki-graph-core to 0.4.1 so maintenance can repair schema-current archives with missing TOC keys
- prepare WikiGraph archives before reading summary metadata, inspection, index, or cover data
- degrade a failed archive preparation or metadata read into a fallback summary instead of failing the whole knowledge list

## Tests
- corepack pnpm vitest run electron/knowledge/node.test.ts electron/knowledge/runner.test.ts
- corepack pnpm run ts-check
- corepack pnpm exec oxfmt --check electron/knowledge/node.ts electron/knowledge/node.test.ts electron/knowledge/runner.ts package.json pnpm-lock.yaml
- corepack pnpm exec oxlint electron/knowledge/node.ts electron/knowledge/node.test.ts electron/knowledge/runner.ts