### PR TITLE
fix(chat): restore capability-gated voice input

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -2063,6 +2063,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                       initialSendPending={initialSendPending}
                       composerFocusRequest={composerFocusRequest}
                       cloudModelsEnabled={runtimeCapabilities?.oomolCloudModels === true}
+                      voiceEnabled={runtimeCapabilities?.voice === true}
                       canManageWorkspaceConnections={oomolLinkActive && canManageWorkspaceConnections}
                       emptyStateConnectionSummary={oomolLinkActive ? emptyStateConnectionSummary : null}
                       teamSkillEntryVisible={oomolEnabled && teamSkillEntryVisible}

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -401,6 +401,7 @@ export const enMessages = {
   "chat.voiceStarting": "Preparing microphone",
   "chat.voiceStop": "Stop voice input",
   "chat.voiceCancel": "Cancel voice input",
+  "chat.voiceDiscard": "Discard voice input",
   "chat.voiceRetry": "Retry voice recognition",
   "chat.contextUsage": "Context: {used} / {limit} ({percent}%)",
   "chat.contextUsageCompaction": "Context: {used} / {limit} auto-compact threshold ({percent}%)",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -385,6 +385,7 @@ export const zhCNMessages = {
   "chat.voiceStarting": "正在准备麦克风",
   "chat.voiceStop": "停止语音输入",
   "chat.voiceCancel": "取消语音输入",
+  "chat.voiceDiscard": "丢弃语音输入",
   "chat.voiceRetry": "重试语音识别",
   "chat.contextUsage": "上下文：{used} / {limit}（{percent}%）",
   "chat.contextUsageCompaction": "上下文：{used} / 自动压缩阈值 {limit}（{percent}%）",

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -54,6 +54,8 @@ import { stripDraftAttachment, useComposerAttachments } from "./useComposerAttac
 import { useComposerPalette } from "./useComposerPalette.ts"
 import { useComposerPreferences } from "./useComposerPreferences.ts"
 import { modelCatalogForRuntime, useModelCatalog } from "./useModelCatalog.ts"
+import { useVoiceComposerInput } from "./useVoiceComposerInput.ts"
+import { getVoiceErrorNotice } from "./voice-error-display.ts"
 import {
   PromptInput,
   PromptInputAttachments,
@@ -72,6 +74,7 @@ import { authTypeLabel } from "@/routes/Connections/shared"
 interface ChatComposerProps {
   error: string | null
   cloudModelsEnabled?: boolean
+  voiceEnabled?: boolean
   focusRequest: number
   generatedArtifacts?: ArtifactSelection | null
   hasMessages: boolean
@@ -175,6 +178,7 @@ function paletteLabels({
 
 export function ChatComposer({
   cloudModelsEnabled = true,
+  voiceEnabled = false,
   error,
   focusRequest,
   generatedArtifacts = null,
@@ -239,6 +243,11 @@ export function ChatComposer({
   )
   const { agentMode, reasoningLevel, setAgentMode, setReasoningLevel } = useComposerPreferences()
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
+  const appendVoiceTranscription = React.useCallback((text: string) => {
+    dispatchComposer({ type: "insert-transcription", text })
+    window.requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [])
+  const voiceInput = useVoiceComposerInput(appendVoiceTranscription)
   const paletteId = React.useId()
   const { attachments, command, contextMentions, dismissedTriggerKey, draft, draftSelection } = composer
   React.useEffect(() => {
@@ -262,7 +271,12 @@ export function ChatComposer({
   const composerWillQueueMessage = activePendingQuestion ? false : willQueueMessage
   const initialSendPending = turnState.status === "submitting" && turnState.initialSendPending
   const submitBlocked = submitDisabled || initialSendPending
-  const composerDisabled = submitDisabled || initialSendPending || answeringQuestion || composerQuestionBlocked
+  const composerDisabled =
+    submitDisabled ||
+    (voiceEnabled && voiceInput.busy) ||
+    initialSendPending ||
+    answeringQuestion ||
+    composerQuestionBlocked
   const composerControlsDisabled = composerModeControlsDisabled({ composerDisabled, modelRequired })
   const modelCatalog = React.useMemo(
     () => modelCatalogForRuntime(modelCatalogState.catalog, cloudModelsEnabled),
@@ -281,6 +295,11 @@ export function ChatComposer({
   React.useEffect(() => {
     setAnsweringQuestion(false)
   }, [activePendingQuestionId])
+  React.useEffect(() => {
+    if (!voiceEnabled && voiceInput.active) {
+      voiceInput.cancel()
+    }
+  }, [voiceEnabled, voiceInput.active, voiceInput.cancel])
   const platform = globalThis.wanta?.platform
   const slashItems = React.useMemo(
     () =>
@@ -582,8 +601,27 @@ export function ChatComposer({
     if (modelError) {
       return { error: modelError, showDiagnosticsCopy: true }
     }
+    if (voiceEnabled) {
+      const voiceNotice = getVoiceErrorNotice({
+        recorderError: voiceInput.recorderError,
+        transcriptionError: voiceInput.error,
+        transcriptionErrorKind: voiceInput.errorKind,
+      })
+      if (voiceNotice) {
+        return { ...voiceNotice, onDismiss: voiceInput.dismissError }
+      }
+    }
     return null
-  }, [error, inputError, modelError])
+  }, [
+    error,
+    inputError,
+    modelError,
+    voiceEnabled,
+    voiceInput.dismissError,
+    voiceInput.error,
+    voiceInput.errorKind,
+    voiceInput.recorderError,
+  ])
   const errorBanner = visibleError ? (
     <ErrorNotice
       error={visibleError.error}
@@ -708,15 +746,28 @@ export function ChatComposer({
           agentMode={agentMode}
           permissionMode={permissionMode}
           reasoningLevel={reasoningLevel}
+          voiceEnabled={voiceEnabled}
+          voiceActive={voiceEnabled && voiceInput.active}
+          voiceBars={voiceInput.bars}
+          voiceDurationMs={voiceInput.durationMs}
+          voiceError={voiceInput.error}
+          voiceRecorderError={voiceInput.recorderError}
+          voiceRetryBlob={voiceInput.retryBlob}
+          voiceStarting={voiceInput.starting}
+          voiceTranscribing={voiceInput.transcribing}
           willQueueMessage={composerWillQueueMessage}
           onAddModel={modelCatalogState.openDialog}
+          onCancelVoice={voiceInput.cancel}
           onDeleteModel={modelCatalogState.deleteModel}
+          onRetryVoice={voiceInput.retry}
           onSelectAgentMode={setAgentMode}
           onSelectDefaultPermissionMode={onPermissionModeDefault}
           onRequestFullAccessPermissionMode={onPermissionModeFullAccess}
           onSelectReasoningLevel={setReasoningLevel}
           onSelectModel={modelCatalogState.selectModel}
+          onStartVoice={voiceInput.start}
           onStop={onStop}
+          onStopVoice={() => void voiceInput.stop()}
         />
       </PromptInputToolbar>
     </PromptInput>

--- a/src/routes/Chat/ChatComposer.tsx
+++ b/src/routes/Chat/ChatComposer.tsx
@@ -750,11 +750,11 @@ export function ChatComposer({
           voiceActive={voiceEnabled && voiceInput.active}
           voiceBars={voiceInput.bars}
           voiceDurationMs={voiceInput.durationMs}
-          voiceError={voiceInput.error}
-          voiceRecorderError={voiceInput.recorderError}
-          voiceRetryBlob={voiceInput.retryBlob}
-          voiceStarting={voiceInput.starting}
-          voiceTranscribing={voiceInput.transcribing}
+          voiceError={voiceEnabled ? voiceInput.error : null}
+          voiceRecorderError={voiceEnabled ? voiceInput.recorderError : undefined}
+          voiceRetryBlob={voiceEnabled ? voiceInput.retryBlob : null}
+          voiceStarting={voiceEnabled && voiceInput.starting}
+          voiceTranscribing={voiceEnabled && voiceInput.transcribing}
           willQueueMessage={composerWillQueueMessage}
           onAddModel={modelCatalogState.openDialog}
           onCancelVoice={voiceInput.cancel}

--- a/src/routes/Chat/ComposerModeControls.test.ts
+++ b/src/routes/Chat/ComposerModeControls.test.ts
@@ -35,11 +35,13 @@ function renderControls(voiceEnabled: boolean): string {
 }
 
 describe("ComposerModeControls", () => {
+  const voiceLabel = `aria-label="${t("chat.voiceInput")}"`
+
   it("shows voice input when the runtime enables voice", () => {
-    expect(renderControls(true)).toContain('aria-label="Voice input"')
+    expect(renderControls(true)).toContain(voiceLabel)
   })
 
   it("hides voice input when the runtime disables voice", () => {
-    expect(renderControls(false)).not.toContain('aria-label="Voice input"')
+    expect(renderControls(false)).not.toContain(voiceLabel)
   })
 })

--- a/src/routes/Chat/ComposerModeControls.test.ts
+++ b/src/routes/Chat/ComposerModeControls.test.ts
@@ -1,0 +1,45 @@
+import type { TranslateFn } from "@/i18n/i18n"
+
+import * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ComposerModeControls } from "./ComposerModeControls.tsx"
+import { I18nContext, translate } from "@/i18n/i18n"
+
+const t: TranslateFn = (key, vars) => translate("en", key, vars)
+
+function renderControls(voiceEnabled: boolean): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      I18nContext.Provider,
+      { value: { locale: "en", setLocale: () => undefined, t } },
+      React.createElement(ComposerModeControls, {
+        agentMode: "build",
+        composerDisabled: false,
+        contextUsage: null,
+        modelCatalog: null,
+        permissionMode: "default",
+        reasoningLevel: "default",
+        voiceEnabled,
+        onAddModel: () => undefined,
+        onDeleteModel: () => undefined,
+        onRequestFullAccessPermissionMode: () => undefined,
+        onSelectAgentMode: () => undefined,
+        onSelectDefaultPermissionMode: () => undefined,
+        onSelectModel: () => undefined,
+        onSelectReasoningLevel: () => undefined,
+        onStartVoice: () => undefined,
+      }),
+    ),
+  )
+}
+
+describe("ComposerModeControls", () => {
+  it("shows voice input when the runtime enables voice", () => {
+    expect(renderControls(true)).toContain('aria-label="Voice input"')
+  })
+
+  it("hides voice input when the runtime disables voice", () => {
+    expect(renderControls(false)).not.toContain('aria-label="Voice input"')
+  })
+})

--- a/src/routes/Chat/ComposerModeControls.tsx
+++ b/src/routes/Chat/ComposerModeControls.tsx
@@ -2,10 +2,13 @@ import type { AgentMode, AgentPermissionMode, ReasoningLevel } from "../../../el
 import type { ModelCatalog, ModelChoice } from "../../../electron/models/common.ts"
 import type { ContextUsageInfo } from "./context-usage.ts"
 
+import { Mic } from "lucide-react"
 import { AgentModePicker } from "./AgentModePicker.tsx"
 import { ComposerContextUsageIndicator } from "./ComposerContextUsageIndicator.tsx"
 import { ModelReasoningPicker } from "./ModelReasoningPicker.tsx"
 import { PermissionModePicker } from "./PermissionModePicker.tsx"
+import { Button } from "@/components/ui/button"
+import { useT } from "@/i18n/i18n"
 
 interface ComposerModeControlsProps {
   agentMode: AgentMode
@@ -15,6 +18,7 @@ interface ComposerModeControlsProps {
   permissionMode: AgentPermissionMode
   reasoningLevel: ReasoningLevel
   modelRequired?: boolean
+  voiceEnabled: boolean
   onAddModel: () => void
   onDeleteModel: (id: string) => void
   onRequestFullAccessPermissionMode: () => void
@@ -22,6 +26,7 @@ interface ComposerModeControlsProps {
   onSelectDefaultPermissionMode: () => void
   onSelectModel: (choice: ModelChoice) => void
   onSelectReasoningLevel: (level: ReasoningLevel) => void
+  onStartVoice: () => void
 }
 
 export function ComposerModeControls({
@@ -32,6 +37,7 @@ export function ComposerModeControls({
   permissionMode,
   reasoningLevel,
   modelRequired = false,
+  voiceEnabled,
   onAddModel,
   onDeleteModel,
   onRequestFullAccessPermissionMode,
@@ -39,7 +45,9 @@ export function ComposerModeControls({
   onSelectDefaultPermissionMode,
   onSelectModel,
   onSelectReasoningLevel,
+  onStartVoice,
 }: ComposerModeControlsProps) {
+  const t = useT()
   return (
     <>
       <ComposerContextUsageIndicator usage={contextUsage} />
@@ -60,6 +68,20 @@ export function ComposerModeControls({
         onSelectModel={onSelectModel}
         onSelectReasoningLevel={onSelectReasoningLevel}
       />
+      {voiceEnabled ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          title={t("chat.voiceInput")}
+          aria-label={t("chat.voiceInput")}
+          disabled={composerDisabled}
+          className="size-8 rounded-full"
+          onClick={onStartVoice}
+        >
+          <Mic className="size-4" />
+        </Button>
+      ) : null}
     </>
   )
 }

--- a/src/routes/Chat/ComposerTrailingControls.test.ts
+++ b/src/routes/Chat/ComposerTrailingControls.test.ts
@@ -1,0 +1,72 @@
+import type { TranslateFn } from "@/i18n/i18n"
+import type { ComponentProps } from "react"
+
+import * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ComposerTrailingControls } from "./ComposerTrailingControls.tsx"
+import { ThemeContext } from "@/components/theme-context"
+import { I18nContext, translate } from "@/i18n/i18n"
+
+const t: TranslateFn = (key, vars) => translate("en", key, vars)
+const baseProps: ComponentProps<typeof ComposerTrailingControls> = {
+  agentMode: "build",
+  canSubmit: false,
+  composerDisabled: false,
+  contextUsage: null,
+  modelCatalog: null,
+  permissionMode: "default",
+  reasoningLevel: "default",
+  turnState: { chatStatus: "ready", status: "idle" },
+  voiceActive: false,
+  voiceBars: [],
+  voiceDurationMs: 0,
+  voiceEnabled: true,
+  voiceError: null,
+  voiceRetryBlob: null,
+  voiceStarting: false,
+  voiceTranscribing: false,
+  willQueueMessage: false,
+  onAddModel: () => undefined,
+  onCancelVoice: () => undefined,
+  onDeleteModel: () => undefined,
+  onRequestFullAccessPermissionMode: () => undefined,
+  onRetryVoice: () => undefined,
+  onSelectAgentMode: () => undefined,
+  onSelectDefaultPermissionMode: () => undefined,
+  onSelectModel: () => undefined,
+  onSelectReasoningLevel: () => undefined,
+  onStartVoice: () => undefined,
+  onStop: () => undefined,
+  onStopVoice: () => undefined,
+}
+
+function renderControls(overrides: Partial<ComponentProps<typeof ComposerTrailingControls>>): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      ThemeContext.Provider,
+      { value: { effectiveTheme: "light", preference: "light", setPreference: () => undefined } },
+      React.createElement(
+        I18nContext.Provider,
+        { value: { locale: "en", setLocale: () => undefined, t } },
+        React.createElement(ComposerTrailingControls, { ...baseProps, ...overrides }),
+      ),
+    ),
+  )
+}
+
+describe("ComposerTrailingControls", () => {
+  it("does not expose stale voice errors when the runtime disables voice", () => {
+    const html = renderControls({ voiceEnabled: false, voiceError: "Transcription failed" })
+
+    expect(html).not.toContain(`aria-label="${t("chat.voiceRetry")}"`)
+    expect(html).not.toContain(`aria-label="${t("chat.voiceCancel")}"`)
+  })
+
+  it("distinguishes cancelling startup from discarding the recording", () => {
+    const html = renderControls({ voiceActive: true, voiceStarting: true })
+
+    expect(html).toContain(`aria-label="${t("chat.voiceCancel")}"`)
+    expect(html).toContain(`aria-label="${t("chat.voiceDiscard")}"`)
+  })
+})

--- a/src/routes/Chat/ComposerTrailingControls.tsx
+++ b/src/routes/Chat/ComposerTrailingControls.tsx
@@ -3,15 +3,18 @@ import type { ModelCatalog, ModelChoice } from "../../../electron/models/common.
 import type { ChatTurnState } from "./chat-turn-state.ts"
 import type { ContextUsageInfo } from "./context-usage.ts"
 
-import { ListPlus } from "lucide-react"
+import { ListPlus, Loader2, RotateCcw, Square, X } from "lucide-react"
+import * as React from "react"
 import { toast } from "sonner"
 import { APP_COMMANDS } from "../../../electron/app-command.ts"
-import { composerSubmitState } from "./composer-controls.ts"
+import { composerSubmitState, composerVoiceControlMode } from "./composer-controls.ts"
 import { ComposerModeControls } from "./ComposerModeControls.tsx"
 import { PromptInputSubmit } from "@/components/ai-elements/prompt-input"
+import { Button } from "@/components/ui/button"
 import { useT } from "@/i18n/i18n"
 import { appCommandAriaShortcut, appCommandShortcutLabel, labelWithShortcut } from "@/lib/app-shortcuts"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
+import { cn } from "@/lib/utils"
 
 interface ComposerTrailingControlsProps {
   canSubmit: boolean
@@ -23,15 +26,141 @@ interface ComposerTrailingControlsProps {
   agentMode: AgentMode
   permissionMode: AgentPermissionMode
   reasoningLevel: ReasoningLevel
+  voiceEnabled: boolean
+  voiceActive: boolean
+  voiceBars: readonly number[]
+  voiceDurationMs: number
+  voiceError: string | null
+  voiceRecorderError?: string
+  voiceRetryBlob: Blob | null
+  voiceStarting: boolean
+  voiceTranscribing: boolean
   willQueueMessage: boolean
   onAddModel: () => void
+  onCancelVoice: () => void
   onDeleteModel: (id: string) => void
+  onRetryVoice: () => void
   onSelectAgentMode: (mode: AgentMode) => void
   onSelectDefaultPermissionMode: () => void
   onRequestFullAccessPermissionMode: () => void
   onSelectModel: (choice: ModelChoice) => void
   onSelectReasoningLevel: (level: ReasoningLevel) => void
+  onStartVoice: () => void
   onStop: () => Promise<void> | void
+  onStopVoice: () => void
+}
+
+function voiceDurationLabel(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
+function VoiceWaveCanvas({ bars, height = 32 }: { bars: readonly number[]; height?: number }) {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
+  const [sizeRevision, setSizeRevision] = React.useState(0)
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || typeof ResizeObserver === "undefined") {
+      return
+    }
+    const observer = new ResizeObserver(() => {
+      setSizeRevision((revision) => revision + 1)
+    })
+    observer.observe(canvas)
+    return () => observer.disconnect()
+  }, [])
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+
+    const rect = canvas.getBoundingClientRect()
+    const dpr = window.devicePixelRatio || 1
+    const width = Math.max(1, Math.floor(rect.width * dpr))
+    const canvasHeight = Math.max(1, Math.floor(height * dpr))
+    if (canvas.width !== width) {
+      canvas.width = width
+    }
+    if (canvas.height !== canvasHeight) {
+      canvas.height = canvasHeight
+    }
+
+    const context = canvas.getContext("2d")
+    if (!context) {
+      return
+    }
+
+    context.clearRect(0, 0, width, canvasHeight)
+    context.fillStyle = getComputedStyle(canvas).color || "#18181b"
+
+    const barWidth = 3 * dpr
+    const gap = 3 * dpr
+    const step = barWidth + gap
+    const centerY = canvasHeight / 2
+    const drawableHeight = canvasHeight - 8 * dpr
+    const visibleCount = Math.max(1, Math.ceil(width / step))
+    const recentBars = bars.slice(-visibleCount)
+    const visibleBars =
+      recentBars.length >= visibleCount
+        ? recentBars
+        : [...Array<number>(visibleCount - recentBars.length).fill(0), ...recentBars]
+
+    visibleBars.forEach((bar, index) => {
+      const normalized = Math.max(0, Math.min(1, bar))
+      const barHeight = Math.max(3 * dpr, normalized * drawableHeight)
+      const x = index * step
+      const y = centerY - barHeight / 2
+      context.globalAlpha = 0.35 + normalized * 0.65
+      context.beginPath()
+      context.roundRect(x, y, barWidth, barHeight, barWidth / 2)
+      context.fill()
+    })
+    context.globalAlpha = 1
+  }, [bars, height, sizeRevision])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      height={height}
+      className="h-8 w-full text-foreground/85"
+      aria-hidden
+      data-testid="voice-wave-canvas"
+    />
+  )
+}
+
+function VoiceRecorderPanel({
+  bars,
+  durationMs,
+  loading,
+}: {
+  bars: readonly number[]
+  durationMs: number
+  loading: boolean
+}) {
+  const t = useT()
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="flex h-8 min-w-0 flex-1 items-center justify-center overflow-hidden">
+        {loading ? (
+          <div className="oo-text-control flex min-w-0 items-center gap-2 text-muted-foreground">
+            <Loader2 className="size-4 shrink-0 animate-spin" />
+            <span className="truncate">{t("chat.voiceStarting")}</span>
+          </div>
+        ) : (
+          <VoiceWaveCanvas bars={bars} height={32} />
+        )}
+      </div>
+      <span className="oo-text-control min-w-9 shrink-0 text-right font-normal text-muted-foreground tabular-nums">
+        {voiceDurationLabel(durationMs)}
+      </span>
+    </div>
+  )
 }
 
 export function ComposerTrailingControls({
@@ -44,72 +173,181 @@ export function ComposerTrailingControls({
   agentMode,
   permissionMode,
   reasoningLevel,
+  voiceEnabled,
+  voiceActive,
+  voiceBars,
+  voiceDurationMs,
+  voiceError,
+  voiceRecorderError,
+  voiceRetryBlob,
+  voiceStarting,
+  voiceTranscribing,
   willQueueMessage,
   onAddModel,
+  onCancelVoice,
   onDeleteModel,
+  onRetryVoice,
   onSelectAgentMode,
   onSelectDefaultPermissionMode,
   onRequestFullAccessPermissionMode,
   onSelectModel,
   onSelectReasoningLevel,
+  onStartVoice,
   onStop,
+  onStopVoice,
 }: ComposerTrailingControlsProps) {
   const t = useT()
+  const visibleVoiceError = voiceError ?? voiceRecorderError
+  const voiceMode = composerVoiceControlMode({ voiceActive, voiceStarting, voiceTranscribing, visibleVoiceError })
   const submit = composerSubmitState({ canSubmit, turnState, willQueueMessage })
+  const retryDisabled = !voiceRetryBlob || voiceTranscribing
   const stopLabel = labelWithShortcut(t("aria.stop"), appCommandShortcutLabel(APP_COMMANDS.stopGeneration))
 
   return (
-    <div className="flex min-w-0 flex-1 items-center justify-end gap-1 overflow-hidden">
-      <ComposerModeControls
-        agentMode={agentMode}
-        composerDisabled={composerDisabled}
-        contextUsage={contextUsage}
-        modelCatalog={modelCatalog}
-        modelRequired={modelRequired}
-        permissionMode={permissionMode}
-        reasoningLevel={reasoningLevel}
-        onAddModel={onAddModel}
-        onDeleteModel={onDeleteModel}
-        onRequestFullAccessPermissionMode={onRequestFullAccessPermissionMode}
-        onSelectAgentMode={onSelectAgentMode}
-        onSelectDefaultPermissionMode={onSelectDefaultPermissionMode}
-        onSelectModel={onSelectModel}
-        onSelectReasoningLevel={onSelectReasoningLevel}
-      />
-      <PromptInputSubmit
-        size="icon-sm"
-        className="size-7"
-        status={submit.visualStatus}
-        disabled={submit.disabled}
-        aria-label={
-          submit.aria === "sending"
-            ? t("aria.sending")
-            : submit.aria === "stop"
-              ? t("aria.stop")
-              : submit.aria === "queue"
-                ? t("chat.queueSend")
-                : t("aria.send")
-        }
-        aria-keyshortcuts={submit.stopsGeneration ? appCommandAriaShortcut(APP_COMMANDS.stopGeneration) : undefined}
-        title={submit.stopsGeneration ? stopLabel : submit.queuesMessage ? t("chat.queueSend") : undefined}
-        onClick={
-          submit.stopsGeneration
-            ? (event) => {
-                event.preventDefault()
-                void (async () => {
-                  try {
-                    await onStop()
-                  } catch (cause) {
-                    reportRendererHandledError("chat", "stopGeneration invoke failed", cause)
-                    toast.error(t("chat.stopFailed"))
-                  }
-                })()
-              }
-            : undefined
-        }
+    <>
+      {voiceActive ? (
+        <VoiceRecorderPanel bars={voiceBars} durationMs={voiceDurationMs} loading={voiceMode === "starting"} />
+      ) : null}
+      <div
+        className={cn(
+          "flex min-w-0 items-center justify-end gap-1 overflow-hidden",
+          voiceActive ? "shrink-0" : "flex-1",
+        )}
       >
-        {submit.queuesMessage ? <ListPlus className="size-4" /> : undefined}
-      </PromptInputSubmit>
-    </div>
+        {voiceActive ? (
+          <>
+            {voiceMode === "recording-error" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                title={visibleVoiceError ?? undefined}
+                aria-label={t("chat.voiceRetry")}
+                className="size-8 rounded-full"
+                disabled={retryDisabled}
+                onClick={onRetryVoice}
+              >
+                <RotateCcw className="size-4" />
+              </Button>
+            ) : voiceMode === "starting" || voiceMode === "transcribing" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={t("chat.voiceCancel")}
+                className="size-8 rounded-full bg-foreground/8 text-muted-foreground hover:bg-foreground/12 hover:text-foreground"
+                onClick={onCancelVoice}
+              >
+                <Loader2 className="size-[18px] animate-spin" />
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={t("chat.voiceStop")}
+                className="size-8 rounded-full bg-foreground/8 text-muted-foreground hover:bg-foreground/12 hover:text-foreground"
+                onClick={onStopVoice}
+              >
+                <Square className="size-3.5" fill="currentColor" />
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={t("chat.voiceCancel")}
+              className="size-8 rounded-full bg-foreground text-background hover:bg-foreground/85 hover:text-background"
+              onClick={onCancelVoice}
+            >
+              <X className="size-4" />
+            </Button>
+          </>
+        ) : (
+          <>
+            {voiceMode === "idle-error" ? (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  title={visibleVoiceError ?? undefined}
+                  aria-label={t("chat.voiceRetry")}
+                  className="size-8 rounded-full"
+                  disabled={retryDisabled}
+                  onClick={onRetryVoice}
+                >
+                  <RotateCcw className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={t("chat.voiceCancel")}
+                  className="size-8 rounded-full"
+                  onClick={onCancelVoice}
+                >
+                  <X className="size-4" />
+                </Button>
+              </>
+            ) : null}
+            <ComposerModeControls
+              agentMode={agentMode}
+              composerDisabled={composerDisabled}
+              contextUsage={contextUsage}
+              modelCatalog={modelCatalog}
+              modelRequired={modelRequired}
+              permissionMode={permissionMode}
+              reasoningLevel={reasoningLevel}
+              voiceEnabled={voiceEnabled}
+              onAddModel={onAddModel}
+              onDeleteModel={onDeleteModel}
+              onRequestFullAccessPermissionMode={onRequestFullAccessPermissionMode}
+              onSelectAgentMode={onSelectAgentMode}
+              onSelectDefaultPermissionMode={onSelectDefaultPermissionMode}
+              onSelectModel={onSelectModel}
+              onSelectReasoningLevel={onSelectReasoningLevel}
+              onStartVoice={onStartVoice}
+            />
+            <PromptInputSubmit
+              size="icon-sm"
+              className="size-7"
+              status={submit.visualStatus}
+              disabled={submit.disabled}
+              aria-label={
+                submit.aria === "sending"
+                  ? t("aria.sending")
+                  : submit.aria === "stop"
+                    ? t("aria.stop")
+                    : submit.aria === "queue"
+                      ? t("chat.queueSend")
+                      : t("aria.send")
+              }
+              aria-keyshortcuts={
+                submit.stopsGeneration ? appCommandAriaShortcut(APP_COMMANDS.stopGeneration) : undefined
+              }
+              title={submit.stopsGeneration ? stopLabel : submit.queuesMessage ? t("chat.queueSend") : undefined}
+              onClick={
+                submit.stopsGeneration
+                  ? (event) => {
+                      event.preventDefault()
+                      void (async () => {
+                        try {
+                          await onStop()
+                        } catch (cause) {
+                          reportRendererHandledError("chat", "stopGeneration invoke failed", cause)
+                          toast.error(t("chat.stopFailed"))
+                        }
+                      })()
+                    }
+                  : undefined
+              }
+            >
+              {submit.queuesMessage ? <ListPlus className="size-4" /> : undefined}
+            </PromptInputSubmit>
+          </>
+        )}
+      </div>
+    </>
   )
 }

--- a/src/routes/Chat/ComposerTrailingControls.tsx
+++ b/src/routes/Chat/ComposerTrailingControls.tsx
@@ -59,18 +59,31 @@ function voiceDurationLabel(durationMs: number): string {
 
 function VoiceWaveCanvas({ bars, height = 32 }: { bars: readonly number[]; height?: number }) {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
-  const [sizeRevision, setSizeRevision] = React.useState(0)
+  const metricsRef = React.useRef({
+    canvasHeight: 1,
+    dpr: 1,
+    fillStyle: "#18181b",
+    width: 1,
+  })
+  const [measurementRevision, setMeasurementRevision] = React.useState(0)
 
   React.useEffect(() => {
     const canvas = canvasRef.current
-    if (!canvas || typeof ResizeObserver === "undefined") {
+    if (!canvas) {
       return
     }
-    const observer = new ResizeObserver(() => {
-      setSizeRevision((revision) => revision + 1)
+    const updateMeasurement = (): void => setMeasurementRevision((revision) => revision + 1)
+    const resizeObserver = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(updateMeasurement)
+    const themeObserver = typeof MutationObserver === "undefined" ? undefined : new MutationObserver(updateMeasurement)
+    resizeObserver?.observe(canvas)
+    themeObserver?.observe(document.documentElement, {
+      attributeFilter: ["class", "data-theme"],
+      attributes: true,
     })
-    observer.observe(canvas)
-    return () => observer.disconnect()
+    return () => {
+      resizeObserver?.disconnect()
+      themeObserver?.disconnect()
+    }
   }, [])
 
   React.useEffect(() => {
@@ -83,11 +96,24 @@ function VoiceWaveCanvas({ bars, height = 32 }: { bars: readonly number[]; heigh
     const dpr = window.devicePixelRatio || 1
     const width = Math.max(1, Math.floor(rect.width * dpr))
     const canvasHeight = Math.max(1, Math.floor(height * dpr))
+    metricsRef.current = {
+      canvasHeight,
+      dpr,
+      fillStyle: getComputedStyle(canvas).color || "#18181b",
+      width,
+    }
     if (canvas.width !== width) {
       canvas.width = width
     }
     if (canvas.height !== canvasHeight) {
       canvas.height = canvasHeight
+    }
+  }, [height, measurementRevision])
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
     }
 
     const context = canvas.getContext("2d")
@@ -95,8 +121,9 @@ function VoiceWaveCanvas({ bars, height = 32 }: { bars: readonly number[]; heigh
       return
     }
 
+    const { canvasHeight, dpr, fillStyle, width } = metricsRef.current
     context.clearRect(0, 0, width, canvasHeight)
-    context.fillStyle = getComputedStyle(canvas).color || "#18181b"
+    context.fillStyle = fillStyle
 
     const barWidth = 3 * dpr
     const gap = 3 * dpr
@@ -121,7 +148,7 @@ function VoiceWaveCanvas({ bars, height = 32 }: { bars: readonly number[]; heigh
       context.fill()
     })
     context.globalAlpha = 1
-  }, [bars, height, sizeRevision])
+  }, [bars, height, measurementRevision])
 
   return (
     <canvas
@@ -197,7 +224,7 @@ export function ComposerTrailingControls({
   onStopVoice,
 }: ComposerTrailingControlsProps) {
   const t = useT()
-  const visibleVoiceError = voiceError ?? voiceRecorderError
+  const visibleVoiceError = voiceEnabled ? (voiceError ?? voiceRecorderError) : undefined
   const voiceMode = composerVoiceControlMode({ voiceActive, voiceStarting, voiceTranscribing, visibleVoiceError })
   const submit = composerSubmitState({ canSubmit, turnState, willQueueMessage })
   const retryDisabled = !voiceRetryBlob || voiceTranscribing
@@ -256,7 +283,7 @@ export function ComposerTrailingControls({
               type="button"
               variant="ghost"
               size="icon"
-              aria-label={t("chat.voiceCancel")}
+              aria-label={t("chat.voiceDiscard")}
               className="size-8 rounded-full bg-foreground text-background hover:bg-foreground/85 hover:text-background"
               onClick={onCancelVoice}
             >

--- a/src/routes/Chat/index.tsx
+++ b/src/routes/Chat/index.tsx
@@ -45,6 +45,7 @@ interface ChatAreaProps {
   composerDraftKey: string
   composerFocusRequest: number
   cloudModelsEnabled?: boolean
+  voiceEnabled?: boolean
   messages: ChatMessage[]
   knowledgeBaseIds: string[]
   knowledgeEnabled: boolean
@@ -251,6 +252,7 @@ export const ChatArea = React.memo(function ChatArea({
   composerDraftKey,
   composerFocusRequest,
   cloudModelsEnabled = true,
+  voiceEnabled = false,
   messages,
   knowledgeBaseIds,
   knowledgeEnabled,
@@ -342,6 +344,7 @@ export const ChatArea = React.memo(function ChatArea({
     <ChatComposer
       key={composerDraftKey}
       cloudModelsEnabled={cloudModelsEnabled}
+      voiceEnabled={voiceEnabled}
       error={error}
       focusRequest={composerFocusRequest}
       generatedArtifacts={generatedArtifacts}


### PR DESCRIPTION
## Summary

Restore voice recording and transcription controls in the chat composer for signed-in OOMOL users.
The microphone button is now driven by the existing runtime voice capability, while local and BYOK
runtime modes continue to hide the OOMOL-only voice feature.

## Issue and user impact

Voice recording, WAV encoding, transcription, and error handling remained in the codebase, but the
composer stopped rendering any entry point for them. As a result, signed-in users could no longer
start voice input even though their runtime advertised `voice: true` and the authenticated ASR
service remained available.

## Root cause

The local-runtime foundation removed the voice integration from the shared composer to keep the
OOMOL ASR service out of anonymous local mode. The runtime capability model introduced a dedicated
`voice` flag at the same time, but that flag was never propagated to the composer. This turned an
intended local-mode restriction into a global UI removal.

## Fix

- Propagate `runtimeCapabilities.voice` from `AppShell` through `ChatArea` to `ChatComposer`.
- Reconnect the existing recorder and transcription hook to the composer draft.
- Restore the microphone trigger, preparation state, waveform, duration, stop, cancel, retry, and
  transcription-loading controls.
- Restore microphone permission, no-speech, and transcription failure notices.
- Cancel active voice work if the runtime loses voice capability.
- Keep the voice entry point hidden when the runtime capability is disabled.
- Add regression coverage for capability-gated microphone rendering.

## Validation

- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`
- `pnpm test` — 282 test files, 2122 tests passed
- Voice-focused tests — 7 test files, 31 tests passed
