### PR TITLE
Add drag-to-collapse right panel

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -622,6 +622,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
     handleTurnOutputOpen,
     hasPanelSelection,
     isArtifactsPanelResizing,
+    isArtifactsPanelDragCollapsed,
     latestArtifactSelection,
     rightPanelVisible,
     setArtifactsPanelOpen,
@@ -632,6 +633,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
     activeSessionId: activeChatSessionId,
     appChromeRef,
     browserPanelVisible,
+    closeBrowserPanel,
     route,
     setIsSidebarRestoring,
     setSidebarCollapsed,
@@ -2160,6 +2162,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
           handleArtifactsPanelResizeKeyDown={handleArtifactsPanelResizeKeyDown}
           handleArtifactsPanelResizeStart={handleArtifactsPanelResizeStart}
           isArtifactsPanelResizing={isArtifactsPanelResizing}
+          isArtifactsPanelDragCollapsed={isArtifactsPanelDragCollapsed}
           onCloseBrowser={closeBrowserPanel}
           rightPanelVisible={rightPanelVisible}
           setArtifactsPanelMaximizedState={setArtifactsPanelMaximizedState}

--- a/src/components/app-shell/AppShellRightPanel.tsx
+++ b/src/components/app-shell/AppShellRightPanel.tsx
@@ -29,6 +29,7 @@ export const AppShellRightPanel = React.memo(function AppShellRightPanel({
   handleArtifactsPanelResizeKeyDown,
   handleArtifactsPanelResizeStart,
   isArtifactsPanelResizing,
+  isArtifactsPanelDragCollapsed,
   onCloseBrowser,
   rightPanelVisible,
   setArtifactsPanelMaximizedState,
@@ -48,6 +49,7 @@ export const AppShellRightPanel = React.memo(function AppShellRightPanel({
   handleArtifactsPanelResizeKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
   handleArtifactsPanelResizeStart: (event: React.PointerEvent<HTMLDivElement>) => void
   isArtifactsPanelResizing: boolean
+  isArtifactsPanelDragCollapsed: boolean
   onCloseBrowser: () => void
   rightPanelVisible: boolean
   setArtifactsPanelMaximizedState: (maximized: boolean) => void
@@ -64,7 +66,7 @@ export const AppShellRightPanel = React.memo(function AppShellRightPanel({
         "oo-artifacts-panel-shell relative min-h-0",
         artifactsPanelIsMaximized ? "min-w-0 flex-1 shrink" : "shrink-0",
         artifactsPanelIsMaximized && "oo-artifacts-panel-maximized",
-        isArtifactsPanelResizing || browserPanelVisible
+        (isArtifactsPanelResizing || browserPanelVisible) && !isArtifactsPanelDragCollapsed
           ? "transition-none"
           : "transition-[width,opacity,transform] duration-200 ease-out",
         rightPanelVisible ? "translate-x-0 opacity-100" : "pointer-events-none translate-x-3 opacity-0",

--- a/src/components/app-shell/app-shell-model.test.ts
+++ b/src/components/app-shell/app-shell-model.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest"
 import {
+  artifactsPanelDragLayout,
+  artifactsPanelMaxWidth,
+  ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX,
+  ARTIFACTS_PANEL_MIN_WIDTH_PX,
   authorizationHandlingForLinkRuntime,
   existingSessionComposerDraftKey,
   chatSendAccepted,
@@ -29,6 +33,37 @@ import {
 
 afterEach(() => {
   vi.unstubAllEnvs()
+})
+
+describe("artifacts panel drag layout", () => {
+  test("holds at the minimum width throughout the collapse resistance zone", () => {
+    expect(ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX).toBe(ARTIFACTS_PANEL_MIN_WIDTH_PX / 2)
+    expect(artifactsPanelDragLayout(ARTIFACTS_PANEL_MIN_WIDTH_PX, 700)).toEqual({
+      collapsed: false,
+      width: ARTIFACTS_PANEL_MIN_WIDTH_PX,
+    })
+    expect(artifactsPanelDragLayout(ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX, 700)).toEqual({
+      collapsed: false,
+      width: ARTIFACTS_PANEL_MIN_WIDTH_PX,
+    })
+  })
+
+  test("collapses only after crossing half the minimum width", () => {
+    expect(artifactsPanelDragLayout(ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX - 1, 700)).toEqual({
+      collapsed: true,
+      width: 0,
+    })
+  })
+
+  test("still permits collapse when the minimum and maximum widths meet", () => {
+    const maxWidth = artifactsPanelMaxWidth(900, 220, false)
+    expect(maxWidth).toBe(ARTIFACTS_PANEL_MIN_WIDTH_PX)
+    expect(artifactsPanelDragLayout(ARTIFACTS_PANEL_MIN_WIDTH_PX + 100, maxWidth)).toEqual({
+      collapsed: false,
+      width: ARTIFACTS_PANEL_MIN_WIDTH_PX,
+    })
+    expect(artifactsPanelDragLayout(0, maxWidth)).toEqual({ collapsed: true, width: 0 })
+  })
 })
 
 describe("team route and scope migration", () => {

--- a/src/components/app-shell/app-shell-model.ts
+++ b/src/components/app-shell/app-shell-model.ts
@@ -35,6 +35,7 @@ export const CHAT_AREA_MIN_WIDTH_PX = 420
 export const CHAT_CONNECTION_DRAWER_WIDTH = "min(31.5rem, 38vw)"
 export const ARTIFACTS_PANEL_DEFAULT_WIDTH_PX = 300
 export const ARTIFACTS_PANEL_MIN_WIDTH_PX = 260
+export const ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX = ARTIFACTS_PANEL_MIN_WIDTH_PX / 2
 export const ARTIFACTS_PANEL_WIDTH_STORAGE_KEY = "wanta.artifactsPanelWidth"
 export const BROWSER_PANEL_DEFAULT_WIDTH_PX = 480
 export const BROWSER_PANEL_WIDTH_STORAGE_KEY = "wanta.browserPanelWidth"
@@ -330,6 +331,16 @@ export function artifactsPanelMaxWidth(appWidth: number, sidebarWidth: number, s
 
 export function clampArtifactsPanelWidthForLayout(width: number, maxWidth: number): number {
   return Math.min(maxWidth, clampArtifactsPanelWidth(width))
+}
+
+export function artifactsPanelDragLayout(rawWidth: number, maxWidth: number): { collapsed: boolean; width: number } {
+  if (rawWidth < ARTIFACTS_PANEL_COLLAPSE_THRESHOLD_PX) {
+    return { collapsed: true, width: 0 }
+  }
+  return {
+    collapsed: false,
+    width: clampArtifactsPanelWidthForLayout(rawWidth, maxWidth),
+  }
 }
 
 export function readStoredArtifactsPanelWidth(): number {

--- a/src/components/app-shell/use-artifacts-panel-state.ts
+++ b/src/components/app-shell/use-artifacts-panel-state.ts
@@ -5,6 +5,7 @@ import type { TurnOutputSelection } from "@/routes/Chat/TurnOutputs"
 
 import * as React from "react"
 import {
+  artifactsPanelDragLayout,
   artifactsPanelMaxWidth,
   ARTIFACTS_PANEL_MIN_WIDTH_PX,
   ARTIFACTS_PANEL_WIDTH_STORAGE_KEY,
@@ -26,6 +27,7 @@ interface UseArtifactsPanelStateOptions {
   activeSessionId: string | null
   appChromeRef: React.RefObject<HTMLDivElement | null>
   browserPanelVisible: boolean
+  closeBrowserPanel: () => void
   route: Route
   setIsSidebarRestoring: React.Dispatch<React.SetStateAction<boolean>>
   setSidebarCollapsed: React.Dispatch<React.SetStateAction<boolean>>
@@ -50,6 +52,7 @@ interface UseArtifactsPanelStateResult {
   handleTurnOutputOpen: (selection: TurnOutputSelection) => void
   hasPanelSelection: boolean
   isArtifactsPanelResizing: boolean
+  isArtifactsPanelDragCollapsed: boolean
   latestArtifactSelection: ArtifactSelection | null
   rightPanelVisible: boolean
   setArtifactsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -62,6 +65,7 @@ export function useArtifactsPanelState({
   activeSessionId,
   appChromeRef,
   browserPanelVisible,
+  closeBrowserPanel,
   route,
   setIsSidebarRestoring,
   setSidebarCollapsed,
@@ -77,6 +81,8 @@ export function useArtifactsPanelState({
   const [browserPanelWidth, setBrowserPanelWidth] = React.useState(readStoredBrowserPanelWidth)
   const [artifactsPanelMaxWidthState, setArtifactsPanelMaxWidthState] = React.useState<number | null>(null)
   const [isArtifactsPanelResizing, setIsArtifactsPanelResizing] = React.useState(false)
+  const [isArtifactsPanelDragCollapsed, setIsArtifactsPanelDragCollapsed] = React.useState(false)
+  const [artifactsPanelDragWidth, setArtifactsPanelDragWidth] = React.useState<number | null>(null)
   const artifactsPanelResizeStart = React.useRef<{
     browser: boolean
     pointerX: number
@@ -84,6 +90,8 @@ export function useArtifactsPanelState({
   } | null>(null)
   const artifactsPanelResizeFrame = React.useRef<number | null>(null)
   const artifactsPanelPendingWidth = React.useRef<number | null>(null)
+  const artifactsPanelPendingRawWidth = React.useRef<number | null>(null)
+  const artifactsPanelDragCollapsedRef = React.useRef(false)
   const artifactsPanelSidebarRestore = React.useRef<boolean | null>(null)
   const sidebarCollapsedRef = React.useRef(sidebarCollapsed)
   const artifactsPanelShellRef = React.useRef<HTMLDivElement | null>(null)
@@ -93,13 +101,11 @@ export function useArtifactsPanelState({
   const turnOutputSelection = panelSelection.kind === "turnOutput" ? panelSelection.selection : null
   const hasPanelSelection = panelSelection.kind !== "empty"
   const artifactsPanelVisible = route === "chat" && artifactsPanelOpen && hasPanelSelection && !browserPanelVisible
-  const rightPanelVisible = browserPanelVisible || artifactsPanelVisible
+  const rightPanelVisible = (browserPanelVisible || artifactsPanelVisible) && !isArtifactsPanelDragCollapsed
   const artifactsPanelIsMaximized = rightPanelVisible && artifactsPanelMaximized
   const preferredRightPanelWidth = browserPanelVisible ? browserPanelWidth : artifactsPanelWidth
-  const visibleRightPanelWidth = clampArtifactsPanelWidthForLayout(
-    preferredRightPanelWidth,
-    artifactsPanelMaxWidthValue,
-  )
+  const visibleRightPanelWidth =
+    artifactsPanelDragWidth ?? clampArtifactsPanelWidthForLayout(preferredRightPanelWidth, artifactsPanelMaxWidthValue)
 
   React.useEffect(() => {
     sidebarCollapsedRef.current = sidebarCollapsed
@@ -129,6 +135,11 @@ export function useArtifactsPanelState({
     if (element) {
       element.style.removeProperty("width")
     }
+  }, [])
+
+  const setArtifactsPanelDragCollapsedState = React.useCallback((collapsed: boolean): void => {
+    artifactsPanelDragCollapsedRef.current = collapsed
+    setIsArtifactsPanelDragCollapsed(collapsed)
   }, [])
 
   const restoreSidebarAfterArtifactsMaximize = React.useCallback((): void => {
@@ -237,9 +248,23 @@ export function useArtifactsPanelState({
       if (!start) {
         return
       }
-      artifactsPanelPendingWidth.current = clampArtifactsPanelWidthToLayout(
-        start.width + start.pointerX - event.clientX,
-      )
+      const rawWidth = start.width + start.pointerX - event.clientX
+      const layout = artifactsPanelDragLayout(rawWidth, artifactsPanelMaxWidthValue)
+      artifactsPanelPendingRawWidth.current = rawWidth
+      artifactsPanelPendingWidth.current = layout.width
+
+      if (layout.collapsed !== artifactsPanelDragCollapsedRef.current) {
+        if (artifactsPanelResizeFrame.current !== null) {
+          window.cancelAnimationFrame(artifactsPanelResizeFrame.current)
+          artifactsPanelResizeFrame.current = null
+        }
+        setArtifactsPanelDragCollapsedState(layout.collapsed)
+        if (layout.collapsed) {
+          return
+        }
+        setArtifactsPanelDragWidth(layout.width)
+        applyArtifactsPanelShellWidth(layout.width)
+      }
       if (artifactsPanelResizeFrame.current === null) {
         artifactsPanelResizeFrame.current = window.requestAnimationFrame(flushArtifactsPanelWidth)
       }
@@ -249,9 +274,19 @@ export function useArtifactsPanelState({
         window.cancelAnimationFrame(artifactsPanelResizeFrame.current)
         artifactsPanelResizeFrame.current = null
       }
+      const rawWidth = artifactsPanelPendingRawWidth.current
       const width = artifactsPanelPendingWidth.current
+      const collapsed = rawWidth !== null && artifactsPanelDragLayout(rawWidth, artifactsPanelMaxWidthValue).collapsed
+      artifactsPanelPendingRawWidth.current = null
       artifactsPanelPendingWidth.current = null
-      if (width !== null) {
+      if (collapsed) {
+        if (artifactsPanelResizeStart.current?.browser) {
+          closeBrowserPanel()
+        } else {
+          setArtifactsPanelOpen(false)
+        }
+        setArtifactsPanelMaximized(false)
+      } else if (width !== null) {
         applyArtifactsPanelShellWidth(width)
         if (artifactsPanelResizeStart.current?.browser) {
           setBrowserPanelWidth(width)
@@ -262,6 +297,8 @@ export function useArtifactsPanelState({
       clearArtifactsPanelContentWidth()
       artifactsPanelResizeStart.current = null
       setIsArtifactsPanelResizing(false)
+      setArtifactsPanelDragCollapsedState(false)
+      setArtifactsPanelDragWidth(null)
     }
 
     window.addEventListener("pointermove", handlePointerMove)
@@ -273,16 +310,21 @@ export function useArtifactsPanelState({
         artifactsPanelResizeFrame.current = null
       }
       artifactsPanelPendingWidth.current = null
+      artifactsPanelPendingRawWidth.current = null
       clearArtifactsPanelContentWidth()
+      setArtifactsPanelDragCollapsedState(false)
+      setArtifactsPanelDragWidth(null)
       window.removeEventListener("pointermove", handlePointerMove)
       window.removeEventListener("pointerup", handlePointerUp)
       window.removeEventListener("pointercancel", handlePointerUp)
     }
   }, [
     applyArtifactsPanelShellWidth,
-    clampArtifactsPanelWidthToLayout,
+    artifactsPanelMaxWidthValue,
     clearArtifactsPanelContentWidth,
+    closeBrowserPanel,
     isArtifactsPanelResizing,
+    setArtifactsPanelDragCollapsedState,
   ])
 
   React.useEffect(() => {
@@ -312,6 +354,10 @@ export function useArtifactsPanelState({
         pointerX: event.clientX,
         width: dragStartWidth,
       }
+      artifactsPanelPendingRawWidth.current = dragStartWidth
+      artifactsPanelPendingWidth.current = dragStartWidth
+      setArtifactsPanelDragCollapsedState(false)
+      setArtifactsPanelDragWidth(null)
       setIsArtifactsPanelResizing(true)
     },
     [
@@ -320,6 +366,7 @@ export function useArtifactsPanelState({
       browserPanelVisible,
       freezeArtifactsPanelContentWidth,
       rightPanelVisible,
+      setArtifactsPanelDragCollapsedState,
       visibleRightPanelWidth,
     ],
   )
@@ -404,6 +451,7 @@ export function useArtifactsPanelState({
     handleTurnOutputOpen,
     hasPanelSelection,
     isArtifactsPanelResizing,
+    isArtifactsPanelDragCollapsed,
     latestArtifactSelection,
     rightPanelVisible,
     setArtifactsPanelOpen: setArtifactsPanelOpenState,

--- a/src/components/app-shell/use-artifacts-panel-state.ts
+++ b/src/components/app-shell/use-artifacts-panel-state.ts
@@ -269,16 +269,23 @@ export function useArtifactsPanelState({
         artifactsPanelResizeFrame.current = window.requestAnimationFrame(flushArtifactsPanelWidth)
       }
     }
-    const handlePointerUp = (): void => {
+    const finishResize = (): void => {
       if (artifactsPanelResizeFrame.current !== null) {
         window.cancelAnimationFrame(artifactsPanelResizeFrame.current)
         artifactsPanelResizeFrame.current = null
       }
+      artifactsPanelPendingRawWidth.current = null
+      artifactsPanelPendingWidth.current = null
+      clearArtifactsPanelContentWidth()
+      artifactsPanelResizeStart.current = null
+      setIsArtifactsPanelResizing(false)
+      setArtifactsPanelDragCollapsedState(false)
+      setArtifactsPanelDragWidth(null)
+    }
+    const handlePointerUp = (): void => {
       const rawWidth = artifactsPanelPendingRawWidth.current
       const width = artifactsPanelPendingWidth.current
       const collapsed = rawWidth !== null && artifactsPanelDragLayout(rawWidth, artifactsPanelMaxWidthValue).collapsed
-      artifactsPanelPendingRawWidth.current = null
-      artifactsPanelPendingWidth.current = null
       if (collapsed) {
         if (artifactsPanelResizeStart.current?.browser) {
           closeBrowserPanel()
@@ -294,16 +301,19 @@ export function useArtifactsPanelState({
           setArtifactsPanelWidth(width)
         }
       }
-      clearArtifactsPanelContentWidth()
-      artifactsPanelResizeStart.current = null
-      setIsArtifactsPanelResizing(false)
-      setArtifactsPanelDragCollapsedState(false)
-      setArtifactsPanelDragWidth(null)
+      finishResize()
+    }
+    const handlePointerCancel = (): void => {
+      const startWidth = artifactsPanelResizeStart.current?.width
+      if (startWidth !== undefined) {
+        applyArtifactsPanelShellWidth(startWidth)
+      }
+      finishResize()
     }
 
     window.addEventListener("pointermove", handlePointerMove)
     window.addEventListener("pointerup", handlePointerUp, { once: true })
-    window.addEventListener("pointercancel", handlePointerUp, { once: true })
+    window.addEventListener("pointercancel", handlePointerCancel, { once: true })
     return () => {
       if (artifactsPanelResizeFrame.current !== null) {
         window.cancelAnimationFrame(artifactsPanelResizeFrame.current)
@@ -316,7 +326,7 @@ export function useArtifactsPanelState({
       setArtifactsPanelDragWidth(null)
       window.removeEventListener("pointermove", handlePointerMove)
       window.removeEventListener("pointerup", handlePointerUp)
-      window.removeEventListener("pointercancel", handlePointerUp)
+      window.removeEventListener("pointercancel", handlePointerCancel)
     }
   }, [
     applyArtifactsPanelShellWidth,


### PR DESCRIPTION
## What changed

The right-side preview panel now supports a deliberate drag-to-collapse gesture for artifacts, execution details, and the integrated browser.

Previously, dragging the divider toward the right stopped at the panel's minimum width. That protected the panel content, but it also left the divider feeling stuck: users could not tell whether they had reached an intentional limit or whether resizing had broken, and there was no direct way to dismiss the panel from the drag gesture.

This change introduces a three-stage interaction:

1. The panel follows the pointer normally until it reaches its 260px minimum presentation width.
2. Further movement enters a resistance zone while the visible panel remains at 260px.
3. Crossing a 130px collapse threshold hides the panel in real time; releasing the pointer closes the active right-side surface.

Reversing direction before release restores the panel at its minimum width and resumes normal resizing. A collapsed drag never persists a zero or undersized width, so reopening the panel restores the user's previous usable width.

## Implementation

- Add a shared drag-layout calculation and collapse threshold alongside the existing panel width constraints.
- Track transient drag width and collapse state independently from persisted panel width.
- Reuse the behavior for both artifact and browser right panels while invoking the correct close action for each surface.
- Allow the existing width, opacity, and transform transition during threshold crossing while preserving transition-free normal resizing.
- Add boundary coverage for the resistance zone, collapse threshold, and constrained-window layout.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run src/components/app-shell/app-shell-model.test.ts` (59 tests)
- Manual Electron verification of resize, resistance, collapse-before-release, reverse-drag recovery, committed close, and width restoration after reopening

