### PR TITLE
Compact knowledge navigation

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -108,6 +108,7 @@ import { chatTurnInputKey } from "@/routes/Chat/chat-turns"
 import { hasComposerDraftContent, toCachedComposerState } from "@/routes/Chat/composer-state"
 import { summarizeEmptyStateConnections } from "@/routes/Chat/empty-state-connections"
 import { normalizeConnectionCatalogFilter } from "@/routes/Connections/connection-route-model.ts"
+import { knowledgeBreadcrumbs, normalizeKnowledgePath } from "@/routes/Knowledge/knowledge-route-model.ts"
 
 const ArchivedRoute = React.lazy(() =>
   import("@/routes/Archived").then((module) => ({ default: module.ArchivedRoute })),
@@ -174,6 +175,8 @@ export function AppShell({ auth }: { auth: UseAuth }) {
     }
   }, [auth.error, t])
   const [ready, setReady] = React.useState(false)
+  const [knowledgeDirectory, setKnowledgeDirectory] = React.useState("")
+  const [knowledgeTitlebarNavigationVersion, setKnowledgeTitlebarNavigationVersion] = React.useState(0)
   const [billingInitialTarget, setBillingInitialTarget] = React.useState<BillingDetailsTarget | null>(null)
   const [agentStatus, setAgentStatus] = React.useState<AgentRuntimeStatus>({ status: "starting" })
   const accountId = oomolEnabled ? auth.state?.account?.id : undefined
@@ -904,6 +907,10 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                   ? t("archived.title")
                   : (activeSession?.title ?? t("chat.newSession"))
   const titlebarEditable = route === "chat" && Boolean(activeSession)
+  const titlebarBreadcrumbs =
+    route === "knowledge" && knowledgeBaseBetaEnabled
+      ? knowledgeBreadcrumbs(knowledgeDirectory, t("knowledge.title"))
+      : undefined
 
   React.useEffect(() => {
     writeStoredSidebarSegment(globalThis.localStorage, sidebarSegment)
@@ -1903,12 +1910,17 @@ export function AppShell({ auth }: { auth: UseAuth }) {
             showBrowserToggle={showBrowserToggle}
             sidebarCollapsed={sidebarCollapsed}
             titlebarEditable={titlebarEditable}
+            titlebarBreadcrumbs={titlebarBreadcrumbs}
             titlebarTitle={titlebarTitle}
             workspace={teamWorkspace.activeWorkspace}
             onArtifactsToggle={handleArtifactsToggle}
             onBrowserToggle={handleBrowserToggle}
             onOpenSearch={handleOpenSearch}
             onRenameSession={sessionActions.handleRename}
+            onTitlebarBreadcrumbNavigate={(path) => {
+              setKnowledgeDirectory(normalizeKnowledgePath(path))
+              setKnowledgeTitlebarNavigationVersion((version) => version + 1)
+            }}
             onToggleSidebar={handleToggleSidebar}
             onViewBilling={oomolEnabled ? handleViewBilling : undefined}
           />
@@ -1939,7 +1951,13 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                   workspace={teamWorkspace}
                 />
               ) : route === "knowledge" && knowledgeBaseBetaEnabled ? (
-                <KnowledgeRoute knowledge={knowledgeLibrary} onStartChat={handleStartKnowledgeChat} />
+                <KnowledgeRoute
+                  currentDirectory={knowledgeDirectory}
+                  knowledge={knowledgeLibrary}
+                  titlebarNavigationVersion={knowledgeTitlebarNavigationVersion}
+                  onCurrentDirectoryChange={setKnowledgeDirectory}
+                  onStartChat={handleStartKnowledgeChat}
+                />
               ) : route === "teams" && oomolEnabled ? (
                 <TeamManagementRoute
                   connectedProvidersLoading={activeProvidersLoading}

--- a/src/components/app-shell/AppShellMainTitlebar.tsx
+++ b/src/components/app-shell/AppShellMainTitlebar.tsx
@@ -4,13 +4,84 @@ import type { UseAppUpdate } from "@/hooks/useAppUpdate"
 import type { WorkspaceSelection } from "@/hooks/useTeamWorkspace"
 import type { LucideIcon } from "lucide-react"
 
-import { Globe2 } from "lucide-react"
+import { ChevronRight, Globe2, MoreHorizontal } from "lucide-react"
 import * as React from "react"
 import { EditableTitlebarTitle } from "./AppShellDialogs.tsx"
 import { SidebarTitlebarActions } from "./AppShellSidebar.tsx"
 import { BillingUsagePopover } from "@/components/app-shell/BillingUsagePopover"
 import { AppUpdateTitlebarEntry } from "@/components/AppUpdateTitlebarEntry"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
+
+interface TitlebarBreadcrumb {
+  label: string
+  path: string
+}
+
+function TitlebarBreadcrumbs({
+  breadcrumbs,
+  onNavigate,
+}: {
+  breadcrumbs: TitlebarBreadcrumb[]
+  onNavigate: (path: string) => void
+}) {
+  const collapsed = breadcrumbs.length > 4 ? breadcrumbs.slice(1, -2) : []
+  const visible = collapsed.length > 0 ? [breadcrumbs[0], ...breadcrumbs.slice(-2)] : breadcrumbs
+
+  return (
+    <nav
+      aria-label={breadcrumbs.map((breadcrumb) => breadcrumb.label).join(" / ")}
+      className="flex min-w-0 items-center"
+    >
+      {visible.map((breadcrumb, index) => {
+        const originalIndex = collapsed.length > 0 && index > 0 ? breadcrumbs.length - (visible.length - index) : index
+        const current = originalIndex === breadcrumbs.length - 1
+        return (
+          <React.Fragment key={breadcrumb.path || "__root__"}>
+            {index > 0 ? <ChevronRight className="mx-1 size-3.5 shrink-0 text-muted-foreground/70" /> : null}
+            {collapsed.length > 0 && index === 1 ? (
+              <>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="oo-toolbar-button mr-1 grid size-6 shrink-0 place-items-center rounded text-muted-foreground [-webkit-app-region:no-drag] hover:bg-accent hover:text-foreground"
+                      aria-label={collapsed.map((item) => item.label).join(" / ")}
+                    >
+                      <MoreHorizontal className="size-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    {collapsed.map((item) => (
+                      <DropdownMenuItem key={item.path} onSelect={() => onNavigate(item.path)}>
+                        {item.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <ChevronRight className="mx-1 size-3.5 shrink-0 text-muted-foreground/70" />
+              </>
+            ) : null}
+            {current ? (
+              <span className="max-w-56 truncate font-semibold text-foreground" title={breadcrumb.label}>
+                {breadcrumb.label}
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="max-w-40 truncate rounded px-1 py-0.5 text-muted-foreground transition-colors [-webkit-app-region:no-drag] hover:bg-accent hover:text-foreground"
+                title={breadcrumb.label}
+                onClick={() => onNavigate(breadcrumb.path)}
+              >
+                {breadcrumb.label}
+              </button>
+            )}
+          </React.Fragment>
+        )
+      })}
+    </nav>
+  )
+}
 
 export const AppShellMainTitlebar = React.memo(function AppShellMainTitlebar({
   activeSession,
@@ -27,12 +98,14 @@ export const AppShellMainTitlebar = React.memo(function AppShellMainTitlebar({
   onBrowserToggle,
   onOpenSearch,
   onRenameSession,
+  onTitlebarBreadcrumbNavigate,
   onToggleSidebar,
   onViewBilling,
   showArtifactsToggle,
   showBrowserToggle,
   sidebarCollapsed,
   titlebarEditable,
+  titlebarBreadcrumbs,
   titlebarTitle,
   workspace,
 }: {
@@ -50,12 +123,14 @@ export const AppShellMainTitlebar = React.memo(function AppShellMainTitlebar({
   onBrowserToggle: () => void
   onOpenSearch: () => void
   onRenameSession: (sessionId: string, title: string) => void
+  onTitlebarBreadcrumbNavigate?: (path: string) => void
   onToggleSidebar: () => void
   onViewBilling?: (target?: BillingDetailsTarget) => void
   showArtifactsToggle: boolean
   showBrowserToggle: boolean
   sidebarCollapsed: boolean
   titlebarEditable: boolean
+  titlebarBreadcrumbs?: TitlebarBreadcrumb[]
   titlebarTitle: string
   workspace: WorkspaceSelection
 }) {
@@ -75,15 +150,19 @@ export const AppShellMainTitlebar = React.memo(function AppShellMainTitlebar({
           isSidebarRestoring && "is-restoring",
         )}
       >
-        <EditableTitlebarTitle
-          title={titlebarTitle}
-          editable={titlebarEditable}
-          onRename={(title) => {
-            if (activeSession) {
-              onRenameSession(activeSession.id, title)
-            }
-          }}
-        />
+        {titlebarBreadcrumbs && onTitlebarBreadcrumbNavigate ? (
+          <TitlebarBreadcrumbs breadcrumbs={titlebarBreadcrumbs} onNavigate={onTitlebarBreadcrumbNavigate} />
+        ) : (
+          <EditableTitlebarTitle
+            title={titlebarTitle}
+            editable={titlebarEditable}
+            onRename={(title) => {
+              if (activeSession) {
+                onRenameSession(activeSession.id, title)
+              }
+            }}
+          />
+        )}
       </div>
       <div className="ml-auto flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
         <AppUpdateTitlebarEntry update={appUpdate} />

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -1542,6 +1542,7 @@ export const enMessages = {
   "knowledge.moveSameFolder": "The target folder is already the current folder",
   "knowledge.pathConflict": "A file or folder with that name already exists in this folder",
   "knowledge.search": "Search knowledge bases",
+  "knowledge.searchCurrentDirectory": "Search “{directory}”",
   "knowledge.back": "Back to knowledge",
   "knowledge.goUp": "Up",
   "knowledge.rootDirectory": "Library",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -1473,6 +1473,7 @@ export const zhCNMessages = {
   "knowledge.moveSameFolder": "目标文件夹与当前文件夹相同",
   "knowledge.pathConflict": "同一文件夹中已存在同名文件或文件夹",
   "knowledge.search": "搜索知识库",
+  "knowledge.searchCurrentDirectory": "搜索“{directory}”",
   "knowledge.back": "返回知识库",
   "knowledge.goUp": "返回上级",
   "knowledge.rootDirectory": "库根目录",

--- a/src/routes/Knowledge/index.tsx
+++ b/src/routes/Knowledge/index.tsx
@@ -11,7 +11,6 @@ import {
   FolderPlus,
   FolderOpen,
   FolderX,
-  Home,
   LibraryBig,
   MessageSquarePlus,
   MoreHorizontal,
@@ -373,54 +372,21 @@ function KnowledgeFolderRow({
   )
 }
 
-function KnowledgeBreadcrumbs({
-  breadcrumbs,
-  onNavigate,
-  t,
-}: {
-  breadcrumbs: Array<{ label: string; path: string }>
-  onNavigate: (path: string) => void
-  t: ReturnType<typeof useT>
-}) {
-  return (
-    <div className="flex min-w-0 flex-wrap items-center gap-1 text-sm text-muted-foreground">
-      {breadcrumbs.map((breadcrumb, index) => (
-        <React.Fragment key={`${breadcrumb.path}:${index}`}>
-          {index > 0 ? <ChevronRight className="size-3.5 shrink-0" /> : null}
-          <button
-            type="button"
-            className={cn(
-              "max-w-full truncate rounded px-1.5 py-0.5 text-left transition-colors hover:bg-muted/60 hover:text-foreground",
-              index === breadcrumbs.length - 1 && "font-medium text-foreground",
-            )}
-            title={breadcrumb.path || t("knowledge.rootDirectory")}
-            onClick={() => onNavigate(breadcrumb.path)}
-          >
-            {index === 0 && breadcrumb.path === "" ? (
-              <span className="inline-flex items-center gap-1.5">
-                <Home className="size-3.5" />
-                {breadcrumb.label}
-              </span>
-            ) : (
-              breadcrumb.label
-            )}
-          </button>
-        </React.Fragment>
-      ))}
-    </div>
-  )
-}
-
 export function KnowledgeRoute({
+  currentDirectory,
   knowledge,
+  titlebarNavigationVersion,
+  onCurrentDirectoryChange,
   onStartChat,
 }: {
+  currentDirectory: string
   knowledge: UseKnowledgeBases
+  titlebarNavigationVersion: number
+  onCurrentDirectoryChange: (directory: string) => void
   onStartChat: (item: KnowledgeBaseSummary) => void
 }) {
   const t = useT()
   const [query, setQuery] = React.useState("")
-  const [currentDirectory, setCurrentDirectory] = React.useState("")
   const [selectedId, setSelectedId] = React.useState<string | null>(null)
   const [removeTarget, setRemoveTarget] = React.useState<KnowledgeBaseSummary | null>(null)
   const [renameTarget, setRenameTarget] = React.useState<KnowledgeBaseSummary | null>(null)
@@ -436,6 +402,7 @@ export function KnowledgeRoute({
   } | null>(null)
   const [dragActive, setDragActive] = React.useState(false)
   const dragDepthRef = React.useRef(0)
+  const previousTitlebarNavigationVersionRef = React.useRef(titlebarNavigationVersion)
   const deferredQuery = React.useDeferredValue(query)
 
   const view = React.useMemo(
@@ -463,6 +430,12 @@ export function KnowledgeRoute({
   }, [knowledge.items, selectedId])
 
   React.useEffect(() => {
+    if (previousTitlebarNavigationVersionRef.current === titlebarNavigationVersion) return
+    previousTitlebarNavigationVersionRef.current = titlebarNavigationVersion
+    setSelectedId(null)
+  }, [titlebarNavigationVersion])
+
+  React.useEffect(() => {
     if (!selectedId) return
     const closeOnEscape = (event: KeyboardEvent): void => {
       if (event.key === "Escape") setSelectedId(null)
@@ -475,7 +448,7 @@ export function KnowledgeRoute({
     const imported = await knowledge.importKnowledgeBase(sourcePath, targetDirectory ?? currentDirectory)
     if (imported) {
       setSelectedId(imported.id)
-      setCurrentDirectory(imported.relativePath ? knowledgePathDirectory(imported.relativePath) : currentDirectory)
+      onCurrentDirectoryChange(imported.relativePath ? knowledgePathDirectory(imported.relativePath) : currentDirectory)
     }
     return imported
   }
@@ -541,7 +514,7 @@ export function KnowledgeRoute({
     if (created) {
       setCreateFolderOpen(false)
       setCreateFolderName("")
-      setCurrentDirectory(created)
+      onCurrentDirectoryChange(created)
       setSelectedId(null)
     }
   }
@@ -565,7 +538,7 @@ export function KnowledgeRoute({
       setRenameTarget(null)
       setRenameValue("")
       setSelectedId(renamed.id)
-      setCurrentDirectory(knowledgePathDirectory(renamed.relativePath))
+      onCurrentDirectoryChange(knowledgePathDirectory(renamed.relativePath))
     }
   }
 
@@ -587,7 +560,7 @@ export function KnowledgeRoute({
       setMoveTarget(null)
       setMoveDirectory("")
       setSelectedId(moved.id)
-      setCurrentDirectory(knowledgePathDirectory(moved.relativePath))
+      onCurrentDirectoryChange(knowledgePathDirectory(moved.relativePath))
     }
   }
 
@@ -604,14 +577,14 @@ export function KnowledgeRoute({
         view.currentDirectory === removeFolderTarget.path ||
         view.currentDirectory.startsWith(`${removeFolderTarget.path}/`)
       ) {
-        setCurrentDirectory(knowledgePathDirectory(removeFolderTarget.path))
+        onCurrentDirectoryChange(knowledgePathDirectory(removeFolderTarget.path))
       }
       setRemoveFolderTarget(null)
     }
   }
 
   const handleNavigate = (path: string): void => {
-    setCurrentDirectory(normalizeKnowledgePath(path))
+    onCurrentDirectoryChange(normalizeKnowledgePath(path))
     setSelectedId(null)
   }
 
@@ -637,51 +610,37 @@ export function KnowledgeRoute({
       onDrop={(event) => void handleDrop(event)}
     >
       <SplitViewRoot narrowPane={narrowPane}>
-        <SplitViewHeader narrowPane={narrowPane} className="oo-border-divider border-b sm:grid-cols-1">
-          <div className="flex min-w-0 flex-1 flex-col gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <SearchField
-                className="max-w-sm flex-1"
-                disabled={knowledge.items.length === 0}
-                placeholder={t("knowledge.search")}
-                value={query}
-                onChange={(event) => setQuery(event.currentTarget.value)}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={knowledge.busy !== null || view.searchMode || !view.currentDirectory}
-                onClick={() => {
-                  setSelectedId(null)
-                  setCurrentDirectory(knowledgePathDirectory(currentDirectory))
-                }}
-              >
-                <ArrowLeft />
-                {t("knowledge.goUp")}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="ml-auto"
-                disabled={knowledge.busy !== null || view.searchMode}
-                onClick={() => setCreateFolderOpen(true)}
-              >
-                <FolderPlus />
-                {knowledge.busy === "create-folder" ? t("knowledge.creatingFolder") : t("knowledge.newFolder")}
-              </Button>
-              <Button type="button" size="sm" disabled={knowledge.busy !== null} onClick={() => void handleImport()}>
-                <Plus />
-                {knowledge.busy === "import"
-                  ? t("knowledge.importing")
-                  : view.currentDirectory
-                    ? t("knowledge.importToCurrent")
-                    : t("knowledge.import")}
-              </Button>
-            </div>
-            <KnowledgeBreadcrumbs breadcrumbs={view.breadcrumbs} onNavigate={handleNavigate} t={t} />
-          </div>
+        <SplitViewHeader narrowPane={narrowPane} className="oo-border-divider flex items-center border-b">
+          <SearchField
+            className="max-w-sm min-w-0 flex-1"
+            disabled={knowledge.items.length === 0}
+            placeholder={
+              view.currentDirectory
+                ? t("knowledge.searchCurrentDirectory", { directory: knowledgePathBaseName(view.currentDirectory) })
+                : t("knowledge.search")
+            }
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="ml-auto"
+            disabled={knowledge.busy !== null || view.searchMode}
+            onClick={() => setCreateFolderOpen(true)}
+          >
+            <FolderPlus />
+            {knowledge.busy === "create-folder" ? t("knowledge.creatingFolder") : t("knowledge.newFolder")}
+          </Button>
+          <Button type="button" size="sm" disabled={knowledge.busy !== null} onClick={() => void handleImport()}>
+            <Plus />
+            {knowledge.busy === "import"
+              ? t("knowledge.importing")
+              : view.currentDirectory
+                ? t("knowledge.importToCurrent")
+                : t("knowledge.import")}
+          </Button>
         </SplitViewHeader>
 
         <SplitViewBody


### PR DESCRIPTION
## Summary

The knowledge library header currently repeats the same navigation hierarchy in three places: the static page title, an “Up” action, and a separate breadcrumb row. This consumes vertical space and gives users two competing ways to perform the same parent-directory navigation.

This change moves the knowledge directory breadcrumb into the existing application title bar and reduces the knowledge library toolbar to a single row containing search and creation/import actions. At the library root, the title bar remains a simple “Knowledge” label. Inside folders, it becomes an interactive path whose ancestors navigate directly to the selected directory.

Deep paths retain the root and the two nearest levels while collapsing intermediate directories into an accessible overflow menu. The current directory is visually emphasized and is not interactive. Navigating through the title bar also clears a file detail selection so stale details are not left open after changing directories.

The redundant “Up” button and the standalone breadcrumb row have been removed. Search placeholder text now reflects the active directory, making the search scope clearer to users.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run src/routes/Knowledge/knowledge-route-model.test.ts`
- Formatting checks for all modified files
- `git diff --check`
