### PR TITLE
Add DeepSeek V4 built-in models

### DIFF
--- a/electron/agent/agent.test.ts
+++ b/electron/agent/agent.test.ts
@@ -6,7 +6,11 @@ import { test } from "vitest"
 import { branding } from "../branding.ts"
 import { llmBaseUrl, ooEndpoint } from "../domain.ts"
 import { BUILTIN_MODEL_DEFINITIONS, BUILTIN_PROVIDER_DEFINITIONS, resolveBuiltinModel } from "../models/builtin.ts"
-import { DEFAULT_MAX_OUTPUT_TOKENS, QWEN_37_MAX_OUTPUT_TOKENS } from "../models/limits.ts"
+import {
+  DEFAULT_MAX_OUTPUT_TOKENS,
+  QWEN_37_MAX_OUTPUT_TOKENS,
+  STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+} from "../models/limits.ts"
 import { buildOpencodeConfig, customProviderId, WANTA_MODEL_ID, WANTA_PROVIDER_ID } from "./config.ts"
 import { AgentManager, buildManagedSkillRuntimeEnv, persistTeamScopeUpdate } from "./manager.ts"
 import { WANTA_BUILD_AGENT_NAME, WANTA_GENERAL_SUBAGENT_NAME, WANTA_PLAN_AGENT_NAME } from "./mode.ts"
@@ -214,6 +218,29 @@ test("Qwen 3.7 models retain a 1M context window and compact within the 256K pri
       input: 256_000,
       output: QWEN_37_MAX_OUTPUT_TOKENS,
     })
+  }
+})
+
+test("DeepSeek V4 built-ins use official model ids with text-only OOMOL routing", () => {
+  const config = buildOpencodeConfig({
+    linkRuntime: { kind: "oomol", sessionToken: "api-test" },
+    modelAccess: { kind: "oomol", sessionToken: "api-test" },
+  })
+
+  for (const modelID of ["deepseek-v4-flash", "deepseek-v4-pro"] as const) {
+    const definition = resolveBuiltinModel(modelID)
+    assert.deepEqual(definition.runtime, { providerID: "oomol", modelID })
+    const model = config.provider?.oomol?.models?.[modelID]
+    assert.ok(model)
+    assert.deepEqual(modelVariantKeys(model), ["low", "high", "max"])
+    assert.deepEqual(modelLimit(model), {
+      context: 1_000_000,
+      input: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+      output: DEFAULT_MAX_OUTPUT_TOKENS,
+    })
+    assert.equal(model.tool_call, true)
+    assert.equal(model.attachment, undefined)
+    assert.equal(model.modalities, undefined)
   }
 })
 

--- a/electron/models/builtin.test.ts
+++ b/electron/models/builtin.test.ts
@@ -74,6 +74,26 @@ test("built-in model registry has unique ids and matching summaries", () => {
         maxOutputTokens: 128_000,
       },
       {
+        id: "deepseek-v4-flash",
+        supportsImages: false,
+        supportsPdf: false,
+        toolCall: true,
+        runtimeKind: "openai-compatible",
+        contextWindow: 1_000_000,
+        inputTokenLimit: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+        maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      },
+      {
+        id: "deepseek-v4-pro",
+        supportsImages: false,
+        supportsPdf: false,
+        toolCall: true,
+        runtimeKind: "openai-compatible",
+        contextWindow: 1_000_000,
+        inputTokenLimit: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+        maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      },
+      {
         id: "qwen3.7-plus",
         supportsImages: true,
         supportsPdf: false,
@@ -145,6 +165,23 @@ test("GPT models use OpenAI Responses runtime routing", () => {
   }
 })
 
+test("DeepSeek V4 models use the OOMOL compatible runtime and remain text-only", () => {
+  const expectedModels = [
+    { id: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash" },
+    { id: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro" },
+  ] as const
+
+  for (const expected of expectedModels) {
+    const model = resolveBuiltinModel(expected.id)
+    assert.equal(model.displayName, expected.displayName)
+    assert.deepEqual(model.runtime, { providerID: "oomol", modelID: expected.id })
+    assert.deepEqual(model.capabilities.reasoningVariants, ["low", "high", "max"])
+    assert.equal(model.capabilities.supportsImages, false)
+    assert.equal(model.capabilities.supportsPdf, false)
+    assert.equal(model.capabilities.toolCall, true)
+  }
+})
+
 test("isBuiltinModelId accepts only registered built-in ids", () => {
   assert.equal(isBuiltinModelId("oopilot"), true)
   assert.equal(isBuiltinModelId("gpt-5.6-sol"), true)
@@ -152,7 +189,7 @@ test("isBuiltinModelId accepts only registered built-in ids", () => {
   assert.equal(isBuiltinModelId("gpt-5.6-luna"), true)
   assert.equal(isBuiltinModelId("gpt-5.5"), false)
   assert.equal(isBuiltinModelId("qwen3.7-max"), true)
-  assert.equal(isBuiltinModelId("deepseek-v4-flash"), false)
-  assert.equal(isBuiltinModelId("deepseek-v4-pro"), false)
+  assert.equal(isBuiltinModelId("deepseek-v4-flash"), true)
+  assert.equal(isBuiltinModelId("deepseek-v4-pro"), true)
   assert.equal(isBuiltinModelId("kimi-k3"), false)
 })

--- a/electron/models/builtin.ts
+++ b/electron/models/builtin.ts
@@ -40,6 +40,7 @@ export interface BuiltinModelDefinition {
 const gptContextWindow = 400_000
 const gptMaxOutputTokens = 128_000
 const millionTokenContextWindow = 1_000_000
+const deepSeekV4ReasoningVariants = ["low", "high", "max"] as const satisfies readonly WantaReasoningVariant[]
 const qwen37ReasoningVariants = ["low", "high"] as const satisfies readonly WantaReasoningVariant[]
 
 export const BUILTIN_MODEL_IDS = [
@@ -47,6 +48,8 @@ export const BUILTIN_MODEL_IDS = [
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "deepseek-v4-flash",
+  "deepseek-v4-pro",
   "qwen3.7-plus",
   "qwen3.7-max",
 ] as const
@@ -141,6 +144,42 @@ export const BUILTIN_MODEL_DEFINITIONS: BuiltinModelDefinition[] = [
     contextWindow: gptContextWindow,
     inputTokenLimit: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
     maxOutputTokens: gptMaxOutputTokens,
+  },
+  {
+    id: "deepseek-v4-flash",
+    displayName: "DeepSeek V4 Flash",
+    providerName: "DeepSeek",
+    runtime: {
+      providerID: "oomol",
+      modelID: "deepseek-v4-flash",
+    },
+    capabilities: {
+      reasoningVariants: deepSeekV4ReasoningVariants,
+      supportsImages: false,
+      supportsPdf: false,
+      toolCall: true,
+    },
+    contextWindow: millionTokenContextWindow,
+    inputTokenLimit: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+    maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+  },
+  {
+    id: "deepseek-v4-pro",
+    displayName: "DeepSeek V4 Pro",
+    providerName: "DeepSeek",
+    runtime: {
+      providerID: "oomol",
+      modelID: "deepseek-v4-pro",
+    },
+    capabilities: {
+      reasoningVariants: deepSeekV4ReasoningVariants,
+      supportsImages: false,
+      supportsPdf: false,
+      toolCall: true,
+    },
+    contextWindow: millionTokenContextWindow,
+    inputTokenLimit: STANDARD_INPUT_TOKEN_LIMIT_TOKENS,
+    maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
   },
   {
     id: "qwen3.7-plus",

--- a/electron/models/store.test.ts
+++ b/electron/models/store.test.ts
@@ -29,13 +29,22 @@ test("ModelsStore returns default catalog on missing file", async () => {
   assert.deepEqual(catalog.selected, defaultModelChoice())
   assert.deepEqual(
     catalog.builtins.map((model) => model.id),
-    ["oopilot", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "qwen3.7-plus", "qwen3.7-max"],
+    [
+      "oopilot",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+      "qwen3.7-plus",
+      "qwen3.7-max",
+    ],
   )
   assert.equal(catalog.customModels.length, 0)
   assert.ok(catalog.providers.some((provider) => provider.id === "deepseek"))
 })
 
-test("ModelsStore falls back to Auto when a removed DeepSeek built-in was selected", async () => {
+test("ModelsStore preserves a persisted DeepSeek built-in selection", async () => {
   const dir = mkdtempSync(path.join(tmpdir(), "wanta-models-"))
   writeFileSync(
     path.join(dir, "models.json"),
@@ -46,7 +55,7 @@ test("ModelsStore falls back to Auto when a removed DeepSeek built-in was select
   )
   const { store } = createStore(dir)
 
-  assert.deepEqual((await store.catalog()).selected, defaultModelChoice())
+  assert.deepEqual((await store.catalog()).selected, { kind: "builtin", id: "deepseek-v4-flash" })
 })
 
 test("ModelsStore falls back to Auto when the removed GPT 5.5 built-in was selected", async () => {


### PR DESCRIPTION
## Summary

Add DeepSeek V4 Flash and DeepSeek V4 Pro to Wanta's built-in model catalog using the official model IDs `deepseek-v4-flash` and `deepseek-v4-pro`.

## User impact

Signed-in users can select both DeepSeek models directly from the built-in-model section without configuring a DeepSeek API key. Existing DeepSeek BYOK presets remain available under the separate custom-model section, so credential ownership stays explicit.

Both built-in models are intentionally text-only. Wanta does not advertise image or native PDF input for them, while tool calling and the `low`, `high`, and `max` reasoning levels remain available.

## Root cause

The DeepSeek V4 entries were already present as custom-provider presets but were not registered in the current built-in catalog. Persisted selections using their former built-in IDs were consequently treated as stale and fell back to Auto.

## Changes

- Register DeepSeek V4 Flash and Pro on the OOMOL OpenAI-compatible runtime with their official model IDs.
- Configure a 1M context window, Wanta's standard 256K input tier, and the default 32K output limit.
- Mark both models as text-only with tool calling and `low`/`high`/`max` reasoning variants.
- Preserve historical persisted selections for the restored built-in IDs.
- Add registry, persistence, capability, routing, and OpenCode configuration coverage.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm exec oxfmt --check electron/models/builtin.ts electron/models/builtin.test.ts electron/models/store.test.ts electron/agent/agent.test.ts`
- `pnpm test` — 283 test files and 2,126 tests passed
- `git diff --check`
