### PR TITLE
Fix empty sidebar scroll

### DIFF
--- a/src/components/app-shell/AppShellNavigationSidebar.tsx
+++ b/src/components/app-shell/AppShellNavigationSidebar.tsx
@@ -301,7 +301,7 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
           <div className="pb-2">
             <SidebarSegmentControl value={sidebarSegment} onChange={onSetSidebarSegment} />
           </div>
-          <div className="oo-sidebar-session-scroll -mx-3 min-h-0 flex-1 overflow-y-auto px-3 pb-2">
+          <div className="oo-sidebar-session-scroll -mx-3 flex min-h-0 flex-1 flex-col overflow-y-auto px-3 pb-2">
             {sidebarSegment === "tasks" ? (
               <div className="group mb-2 flex h-7 items-center justify-between px-3">
                 <div className="oo-sidebar-section-heading oo-text-caption">{t("sidebar.tasks")}</div>

--- a/src/components/app-shell/AppShellSidebar.tsx
+++ b/src/components/app-shell/AppShellSidebar.tsx
@@ -158,7 +158,7 @@ export function SidebarEmptyState() {
   const t = useT()
 
   return (
-    <div className="flex min-h-full flex-1 items-center justify-center px-5 py-8 text-center">
+    <div className="flex min-h-0 flex-1 items-center justify-center px-5 py-8 text-center">
       <div className="max-w-40">
         <div className="mx-auto flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-sidebar-accent/65 text-sidebar-foreground shadow-sm">
           <MessageSquarePlus className="size-5" aria-hidden="true" />
@@ -174,7 +174,7 @@ export function ProjectSidebarEmptyState({ onSelectFolder }: { onSelectFolder: (
   const t = useT()
 
   return (
-    <div className="flex min-h-full flex-1 items-center justify-center px-5 py-8 text-center">
+    <div className="flex min-h-0 flex-1 items-center justify-center px-5 py-8 text-center">
       <div className="max-w-44">
         <div className="mx-auto flex size-12 items-center justify-center rounded-lg border border-sidebar-border bg-sidebar-accent/65 text-sidebar-foreground shadow-sm">
           <Folder className="size-5" aria-hidden="true" />


### PR DESCRIPTION
## Summary

Fix the sidebar showing a vertical scrollbar when the task list is empty.

## Problem

With no tasks, the sidebar still displayed a scrollbar even though the empty state visually fit within the available area. This made the empty task panel look slightly overflowed and suggested that hidden content was present.

## Root cause

The task section heading was rendered before an empty-state component whose minimum height was set to the full height of the scroll container. The heading height and margin were therefore added on top of a full-height empty state, making the total content slightly taller than the container and triggering vertical overflow.

## Fix

The sidebar session scroll container now uses a vertical flex layout. The task and project empty states use `min-h-0` with `flex-1`, so they occupy only the remaining height after section controls and headings. The scroll container keeps `overflow-y-auto`, preserving normal scrolling when task or project content genuinely exceeds the available space.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- Oxfmt check for the modified files
- `git diff --check`
- Electron development startup
