### PR TITLE
fix(artifacts): improve video previews

### DIFF
--- a/electron/chat/artifacts.test.ts
+++ b/electron/chat/artifacts.test.ts
@@ -27,6 +27,8 @@ describe("mimeFromPath", () => {
   it("recognizes common generated audio and video files", () => {
     expect(mimeFromPath("/tmp/result.mp3")).toBe("audio/mpeg")
     expect(mimeFromPath("/tmp/result.wav")).toBe("audio/wav")
+    expect(mimeFromPath("/tmp/result.avi")).toBe("video/x-msvideo")
+    expect(mimeFromPath("/tmp/result.mkv")).toBe("video/x-matroska")
     expect(mimeFromPath("/tmp/result.mp4")).toBe("video/mp4")
     expect(mimeFromPath("/tmp/result.mov")).toBe("video/quicktime")
   })

--- a/electron/chat/artifacts.ts
+++ b/electron/chat/artifacts.ts
@@ -129,6 +129,10 @@ export function mimeFromPath(filePath: string): string {
       return "audio/wav"
     case "webm":
       return "video/webm"
+    case "avi":
+      return "video/x-msvideo"
+    case "mkv":
+      return "video/x-matroska"
     case "m4v":
       return "video/mp4"
     case "mov":

--- a/electron/chat/previews.test.ts
+++ b/electron/chat/previews.test.ts
@@ -74,3 +74,24 @@ test("localArtifactPreview routes CSV and TSV through the spreadsheet preview wo
     await rm(directory, { force: true, recursive: true })
   }
 })
+
+test("localArtifactPreview streams large videos through an artifact resource lease", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "wanta-preview-video-"))
+  try {
+    const videoPath = path.join(directory, "large.mp4")
+    await writeFile(videoPath, Buffer.alloc(16 * 1024 * 1024 + 1))
+    let grantedSize = 0
+
+    const preview = await localArtifactPreview({ path: videoPath }, ({ size }) => {
+      grantedSize = size
+      return { expiresAt: 123, url: "wanta-resource://artifact/video-token" }
+    })
+
+    assert.equal(preview.kind, "media")
+    assert.equal(preview.mime, "video/mp4")
+    assert.equal(preview.resourceUrl, "wanta-resource://artifact/video-token")
+    assert.equal(grantedSize, 16 * 1024 * 1024 + 1)
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+})

--- a/electron/chat/previews.ts
+++ b/electron/chat/previews.ts
@@ -146,12 +146,12 @@ export async function localArtifactPreview(
   }
 
   if (item.mime.toLowerCase().startsWith("audio/") || item.mime.toLowerCase().startsWith("video/")) {
-    if (size > attachmentPreviewMaxBytes) {
-      return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
-    }
     const resource = requestResource()
     if (resource) {
       return { kind: "media", mime: item.mime, size, ...resourceResult(resource) }
+    }
+    if (size > attachmentPreviewMaxBytes) {
+      return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
     }
     try {
       const bytes = await readFile(item.path)

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -1065,6 +1065,8 @@ export const enMessages = {
   "artifacts.previewReadFailed": "Wanta could not read this file. You can still open it with a system app.",
   "artifacts.previewTooLarge": "This file is too large to preview in Wanta. You can open it with a system app.",
   "artifacts.previewUnsupported": "{type} files can be opened with a system app.",
+  "artifacts.videoCodecUnsupported":
+    "This video's format or codec cannot be played in Wanta. You can open it with a system app.",
   "artifacts.htmlPreviewTruncated":
     "This HTML file is large, so the embedded preview may be incomplete. View the source or open the full file in your browser.",
   "artifacts.pdfPage": "Page {page}/{total}",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -1018,6 +1018,7 @@ export const zhCNMessages = {
   "artifacts.previewReadFailed": "Wanta 无法读取这个文件。你仍然可以用系统应用打开。",
   "artifacts.previewTooLarge": "文件太大，无法在 Wanta 中预览。你可以用系统应用打开。",
   "artifacts.previewUnsupported": "{type} 文件可以用系统应用打开。",
+  "artifacts.videoCodecUnsupported": "Wanta 无法播放这个视频的格式或编码。你可以用系统应用打开。",
   "artifacts.htmlPreviewTruncated": "HTML 文件较大，内嵌预览可能不完整。请查看源码或用系统浏览器打开完整文件。",
   "artifacts.pdfPage": "第 {page}/{total} 页",
   "artifacts.pdfPrevious": "上一页",

--- a/src/routes/Chat/ArtifactPreviewPane.tsx
+++ b/src/routes/Chat/ArtifactPreviewPane.tsx
@@ -431,6 +431,57 @@ function ArtifactArchivePreview({ preview }: { preview: LocalArtifactPreviewResu
   )
 }
 
+function ArtifactVideoPreview({
+  item,
+  onOpen,
+  onResourceError,
+  pack,
+  preview,
+  source,
+}: {
+  item: LocalArtifactItem
+  onOpen: () => void
+  onResourceError?: () => void
+  pack?: LocalArtifactPack | null
+  preview: LocalArtifactPreviewResult
+  source: string
+}) {
+  const t = useT()
+  const [failed, setFailed] = React.useState(false)
+
+  React.useEffect(() => {
+    setFailed(false)
+  }, [source])
+
+  if (failed) {
+    return (
+      <ArtifactUnavailablePreview
+        description={t("artifacts.videoCodecUnsupported")}
+        item={item}
+        pack={pack}
+        preview={preview}
+        onOpen={onOpen}
+      />
+    )
+  }
+
+  return (
+    <div className="flex min-h-full items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
+      <video
+        src={source}
+        controls
+        playsInline
+        preload="metadata"
+        className="max-h-full max-w-full rounded-md bg-black shadow-sm"
+        onError={() => {
+          setFailed(true)
+          onResourceError?.()
+        }}
+      />
+    </div>
+  )
+}
+
 export function ArtifactConsumablePreview({
   item,
   preview,
@@ -469,15 +520,14 @@ export function ArtifactConsumablePreview({
 
   if (preview?.kind === "media" && resourceSource && isVideoArtifact(item)) {
     return (
-      <div className="flex min-h-full items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
-        <video
-          src={resourceSource}
-          controls
-          preload="metadata"
-          className="max-h-full max-w-full rounded-md bg-black shadow-sm"
-          onError={onResourceError}
-        />
-      </div>
+      <ArtifactVideoPreview
+        item={item}
+        pack={pack}
+        preview={preview}
+        source={resourceSource}
+        onOpen={onOpen}
+        onResourceError={onResourceError}
+      />
     )
   }
 

--- a/src/routes/Chat/ArtifactPreviewPane.tsx
+++ b/src/routes/Chat/ArtifactPreviewPane.tsx
@@ -447,16 +447,18 @@ function ArtifactVideoPreview({
   source: string
 }) {
   const t = useT()
-  const [failed, setFailed] = React.useState(false)
+  const [failure, setFailure] = React.useState<"resource" | "unsupported_source" | null>(null)
 
   React.useEffect(() => {
-    setFailed(false)
+    setFailure(null)
   }, [source])
 
-  if (failed) {
+  if (failure) {
     return (
       <ArtifactUnavailablePreview
-        description={t("artifacts.videoCodecUnsupported")}
+        description={t(
+          failure === "unsupported_source" ? "artifacts.videoCodecUnsupported" : "artifacts.previewReadFailed",
+        )}
         item={item}
         pack={pack}
         preview={preview}
@@ -473,8 +475,12 @@ function ArtifactVideoPreview({
         playsInline
         preload="metadata"
         className="max-h-full max-w-full rounded-md bg-black shadow-sm"
-        onError={() => {
-          setFailed(true)
+        onError={(event) => {
+          if (event.currentTarget.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
+            setFailure("unsupported_source")
+            return
+          }
+          setFailure("resource")
           onResourceError?.()
         }}
       />

--- a/src/routes/Chat/GeneratedArtifacts.test.ts
+++ b/src/routes/Chat/GeneratedArtifacts.test.ts
@@ -7,7 +7,7 @@ import * as React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { htmlPreviewSrcDoc } from "./artifact-html-preview.ts"
-import { artifactGroupDisplayItem, artifactKindLabel } from "./artifact-metadata.ts"
+import { artifactGroupDisplayItem, artifactKindLabel, isVideoArtifact } from "./artifact-metadata.ts"
 import { buildArtifactPaletteItems } from "./composer-palette-items.ts"
 import { GeneratedArtifactsShelf } from "./GeneratedArtifacts.tsx"
 import { I18nContext, translate } from "@/i18n/i18n"
@@ -75,6 +75,12 @@ describe("htmlPreviewSrcDoc", () => {
 })
 
 describe("artifact group display", () => {
+  it("recognizes common video extensions when MIME metadata is generic", () => {
+    expect(isVideoArtifact(artifactItem("recording.mkv", "application/octet-stream"))).toBe(true)
+    expect(isVideoArtifact(artifactItem("recording.avi", "application/octet-stream"))).toBe(true)
+    expect(isVideoArtifact(artifactItem("notes.txt", "application/octet-stream"))).toBe(false)
+  })
+
   it("uses the root folder as the cover for file-list artifact packs", () => {
     const pdf = artifactItem("sample.pdf", "application/pdf")
     const spreadsheet = artifactItem("sample.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/src/routes/Chat/artifact-metadata.ts
+++ b/src/routes/Chat/artifact-metadata.ts
@@ -52,7 +52,11 @@ export function isImageArtifact(item: LocalArtifactItem | undefined): boolean {
 }
 
 export function isVideoArtifact(item: LocalArtifactItem | undefined): boolean {
-  return Boolean(item?.mime.toLowerCase().startsWith("video/"))
+  return Boolean(
+    item &&
+    (item.mime.toLowerCase().startsWith("video/") ||
+      [".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm"].includes(fileExtension(item.name))),
+  )
 }
 
 export function isAudioArtifact(item: LocalArtifactItem | undefined): boolean {


### PR DESCRIPTION
## Summary

Wanta already rendered video artifacts with Chromium's native video element, but the main-process preview path rejected every audio or video file larger than 16 MiB before it could receive a streamable artifact URL. In practice, that made ordinary video outputs appear unsupported even though the custom resource protocol already supports byte ranges.

This change allows large media files to use the existing leased `wanta-resource` stream while preserving the size limit for the Base64 fallback path. It also recognizes AVI and MKV MIME types, falls back to common video filename extensions when MIME metadata is generic, and replaces a permanently broken video element with a localized codec/format error state that still lets the user open the file in a system application.

No player or transcoding dependency is added. Chromium continues to provide the playback controls and codec support, so formats such as MKV, AVI, MOV, or HEVC are attempted but remain dependent on the codecs available in the packaged Electron runtime.

## Verification

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm test` — 283 test files and 2144 tests passed
- Focused formatting check for all changed files
- `git diff --check`

Added regression coverage for large resource-backed MP4 previews, AVI/MKV MIME detection, and extension-based video recognition when MIME metadata is generic.

## Safety and Compatibility

- [x] Large media remains behind Wanta's short-lived artifact resource lease and trusted-path validation.
- [x] Byte-range streaming is reused; large videos are not copied into renderer memory as Base64 data URLs.
- [x] The 16 MiB limit remains in place for the inline fallback path and for existing non-media previews.
- [x] No new runtime dependency, native binary, codec, permission, credential, or external network surface is introduced.
- [x] Existing image, audio, PDF, document, spreadsheet, archive, and text preview behavior is unchanged.
- [x] Unsupported codecs retain the system-application fallback, while network and resource failures now use the generic read-failure message and preserve the cache's single retry limit.
