### PR TITLE
Fix WikiGraph activity coalescing

### DIFF
--- a/src/routes/Chat/AssistantTurnRenderer.tsx
+++ b/src/routes/Chat/AssistantTurnRenderer.tsx
@@ -30,7 +30,7 @@ import { formatWholeSecondDuration } from "./tool-activity.ts"
 import { toolActionSummary, toolServiceSlug } from "./tool-display.ts"
 import { isActiveToolPart } from "./tool-state.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
-import { groupedToolActivityParts } from "./wikigraph-tool-grouping.ts"
+import { groupedToolActivityParts, groupedWikigraphToolActivityBlocks } from "./wikigraph-tool-grouping.ts"
 import { MessageResponse } from "@/components/ai-elements/message"
 import { MarkdownImage } from "@/components/ai-elements/message-image"
 import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task"
@@ -132,7 +132,8 @@ export function TurnProcessActivity({
   const restoreScrollAnchorRef = React.useRef<(() => void) | null>(null)
   const duration = formatProcessDuration(process, now, live)
   const title = processTitle(t, status, duration)
-  const renderBlocks = blocks.map((item) => item.block)
+  const activityBlocks = React.useMemo(() => groupedWikigraphToolActivityBlocks(blocks, { live }), [blocks, live])
+  const renderBlocks = activityBlocks.map((item) => item.block)
   const showLiveStatus =
     (renderBlocks.length === 0 || shouldSurfaceProcessActivity(process.activity)) &&
     shouldShowLiveStatus(process, status)
@@ -192,7 +193,7 @@ export function TurnProcessActivity({
       </div>
       <TaskContent className="[&>div]:mt-0">
         <ProcessActivityViewport followKey={statusKey} label={title} live={isLiveTurnProcess(process, live)}>
-          {blocks.map(({ message, block }, index) => (
+          {activityBlocks.map(({ message, block }, index) => (
             <AssistantBlock
               key={`${message.id}:${block.kind === "tools" ? block.key : block.part.partId}`}
               block={block}

--- a/src/routes/Chat/AssistantTurnRenderer.tsx
+++ b/src/routes/Chat/AssistantTurnRenderer.tsx
@@ -15,22 +15,20 @@ import type { TranslateFn } from "@/i18n/i18n"
 import { ChevronRight } from "lucide-react"
 import * as React from "react"
 import { assistantBlockClassName } from "./assistant-turn-renderer-model.ts"
-import {
-  chatTurnProcessStatus,
-  isLiveTurnProcess,
-  settlingToolPartId,
-  shouldSurfaceProcessActivity,
-  summarizeTurnProcess,
-} from "./chat-turns.ts"
+import { chatTurnProcessStatus, isLiveTurnProcess, summarizeTurnProcess } from "./chat-turns.ts"
 import { ChatErrorNotice } from "./ChatErrorNotice.tsx"
 import { LoadingShimmerText } from "./LoadingShimmerText.tsx"
 import { processOpenAfterStatusChange, processShouldOpenAutomatically } from "./process-activity-open.ts"
+import {
+  buildTurnProcessActivityRenderModel,
+  latestActiveProcessTool,
+  shouldShowProcessLiveStatus,
+} from "./process-activity-render-model.ts"
 import { ProcessActivityViewport } from "./ProcessActivityViewport.tsx"
 import { formatWholeSecondDuration } from "./tool-activity.ts"
 import { toolActionSummary, toolServiceSlug } from "./tool-display.ts"
-import { isActiveToolPart } from "./tool-state.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
-import { groupedToolActivityParts, groupedWikigraphToolActivityBlocks } from "./wikigraph-tool-grouping.ts"
+import { groupedToolActivityParts } from "./wikigraph-tool-grouping.ts"
 import { MessageResponse } from "@/components/ai-elements/message"
 import { MarkdownImage } from "@/components/ai-elements/message-image"
 import { Task, TaskContent, TaskTrigger } from "@/components/ai-elements/task"
@@ -117,28 +115,24 @@ export function TurnProcessActivity({
   onBeforeDisclosure?: (anchor: HTMLElement | null) => () => void
 }) {
   const t = useT()
-  const status = chatTurnProcessStatus(process, live)
+  const renderModel = React.useMemo(
+    () => buildTurnProcessActivityRenderModel({ blocks, live, process }),
+    [blocks, live, process],
+  )
+  const status = renderModel.status
   const shouldOpen = processShouldOpenAutomatically(status, process.hasVisibleOutcome)
-  const statusKey = [
-    status,
-    live ? "live" : "",
-    process.activity?.phase,
-    process.tools.map((part) => `${part.partId}:${part.status}`).join("|"),
-    process.errors.map((part) => part.partId).join("|"),
-  ].join(":")
+  const statusKey = renderModel.statusKey
   const [open, setOpen] = React.useState(shouldOpen)
   const [now, setNow] = React.useState(() => Date.now())
   const triggerRef = React.useRef<HTMLButtonElement>(null)
   const restoreScrollAnchorRef = React.useRef<(() => void) | null>(null)
   const duration = formatProcessDuration(process, now, live)
   const title = processTitle(t, status, duration)
-  const activityBlocks = React.useMemo(() => groupedWikigraphToolActivityBlocks(blocks, { live }), [blocks, live])
-  const renderBlocks = activityBlocks.map((item) => item.block)
-  const showLiveStatus =
-    (renderBlocks.length === 0 || shouldSurfaceProcessActivity(process.activity)) &&
-    shouldShowLiveStatus(process, status)
+  const activityBlocks = renderModel.activityBlocks
+  const renderBlocks = renderModel.renderBlocks
+  const showLiveStatus = renderModel.showLiveStatus
   const titleText = processStatusText(t, status)
-  const settlingPartId = settlingToolPartId(process, status)
+  const settlingPartId = renderModel.settlingPartId
   const openPreferenceRef = React.useRef<ProcessOpenPreference>("auto")
 
   React.useEffect(() => {
@@ -217,28 +211,6 @@ export function TurnProcessActivity({
   )
 }
 
-function latestActiveTool(process: ReturnType<typeof summarizeTurnProcess>): ChatMessagePart | null {
-  for (let index = process.tools.length - 1; index >= 0; index -= 1) {
-    const part = process.tools[index]
-    if (part && isActiveToolPart(part)) {
-      return part
-    }
-  }
-  return null
-}
-
-function shouldShowLiveStatus(
-  process: ReturnType<typeof summarizeTurnProcess>,
-  status = chatTurnProcessStatus(process),
-): boolean {
-  const activeTool = latestActiveTool(process)
-  return (
-    (status === "running" && !activeTool) ||
-    status === "retrying" ||
-    Boolean(process.activity && status !== "completed" && status !== "stopped")
-  )
-}
-
 function LiveStatusBar({
   process,
   live = false,
@@ -253,8 +225,8 @@ function LiveStatusBar({
   }
 
   const status = chatTurnProcessStatus(process, live)
-  const activeTool = latestActiveTool(process)
-  if (!shouldShowLiveStatus(process, status)) {
+  const activeTool = latestActiveProcessTool(process)
+  if (!shouldShowProcessLiveStatus(process, status)) {
     return null
   }
 

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -290,6 +290,35 @@ describe("ToolActivityStep", () => {
     expect(html).not.toContain("lucide-chevron-right")
   })
 
+  it("hides unsettled WG Bash commands before they can be classified as knowledge activity", () => {
+    const message = assistantMessage("assistant-1")
+    const blocks = groupedWikigraphToolActivityBlocks([
+      {
+        message,
+        block: {
+          kind: "tools",
+          key: "tool-wg-pending",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-wg-pending",
+              callId: "call-wg-pending",
+              tool: "bash",
+              status: "running",
+              input: { command: "wg" },
+            },
+          ],
+        },
+      },
+    ])
+    const parts = blocks.flatMap(({ block }) => (block.kind === "tools" ? block.parts : []))
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(0)
+    expect(html).not.toContain("运行命令")
+    expect(html).not.toContain("wg")
+  })
+
   it("keeps the trailing WikiGraph activity running while the process is live", () => {
     const message = assistantMessage("assistant-1")
     const sourceBlocks = [

--- a/src/routes/Chat/ToolActivityStep.test.ts
+++ b/src/routes/Chat/ToolActivityStep.test.ts
@@ -1,11 +1,11 @@
-import type { ChatMessagePart } from "../../../electron/chat/common.ts"
+import type { ChatMessage, ChatMessagePart } from "../../../electron/chat/common.ts"
 
 import * as React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { I18nContext, translate } from "../../i18n/i18n.ts"
 import { ToolActivityStep } from "./ToolActivityStep.tsx"
-import { groupedToolActivityParts } from "./wikigraph-tool-grouping.ts"
+import { groupedToolActivityParts, groupedWikigraphToolActivityBlocks } from "./wikigraph-tool-grouping.ts"
 
 function renderToolActivityStep(
   part: ChatMessagePart,
@@ -40,6 +40,10 @@ function shimmerClassFor(html: string, text: string): string {
     throw new Error(`Missing shimmer span for ${text}.`)
   }
   return match[1]
+}
+
+function assistantMessage(id: string): ChatMessage {
+  return { id, role: "assistant", parts: [], createdAt: 1 }
 }
 
 describe("ToolActivityStep", () => {
@@ -165,6 +169,295 @@ describe("ToolActivityStep", () => {
     expect(html).not.toContain("wg wikg://lib")
     expect(html).not.toContain("jq .")
     expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("coalesces WikiGraph activity across adjacent tool blocks before rendering", () => {
+    const firstMessage = assistantMessage("assistant-1")
+    const secondMessage = assistantMessage("assistant-2")
+    const blocks = groupedWikigraphToolActivityBlocks([
+      {
+        message: firstMessage,
+        block: {
+          kind: "tools",
+          key: "tool-skill",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-skill",
+              callId: "call-skill",
+              tool: "skill",
+              status: "completed",
+              title: "Loaded skill: wikigraph-knowledge",
+            },
+            {
+              kind: "tool",
+              partId: "tool-wg-help",
+              callId: "call-wg-help",
+              tool: "bash",
+              status: "completed",
+              input: { command: "wg help recipe 2>&1" },
+              output: "Usage: wg ...",
+            },
+          ],
+        },
+      },
+      {
+        message: secondMessage,
+        block: {
+          kind: "tools",
+          key: "tool-wg-1",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-wg-1",
+              callId: "call-wg-1",
+              tool: "bash",
+              status: "completed",
+              input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+            },
+            {
+              kind: "tool",
+              partId: "tool-wg-2",
+              callId: "call-wg-2",
+              tool: "bash",
+              status: "running",
+              input: { command: 'wg wikg://lib/evidence --query "关羽 曹操" --json' },
+            },
+          ],
+        },
+      },
+    ])
+    const html = blocks
+      .flatMap(({ block }) => (block.kind === "tools" ? block.parts : []))
+      .map((part) => renderToolActivityStep(part))
+      .join("\n")
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]?.block.kind).toBe("tools")
+    expect(blocks[0]?.block.kind === "tools" ? blocks[0].block.parts : []).toHaveLength(1)
+    expect(html.match(/查询知识库/g)).toHaveLength(1)
+    expect(html).toContain("运行中")
+    expect(html).not.toContain("wg help recipe")
+    expect(html).not.toContain("wg wikg://")
+    expect(html).not.toContain("wikigraph-knowledge")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("hides unsettled unknown Bash commands while a WikiGraph activity lock is active", () => {
+    const message = assistantMessage("assistant-1")
+    const blocks = groupedWikigraphToolActivityBlocks([
+      {
+        message,
+        block: {
+          kind: "tools",
+          key: "tool-wg",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-wg",
+              callId: "call-wg",
+              tool: "bash",
+              status: "completed",
+              input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+            },
+          ],
+        },
+      },
+      {
+        message,
+        block: {
+          kind: "tools",
+          key: "tool-pending",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-pending",
+              callId: "call-pending",
+              tool: "bash",
+              status: "pending",
+              input: {},
+            },
+          ],
+        },
+      },
+    ])
+    const parts = blocks.flatMap(({ block }) => (block.kind === "tools" ? block.parts : []))
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(1)
+    expect(html.match(/查询知识库/g)).toHaveLength(1)
+    expect(html).not.toContain("运行命令")
+    expect(html).not.toContain("lucide-chevron-right")
+  })
+
+  it("keeps the trailing WikiGraph activity running while the process is live", () => {
+    const message = assistantMessage("assistant-1")
+    const sourceBlocks = [
+      {
+        message,
+        block: {
+          kind: "tools" as const,
+          key: "tool-wg",
+          parts: [
+            {
+              kind: "tool" as const,
+              partId: "tool-wg",
+              callId: "call-wg",
+              tool: "bash",
+              status: "completed" as const,
+              input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+            },
+          ],
+        },
+      },
+    ]
+    const liveParts = groupedWikigraphToolActivityBlocks(sourceBlocks, { live: true }).flatMap(({ block }) =>
+      block.kind === "tools" ? block.parts : [],
+    )
+    const settledParts = groupedWikigraphToolActivityBlocks(sourceBlocks, { live: false }).flatMap(({ block }) =>
+      block.kind === "tools" ? block.parts : [],
+    )
+
+    expect(liveParts[0]?.status).toBe("running")
+    expect(renderToolActivityStep(liveParts[0]!, { live: true })).toContain("运行中")
+    expect(settledParts[0]?.status).toBe("completed")
+    expect(renderToolActivityStep(settledParts[0]!, { live: false })).toContain("已完成")
+  })
+
+  it("completes a WikiGraph activity once assistant text appears after it", () => {
+    const message = assistantMessage("assistant-1")
+    const blocks = groupedWikigraphToolActivityBlocks(
+      [
+        {
+          message,
+          block: {
+            kind: "tools",
+            key: "tool-wg",
+            parts: [
+              {
+                kind: "tool",
+                partId: "tool-wg",
+                callId: "call-wg",
+                tool: "bash",
+                status: "completed",
+                input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+              },
+            ],
+          },
+        },
+        {
+          message,
+          block: {
+            kind: "text",
+            part: { kind: "text", partId: "text-1", text: "我会继续整理结果。" },
+          },
+        },
+      ],
+      { live: true },
+    )
+    const firstBlock = blocks[0]?.block
+    const parts = firstBlock?.kind === "tools" ? firstBlock.parts : []
+
+    expect(parts[0]?.status).toBe("completed")
+    expect(renderToolActivityStep(parts[0]!, { live: true })).toContain("已完成")
+  })
+
+  it("shows a settled non-WG Bash command and exits the WikiGraph activity lock", () => {
+    const message = assistantMessage("assistant-1")
+    const blocks = groupedWikigraphToolActivityBlocks([
+      {
+        message,
+        block: {
+          kind: "tools",
+          key: "tool-wg",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-wg",
+              callId: "call-wg",
+              tool: "bash",
+              status: "completed",
+              input: { command: 'wg wikg://lib/search --query "华容道" --json' },
+            },
+          ],
+        },
+      },
+      {
+        message,
+        block: {
+          kind: "tools",
+          key: "tool-echo",
+          parts: [
+            {
+              kind: "tool",
+              partId: "tool-echo",
+              callId: "call-echo",
+              tool: "bash",
+              status: "completed",
+              input: { command: "echo ok" },
+            },
+            {
+              kind: "tool",
+              partId: "tool-wg-next",
+              callId: "call-wg-next",
+              tool: "bash",
+              status: "completed",
+              input: { command: 'wg wikg://lib/evidence --query "曹操" --json' },
+            },
+          ],
+        },
+      },
+    ])
+    const parts = blocks.flatMap(({ block }) => (block.kind === "tools" ? block.parts : []))
+    const html = parts.map((part) => renderToolActivityStep(part)).join("\n")
+
+    expect(parts).toHaveLength(3)
+    expect(html.match(/查询知识库/g)).toHaveLength(2)
+    expect(html).toContain("echo ok")
+    expect(html).toContain("lucide-chevron-right")
+  })
+
+  it("preserves adjacent ordinary tool blocks when no WikiGraph grouping changes", () => {
+    const firstMessage = assistantMessage("assistant-1")
+    const secondMessage = assistantMessage("assistant-2")
+    const blocks = [
+      {
+        message: firstMessage,
+        block: {
+          kind: "tools" as const,
+          key: "tool-ls",
+          parts: [
+            {
+              kind: "tool" as const,
+              partId: "tool-ls",
+              callId: "call-ls",
+              tool: "bash",
+              status: "completed" as const,
+              input: { command: "ls" },
+            },
+          ],
+        },
+      },
+      {
+        message: secondMessage,
+        block: {
+          kind: "tools" as const,
+          key: "tool-echo",
+          parts: [
+            {
+              kind: "tool" as const,
+              partId: "tool-echo",
+              callId: "call-echo",
+              tool: "bash",
+              status: "completed" as const,
+              input: { command: "echo ok" },
+            },
+          ],
+        },
+      },
+    ]
+
+    expect(groupedWikigraphToolActivityBlocks(blocks)).toEqual(blocks)
   })
 
   it("coalesces WikiGraph skill loads with WG Bash calls in both orders", () => {

--- a/src/routes/Chat/process-activity-render-model.test.ts
+++ b/src/routes/Chat/process-activity-render-model.test.ts
@@ -1,0 +1,124 @@
+import type { ChatMessage, ChatMessagePart } from "../../../electron/chat/common.ts"
+import type { AssistantTimelineBlock } from "./assistant-timeline.ts"
+import type { ChatTurnProcess } from "./chat-turns.ts"
+
+import { describe, expect, it } from "vitest"
+import { buildTurnProcessActivityRenderModel } from "./process-activity-render-model.ts"
+
+function message(id: string): ChatMessage {
+  return { id, role: "assistant", parts: [], createdAt: 1 }
+}
+
+function wgTool(partId: string, command: string, status: ChatMessagePart["status"] = "completed"): ChatMessagePart {
+  return {
+    kind: "tool",
+    partId,
+    callId: partId,
+    tool: "bash",
+    status,
+    input: { command },
+  }
+}
+
+function wikigraphSkillTool(partId: string, status: ChatMessagePart["status"] = "completed"): ChatMessagePart {
+  return {
+    kind: "tool",
+    partId,
+    callId: partId,
+    tool: "skill",
+    status,
+    title: "Loaded skill: wikigraph-knowledge",
+  }
+}
+
+function textBlock(partId: string, text: string): AssistantTimelineBlock {
+  return {
+    message: message(`message-${partId}`),
+    block: { kind: "text", part: { kind: "text", partId, text } },
+  }
+}
+
+function toolBlock(key: string, parts: ChatMessagePart[]): AssistantTimelineBlock {
+  return {
+    message: message(`message-${key}`),
+    block: { kind: "tools", key, parts },
+  }
+}
+
+function processFor(parts: ChatMessagePart[], overrides: Partial<ChatTurnProcess> = {}): ChatTurnProcess {
+  return {
+    activity: null,
+    authorizationIssues: [],
+    errors: [],
+    hasActiveTool: parts.some((part) => part.status === "running" || part.status === "pending"),
+    hasAuthorization: false,
+    hasBlockingError: false,
+    hasStoppedTool: false,
+    hasSuccessfulConnectorCall: false,
+    hasToolError: false,
+    hasVisibleOutcome: false,
+    tools: parts,
+    ...overrides,
+  }
+}
+
+function renderedToolParts(model: ReturnType<typeof buildTurnProcessActivityRenderModel>): ChatMessagePart[] {
+  return model.activityBlocks.flatMap(({ block }) => (block.kind === "tools" ? block.parts : []))
+}
+
+describe("buildTurnProcessActivityRenderModel", () => {
+  it("normalizes adjacent WikiGraph blocks through the same render model for live and completed views", () => {
+    const tools = [
+      wikigraphSkillTool("tool-skill"),
+      wgTool("tool-help", "wg help recipe 2>&1"),
+      wgTool("tool-wg-1", 'wg wikg://lib/entity --query "华容道" --json'),
+      wgTool("tool-wg-2", 'wg wikg://lib/chapter --query "关羽 曹操"'),
+    ]
+    const blocks = [toolBlock("tools-1", [tools[0]!, tools[1]!, tools[2]!]), toolBlock("tools-2", [tools[3]!])]
+
+    const live = buildTurnProcessActivityRenderModel({ blocks, live: true, process: processFor(tools) })
+    const completed = buildTurnProcessActivityRenderModel({ blocks, live: false, process: processFor(tools) })
+    const liveParts = renderedToolParts(live)
+    const completedParts = renderedToolParts(completed)
+
+    expect(liveParts).toHaveLength(1)
+    expect(completedParts).toHaveLength(1)
+    expect(liveParts[0]?.title).toBe(completedParts[0]?.title)
+    expect(liveParts[0]?.input).toEqual(completedParts[0]?.input)
+    expect(liveParts[0]?.output).toBeUndefined()
+    expect(completedParts[0]?.output).toBeUndefined()
+    expect(liveParts[0]?.status).toBe("running")
+    expect(completedParts[0]?.status).toBe("completed")
+  })
+
+  it("uses visible text as a boundary so a finished WikiGraph group is completed even while later work is live", () => {
+    const tools = [
+      wgTool("tool-wg", 'wg wikg://lib/entity --query "华容道" --json'),
+      { ...wgTool("tool-running", "node script.js"), status: "running" as const },
+    ]
+    const blocks = [
+      toolBlock("tools-wg", [tools[0]!]),
+      textBlock("text-1", "我会继续整理结果。"),
+      toolBlock("tools-running", [tools[1]!]),
+    ]
+
+    const model = buildTurnProcessActivityRenderModel({ blocks, live: true, process: processFor(tools) })
+    const parts = renderedToolParts(model)
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0]?.title).toBe("Loaded skill: wikigraph-knowledge")
+    expect(parts[0]?.status).toBe("completed")
+    expect(parts[1]?.tool).toBe("bash")
+    expect(parts[1]?.status).toBe("running")
+  })
+
+  it("hides pending WG commands before they are complete enough to render", () => {
+    const pendingWg = wgTool("tool-pending-wg", "wg", "running")
+    const blocks = [toolBlock("tools-pending-wg", [pendingWg])]
+
+    const model = buildTurnProcessActivityRenderModel({ blocks, live: true, process: processFor([pendingWg]) })
+
+    expect(model.activityBlocks).toHaveLength(0)
+    expect(renderedToolParts(model)).toHaveLength(0)
+  })
+})

--- a/src/routes/Chat/process-activity-render-model.ts
+++ b/src/routes/Chat/process-activity-render-model.ts
@@ -1,0 +1,75 @@
+import type { ChatMessagePart } from "../../../electron/chat/common.ts"
+import type { AssistantTimelineBlock } from "./assistant-timeline.ts"
+import type { ChatTurnProcess, ChatTurnProcessStatus } from "./chat-turns.ts"
+import type { RenderBlock } from "./render-blocks.ts"
+
+import {
+  chatTurnProcessStatus,
+  settlingToolPartId,
+  shouldSurfaceProcessActivity,
+  summarizeTurnProcess,
+} from "./chat-turns.ts"
+import { isActiveToolPart } from "./tool-state.ts"
+import { groupedWikigraphToolActivityBlocks } from "./wikigraph-tool-grouping.ts"
+
+export interface TurnProcessActivityRenderModel {
+  activityBlocks: AssistantTimelineBlock[]
+  renderBlocks: RenderBlock[]
+  settlingPartId?: string
+  showLiveStatus: boolean
+  status: ChatTurnProcessStatus
+  statusKey: string
+}
+
+export function latestActiveProcessTool(process: Pick<ChatTurnProcess, "tools">): ChatMessagePart | null {
+  for (let index = process.tools.length - 1; index >= 0; index -= 1) {
+    const part = process.tools[index]
+    if (part && isActiveToolPart(part)) {
+      return part
+    }
+  }
+  return null
+}
+
+export function shouldShowProcessLiveStatus(
+  process: Pick<ChatTurnProcess, "activity" | "tools">,
+  status: ChatTurnProcessStatus,
+): boolean {
+  const activeTool = latestActiveProcessTool(process)
+  return (
+    (status === "running" && !activeTool) ||
+    status === "retrying" ||
+    Boolean(process.activity && status !== "completed" && status !== "stopped")
+  )
+}
+
+export function buildTurnProcessActivityRenderModel({
+  blocks,
+  live = false,
+  process,
+}: {
+  blocks: AssistantTimelineBlock[]
+  live?: boolean
+  process: ReturnType<typeof summarizeTurnProcess>
+}): TurnProcessActivityRenderModel {
+  const status = chatTurnProcessStatus(process, live)
+  const statusKey = [
+    status,
+    live ? "live" : "",
+    process.activity?.phase,
+    process.tools.map((part) => `${part.partId}:${part.status}`).join("|"),
+    process.errors.map((part) => part.partId).join("|"),
+  ].join(":")
+  const activityBlocks = groupedWikigraphToolActivityBlocks(blocks, { live })
+  const renderBlocks = activityBlocks.map((item) => item.block)
+  return {
+    activityBlocks,
+    renderBlocks,
+    settlingPartId: settlingToolPartId(process, status),
+    showLiveStatus:
+      (renderBlocks.length === 0 || shouldSurfaceProcessActivity(process.activity)) &&
+      shouldShowProcessLiveStatus(process, status),
+    status,
+    statusKey,
+  }
+}

--- a/src/routes/Chat/wg-shell-detection.test.ts
+++ b/src/routes/Chat/wg-shell-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { isWgKnowledgeShellCommand } from "./wg-shell-detection.ts"
+import { isWgKnowledgeShellCommand, isWgShellCommand } from "./wg-shell-detection.ts"
 
 const positiveCases = [
   'wg wikg://lib --query "唐僧" --json',
@@ -70,4 +70,18 @@ describe("WG shell detection", () => {
   it.each(unbashBoundaryNegativeCases)("keeps unbash boundary behavior negative: %s", (command) => {
     expect(isWgKnowledgeShellCommand(command)).toBe(false)
   })
+
+  it.each(["wg help recipe 2>&1", "wg maintenance upgrade --help 2>&1", 'bash -lc "wg help recipe 2>&1"'])(
+    "recognizes any executed WG command for locked knowledge activity: %s",
+    (command) => {
+      expect(isWgShellCommand(command)).toBe(true)
+    },
+  )
+
+  it.each(["echo wg help", "node -e \"console.log('wg help')\"", "grep wg notes.txt"])(
+    "does not recognize plain WG text as an executed WG command: %s",
+    (command) => {
+      expect(isWgShellCommand(command)).toBe(false)
+    },
+  )
 })

--- a/src/routes/Chat/wg-shell-detection.ts
+++ b/src/routes/Chat/wg-shell-detection.ts
@@ -5,10 +5,14 @@ import { parse } from "unbash"
 const shellRecursionLimit = 6
 
 export function isWgKnowledgeShellCommand(command: string): boolean {
-  return scanShell(command, 0)
+  return scanShell(command, 0, "knowledge")
 }
 
-function scanShell(command: string, depth: number): boolean {
+export function isWgShellCommand(command: string): boolean {
+  return scanShell(command, 0, "executable")
+}
+
+function scanShell(command: string, depth: number, mode: "executable" | "knowledge"): boolean {
   if (depth > shellRecursionLimit || command.trim() === "") {
     return false
   }
@@ -18,7 +22,7 @@ function scanShell(command: string, depth: number): boolean {
     return false
   }
 
-  return scanAstValue(script, command, depth)
+  return scanAstValue(script, command, depth, mode)
 }
 
 function parseShell(command: string): Script | null {
@@ -30,18 +34,18 @@ function parseShell(command: string): Script | null {
   }
 }
 
-function scanAstValue(value: unknown, source: string, depth: number): boolean {
+function scanAstValue(value: unknown, source: string, depth: number, mode: "executable" | "knowledge"): boolean {
   if (Array.isArray(value)) {
-    return value.some((item) => scanAstValue(item, source, depth))
+    return value.some((item) => scanAstValue(item, source, depth, mode))
   }
   if (isAssignmentNode(value)) {
-    return scanWord(value.value, depth)
+    return scanWord(value.value, depth, mode)
   }
   if (isWord(value)) {
-    return scanWord(value, depth)
+    return scanWord(value, depth, mode)
   }
   if (isCommand(value)) {
-    return scanCommand(value, source, depth)
+    return scanCommand(value, source, depth, mode)
   }
   if (!isRecord(value)) {
     return false
@@ -51,60 +55,71 @@ function scanAstValue(value: unknown, source: string, depth: number): boolean {
     if (key === "type" || key === "pos" || key === "end" || key === "text" || key === "value") {
       continue
     }
-    if (scanAstValue(child, source, depth)) {
+    if (scanAstValue(child, source, depth, mode)) {
       return true
     }
   }
   return false
 }
 
-function scanCommand(command: Command, source: string, depth: number): boolean {
+function scanCommand(command: Command, source: string, depth: number, mode: "executable" | "knowledge"): boolean {
   const words = command.name ? [command.name, ...command.suffix] : [...command.suffix]
-  return scanAstValue(command.prefix, source, depth) || scanCommandWords(words, command.redirects, source, depth)
+  return (
+    scanAstValue(command.prefix, source, depth, mode) || scanCommandWords(words, command.redirects, source, depth, mode)
+  )
 }
 
-function scanCommandWords(words: Word[], redirects: Redirect[], source: string, depth: number): boolean {
+function scanCommandWords(
+  words: Word[],
+  redirects: Redirect[],
+  source: string,
+  depth: number,
+  mode: "executable" | "knowledge",
+): boolean {
   const commandIndex = firstCommandWordIndex(words, 0)
   if (commandIndex >= words.length) {
-    return scanNestedWords(words, depth) || scanAstValue(redirects, source, depth)
+    return scanNestedWords(words, depth, mode) || scanAstValue(redirects, source, depth, mode)
   }
 
   const executable = executableName(wordValue(words[commandIndex]))
   if (executable === "env") {
     const envCommandIndex = skipEnvPrefix(words, commandIndex + 1)
-    if (scanNestedWords(words.slice(commandIndex + 1, envCommandIndex), depth)) {
+    if (scanNestedWords(words.slice(commandIndex + 1, envCommandIndex), depth, mode)) {
       return true
     }
     if (envCommandIndex < words.length) {
-      return scanCommandWords(words.slice(envCommandIndex), redirects, source, depth)
+      return scanCommandWords(words.slice(envCommandIndex), redirects, source, depth, mode)
     }
   }
 
   const shellCommandIndex = shellCommandStringIndex(words, commandIndex)
   if (shellCommandIndex !== null) {
     const shellCommand = words[shellCommandIndex]
-    if (shellCommand && scanShell(wordValue(shellCommand), depth + 1)) {
+    if (shellCommand && scanShell(wordValue(shellCommand), depth + 1, mode)) {
       return true
     }
   }
 
+  if (mode === "executable" && isWgExecutable(executable)) {
+    return true
+  }
   if (isWgExecutable(executable) && words.slice(commandIndex + 1).some((word) => wordContainsWikgUri(word))) {
     return true
   }
 
-  return scanNestedWords(words, depth) || scanAstValue(redirects, source, depth)
+  return scanNestedWords(words, depth, mode) || scanAstValue(redirects, source, depth, mode)
 }
 
-function scanNestedWords(words: Word[], depth: number): boolean {
-  return words.some((word) => scanWord(word, depth))
+function scanNestedWords(words: Word[], depth: number, mode: "executable" | "knowledge"): boolean {
+  return words.some((word) => scanWord(word, depth, mode))
 }
 
-function scanWord(word: Word, depth: number): boolean {
+function scanWord(word: Word, depth: number, mode: "executable" | "knowledge"): boolean {
   // unbash exposes the command structure as AST, but its public package exports do not include the
   // word-part helper that materializes command/process substitutions. Keep this small scanner bounded
   // to unbash-provided Word nodes so the main detection path remains AST-based.
   for (const substitution of executableSubstitutionsInWord(word.text)) {
-    if (scanShell(substitution, depth + 1)) {
+    if (scanShell(substitution, depth + 1, mode)) {
       return true
     }
   }

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -221,6 +221,12 @@ function groupedLockedWikigraphToolActivityParts(
       knowledgeLocked = true
       continue
     }
+    if (!knowledgeLocked && isBashPart(part) && !isSettledToolPart(part)) {
+      const command = str(part.input?.command)
+      if (command && isWgShellCommand(command)) {
+        continue
+      }
+    }
     if (knowledgeLocked && isWikigraphKnowledgeAuxiliaryPart(part)) {
       pendingKnowledge.push(part)
       continue

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -1,7 +1,9 @@
 import type { ChatMessagePart, ToolStatus } from "../../../electron/chat/common.ts"
+import type { AssistantTimelineBlock } from "./assistant-timeline.ts"
 
 import { isWikigraphKnowledgeActivityPart } from "./tool-display.ts"
 import { isToolCancellation } from "./tool-state.ts"
+import { isWgShellCommand } from "./wg-shell-detection.ts"
 
 function str(value: unknown): string {
   return typeof value === "string" ? value : ""
@@ -36,6 +38,14 @@ function isWikigraphKnowledgeAuxiliaryPart(part: ChatMessagePart): boolean {
   return part.tool === "bash" && isWikigraphProbeCommand(str(part.input?.command))
 }
 
+function isBashPart(part: ChatMessagePart): boolean {
+  return part.tool === "bash"
+}
+
+function isSettledToolPart(part: ChatMessagePart): boolean {
+  return part.status === "completed" || part.status === "error"
+}
+
 function mergedStatus(parts: ChatMessagePart[]): ToolStatus | undefined {
   if (parts.some((part) => part.status === "error")) {
     return "error"
@@ -66,22 +76,26 @@ function mergedTiming(parts: ChatMessagePart[]): ChatMessagePart["timing"] {
   return start === undefined && end === undefined ? undefined : { start, end }
 }
 
-function mergeWikigraphKnowledgeParts(parts: ChatMessagePart[]): ChatMessagePart {
+function mergeWikigraphKnowledgeParts(
+  parts: ChatMessagePart[],
+  options: { forceRunning?: boolean } = {},
+): ChatMessagePart {
   const first = parts[0]
   const errorPart = parts.find((part) => part.status === "error" || part.error)
+  const cancelled = parts.some((part) => isToolCancellation(part))
   return {
     ...first,
     partId: first.partId,
     callId: first.callId ?? first.partId,
     title: "Loaded skill: wikigraph-knowledge",
-    status: mergedStatus(parts),
+    status: options.forceRunning && !errorPart && !cancelled ? "running" : mergedStatus(parts),
     error: errorPart?.error,
     output: undefined,
     input: {},
     metadata: undefined,
     attachmentsCount: undefined,
     authorization: undefined,
-    cancelled: parts.some((part) => isToolCancellation(part)) || undefined,
+    cancelled: cancelled || undefined,
     timing: mergedTiming(parts),
   }
 }
@@ -132,5 +146,103 @@ export function groupedToolActivityParts(parts: ChatMessagePart[]): ChatMessageP
     grouped.push(part)
   }
   flushKnowledge()
+  return grouped
+}
+
+export function groupedWikigraphToolActivityBlocks(
+  blocks: AssistantTimelineBlock[],
+  options: { live?: boolean } = {},
+): AssistantTimelineBlock[] {
+  const grouped: AssistantTimelineBlock[] = []
+  let pendingTools: AssistantTimelineBlock[] = []
+  const flushTools = (flushOptions: { trailing?: boolean } = {}) => {
+    if (pendingTools.length === 0) {
+      return
+    }
+    const first = pendingTools[0]
+    if (!first || first.block.kind !== "tools") {
+      pendingTools = []
+      return
+    }
+    const originalParts = pendingTools.flatMap((item) => (item.block.kind === "tools" ? item.block.parts : []))
+    const parts = groupedLockedWikigraphToolActivityParts(originalParts, {
+      forceTrailingKnowledgeRunning: options.live === true && flushOptions.trailing === true,
+    })
+    if (parts.length === originalParts.length && parts.every((part, index) => part === originalParts[index])) {
+      grouped.push(...pendingTools)
+      pendingTools = []
+      return
+    }
+    grouped.push({
+      message: first.message,
+      block: {
+        kind: "tools",
+        key: first.block.key,
+        parts,
+      },
+    })
+    pendingTools = []
+  }
+
+  for (const item of blocks) {
+    if (item.block.kind === "tools") {
+      pendingTools.push(item)
+      continue
+    }
+    flushTools()
+    grouped.push(item)
+  }
+  flushTools({ trailing: true })
+  return grouped
+}
+
+function groupedLockedWikigraphToolActivityParts(
+  parts: ChatMessagePart[],
+  options: { forceTrailingKnowledgeRunning?: boolean } = {},
+): ChatMessagePart[] {
+  const grouped: ChatMessagePart[] = []
+  let pendingKnowledge: ChatMessagePart[] = []
+  let knowledgeLocked = false
+  const flushKnowledge = (flushOptions: { trailing?: boolean } = {}) => {
+    if (pendingKnowledge.length === 0) {
+      return
+    }
+    grouped.push(
+      mergeWikigraphKnowledgeParts(pendingKnowledge, {
+        forceRunning: options.forceTrailingKnowledgeRunning === true && flushOptions.trailing === true,
+      }),
+    )
+    pendingKnowledge = []
+  }
+
+  for (const part of parts) {
+    if (isWikigraphKnowledgeActivityPart(part)) {
+      pendingKnowledge.push(part)
+      knowledgeLocked = true
+      continue
+    }
+    if (knowledgeLocked && isWikigraphKnowledgeAuxiliaryPart(part)) {
+      pendingKnowledge.push(part)
+      continue
+    }
+    if (knowledgeLocked && isBashPart(part)) {
+      const command = str(part.input?.command)
+      if (command && isWgShellCommand(command)) {
+        pendingKnowledge.push(part)
+        continue
+      }
+      if (!isSettledToolPart(part)) {
+        continue
+      }
+      flushKnowledge()
+      knowledgeLocked = false
+      grouped.push(part)
+      continue
+    }
+    flushKnowledge()
+    knowledgeLocked = false
+    grouped.push(part)
+  }
+  flushKnowledge({ trailing: true })
   return grouped
 }

--- a/src/routes/Chat/wikigraph-tool-grouping.ts
+++ b/src/routes/Chat/wikigraph-tool-grouping.ts
@@ -168,6 +168,10 @@ export function groupedWikigraphToolActivityBlocks(
     const parts = groupedLockedWikigraphToolActivityParts(originalParts, {
       forceTrailingKnowledgeRunning: options.live === true && flushOptions.trailing === true,
     })
+    if (parts.length === 0) {
+      pendingTools = []
+      return
+    }
     if (parts.length === originalParts.length && parts.every((part, index) => part === originalParts[index])) {
       grouped.push(...pendingTools)
       pendingTools = []


### PR DESCRIPTION
## Summary
- coalesce adjacent WikiGraph skill and wg bash activity into a single knowledge-query step
- hide pending/running wg command shells while the knowledge-query lock is active
- centralize process activity render state so live and completed views use the same render model

## Verification
- corepack pnpm vitest run src/routes/Chat/assistant-timeline.test.ts src/routes/Chat/chat-turns.test.ts src/routes/Chat/render-blocks.test.ts src/routes/Chat/ToolActivityStep.test.ts src/routes/Chat/wg-shell-detection.test.ts src/routes/Chat/process-activity-render-model.test.ts
- corepack pnpm run ts-check
- corepack pnpm exec oxlint src/routes/Chat/AssistantTurnRenderer.tsx src/routes/Chat/process-activity-render-model.ts src/routes/Chat/process-activity-render-model.test.ts src/routes/Chat/wikigraph-tool-grouping.ts
- corepack pnpm exec oxfmt src/routes/Chat/AssistantTurnRenderer.tsx src/routes/Chat/process-activity-render-model.ts src/routes/Chat/process-activity-render-model.test.ts src/routes/Chat/wikigraph-tool-grouping.ts --check
- Electron App manual verification by user: new session behavior is good