### PR TITLE
Improve billing plan and usage UX

### DIFF
--- a/src/components/app-shell/BillingUsagePopover.test.ts
+++ b/src/components/app-shell/BillingUsagePopover.test.ts
@@ -5,8 +5,24 @@ import type { WorkspaceSelection } from "@/hooks/useTeamWorkspace"
 import * as React from "react"
 import { act } from "react"
 import { createRoot } from "react-dom/client"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { I18nContext, translate } from "@/i18n/i18n"
+
+const mockBilling = vi.hoisted(() => ({
+  data: {
+    balance: null,
+    balanceAvailable: false,
+    metering: null,
+    meteringAvailable: false,
+    spend: null,
+    spendAvailable: false,
+    subscription: null,
+    subscriptionAvailable: false,
+    teamPendingPayment: null,
+    teamPendingPaymentAvailable: false,
+  } as Record<string, unknown>,
+  seatCount: null as number | null,
+}))
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({
@@ -16,7 +32,7 @@ vi.mock("@/hooks/useAuth", () => ({
 
 vi.mock("@/hooks/useBillableSeats", () => ({
   useBillableSeats: () => ({
-    count: null,
+    count: mockBilling.seatCount,
     error: null,
     loading: false,
   }),
@@ -24,18 +40,7 @@ vi.mock("@/hooks/useBillableSeats", () => ({
 
 vi.mock("@/hooks/useBillingOverview", () => ({
   useBillingOverview: () => ({
-    data: {
-      balance: null,
-      balanceAvailable: false,
-      metering: null,
-      meteringAvailable: false,
-      spend: null,
-      spendAvailable: false,
-      subscription: null,
-      subscriptionAvailable: false,
-      teamPendingPayment: null,
-      teamPendingPaymentAvailable: false,
-    },
+    data: mockBilling.data,
     error: null,
     loading: false,
     refresh: vi.fn(async () => null),
@@ -61,7 +66,23 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
-async function renderPopover(workspaceSelection: WorkspaceSelection) {
+beforeEach(() => {
+  mockBilling.seatCount = null
+  mockBilling.data = {
+    balance: null,
+    balanceAvailable: false,
+    metering: null,
+    meteringAvailable: false,
+    spend: null,
+    spendAvailable: false,
+    subscription: null,
+    subscriptionAvailable: false,
+    teamPendingPayment: null,
+    teamPendingPaymentAvailable: false,
+  }
+})
+
+async function renderPopover(workspaceSelection: WorkspaceSelection, onViewDetails = vi.fn()) {
   const titlebar = document.createElement("header")
   titlebar.style.overflow = "hidden"
   document.body.append(titlebar)
@@ -79,7 +100,7 @@ async function renderPopover(workspaceSelection: WorkspaceSelection) {
         },
         React.createElement(BillingUsagePopover, {
           cacheScope: "test",
-          onViewDetails: vi.fn(),
+          onViewDetails,
           workspace: workspaceSelection,
         }),
       ),
@@ -90,6 +111,21 @@ async function renderPopover(workspaceSelection: WorkspaceSelection) {
     trigger?.click()
   })
   return { root, titlebar }
+}
+
+function setAvailablePlan(plan: "team_plus" | "team_pro" | null) {
+  mockBilling.seatCount = 2
+  mockBilling.data = {
+    ...mockBilling.data,
+    subscription: {
+      features: [],
+      plan,
+      plans: [],
+      platforms: {},
+    },
+    subscriptionAvailable: true,
+    teamPendingPaymentAvailable: true,
+  }
 }
 
 describe("BillingUsagePopover", () => {
@@ -125,6 +161,100 @@ describe("BillingUsagePopover", () => {
 
     expect(content?.textContent).not.toContain("当前计划与席位")
     expect(content?.textContent).not.toContain("计划与席位数据暂不可用")
+
+    act(() => root.unmount())
+  })
+
+  it("shows the balance directly without an ambiguous original-credit progress bar", async () => {
+    mockBilling.data = {
+      ...mockBilling.data,
+      balance: {
+        items: [],
+        total: {
+          currentCredit: "89.03",
+          originalCredit: "445.15",
+        },
+      },
+      balanceAvailable: true,
+    }
+    const { root } = await renderPopover(workspace)
+    const content = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+
+    expect(content?.textContent).toContain("$89.03")
+    expect(content?.querySelector('[role="progressbar"]')).toBeNull()
+
+    act(() => root.unmount())
+  })
+
+  it("routes the whole inactive plan card to plan selection", async () => {
+    setAvailablePlan(null)
+    const onViewDetails = vi.fn()
+    const { root } = await renderPopover(workspace, onViewDetails)
+    const content = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+    const planCard = Array.from(content?.querySelectorAll("button") ?? []).find((button) =>
+      button.textContent?.includes("升级 Team 计划"),
+    )
+
+    expect(planCard).toBeDefined()
+    expect(planCard?.textContent).toContain("Team 协作计划")
+    expect(planCard?.textContent).toContain("统一管理成员和权限")
+    expect(planCard?.textContent).toContain("仍从下方个人用量账户扣除")
+    const upgradeAction = Array.from(planCard?.querySelectorAll("span") ?? []).find(
+      (element) => element.textContent?.trim() === "升级 Team 计划",
+    )
+    expect(upgradeAction?.className).not.toContain("border")
+    expect(upgradeAction?.className).toContain("group-hover:underline")
+    const inactiveBadge = Array.from(planCard?.querySelectorAll('[data-slot="badge"]') ?? []).find(
+      (badge) => badge.textContent === "未启用",
+    )
+    expect(inactiveBadge?.getAttribute("data-variant")).toBe("muted")
+    await act(async () => planCard?.click())
+    expect(onViewDetails).toHaveBeenCalledWith("plans")
+
+    act(() => root.unmount())
+  })
+
+  it("offers upgrade for Plus and keeps recharge as the primary balance action", async () => {
+    setAvailablePlan("team_plus")
+    const onViewDetails = vi.fn()
+    const { root } = await renderPopover(workspace, onViewDetails)
+    const content = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+
+    expect(content?.textContent).toContain("升级 Team 计划")
+    const topUp = Array.from(content?.querySelectorAll("button") ?? []).find(
+      (button) => button.textContent?.trim() === "充值余额",
+    )
+    expect(topUp).toBeDefined()
+    await act(async () => topUp?.click())
+    expect(onViewDetails).toHaveBeenCalledWith("credits")
+
+    act(() => root.unmount())
+  })
+
+  it("does not show an upgrade action for the highest Team plan", async () => {
+    setAvailablePlan("team_pro")
+    const { root } = await renderPopover(workspace)
+    const content = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+
+    expect(content?.textContent).toContain("Team Pro")
+    expect(content?.textContent).not.toContain("升级 Team 计划")
+    expect(content?.textContent).toContain("充值余额")
+
+    act(() => root.unmount())
+  })
+
+  it("keeps the compact details footer fully clickable", async () => {
+    const onViewDetails = vi.fn()
+    const { root } = await renderPopover(workspace, onViewDetails)
+    const content = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+    const details = Array.from(content?.querySelectorAll("button") ?? []).find(
+      (button) => button.textContent?.trim() === "查看详情",
+    )
+
+    expect(details).toBeDefined()
+    expect(details?.className).toContain("h-10")
+    await act(async () => details?.click())
+    expect(onViewDetails).toHaveBeenCalledWith(undefined)
 
     act(() => root.unmount())
   })

--- a/src/components/app-shell/BillingUsagePopover.tsx
+++ b/src/components/app-shell/BillingUsagePopover.tsx
@@ -14,7 +14,6 @@ import { ErrorNotice } from "@/components/ErrorNotice"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Progress } from "@/components/ui/progress"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useAuth } from "@/hooks/useAuth"
 import { useBillableSeats } from "@/hooks/useBillableSeats"
@@ -79,7 +78,6 @@ export function BillingUsagePopover({
   const spendAvailable = data?.spendAvailable === true
   const hasNoUsage = spendAvailable && totalSpend === 0
   const currentCredit = toNumber(data?.balance?.total.currentCredit)
-  const originalCredit = toNumber(data?.balance?.total.originalCredit)
   const averageDailySpend = totalSpend / usagePeriodDays
   const coverageDays = averageDailySpend > 0 ? Math.floor(currentCredit / averageDailySpend) : 0
   const showCoverageDays = totalSpend >= 0.01 && coverageDays > 0 && coverageDays <= 999
@@ -101,22 +99,6 @@ export function BillingUsagePopover({
       }),
     [canManageTeamSubscription, data?.subscription, data?.teamPendingPayment, seatState.count, sharedConnectorCount],
   )
-  const showPlanPrompt = Boolean(
-    showTeamPlanSection &&
-    teamDetailsAvailable &&
-    data &&
-    !error &&
-    seatCountAvailable &&
-    teamOverview.recommendedAction === "choose_plan",
-  )
-  const showPendingPaymentPrompt = Boolean(
-    showTeamPlanSection &&
-    teamDetailsAvailable &&
-    data &&
-    !error &&
-    seatCountAvailable &&
-    teamOverview.recommendedAction === "continue_payment",
-  )
   const showUpgradePrompt = Boolean(
     showTeamPlanSection &&
     teamDetailsAvailable &&
@@ -133,14 +115,95 @@ export function BillingUsagePopover({
     seatCountAvailable &&
     teamOverview.recommendedAction === "add_seats",
   )
-  const availableShare =
-    originalCredit > 0
-      ? Math.max(0, Math.min(100, (currentCredit / originalCredit) * 100))
-      : currentCredit > 0
-        ? 100
-        : 0
   // 仅在真正拿到余额（无错误）且为 0 时才提示耗尽；会话过期/读取失败一律不显示破坏性"余额耗尽"。
   const hasNoCredits = Boolean(canManageFunding && balanceAvailable && data?.balance && currentCredit <= 0 && !error)
+  const planActionLabel = !teamDetailsAvailable
+    ? null
+    : teamOverview.hasPendingPayment
+      ? t("billing.teamContinuePayment")
+      : showSeatPrompt
+        ? t("billing.popover.manageSeats")
+        : teamOverview.currentPlan === null
+          ? t("billing.popover.upgradeTeamPlanAction")
+          : teamOverview.currentPlan === "team_plus"
+            ? t("billing.popover.upgradePlanAction")
+            : null
+  const planStatusVariant: React.ComponentProps<typeof Badge>["variant"] = !teamDetailsAvailable
+    ? "outline"
+    : teamOverview.hasPendingPayment || showSeatPrompt
+      ? "warning"
+      : teamOverview.currentPlan === null || showUpgradePrompt
+        ? "muted"
+        : "success"
+
+  const planCardContent = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="oo-text-label flex items-center gap-2 text-foreground">
+            <ShieldCheckIcon className="size-4 text-muted-foreground" />
+            <span>
+              {!teamDetailsAvailable
+                ? t("billing.planStatus.title")
+                : teamOverview.currentPlan
+                  ? teamPlanLabel(teamOverview.currentPlan, t)
+                  : t("billing.popover.teamPlanTitle")}
+            </span>
+          </div>
+          <div className="oo-text-caption-compact mt-1 text-muted-foreground">
+            {teamDetailsAvailable && teamOverview.currentPlan === null ? `${t("billing.popover.currentTeam")} · ` : ""}
+            {!teamDetailsAvailable
+              ? t("billing.popover.planUnavailableMeta")
+              : seatState.loading
+                ? t("billing.popover.planSeatsLoading")
+                : !seatCountAvailable || teamOverview.usedSeats === null
+                  ? t("billing.popover.planSeatsUnavailable")
+                  : teamOverview.seatCapacity === null
+                    ? t("billing.popover.planMembers", { count: teamOverview.usedSeats })
+                    : t("billing.popover.planSeats", {
+                        count: teamOverview.usedSeats,
+                        limit: teamOverview.seatCapacity,
+                      })}
+            {sharedConnectorCount === undefined
+              ? ""
+              : ` · ${t("billing.popover.sharedLinks", { count: sharedConnectorCount })}`}
+          </div>
+        </div>
+        <Badge variant={planStatusVariant}>
+          {!teamDetailsAvailable
+            ? t("billing.popover.planUnavailableStatus")
+            : teamOverview.hasPendingPayment
+              ? t("billing.teamPaymentPending")
+              : showSeatPrompt
+                ? t("billing.popover.seatLimitHint")
+                : showUpgradePrompt
+                  ? t("billing.popover.upgradeHint")
+                  : teamOverview.currentPlan === null
+                    ? t("billing.popover.planInactive")
+                    : t("billing.popover.planActive")}
+        </Badge>
+      </div>
+      <p className="oo-text-caption mt-3 text-muted-foreground">
+        {!teamDetailsAvailable
+          ? t("billing.popover.planUnavailableDescription")
+          : teamOverview.hasPendingPayment
+            ? t("billing.popover.pendingPaymentRecommendation")
+            : showSeatPrompt
+              ? t("billing.popover.seatRecommendation")
+              : teamOverview.currentPlan === null
+                ? t("billing.popover.noPlanRecommendation")
+                : showUpgradePrompt
+                  ? t("billing.popover.proRecommendation")
+                  : t("billing.popover.planDescription")}
+      </p>
+      {planActionLabel ? (
+        <span className="oo-text-label mt-3 ml-auto flex w-fit items-center justify-center gap-1 text-foreground underline-offset-4 group-hover:underline">
+          {planActionLabel}
+          <ArrowRightIcon className="size-4" />
+        </span>
+      ) : null}
+    </>
+  )
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -210,88 +273,35 @@ export function BillingUsagePopover({
             ) : (
               <>
                 {showTeamPlanSection ? (
-                  <section className="rounded-lg border border-border p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="oo-text-label flex items-center gap-2 text-foreground">
-                          <ShieldCheckIcon className="size-4 text-muted-foreground" />
-                          <span>
-                            {!teamDetailsAvailable
-                              ? t("billing.planStatus.title")
-                              : teamOverview.currentPlan
-                                ? teamPlanLabel(teamOverview.currentPlan, t)
-                                : t("billing.teamNoPlan")}
-                          </span>
-                        </div>
-                        <div className="oo-text-caption-compact mt-1 text-muted-foreground">
-                          {!teamDetailsAvailable
-                            ? t("billing.popover.planUnavailableMeta")
-                            : seatState.loading
-                              ? t("billing.popover.planSeatsLoading")
-                              : !seatCountAvailable || teamOverview.usedSeats === null
-                                ? t("billing.popover.planSeatsUnavailable")
-                                : teamOverview.seatCapacity === null
-                                  ? t("billing.popover.planMembers", { count: teamOverview.usedSeats })
-                                  : t("billing.popover.planSeats", {
-                                      count: teamOverview.usedSeats,
-                                      limit: teamOverview.seatCapacity,
-                                    })}
-                          {sharedConnectorCount === undefined
-                            ? ""
-                            : ` · ${t("billing.popover.sharedLinks", { count: sharedConnectorCount })}`}
-                        </div>
-                      </div>
-                      <PlanStatusBadge
-                        clickable={teamDetailsAvailable && teamOverview.currentPlan === null}
-                        label={
-                          !teamDetailsAvailable
-                            ? t("billing.popover.planUnavailableStatus")
-                            : teamOverview.hasPendingPayment
-                              ? t("billing.teamPaymentPending")
-                              : showSeatPrompt
-                                ? t("billing.popover.seatLimitHint")
-                                : showUpgradePrompt
-                                  ? t("billing.popover.upgradeHint")
-                                  : teamOverview.currentPlan === null
-                                    ? t("billing.popover.planInactive")
-                                    : t("billing.popover.planActive")
-                        }
-                        variant={
-                          teamDetailsAvailable &&
-                          (teamOverview.hasPendingPayment || showUpgradePrompt || showPlanPrompt || showSeatPrompt)
-                            ? "default"
-                            : "outline"
-                        }
-                        onClick={() => openDetails("plans")}
-                      />
-                    </div>
-                    <p className="oo-text-caption mt-3 text-muted-foreground">
-                      {!teamDetailsAvailable
-                        ? t("billing.popover.planUnavailableDescription")
-                        : teamOverview.hasPendingPayment
-                          ? t("billing.popover.pendingPaymentRecommendation")
-                          : showSeatPrompt
-                            ? t("billing.popover.seatRecommendation")
-                            : teamOverview.currentPlan === null
-                              ? t("billing.popover.noPlanRecommendation")
-                              : showUpgradePrompt
-                                ? t("billing.popover.proRecommendation")
-                                : t("billing.popover.planDescription")}
-                    </p>
-                  </section>
+                  planActionLabel ? (
+                    <button
+                      type="button"
+                      className="group rounded-lg border border-border p-3 text-left transition-colors hover:border-foreground/20 hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
+                      onClick={() => openDetails("plans")}
+                    >
+                      {planCardContent}
+                    </button>
+                  ) : (
+                    <section className="rounded-lg border border-border p-3">{planCardContent}</section>
+                  )
                 ) : null}
 
                 <section className="grid gap-3">
-                  <div className="flex items-start justify-between gap-3">
-                    {canManageFunding ? (
-                      <>
+                  {canManageFunding ? (
+                    <>
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="oo-text-label text-muted-foreground">{t("billing.availableCredits")}</div>
+                        <Button type="button" size="sm" onClick={() => openDetails("credits")}>
+                          {t("billing.topUpBalance")}
+                        </Button>
+                      </div>
+                      <div className="flex items-end justify-between gap-3">
                         <div>
-                          <div className="oo-text-label text-muted-foreground">{t("billing.availableCredits")}</div>
-                          <div className="oo-text-metric-large mt-1 text-foreground">
+                          <div className="oo-text-metric-large text-foreground">
                             {balanceAvailable ? formatCredit(currentCredit) : "—"}
                           </div>
                         </div>
-                        <div className="oo-text-body pt-5 text-right text-muted-foreground">
+                        <div className="oo-text-body text-right text-muted-foreground">
                           {!spendAvailable
                             ? t("billing.usageUnavailable")
                             : hasNoUsage
@@ -300,19 +310,18 @@ export function BillingUsagePopover({
                                 ? t("billing.popover.coverageDays", { days: coverageDays })
                                 : t("billing.coverageStable")}
                         </div>
-                      </>
-                    ) : (
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex items-start justify-between gap-3">
                       <div className="grid gap-1">
                         <div className="oo-text-label text-muted-foreground">{t("billing.fundingAccount")}</div>
                         <div className="oo-text-title text-foreground">{t("billing.fundingManagedByCreator")}</div>
                         <p className="oo-text-caption text-muted-foreground">{t("billing.fundingMemberDescription")}</p>
                       </div>
-                    )}
-                  </div>
-                  <div className="grid gap-2">
-                    {canManageFunding && balanceAvailable ? (
-                      <Progress value={availableShare} className="h-1.5 bg-muted" />
-                    ) : null}
+                    </div>
+                  )}
+                  <div className="grid gap-2 border-t border-border pt-3">
                     {spendAvailable && !hasNoUsage ? (
                       <div className="oo-text-caption-compact flex items-center justify-between gap-3 text-muted-foreground">
                         <span>{t("billing.popover.periodSpend", { amount: formatCredit(totalSpend) })}</span>
@@ -344,70 +353,17 @@ export function BillingUsagePopover({
             )}
           </div>
 
-          <div className="border-t border-border bg-muted/40 px-4 py-3">
-            <Button
-              type="button"
-              className="w-full min-w-0"
-              onClick={() => {
-                openDetails(
-                  showPlanPrompt || showPendingPaymentPrompt || showSeatPrompt || showUpgradePrompt
-                    ? "plans"
-                    : hasNoCredits
-                      ? "credits"
-                      : undefined,
-                )
-              }}
-            >
-              {t(
-                showPlanPrompt
-                  ? "billing.planComparison.choosePlan"
-                  : showPendingPaymentPrompt
-                    ? "billing.teamContinuePayment"
-                    : showSeatPrompt
-                      ? "billing.popover.manageSeats"
-                      : showUpgradePrompt
-                        ? "billing.proRecommendation.cta"
-                        : hasNoCredits
-                          ? "billing.purchaseCredits"
-                          : "billing.popover.viewDetails",
-              )}
-              <ArrowRightIcon className="size-4" />
-            </Button>
-          </div>
+          <button
+            type="button"
+            className="oo-text-label flex h-10 w-full items-center justify-center gap-2 border-t border-border bg-muted/20 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
+            onClick={() => openDetails()}
+          >
+            {t("billing.popover.viewDetails")}
+            <ArrowRightIcon className="size-4" />
+          </button>
         </div>
       </PopoverContent>
     </Popover>
-  )
-}
-
-function PlanStatusBadge({
-  clickable,
-  label,
-  variant,
-  onClick,
-}: {
-  clickable: boolean
-  label: string
-  variant: React.ComponentProps<typeof Badge>["variant"]
-  onClick: () => void
-}) {
-  if (!clickable) {
-    return <Badge variant={variant}>{label}</Badge>
-  }
-  return (
-    <Badge asChild variant={variant}>
-      <button
-        type="button"
-        title={label}
-        className="cursor-pointer focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none"
-        onClick={(event) => {
-          event.stopPropagation()
-          onClick()
-        }}
-      >
-        {label}
-      </button>
-    </Badge>
   )
 }
 
@@ -435,8 +391,7 @@ function BillingUsageSkeleton() {
           </div>
           <Skeleton className="mt-5 h-5 w-24" />
         </div>
-        <Skeleton className="h-2 w-full" />
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-3">
           <Skeleton className="h-4 w-28" />
           <Skeleton className="h-4 w-24" />
         </div>

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -628,11 +628,13 @@ export const enMessages = {
   "billing.popover.planMembers": "{count} members",
   "billing.popover.planSeatsLoading": "Reading member capacity",
   "billing.popover.planSeatsUnavailable": "Member count unavailable",
+  "billing.popover.teamPlanTitle": "Team collaboration plan",
+  "billing.popover.currentTeam": "Current team",
   "billing.popover.planUnavailableMeta": "Plan and seat data unavailable",
   "billing.popover.planUnavailableStatus": "Unavailable",
   "billing.popover.planUnavailableDescription":
     "The current Team plan or pending payment status could not be read. Refresh to try again.",
-  "billing.popover.sharedLinks": "{count} shared connection(s)",
+  "billing.popover.sharedLinks": "{count} connected app(s)",
   "billing.popover.upgradeHint": "Upgrade suggested",
   "billing.popover.seatLimitHint": "Seat limit",
   "billing.popover.planInactive": "Not active",
@@ -644,9 +646,11 @@ export const enMessages = {
   "billing.popover.proRecommendation":
     "Your team size or connector call frequency is getting close to the main Plus use case. Pro fits stable sharing and higher-frequency automation.",
   "billing.popover.noPlanRecommendation":
-    "Choose a Team plan to enable shared connections and team management. Extra seats can also be added separately.",
+    "Let team members share connected accounts while the creator manages members and permissions. Model, API, and connector spend still comes from the personal usage account below.",
   "billing.popover.planDescription":
-    "Team plans support collaboration and team management. Additional seats and usage balance are managed separately.",
+    "The current plan enables shared connected accounts, member collaboration, and team management. Model, API, and connector spend still comes from the personal usage account below.",
+  "billing.popover.upgradeTeamPlanAction": "Upgrade Team plan",
+  "billing.popover.upgradePlanAction": "Upgrade Team plan",
   "billing.popover.manageSeats": "Manage seats",
   "billing.summary": "Usage summary",
   "billing.availableCredits": "Personal usage account",
@@ -733,7 +737,7 @@ export const enMessages = {
   "billing.managePermission.title": "This account cannot manage this team's plan",
   "billing.managePermission.description":
     "Team plans, seats, and payments can only be managed by the team creator. Admins can still view the current status and team usage.",
-  "billing.teamSharedLinks": "Shared connections",
+  "billing.teamSharedLinks": "Connected apps",
   "billing.teamWorkspace": "Team workspace",
   "billing.teamPromotionTitle": "Current promotion",
   "billing.teamPromotionDescription": "Choose a Team plan during the promotion to keep permanent 20% off pricing.",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -600,10 +600,12 @@ export const zhCNMessages = {
   "billing.popover.planMembers": "{count} 个成员",
   "billing.popover.planSeatsLoading": "正在读取成员容量",
   "billing.popover.planSeatsUnavailable": "成员数暂不可用",
+  "billing.popover.teamPlanTitle": "Team 协作计划",
+  "billing.popover.currentTeam": "当前团队",
   "billing.popover.planUnavailableMeta": "计划与席位数据暂不可用",
   "billing.popover.planUnavailableStatus": "暂不可用",
   "billing.popover.planUnavailableDescription": "暂时无法读取当前 Team 计划或待支付状态；刷新后会再次尝试。",
-  "billing.popover.sharedLinks": "{count} 个共享连接",
+  "billing.popover.sharedLinks": "{count} 个已连接 App",
   "billing.popover.upgradeHint": "建议升级",
   "billing.popover.seatLimitHint": "席位不足",
   "billing.popover.planInactive": "未启用",
@@ -613,8 +615,12 @@ export const zhCNMessages = {
     "当前成员数已超过计划席位容量。增加额外席位后，团队成员可以继续稳定使用 Wanta。",
   "billing.popover.proRecommendation":
     "团队人数或连接器调用频次正在接近 Plus 的主要场景，Pro 更适合稳定共享和高频自动化。",
-  "billing.popover.noPlanRecommendation": "可先选择 Team 计划启用共享连接和团队管理；额外席位也可以单独添加。",
-  "billing.popover.planDescription": "Team 计划提供成员协作和团队管理能力；额外席位、用量余额分别单独管理。",
+  "billing.popover.noPlanRecommendation":
+    "用于让团队成员共享连接账号，并由创建者统一管理成员和权限。模型、API 和连接器消耗仍从下方个人用量账户扣除。",
+  "billing.popover.planDescription":
+    "当前计划已启用连接账号共享、成员协作和团队管理。模型、API 和连接器消耗仍从下方个人用量账户扣除。",
+  "billing.popover.upgradeTeamPlanAction": "升级 Team 计划",
+  "billing.popover.upgradePlanAction": "升级 Team 计划",
   "billing.popover.manageSeats": "管理席位",
   "billing.summary": "用量概览",
   "billing.availableCredits": "个人用量账户",
@@ -700,7 +706,7 @@ export const zhCNMessages = {
   "billing.managePermission.title": "当前账号无法管理此团队的计划",
   "billing.managePermission.description":
     "Team 计划、席位和付款只能由团队创建者管理。管理员仍然可以查看当前状态和团队用量。",
-  "billing.teamSharedLinks": "共享连接",
+  "billing.teamSharedLinks": "已连接 App",
   "billing.teamWorkspace": "团队工作区",
   "billing.teamPromotionTitle": "当前活动",
   "billing.teamPromotionDescription": "活动期间选择 Team 计划，可永久保留 8 折价格。",

--- a/src/routes/Billing/BillingUsagePanels.tsx
+++ b/src/routes/Billing/BillingUsagePanels.tsx
@@ -203,7 +203,6 @@ function PeriodToggle({
 
 export function BalanceOverview({
   averageDailySpend,
-  availableShare,
   balanceAvailable,
   modelSpend,
   coverageDays,
@@ -223,7 +222,6 @@ export function BalanceOverview({
   totalSpend,
 }: {
   averageDailySpend: number
-  availableShare: number
   balanceAvailable: boolean
   modelSpend: number
   coverageDays: number
@@ -244,72 +242,71 @@ export function BalanceOverview({
 }) {
   const t = useT()
   return (
-    <section className="h-full overflow-hidden rounded-md border border-[var(--oo-divider)] bg-background">
-      <div className="flex min-h-10 items-center justify-between gap-3 border-b border-[var(--oo-divider)] px-3 py-2">
-        <h2 className="oo-text-title truncate text-foreground">
+    <section className="overflow-hidden rounded-md border border-[var(--oo-divider)] bg-background">
+      <div className="flex min-h-10 flex-wrap items-center justify-between gap-3 border-b border-[var(--oo-divider)] px-3 py-2">
+        <h2 className="oo-text-title min-w-0 text-foreground">
           {t(canManageFunding ? "billing.availableCredits" : "billing.fundingAccount")}
         </h2>
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           <PeriodToggle period={period} onChange={onPeriodChange} />
           <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onRefresh}>
             <RefreshCwIcon className={cn("size-4", loading && "animate-spin")} />
             {t("billing.refresh")}
           </Button>
+          {canManageFunding ? (
+            <Button type="button" size="sm" disabled={topUpDisabled} onClick={onTopUp}>
+              {t("billing.topUpBalance")}
+            </Button>
+          ) : null}
         </div>
       </div>
-      <div className="grid h-[calc(100%-2.75rem)] gap-4 p-4 md:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]">
-        <div className="grid min-w-0 gap-3">
-          <div className="flex min-w-0 items-start justify-between gap-3">
-            <div className="min-w-0">
-              <PiggyBankIcon className="oo-icon-muted size-4 shrink-0" />
-              {canManageFunding ? (
-                <div className="oo-text-metric-large mt-2 text-foreground">
+      <div className="grid gap-3 p-4 xl:grid-cols-[minmax(16rem,1.35fr)_minmax(0,3fr)]">
+        <div className="grid min-w-0 content-between gap-4 rounded-md border border-border bg-muted/20 px-4 py-3">
+          <div className="flex min-w-0 items-start gap-2">
+            <PiggyBankIcon className="oo-icon-muted mt-0.5 size-4 shrink-0" />
+            {canManageFunding ? (
+              <div className="min-w-0">
+                <div className="oo-text-caption text-muted-foreground">{t("billing.availableCredits")}</div>
+                <div className="oo-text-metric-large mt-1 text-foreground">
                   {loading ? "..." : balanceAvailable ? formatCredit(currentCredit) : "—"}
                 </div>
-              ) : (
-                <div className="mt-2 grid gap-1">
-                  <div className="oo-text-title text-foreground">{t("billing.fundingManagedByCreator")}</div>
-                  <p className="oo-text-caption text-muted-foreground">{t("billing.fundingMemberDescription")}</p>
-                </div>
-              )}
-            </div>
-            {canManageFunding ? (
-              <Button type="button" variant="outline" size="sm" disabled={topUpDisabled} onClick={onTopUp}>
-                {t("billing.topUpBalance")}
-              </Button>
-            ) : null}
+              </div>
+            ) : (
+              <div className="grid min-w-0 gap-1">
+                <div className="oo-text-title text-foreground">{t("billing.fundingManagedByCreator")}</div>
+                <p className="oo-text-caption text-muted-foreground">{t("billing.fundingMemberDescription")}</p>
+              </div>
+            )}
           </div>
 
           {canManageFunding ? (
-            <div className="grid gap-2">
-              {balanceAvailable ? <Progress value={availableShare} className="h-1.5 bg-muted" /> : null}
-              <div className="oo-text-caption flex flex-wrap items-center justify-between gap-2">
-                <span>
-                  {!spendAvailable
-                    ? t("billing.usageUnavailable")
-                    : hasNoUsage
-                      ? t("billing.popover.noUsageTitle")
-                      : showCoverageDays
-                        ? t("billing.coverage", { days: coverageDays })
-                        : t("billing.coverageStable")}
-                </span>
-                {spendAvailable && !hasNoUsage ? (
-                  <span>{t("billing.averageDaily", { amount: formatCredit(averageDailySpend) })}</span>
-                ) : null}
-              </div>
+            <div className="oo-text-caption flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-muted-foreground">
+              <span>
+                {!spendAvailable
+                  ? t("billing.usageUnavailable")
+                  : hasNoUsage
+                    ? t("billing.popover.noUsageTitle")
+                    : showCoverageDays
+                      ? t("billing.coverage", { days: coverageDays })
+                      : t("billing.coverageStable")}
+              </span>
+              {spendAvailable && !hasNoUsage ? (
+                <span>{t("billing.averageDaily", { amount: formatCredit(averageDailySpend) })}</span>
+              ) : null}
             </div>
           ) : null}
         </div>
 
         {hasNoUsage ? (
-          <div className="oo-text-caption flex min-h-24 items-center rounded-md border border-dashed border-border px-4 text-muted-foreground">
+          <div className="oo-text-caption flex min-h-28 items-center rounded-md border border-dashed border-border px-4 text-muted-foreground">
             {t("billing.popover.noUsageDescription")}
           </div>
         ) : (
-          <div className="grid min-w-0 grid-cols-3 gap-2 max-[760px]:grid-cols-1">
+          <div className="grid min-w-0 grid-cols-1 gap-3 min-[720px]:grid-cols-3">
             <MiniStat
               icon={<SparklesIcon className="size-4" />}
               label={t("billing.periodSpend")}
+              meta={t(`billing.period${period}`)}
               value={loading ? "..." : spendAvailable ? formatCredit(totalSpend) : "—"}
             />
             <MiniStat
@@ -329,14 +326,27 @@ export function BalanceOverview({
   )
 }
 
-function MiniStat({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+function MiniStat({
+  icon,
+  label,
+  meta,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  meta?: string
+  value: string
+}) {
   return (
-    <div className="grid min-w-0 gap-1 rounded-md border border-border bg-muted/30 px-3 py-2.5">
+    <div className="grid min-h-28 min-w-0 content-between gap-3 rounded-md border border-border bg-muted/20 px-4 py-3">
       <div className="oo-text-caption flex min-w-0 items-center gap-1.5">
         <span className="oo-icon-muted shrink-0">{icon}</span>
-        <span className="truncate">{label}</span>
+        <span>{label}</span>
       </div>
-      <div className="oo-text-value truncate text-foreground">{value}</div>
+      <div>
+        <div className="oo-text-value text-foreground">{value}</div>
+        {meta ? <div className="oo-text-caption-compact mt-1 text-muted-foreground">{meta}</div> : null}
+      </div>
     </div>
   )
 }

--- a/src/routes/Billing/index.tsx
+++ b/src/routes/Billing/index.tsx
@@ -94,7 +94,6 @@ export function BillingRoute({
   const categoryEventTotal = summaries.reduce((sum, item) => sum + item.eventCount, 0)
   const totalEvents = categoryEventTotal > 0 ? categoryEventTotal : statsTotalEvents(data?.metering)
   const currentCredit = toNumber(data?.balance?.total.currentCredit)
-  const originalCredit = toNumber(data?.balance?.total.originalCredit)
   const balanceAvailable = data?.balanceAvailable === true
   const spendAvailable = data?.spendAvailable === true
   const meteringAvailable = data?.meteringAvailable === true
@@ -150,12 +149,6 @@ export function BillingRoute({
   const averageDailySpend = period > 0 ? totalSpend / period : 0
   const coverageDays = averageDailySpend > 0 ? Math.floor(currentCredit / averageDailySpend) : 0
   const showCoverageDays = totalSpend >= 0.01 && coverageDays > 0 && coverageDays <= 999
-  const availableShare =
-    originalCredit > 0
-      ? Math.max(0, Math.min(100, (currentCredit / originalCredit) * 100))
-      : currentCredit > 0
-        ? 100
-        : 0
   const dailyBuckets = React.useMemo(
     () => buildDailySpendBuckets(data?.spend?.items ?? [], period, totalSpend),
     [data?.spend, period, totalSpend],
@@ -227,7 +220,6 @@ export function BillingRoute({
       spendAvailable={spendAvailable}
       totalEvents={totalEvents}
       totalSpend={totalSpend}
-      availableShare={availableShare}
       period={period}
       topUpDisabled={isSessionExpired}
       onPeriodChange={setPeriod}
@@ -284,7 +276,7 @@ export function BillingRoute({
               onChoosePlan={teamCheckout.choosePlan}
             />
 
-            <section className="grid gap-4 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
+            <section className="grid gap-4">
               <AdditionalSeatsPanel
                 currentAdditionalSeats={teamOverview.additionalSeats}
                 disabled={teamActionDisabled}


### PR DESCRIPTION
## Summary

Improve the plans and usage experience so users can distinguish Team collaboration features from personal usage balance, reach the correct action quickly, and scan billing information without unnecessary visual weight.

## Problem

The billing popover gave plan selection a large, generic call to action regardless of account state while the higher-frequency balance top-up path was less visible. The inactive Team status also looked like a primary button, plan copy did not clearly explain what Team plans unlock or how they differ from usage credits, and the footer wrapped a button in a padded container that consumed disproportionate height.

The billing details page compounded the issue by placing additional seats and personal usage side by side. That constrained the usage summary, forced metric labels to truncate, and devoted a large area to a balance progress bar whose denominator was not visible to users. The progress bar was based on current credit divided by original credit, which did not communicate when a user actually needed to top up.

## Changes

- Make the Team plan card state-aware and fully clickable for plan actions.
- Add explicit upgrade, payment, and seat-management labels while keeping status badges semantically subordinate to real actions.
- Explain that Team plans cover shared connected accounts, collaboration, members, and permissions while model, API, and connector spend remains in the personal usage account.
- Correct connected-provider counts from the misleading shared-connections label to connected apps.
- Promote top-up to a clear action beside the personal usage account.
- Remove the ambiguous original-credit progress bar and present balance, coverage days, period spend, and daily average directly.
- Replace the padded footer/button combination with one compact, fully clickable details row.
- Stack additional seats and usage panels on the details page, then use a responsive one-large/three-small usage summary that preserves full metric labels.
- Keep Team Pro free of an invalid upgrade action and preserve creator/admin visibility rules.
- Update Chinese and English copy together.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm run test` (283 test files, 2134 tests)
- `git diff --check`

The popover tests cover inactive-plan navigation, Team Plus upgrades, Team Pro behavior, top-up routing, compact details navigation, removal of the credit progress bar, plan-copy boundaries, and the muted inactive status treatment.
