### PR TITLE
feat(agent): gate direct CLI skills on connection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,10 +130,12 @@ state through `LinkRuntimeServiceImpl`. The shipped app contains a checksum-veri
 its matching embedded `lark-*` Skills. On Connect, Wanta first checks the official latest version;
 an available update is downloaded to a versioned user-data runtime, verified against the release
 checksum, and atomically activated. Update failure is non-fatal: authorization continues with the
-already usable version. The active binary directory is prepended to the Agent sidecar `PATH`, its
-config root is injected through `LARKSUITE_CLI_CONFIG_DIR`, and its matching Skills are copied into
-the private Agent workspace. Thus chat uses the same local identity authorized from Connections,
-independently of the selected OOMOL/OpenConnector Link runtime.
+already usable version. The CLI and matching Skills remain packaged while disconnected; only after
+the isolated identity verifies as `connected` is the active binary directory prepended to the Agent
+sidecar `PATH`, its config root injected through `LARKSUITE_CLI_CONFIG_DIR`, and its matching Skills
+projected into the private Agent workspace. Disconnecting or detecting an expired identity removes
+that capability on the next safe Agent refresh. Thus chat uses the same local identity authorized
+from Connections, independently of the selected OOMOL/OpenConnector Link runtime.
 
 WeCom CLI is a separate local `direct` provider with a provider-specific QR-code experience rather
 than a Lark-shaped authorization flow. `WecomCliManager` runs the official
@@ -145,9 +147,11 @@ errors cross `LinkRuntimeServiceImpl`. Disconnect removes only Wanta's isolated 
 temporary-media directories, never the user's global `~/.config/wecom` or the robot in WeCom. The
 shipped platform binary is downloaded from the matching `@wecom/cli-*` npm package and verified
 against registry `dist.integrity`; `wecomcli-*` Skills come from the exact source `gitHead` recorded
-by the pinned `@wecom/cli` package. `WECOM_CLI_CONFIG_DIR` / `WECOM_CLI_TMP_DIR`, the managed binary
-directory, and these Skills are injected into the private Agent runtime independently of Lark and of
-the selected Link backend. Credentials and raw QR output never enter the renderer.
+by the pinned `@wecom/cli` package. The managed binary, config environment, and `wecomcli-*` Skills
+are exposed to the private Agent runtime only while the isolated bot identity verifies as
+`connected`; otherwise they remain packaged but absent from the Agent `PATH`, environment, and Skill
+index. This activation remains independent of Lark and of the selected Link backend. Credentials and
+raw QR output never enter the renderer.
 
 DingTalk Workspace CLI is a third independent local `direct` provider, with its own browser OAuth
 and organization-approval flow rather than a shared Lark/WeCom state machine. `DingTalkCliManager`
@@ -156,8 +160,10 @@ roots, opens only the allowlisted `https://login.dingtalk.com/oauth2/auth` page,
 result through structured `dws auth status --format json` output. Disconnect targets the exact
 active `corpId:userId` profile and never logs out every saved organization. Tokens remain encrypted
 by the official CLI credential backend; only redacted account, phase, availability, and version
-state crosses IPC. The stable mono `dws` Skill is packaged from the same pinned release and injected
-into the private Agent workspace independently of the selected Link backend.
+state crosses IPC. The stable mono `dws` Skill is packaged from the same pinned release and is
+projected into the private Agent workspace, together with the managed binary and isolated config
+environment, only while an exact profile verifies as `connected`. Disconnected and expired states
+remain absent from the Agent independently of the selected Link backend.
 
 Vite (`vite-plugin-electron/simple` in `vite.config.ts`) bundles `electron/main.ts` and
 `electron/preload.ts` into `dist-electron/main.js` + `preload.js`; the main-process build has a

--- a/electron/agent/direct-cli-bin.test.ts
+++ b/electron/agent/direct-cli-bin.test.ts
@@ -1,0 +1,43 @@
+import { execFile } from "node:child_process"
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+import { describe, expect, it } from "vitest"
+import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
+
+const execFileAsync = promisify(execFile)
+
+describe("ensureDirectCliCommandBin", () => {
+  it("writes forwarding shims only for connected direct CLIs", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "wanta-direct-cli-bin-"))
+    try {
+      const binDir = path.join(base, "bin")
+      const larkCliBinPath = path.join(base, "managed lark-cli")
+      await writeFile(larkCliBinPath, "#!/bin/sh\nprintf 'forwarded:%s' \"$1\"\n", "utf-8")
+      await chmod(larkCliBinPath, 0o755)
+
+      await ensureDirectCliCommandBin({ binDir, larkCliBinPath })
+
+      if (process.platform === "win32") {
+        expect(await readFile(path.join(binDir, "lark-cli.cmd"), "utf-8")).toContain(`"${larkCliBinPath}" %*`)
+        expect(await readFile(path.join(binDir, "wecom-cli.cmd"), "utf-8")).toContain("exit /b 69")
+        expect(await readFile(path.join(binDir, "dws.cmd"), "utf-8")).toContain("exit /b 69")
+      } else {
+        await expect(execFileAsync(path.join(binDir, "lark-cli"), ["calendar.list"])).resolves.toMatchObject({
+          stdout: "forwarded:calendar.list",
+        })
+        await expect(execFileAsync(path.join(binDir, "wecom-cli"))).rejects.toMatchObject({
+          code: 69,
+          stderr: expect.stringContaining("WeCom CLI is not connected"),
+        })
+        await expect(execFileAsync(path.join(binDir, "dws"))).rejects.toMatchObject({
+          code: 69,
+          stderr: expect.stringContaining("DingTalk CLI is not connected"),
+        })
+      }
+    } finally {
+      await rm(base, { force: true, recursive: true })
+    }
+  })
+})

--- a/electron/agent/direct-cli-bin.ts
+++ b/electron/agent/direct-cli-bin.ts
@@ -1,0 +1,63 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+export interface DirectCliCommandBinOptions {
+  binDir: string
+  dingTalkCliBinPath?: string
+  larkCliBinPath?: string
+  platform?: NodeJS.Platform
+  wecomCliBinPath?: string
+}
+
+interface DirectCliCommand {
+  binaryPath?: string
+  command: string
+  provider: string
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function disconnectedMessage(provider: string, command: string): string {
+  return `Wanta: ${provider} is not connected. Connect it in Settings before using ${command}.`
+}
+
+export async function ensureDirectCliCommandBin({
+  binDir,
+  dingTalkCliBinPath,
+  larkCliBinPath,
+  platform = process.platform,
+  wecomCliBinPath,
+}: DirectCliCommandBinOptions): Promise<string> {
+  await mkdir(binDir, { recursive: true })
+  const commands: DirectCliCommand[] = [
+    { binaryPath: larkCliBinPath, command: "lark-cli", provider: "Lark CLI" },
+    { binaryPath: wecomCliBinPath, command: "wecom-cli", provider: "WeCom CLI" },
+    { binaryPath: dingTalkCliBinPath, command: "dws", provider: "DingTalk CLI" },
+  ]
+
+  await Promise.all(commands.map((command) => writeDirectCliCommand(binDir, command, platform)))
+  return binDir
+}
+
+async function writeDirectCliCommand(
+  binDir: string,
+  { binaryPath, command, provider }: DirectCliCommand,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  if (platform === "win32") {
+    const source = binaryPath
+      ? ["@echo off", `"${binaryPath}" %*`, "exit /b %errorlevel%", ""]
+      : ["@echo off", `echo ${disconnectedMessage(provider, command)} 1^>^&2`, "exit /b 69", ""]
+    await writeFile(path.join(binDir, `${command}.cmd`), source.join("\r\n"), "utf-8")
+    return
+  }
+
+  const source = binaryPath
+    ? ["#!/bin/sh", `exec ${shellQuote(binaryPath)} "$@"`, ""]
+    : ["#!/bin/sh", `echo ${shellQuote(disconnectedMessage(provider, command))} >&2`, "exit 69", ""]
+  const commandPath = path.join(binDir, command)
+  await writeFile(commandPath, source.join("\n"), "utf-8")
+  await chmod(commandPath, 0o755)
+}

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -162,6 +162,12 @@ describe("AgentManager", () => {
     expect(env).not.toHaveProperty("WANTA_WIKIGRAPH_STATE_DIR")
     expect(env).not.toHaveProperty("WANTA_WIKIGRAPH_WRAPPER_PATH")
     expect(env).not.toHaveProperty("WIKIGRAPH_STATE_DIR")
+    expect(env).not.toHaveProperty("WANTA_LARK_CLI_BIN")
+    expect(env).not.toHaveProperty("LARKSUITE_CLI_CONFIG_DIR")
+    expect(env).not.toHaveProperty("WANTA_WECOM_CLI_BIN")
+    expect(env).not.toHaveProperty("WECOM_CLI_CONFIG_DIR")
+    expect(env).not.toHaveProperty("WANTA_DINGTALK_CLI_BIN")
+    expect(env).not.toHaveProperty("DWS_CONFIG_DIR")
   })
 
   it("isolates local direct CLI configuration in the sidecar", () => {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -28,6 +28,7 @@ import { connectorBaseUrl, llmBaseUrl } from "../domain.ts"
 import { DEFAULT_BUILTIN_MODEL_ID, isBuiltinModelId, resolveBuiltinModel } from "../models/builtin.ts"
 import { planAttachmentInputs } from "./attachment-input.ts"
 import { buildOpencodeConfig, customProviderId, WANTA_MODEL_ID, WANTA_PROVIDER_ID } from "./config.ts"
+import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
 import { normalizeMessage, normalizePermissionRequest, normalizeQuestionRequest } from "./event-translator.ts"
 import { normalizeWantaAgentMode } from "./mode.ts"
 import { writeOoIdentitySettings } from "./oo-identity.ts"
@@ -503,23 +504,23 @@ export class AgentManager {
 
     const config = buildOpencodeConfig({ customModels, defaultModel, linkRuntime, modelAccess })
     const baseCommandPath = await resolveUserCommandPath({
-      preferredDirectories: [
-        ...(larkCliBinPath ? [path.dirname(larkCliBinPath)] : []),
-        ...(wecomCliBinPath ? [path.dirname(wecomCliBinPath)] : []),
-        ...(dingTalkCliBinPath ? [path.dirname(dingTalkCliBinPath)] : []),
-        ...(linkRuntime && ooBinPath ? [path.dirname(ooBinPath)] : []),
-      ],
+      preferredDirectories: linkRuntime && ooBinPath ? [path.dirname(ooBinPath)] : [],
     })
-    const wikiGraphBinDir =
-      wikiGraphCliPath && wikiGraphStateDir
-        ? await ensureWikiGraphCommandBin({
-            binDir: path.join(rootDir, "bin"),
-            nodeBin: process.execPath,
-            stateDir: wikiGraphStateDir,
-            wikiGraphCliPath,
-          })
-        : undefined
-    const commandPath = wikiGraphBinDir ? `${wikiGraphBinDir}${path.delimiter}${baseCommandPath}` : baseCommandPath
+    const commandBinDir = await ensureDirectCliCommandBin({
+      binDir: path.join(rootDir, "bin"),
+      dingTalkCliBinPath,
+      larkCliBinPath,
+      wecomCliBinPath,
+    })
+    if (wikiGraphCliPath && wikiGraphStateDir) {
+      await ensureWikiGraphCommandBin({
+        binDir: commandBinDir,
+        nodeBin: process.execPath,
+        stateDir: wikiGraphStateDir,
+        wikiGraphCliPath,
+      })
+    }
+    const commandPath = `${commandBinDir}${path.delimiter}${baseCommandPath}`
     const browserControl = await this.options.browserControl?.()
     const env = buildAgentSidecarEnv({
       browserControl,

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -55,8 +55,8 @@ export interface AgentManagerOptions {
   listOpenConnectorAuthorizedServices?: (signal?: AbortSignal) => Promise<string[]>
   /** 内置 skill 源目录（resources/skills 或打包 Resources/skills）；启动时拷进 .opencode/skill/。 */
   bundledSkillsDir?: string
-  /** Official local direct-CLI skills, independent of the selected Link runtime. */
-  bundledDirectSkillsDirs?: string[]
+  /** Skills for connected local direct-CLI providers, independent of the selected Link runtime. */
+  activeDirectSkillsDirs?: string[]
   /** Active Wanta-managed Lark CLI direct-runtime binary. */
   larkCliBinPath?: string
   /** Isolated Lark CLI config directory; credentials remain owned by the CLI/keychain. */
@@ -163,16 +163,28 @@ export function buildAgentSidecarEnv({
     PATH: commandPath,
     WANTA_BROWSER_CONTROL_TOKEN: browserControl?.token ?? "",
     WANTA_BROWSER_CONTROL_URL: browserControl?.url ?? "",
-    WANTA_LARK_CLI_BIN: larkCliBinPath ?? "",
-    LARKSUITE_CLI_CONFIG_DIR: larkCliConfigDir ?? "",
-    LARKSUITE_CLI_NO_SKILLS_NOTIFIER: "1",
-    LARKSUITE_CLI_NO_UPDATE_NOTIFIER: "1",
-    WANTA_WECOM_CLI_BIN: wecomCliBinPath ?? "",
-    WECOM_CLI_CONFIG_DIR: wecomCliConfigDir ?? "",
-    WECOM_CLI_TMP_DIR: wecomCliTmpDir ?? "",
-    WANTA_DINGTALK_CLI_BIN: dingTalkCliBinPath ?? "",
-    DWS_CONFIG_DIR: dingTalkCliConfigDir ?? "",
-    DWS_KEYCHAIN_DIR: dingTalkCliKeychainDir ?? "",
+    ...(larkCliBinPath && larkCliConfigDir
+      ? {
+          WANTA_LARK_CLI_BIN: larkCliBinPath,
+          LARKSUITE_CLI_CONFIG_DIR: larkCliConfigDir,
+          LARKSUITE_CLI_NO_SKILLS_NOTIFIER: "1",
+          LARKSUITE_CLI_NO_UPDATE_NOTIFIER: "1",
+        }
+      : {}),
+    ...(wecomCliBinPath && wecomCliConfigDir && wecomCliTmpDir
+      ? {
+          WANTA_WECOM_CLI_BIN: wecomCliBinPath,
+          WECOM_CLI_CONFIG_DIR: wecomCliConfigDir,
+          WECOM_CLI_TMP_DIR: wecomCliTmpDir,
+        }
+      : {}),
+    ...(dingTalkCliBinPath && dingTalkCliConfigDir && dingTalkCliKeychainDir
+      ? {
+          WANTA_DINGTALK_CLI_BIN: dingTalkCliBinPath,
+          DWS_CONFIG_DIR: dingTalkCliConfigDir,
+          DWS_KEYCHAIN_DIR: dingTalkCliKeychainDir,
+        }
+      : {}),
   }
 }
 
@@ -457,7 +469,7 @@ export class AgentManager {
     await ensureAgentWorkspace(workspaceDir, bundledSkillsDir, bundledToolRuntimePath, {
       bundledOoSkills: this.options.linkRuntime?.kind === "oomol",
       connectors: this.options.linkRuntime !== null,
-      directSkillsDirs: this.options.bundledDirectSkillsDirs,
+      directSkillsDirs: this.options.activeDirectSkillsDirs,
     })
     this.teamScopePath = teamScopePath
     await this.writeTeamState(this.teamName)

--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -1,7 +1,10 @@
 import type { ProcessSnapshotEntry } from "./sidecar.ts"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import type { ChildProcessWithoutNullStreams } from "node:child_process"
+import type { SpawnOptionsWithoutStdio } from "node:child_process"
 
+import { EventEmitter } from "node:events"
+import { PassThrough } from "node:stream"
 import { describe, expect, it, vi } from "vitest"
 import { sanitizeDingTalkEnvironment } from "../dingtalk-cli-environment.ts"
 import {
@@ -15,6 +18,7 @@ import {
   parsePsSnapshot,
   reapProcessTree,
   reapWindowsProcessTree,
+  sanitizeInheritedDirectCliEnvironment,
 } from "./sidecar.ts"
 
 describe("OpencodeSidecar", () => {
@@ -127,6 +131,74 @@ describe("OpencodeSidecar", () => {
 
     await expect(start).rejects.toThrow("disposed during startup")
     expect(spawnProcess).not.toHaveBeenCalled()
+  })
+
+  it("scrubs disconnected direct CLI variables inherited from the launcher before spawning", async () => {
+    const inheritedVariables = {
+      DWS_CONFIG_DIR: "/launcher/dingtalk/config",
+      DWS_KEYCHAIN_DIR: "/launcher/dingtalk/keychain",
+      LARKSUITE_CLI_CONFIG_DIR: "/launcher/lark/config",
+      LARKSUITE_CLI_NO_SKILLS_NOTIFIER: "1",
+      LARKSUITE_CLI_NO_UPDATE_NOTIFIER: "1",
+      WANTA_DINGTALK_CLI_BIN: "/launcher/dws",
+      WANTA_LARK_CLI_BIN: "/launcher/lark-cli",
+      WANTA_WECOM_CLI_BIN: "/launcher/wecom-cli",
+      WECOM_CLI_CONFIG_DIR: "/launcher/wecom/config",
+      WECOM_CLI_TMP_DIR: "/launcher/wecom/tmp",
+    }
+    for (const [name, value] of Object.entries(inheritedVariables)) vi.stubEnv(name, value)
+
+    let spawnedEnvironment: NodeJS.ProcessEnv | undefined
+    const proc = new EventEmitter() as ChildProcessWithoutNullStreams
+    const stdout = new PassThrough()
+    proc.stdin = new PassThrough()
+    proc.stdout = stdout
+    proc.stderr = new PassThrough()
+    const spawnProcess = vi.fn((_command: string, _args: string[], options: SpawnOptionsWithoutStdio) => {
+      spawnedEnvironment = options.env
+      queueMicrotask(() => stdout.write("listening on http://127.0.0.1:4096\n"))
+      return proc
+    })
+    const sidecar = new OpencodeSidecar(
+      {
+        config: {},
+        env: {
+          LARKSUITE_CLI_CONFIG_DIR: "/private/lark/config",
+          WANTA_LARK_CLI_BIN: "/managed/lark-cli",
+        },
+        isolationDir: "/tmp/wanta-sidecar-direct-cli-isolation",
+        opencodeBinPath: "/tmp/wanta-sidecar-direct-cli-opencode",
+        workspaceDir: "/tmp/wanta-sidecar-direct-cli-workspace",
+      },
+      { createDirectory: async () => undefined, spawnProcess },
+    )
+
+    try {
+      await sidecar.start()
+      expect(spawnedEnvironment).toMatchObject({
+        LARKSUITE_CLI_CONFIG_DIR: "/private/lark/config",
+        WANTA_LARK_CLI_BIN: "/managed/lark-cli",
+      })
+      for (const name of Object.keys(inheritedVariables)) {
+        if (name === "LARKSUITE_CLI_CONFIG_DIR" || name === "WANTA_LARK_CLI_BIN") continue
+        expect(spawnedEnvironment).not.toHaveProperty(name)
+      }
+    } finally {
+      ;(sidecar as unknown as { proc: ChildProcessWithoutNullStreams | null }).proc = null
+      await sidecar.dispose()
+      vi.unstubAllEnvs()
+    }
+  })
+})
+
+describe("sanitizeInheritedDirectCliEnvironment", () => {
+  it("removes managed names case-insensitively on Windows", () => {
+    expect(
+      sanitizeInheritedDirectCliEnvironment(
+        { Path: "C:\\Windows", wanta_lark_cli_bin: "untrusted", wecom_cli_config_dir: "untrusted" },
+        "win32",
+      ),
+    ).toEqual({ Path: "C:\\Windows" })
   })
 })
 

--- a/electron/agent/sidecar.test.ts
+++ b/electron/agent/sidecar.test.ts
@@ -195,7 +195,13 @@ describe("sanitizeInheritedDirectCliEnvironment", () => {
   it("removes managed names case-insensitively on Windows", () => {
     expect(
       sanitizeInheritedDirectCliEnvironment(
-        { Path: "C:\\Windows", wanta_lark_cli_bin: "untrusted", wecom_cli_config_dir: "untrusted" },
+        {
+          Path: "C:\\Windows",
+          wanta_lark_cli_bin: "untrusted",
+          wecom_cli_config_dir: "untrusted",
+          wecom_cli_log_file: "C:\\outside\\wecom.log",
+          wecom_cli_log_level: "debug",
+        },
         "win32",
       ),
     ).toEqual({ Path: "C:\\Windows" })

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -76,6 +76,30 @@ const networkEnvironmentKeys = [
   "CURL_CA_BUNDLE",
 ] as const
 
+const managedDirectCliEnvironmentNames = new Set([
+  "DWS_CONFIG_DIR",
+  "DWS_KEYCHAIN_DIR",
+  "LARKSUITE_CLI_CONFIG_DIR",
+  "LARKSUITE_CLI_NO_SKILLS_NOTIFIER",
+  "LARKSUITE_CLI_NO_UPDATE_NOTIFIER",
+  "WANTA_DINGTALK_CLI_BIN",
+  "WANTA_LARK_CLI_BIN",
+  "WANTA_WECOM_CLI_BIN",
+  "WECOM_CLI_CONFIG_DIR",
+  "WECOM_CLI_TMP_DIR",
+])
+
+export function sanitizeInheritedDirectCliEnvironment(
+  environment: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  for (const name of Object.keys(environment)) {
+    const normalized = platform === "win32" ? name.toUpperCase() : name
+    if (managedDirectCliEnvironmentNames.has(normalized)) delete environment[name]
+  }
+  return environment
+}
+
 interface ProxyEndpoint {
   host: string
   port: string
@@ -421,8 +445,9 @@ export class OpencodeSidecar {
       throw new Error("OpencodeSidecar disposed during startup")
     }
 
+    const inheritedEnvironment = sanitizeInheritedDirectCliEnvironment({ ...process.env })
     const baseChildEnv: NodeJS.ProcessEnv = {
-      ...process.env,
+      ...inheritedEnvironment,
       ...env,
       // 外部 agent skill 由 SkillService 扫描后同步到私有 workspace；sidecar 不直接扫全局根，避免同名旧副本抢占。
       OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",

--- a/electron/agent/sidecar.ts
+++ b/electron/agent/sidecar.ts
@@ -86,6 +86,8 @@ const managedDirectCliEnvironmentNames = new Set([
   "WANTA_LARK_CLI_BIN",
   "WANTA_WECOM_CLI_BIN",
   "WECOM_CLI_CONFIG_DIR",
+  "WECOM_CLI_LOG_FILE",
+  "WECOM_CLI_LOG_LEVEL",
   "WECOM_CLI_TMP_DIR",
 ])
 

--- a/electron/agent/workspace.test.ts
+++ b/electron/agent/workspace.test.ts
@@ -209,6 +209,43 @@ test("ensureAgentWorkspace installs independent Lark and WeCom direct-mode skill
   }
 })
 
+test("ensureAgentWorkspace removes direct-mode skills after their providers disconnect", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "wanta-workspace-"))
+  try {
+    const workspaceDir = path.join(base, "workspace")
+    const bundledSkillsDir = path.join(base, "bundled-skills")
+    const bundledToolRuntimePath = await writeToolRuntime(base)
+    const larkSkillsDir = path.join(base, "lark-skills")
+    const wecomSkillsDir = path.join(base, "wecom-skills")
+    await writeSkill(bundledSkillsDir, "browser")
+    await writeSkill(larkSkillsDir, "lark-calendar")
+    await writeSkill(wecomSkillsDir, "wecomcli-todo")
+
+    await ensureAgentWorkspace(workspaceDir, bundledSkillsDir, bundledToolRuntimePath, {
+      bundledOoSkills: false,
+      connectors: false,
+      directSkillsDirs: [larkSkillsDir, wecomSkillsDir],
+    })
+
+    const skillRoot = path.join(workspaceDir, ".opencode", "skill")
+    assert.ok(await exists(path.join(skillRoot, "browser", "SKILL.md")))
+    assert.ok(await exists(path.join(skillRoot, "lark-calendar", "SKILL.md")))
+    assert.ok(await exists(path.join(skillRoot, "wecomcli-todo", "SKILL.md")))
+
+    await ensureAgentWorkspace(workspaceDir, bundledSkillsDir, bundledToolRuntimePath, {
+      bundledOoSkills: false,
+      connectors: false,
+      directSkillsDirs: [],
+    })
+
+    assert.ok(await exists(path.join(skillRoot, "browser", "SKILL.md")))
+    assert.equal(await exists(path.join(skillRoot, "lark-calendar")), false)
+    assert.equal(await exists(path.join(skillRoot, "wecomcli-todo")), false)
+  } finally {
+    await rm(base, { force: true, recursive: true })
+  }
+})
+
 test("ensureAgentWorkspace works without a bundled skills directory", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "wanta-workspace-"))
   try {

--- a/electron/link-runtime/dingtalk-cli.test.ts
+++ b/electron/link-runtime/dingtalk-cli.test.ts
@@ -128,7 +128,7 @@ exit 1
 
 function waitForAuthorization(opened: Promise<void>, connection: Promise<unknown>): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("DingTalk authorization URL did not open in time.")), 1_000)
+    const timeout = setTimeout(() => reject(new Error("DingTalk authorization URL did not open in time.")), 3_000)
     const fail = (error: unknown) => {
       clearTimeout(timeout)
       reject(error)

--- a/electron/link-runtime/dingtalk-cli.test.ts
+++ b/electron/link-runtime/dingtalk-cli.test.ts
@@ -188,6 +188,21 @@ describe.runIf(process.platform !== "win32")("DingTalk CLI lifecycle", () => {
       await writeFile(path.join(fixture.rootDir, "config", "expired"), "1", "utf-8")
 
       await expect(fixture.manager.getState()).resolves.toMatchObject({ available: true, connection: "expired" })
+      await expect(fixture.manager.availableRuntime()).resolves.toMatchObject({ skillsDir: expect.any(String) })
+      await expect(fixture.manager.agentRuntime()).resolves.toBeNull()
+    } finally {
+      await rm(fixture.base, { force: true, recursive: true })
+    }
+  })
+
+  test("exposes the Agent runtime only after connection and removes it after disconnect", async () => {
+    const fixture = await createMockDingTalkCli()
+    try {
+      await expect(fixture.manager.agentRuntime()).resolves.toBeNull()
+      await fixture.manager.connect()
+      await expect(fixture.manager.agentRuntime()).resolves.toMatchObject({ skillsDir: expect.any(String) })
+      await fixture.manager.disconnect()
+      await expect(fixture.manager.agentRuntime()).resolves.toBeNull()
     } finally {
       await rm(fixture.base, { force: true, recursive: true })
     }

--- a/electron/link-runtime/dingtalk-cli.test.ts
+++ b/electron/link-runtime/dingtalk-cli.test.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { describe, expect, test } from "vitest"
+import { describe, expect, test, vi } from "vitest"
 import {
   DingTalkCliManager,
   extractOfficialDingTalkAuthorizationUrl,
@@ -62,7 +62,7 @@ interface MockDingTalkCli {
   states: Array<{ error?: string; phase: string }>
 }
 
-async function createMockDingTalkCli(): Promise<MockDingTalkCli> {
+async function createMockDingTalkCli(onRuntimeChanged?: () => void): Promise<MockDingTalkCli> {
   const base = await mkdtemp(path.join(os.tmpdir(), "wanta-dingtalk-cli-"))
   const binaryPath = path.join(base, "dws")
   const rootDir = path.join(base, "private-runtime")
@@ -89,7 +89,7 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
 fi
 if [ "$1" = "auth" ] && [ "$2" = "login" ]; then
   printf 'https://login.dingtalk.com/oauth2/auth?client_id=test&redirect_uri=http%%3A%%2F%%2F127.0.0.1'
-  while [ -f "$DWS_CONFIG_DIR/pause-login" ]; do :; done
+  while [ -f "$DWS_CONFIG_DIR/pause-login" ]; do sleep 0.01; done
   sleep 0.05
   mkdir -p "$DWS_CONFIG_DIR"
   touch "$DWS_CONFIG_DIR/authorized"
@@ -114,6 +114,7 @@ exit 1
   const states: MockDingTalkCli["states"] = []
   const manager = new DingTalkCliManager({
     binaryPath,
+    onRuntimeChanged,
     openExternalUrl: (url) => {
       opened.push(url)
       resolveAuthorizationOpened?.()
@@ -182,12 +183,17 @@ describe.runIf(process.platform !== "win32")("DingTalk CLI lifecycle", () => {
   })
 
   test("reports expired credentials while keeping the runtime available", async () => {
-    const fixture = await createMockDingTalkCli()
+    const onRuntimeChanged = vi.fn()
+    const fixture = await createMockDingTalkCli(onRuntimeChanged)
     try {
+      await fixture.manager.connect()
       await mkdir(path.join(fixture.rootDir, "config"), { recursive: true })
       await writeFile(path.join(fixture.rootDir, "config", "expired"), "1", "utf-8")
 
       await expect(fixture.manager.getState()).resolves.toMatchObject({ available: true, connection: "expired" })
+      expect(onRuntimeChanged).toHaveBeenCalledTimes(2)
+      await fixture.manager.getState()
+      expect(onRuntimeChanged).toHaveBeenCalledTimes(2)
       await expect(fixture.manager.availableRuntime()).resolves.toMatchObject({ skillsDir: expect.any(String) })
       await expect(fixture.manager.agentRuntime()).resolves.toBeNull()
     } finally {

--- a/electron/link-runtime/dingtalk-cli.ts
+++ b/electron/link-runtime/dingtalk-cli.ts
@@ -48,6 +48,7 @@ export class DingTalkCliManager {
   private activeChild: ChildProcess | null = null
   private cancelRequested = false
   private operation: { kind: "connect" | "disconnect"; promise: Promise<DingTalkCliState> } | null = null
+  private runtimeStateObserved = false
   private state: DingTalkCliState = {
     activeVersion: null,
     available: false,
@@ -67,8 +68,9 @@ export class DingTalkCliManager {
     this.skillsDir = options.skillsDir
   }
 
-  public async getState(): Promise<DingTalkCliState> {
+  public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<DingTalkCliState> {
     if (this.operation) return this.state
+    const previousConnection = this.state.connection
     try {
       const runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled DingTalk CLI runtime is unavailable.")
@@ -94,6 +96,7 @@ export class DingTalkCliManager {
         phase: "idle",
       })
     }
+    this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
     return this.state
   }
 
@@ -186,7 +189,7 @@ export class DingTalkCliManager {
 
   /** Expose the managed CLI to the Agent only while an isolated DingTalk profile is connected. */
   public async agentRuntime(): Promise<DingTalkCliRuntime | null> {
-    const state = await this.getState()
+    const state = await this.getState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
     return this.availableRuntime()
   }
@@ -216,7 +219,8 @@ export class DingTalkCliManager {
       error: undefined,
       phase: "idle",
     })
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
@@ -225,6 +229,8 @@ export class DingTalkCliManager {
     const auth = await this.readAuthState()
     if (!auth.authenticated) {
       this.setState({ accountLabel: undefined, connection: "disconnected", error: undefined, phase: "idle" })
+      this.runtimeStateObserved = true
+      this.notifyRuntimeChanged()
       return this.state
     }
     if (!auth.profile) throw new Error("DingTalk CLI did not report an exact account identity to disconnect.")
@@ -237,7 +243,8 @@ export class DingTalkCliManager {
       error: undefined,
       phase: "idle",
     })
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
@@ -248,6 +255,16 @@ export class DingTalkCliManager {
       throw new Error("DingTalk CLI returned an unreadable version.")
     }
     return value.version.replace(/^v/u, "")
+  }
+
+  private observeRuntimeState(previousConnection: DingTalkCliState["connection"], notify: boolean): void {
+    const changed = this.runtimeStateObserved && previousConnection !== this.state.connection
+    this.runtimeStateObserved = true
+    if (changed && notify) this.notifyRuntimeChanged()
+  }
+
+  private notifyRuntimeChanged(): void {
+    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
   }
 
   private async readAuthState(): Promise<DingTalkAuthStatus> {

--- a/electron/link-runtime/dingtalk-cli.ts
+++ b/electron/link-runtime/dingtalk-cli.ts
@@ -70,7 +70,7 @@ export class DingTalkCliManager {
   public async getState(): Promise<DingTalkCliState> {
     if (this.operation) return this.state
     try {
-      const runtime = await this.activeRuntime()
+      const runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled DingTalk CLI runtime is unavailable.")
       await this.ensurePrivateDirectories()
       const auth = await this.readAuthState()
@@ -164,7 +164,7 @@ export class DingTalkCliManager {
     return true
   }
 
-  public async activeRuntime(): Promise<DingTalkCliRuntime | null> {
+  public async availableRuntime(): Promise<DingTalkCliRuntime | null> {
     try {
       const [binary, skills, version] = await Promise.all([
         stat(this.binaryPath),
@@ -184,8 +184,15 @@ export class DingTalkCliManager {
     }
   }
 
+  /** Expose the managed CLI to the Agent only while an isolated DingTalk profile is connected. */
+  public async agentRuntime(): Promise<DingTalkCliRuntime | null> {
+    const state = await this.getState()
+    if (state.connection !== "connected") return null
+    return this.availableRuntime()
+  }
+
   private async connectNow(): Promise<DingTalkCliState> {
-    const runtime = await this.activeRuntime()
+    const runtime = await this.availableRuntime()
     if (!runtime) throw new Error("The bundled DingTalk CLI runtime is unavailable.")
     await this.ensurePrivateDirectories()
     this.setState({

--- a/electron/link-runtime/dingtalk-cli.ts
+++ b/electron/link-runtime/dingtalk-cli.ts
@@ -69,10 +69,17 @@ export class DingTalkCliManager {
   }
 
   public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<DingTalkCliState> {
-    if (this.operation) return this.state
+    return (await this.resolveState(options)).state
+  }
+
+  private async resolveState(
+    options: { notifyRuntimeChange?: boolean } = {},
+  ): Promise<{ runtime: DingTalkCliRuntime | null; state: DingTalkCliState }> {
+    if (this.operation) return { runtime: null, state: this.state }
     const previousConnection = this.state.connection
+    let runtime: DingTalkCliRuntime | null = null
     try {
-      const runtime = await this.availableRuntime()
+      runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled DingTalk CLI runtime is unavailable.")
       await this.ensurePrivateDirectories()
       const auth = await this.readAuthState()
@@ -97,7 +104,7 @@ export class DingTalkCliManager {
       })
     }
     this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
-    return this.state
+    return { runtime, state: this.state }
   }
 
   public connect(): Promise<DingTalkCliState> {
@@ -189,9 +196,9 @@ export class DingTalkCliManager {
 
   /** Expose the managed CLI to the Agent only while an isolated DingTalk profile is connected. */
   public async agentRuntime(): Promise<DingTalkCliRuntime | null> {
-    const state = await this.getState({ notifyRuntimeChange: false })
+    const { runtime, state } = await this.resolveState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
-    return this.availableRuntime()
+    return runtime
   }
 
   private async connectNow(): Promise<DingTalkCliState> {

--- a/electron/link-runtime/lark-cli.test.ts
+++ b/electron/link-runtime/lark-cli.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict"
-import { test } from "vitest"
-import { findOfficialAuthorizationUrl, isVersionNewer, redactCommandError } from "./lark-cli.ts"
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, expect, test } from "vitest"
+import { findOfficialAuthorizationUrl, isVersionNewer, LarkCliManager, redactCommandError } from "./lark-cli.ts"
 
 test("Lark CLI update comparison handles stable and prerelease versions", () => {
   assert.equal(isVersionNewer("1.0.82", "1.0.81"), true)
@@ -37,4 +40,52 @@ test("Lark CLI command errors redact authorization URLs and credentials", () => 
   assert.equal(redacted.includes("id=secret"), false)
   assert.match(redacted, /\[redacted\]/u)
   assert.match(redacted, /\[authorization-url\]/u)
+})
+
+describe.runIf(process.platform !== "win32")("Lark CLI Agent activation", () => {
+  test("exposes the runtime only while the isolated identity is connected", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "wanta-lark-cli-agent-"))
+    try {
+      const binaryPath = path.join(base, "lark-cli")
+      const rootDir = path.join(base, "private-runtime")
+      const skillsDir = path.join(base, "skills")
+      await mkdir(path.join(skillsDir, "lark-calendar"), { recursive: true })
+      await writeFile(path.join(skillsDir, "lark-calendar", "SKILL.md"), "---\nname: lark-calendar\n---\n", "utf-8")
+      await writeFile(
+        binaryPath,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "lark-cli 1.0.81"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -f "$LARKSUITE_CLI_CONFIG_DIR/authorized" ]; then
+    echo '{"identity":"user","verified":true,"name":"Shaun"}'
+  else
+    echo '{"identity":"none"}'
+  fi
+  exit 0
+fi
+exit 1
+`,
+        "utf-8",
+      )
+      await chmod(binaryPath, 0o755)
+      const manager = new LarkCliManager({
+        bundledBinaryPath: binaryPath,
+        bundledSkillsDir: skillsDir,
+        openExternalUrl: () => undefined,
+        rootDir,
+      })
+
+      await expect(manager.availableRuntime()).resolves.toMatchObject({ binaryPath, skillsDir })
+      await expect(manager.agentRuntime()).resolves.toBeNull()
+
+      await mkdir(path.join(rootDir, "config"), { recursive: true })
+      await writeFile(path.join(rootDir, "config", "authorized"), "1", "utf-8")
+      await expect(manager.agentRuntime()).resolves.toMatchObject({ binaryPath, skillsDir })
+
+      await rm(path.join(rootDir, "config", "authorized"))
+      await expect(manager.agentRuntime()).resolves.toBeNull()
+    } finally {
+      await rm(base, { force: true, recursive: true })
+    }
+  })
 })

--- a/electron/link-runtime/lark-cli.test.ts
+++ b/electron/link-runtime/lark-cli.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { describe, expect, test } from "vitest"
+import { describe, expect, test, vi } from "vitest"
 import { findOfficialAuthorizationUrl, isVersionNewer, LarkCliManager, redactCommandError } from "./lark-cli.ts"
 
 test("Lark CLI update comparison handles stable and prerelease versions", () => {
@@ -84,6 +84,51 @@ exit 1
 
       await rm(path.join(rootDir, "config", "authorized"))
       await expect(manager.agentRuntime()).resolves.toBeNull()
+    } finally {
+      await rm(base, { force: true, recursive: true })
+    }
+  })
+
+  test("requests one Agent refresh when a previously observed identity expires", async () => {
+    const base = await mkdtemp(path.join(os.tmpdir(), "wanta-lark-cli-refresh-"))
+    try {
+      const binaryPath = path.join(base, "lark-cli")
+      const rootDir = path.join(base, "private-runtime")
+      const skillsDir = path.join(base, "skills")
+      await mkdir(path.join(skillsDir, "lark-calendar"), { recursive: true })
+      await writeFile(path.join(skillsDir, "lark-calendar", "SKILL.md"), "---\nname: lark-calendar\n---\n", "utf-8")
+      await writeFile(
+        binaryPath,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "lark-cli 1.0.81"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -f "$LARKSUITE_CLI_CONFIG_DIR/expired" ]; then echo '{"identity":"user","verified":false}'
+  else echo '{"identity":"user","verified":true}'
+  fi
+  exit 0
+fi
+exit 1
+`,
+        "utf-8",
+      )
+      await chmod(binaryPath, 0o755)
+      const onRuntimeChanged = vi.fn()
+      const manager = new LarkCliManager({
+        bundledBinaryPath: binaryPath,
+        bundledSkillsDir: skillsDir,
+        onRuntimeChanged,
+        openExternalUrl: () => undefined,
+        rootDir,
+      })
+
+      await expect(manager.agentRuntime()).resolves.toMatchObject({ binaryPath })
+      expect(onRuntimeChanged).not.toHaveBeenCalled()
+      await mkdir(path.join(rootDir, "config"), { recursive: true })
+      await writeFile(path.join(rootDir, "config", "expired"), "1", "utf-8")
+      await expect(manager.getState()).resolves.toMatchObject({ connection: "expired" })
+      expect(onRuntimeChanged).toHaveBeenCalledOnce()
+      await manager.getState()
+      expect(onRuntimeChanged).toHaveBeenCalledOnce()
     } finally {
       await rm(base, { force: true, recursive: true })
     }

--- a/electron/link-runtime/lark-cli.ts
+++ b/electron/link-runtime/lark-cli.ts
@@ -65,6 +65,7 @@ export class LarkCliManager {
   private operation: { kind: "connect" | "disconnect"; promise: Promise<LarkCliState> } | null = null
   private activeChild: ChildProcess | null = null
   private cancelRequested = false
+  private runtimeStateObserved = false
   private state: LarkCliState = {
     activeVersion: null,
     available: false,
@@ -86,8 +87,9 @@ export class LarkCliManager {
     this.rootDir = options.rootDir
   }
 
-  public async getState(): Promise<LarkCliState> {
+  public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<LarkCliState> {
     if (this.operation) return this.state
+    const previousConnection = this.state.connection
     try {
       const bundle = await this.resolveActiveBundle()
       const auth = await this.readAuthState(bundle.binaryPath)
@@ -111,6 +113,7 @@ export class LarkCliManager {
         phase: "idle",
       }
     }
+    this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
     return this.state
   }
 
@@ -182,7 +185,7 @@ export class LarkCliManager {
 
   /** Expose the managed CLI to the Agent only while its isolated identity is connected. */
   public async agentRuntime(): Promise<ActiveBundle | null> {
-    const state = await this.getState()
+    const state = await this.getState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
     return this.availableRuntime()
   }
@@ -234,7 +237,8 @@ export class LarkCliManager {
       phase: "idle",
     }
     this.stateChanged.emit(this.state)
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
@@ -250,13 +254,24 @@ export class LarkCliManager {
       phase: "idle",
     }
     this.stateChanged.emit(this.state)
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
   private setState(patch: Partial<LarkCliState>): void {
     this.state = { ...this.state, ...patch }
     this.stateChanged.emit(this.state)
+  }
+
+  private observeRuntimeState(previousConnection: LarkCliState["connection"], notify: boolean): void {
+    const changed = this.runtimeStateObserved && previousConnection !== this.state.connection
+    this.runtimeStateObserved = true
+    if (changed && notify) this.notifyRuntimeChanged()
+  }
+
+  private notifyRuntimeChanged(): void {
+    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
   }
 
   private assertNotCancelled(): void {

--- a/electron/link-runtime/lark-cli.ts
+++ b/electron/link-runtime/lark-cli.ts
@@ -88,14 +88,21 @@ export class LarkCliManager {
   }
 
   public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<LarkCliState> {
-    if (this.operation) return this.state
+    return (await this.resolveState(options)).state
+  }
+
+  private async resolveState(
+    options: { notifyRuntimeChange?: boolean } = {},
+  ): Promise<{ runtime: ActiveBundle | null; state: LarkCliState }> {
+    if (this.operation) return { runtime: null, state: this.state }
     const previousConnection = this.state.connection
+    let runtime: ActiveBundle | null = null
     try {
-      const bundle = await this.resolveActiveBundle()
-      const auth = await this.readAuthState(bundle.binaryPath)
+      runtime = await this.resolveActiveBundle()
+      const auth = await this.readAuthState(runtime.binaryPath)
       this.state = {
         ...this.state,
-        activeVersion: bundle.version,
+        activeVersion: runtime.version,
         available: true,
         bundledVersion: await this.readVersion(this.bundledBinaryPath).catch(() => null),
         connection: auth.connection,
@@ -114,7 +121,7 @@ export class LarkCliManager {
       }
     }
     this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
-    return this.state
+    return { runtime, state: this.state }
   }
 
   public connect(): Promise<LarkCliState> {
@@ -185,9 +192,9 @@ export class LarkCliManager {
 
   /** Expose the managed CLI to the Agent only while its isolated identity is connected. */
   public async agentRuntime(): Promise<ActiveBundle | null> {
-    const state = await this.getState({ notifyRuntimeChange: false })
+    const { runtime, state } = await this.resolveState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
-    return this.availableRuntime()
+    return runtime
   }
 
   private async connectNow(): Promise<LarkCliState> {

--- a/electron/link-runtime/lark-cli.ts
+++ b/electron/link-runtime/lark-cli.ts
@@ -172,12 +172,19 @@ export class LarkCliManager {
     this.setState({ phase: "idle" })
   }
 
-  public async activeRuntime(): Promise<ActiveBundle | null> {
+  public async availableRuntime(): Promise<ActiveBundle | null> {
     try {
       return await this.resolveActiveBundle()
     } catch {
       return null
     }
+  }
+
+  /** Expose the managed CLI to the Agent only while its isolated identity is connected. */
+  public async agentRuntime(): Promise<ActiveBundle | null> {
+    const state = await this.getState()
+    if (state.connection !== "connected") return null
+    return this.availableRuntime()
   }
 
   private async connectNow(): Promise<LarkCliState> {

--- a/electron/link-runtime/wecom-cli.test.ts
+++ b/electron/link-runtime/wecom-cli.test.ts
@@ -77,6 +77,9 @@ exit 1
         skillsDir,
       })
 
+      await expect(manager.availableRuntime()).resolves.toMatchObject({ binaryPath, skillsDir })
+      await expect(manager.agentRuntime()).resolves.toBeNull()
+
       const connected = await manager.connect()
       expect(connected).toMatchObject({
         accountLabel: "bot-123",
@@ -85,9 +88,11 @@ exit 1
         phase: "idle",
       })
       expect(opened).toEqual(["https://work.weixin.qq.com/ai/qc/gen?source=test&scode=temporary"])
+      await expect(manager.agentRuntime()).resolves.toMatchObject({ binaryPath, skillsDir })
 
       const disconnected = await manager.disconnect()
       expect(disconnected.connection).toBe("disconnected")
+      await expect(manager.agentRuntime()).resolves.toBeNull()
       await expect(readFile(retained, "utf-8")).resolves.toBe("keep")
       await expect(stat(path.join(rootDir, "config"))).resolves.toMatchObject({})
     } finally {

--- a/electron/link-runtime/wecom-cli.ts
+++ b/electron/link-runtime/wecom-cli.ts
@@ -60,7 +60,7 @@ export class WecomCliManager {
   public async getState(): Promise<WecomCliState> {
     if (this.operation) return this.state
     try {
-      const runtime = await this.activeRuntime()
+      const runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled WeCom CLI runtime is unavailable.")
       const auth = await this.readAuthState()
       this.state = {
@@ -149,7 +149,7 @@ export class WecomCliManager {
     return true
   }
 
-  public async activeRuntime(): Promise<WecomCliRuntime | null> {
+  public async availableRuntime(): Promise<WecomCliRuntime | null> {
     try {
       const [binary, skills, version] = await Promise.all([
         stat(this.binaryPath),
@@ -163,9 +163,16 @@ export class WecomCliManager {
     }
   }
 
+  /** Expose the managed CLI to the Agent only while its isolated bot identity is connected. */
+  public async agentRuntime(): Promise<WecomCliRuntime | null> {
+    const state = await this.getState()
+    if (state.connection !== "connected") return null
+    return this.availableRuntime()
+  }
+
   private async connectNow(): Promise<WecomCliState> {
     this.setState({ canReopenAuthorization: false, error: undefined, phase: "preparing" })
-    const runtime = await this.activeRuntime()
+    const runtime = await this.availableRuntime()
     if (!runtime) throw new Error("The bundled WeCom CLI runtime is unavailable.")
     await this.ensurePrivateDirectories()
     const current = await this.readAuthState()

--- a/electron/link-runtime/wecom-cli.ts
+++ b/electron/link-runtime/wecom-cli.ts
@@ -59,10 +59,17 @@ export class WecomCliManager {
   }
 
   public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<WecomCliState> {
-    if (this.operation) return this.state
+    return (await this.resolveState(options)).state
+  }
+
+  private async resolveState(
+    options: { notifyRuntimeChange?: boolean } = {},
+  ): Promise<{ runtime: WecomCliRuntime | null; state: WecomCliState }> {
+    if (this.operation) return { runtime: null, state: this.state }
     const previousConnection = this.state.connection
+    let runtime: WecomCliRuntime | null = null
     try {
-      const runtime = await this.availableRuntime()
+      runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled WeCom CLI runtime is unavailable.")
       const auth = await this.readAuthState()
       this.state = {
@@ -86,7 +93,7 @@ export class WecomCliManager {
       }
     }
     this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
-    return this.state
+    return { runtime, state: this.state }
   }
 
   public connect(): Promise<WecomCliState> {
@@ -168,9 +175,9 @@ export class WecomCliManager {
 
   /** Expose the managed CLI to the Agent only while its isolated bot identity is connected. */
   public async agentRuntime(): Promise<WecomCliRuntime | null> {
-    const state = await this.getState({ notifyRuntimeChange: false })
+    const { runtime, state } = await this.resolveState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
-    return this.availableRuntime()
+    return runtime
   }
 
   private async connectNow(): Promise<WecomCliState> {

--- a/electron/link-runtime/wecom-cli.ts
+++ b/electron/link-runtime/wecom-cli.ts
@@ -38,6 +38,7 @@ export class WecomCliManager {
   private activeAuthorizationUrl: string | null = null
   private cancelRequested = false
   private operation: { kind: "connect" | "disconnect"; promise: Promise<WecomCliState> } | null = null
+  private runtimeStateObserved = false
   private state: WecomCliState = {
     activeVersion: null,
     available: false,
@@ -57,8 +58,9 @@ export class WecomCliManager {
     this.temporaryDir = path.join(options.rootDir, "tmp")
   }
 
-  public async getState(): Promise<WecomCliState> {
+  public async getState(options: { notifyRuntimeChange?: boolean } = {}): Promise<WecomCliState> {
     if (this.operation) return this.state
+    const previousConnection = this.state.connection
     try {
       const runtime = await this.availableRuntime()
       if (!runtime) throw new Error("The bundled WeCom CLI runtime is unavailable.")
@@ -83,6 +85,7 @@ export class WecomCliManager {
         phase: "idle",
       }
     }
+    this.observeRuntimeState(previousConnection, options.notifyRuntimeChange ?? true)
     return this.state
   }
 
@@ -165,7 +168,7 @@ export class WecomCliManager {
 
   /** Expose the managed CLI to the Agent only while its isolated bot identity is connected. */
   public async agentRuntime(): Promise<WecomCliRuntime | null> {
-    const state = await this.getState()
+    const state = await this.getState({ notifyRuntimeChange: false })
     if (state.connection !== "connected") return null
     return this.availableRuntime()
   }
@@ -194,7 +197,8 @@ export class WecomCliManager {
       error: undefined,
       phase: "idle",
     })
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
@@ -211,7 +215,8 @@ export class WecomCliManager {
       connection: "disconnected",
       phase: "idle",
     })
-    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
+    this.runtimeStateObserved = true
+    this.notifyRuntimeChanged()
     return this.state
   }
 
@@ -224,6 +229,16 @@ export class WecomCliManager {
     if (process.platform !== "win32") {
       await Promise.all([chmod(this.rootDir, 0o700), chmod(this.configDir, 0o700), chmod(this.temporaryDir, 0o700)])
     }
+  }
+
+  private observeRuntimeState(previousConnection: WecomCliState["connection"], notify: boolean): void {
+    const changed = this.runtimeStateObserved && previousConnection !== this.state.connection
+    this.runtimeStateObserved = true
+    if (changed && notify) this.notifyRuntimeChanged()
+  }
+
+  private notifyRuntimeChanged(): void {
+    void Promise.resolve(this.onRuntimeChanged?.()).catch(() => undefined)
   }
 
   private commandEnvironment(): NodeJS.ProcessEnv {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -749,9 +749,11 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   if (isQuitting) {
     return
   }
-  const larkCliRuntime = await larkCliManager.activeRuntime()
-  const wecomCliRuntime = await wecomCliManager.activeRuntime()
-  const dingTalkCliRuntime = await dingTalkCliManager.activeRuntime()
+  const [larkCliRuntime, wecomCliRuntime, dingTalkCliRuntime] = await Promise.all([
+    larkCliManager.agentRuntime(),
+    wecomCliManager.agentRuntime(),
+    dingTalkCliManager.agentRuntime(),
+  ])
   const nextAgent = new AgentManager({
     browserControl: browserControlConnection,
     defaultModel: runtime.defaultModel,
@@ -766,20 +768,22 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
         .filter((item) => item.status === "active")
         .map((item) => item.service),
     bundledSkillsDir,
-    bundledDirectSkillsDirs: [
-      larkCliRuntime?.skillsDir ?? bundledLarkSkillsDir,
-      wecomCliRuntime?.skillsDir ?? bundledWecomSkillsDir,
-      dingTalkCliRuntime?.skillsDir ?? bundledDingTalkSkillsDir,
-    ],
+    activeDirectSkillsDirs: [
+      larkCliRuntime?.skillsDir,
+      wecomCliRuntime?.skillsDir,
+      dingTalkCliRuntime?.skillsDir,
+    ].filter((directory): directory is string => Boolean(directory)),
     bundledToolRuntimePath,
-    larkCliBinPath: larkCliRuntime?.binaryPath ?? bundledLarkCliBinPath,
-    larkCliConfigDir: path.join(app.getPath("userData"), "lark-cli", "config"),
-    wecomCliBinPath: wecomCliRuntime?.binaryPath ?? bundledWecomCliBinPath,
-    wecomCliConfigDir: path.join(app.getPath("userData"), "wecom-cli", "config"),
-    wecomCliTmpDir: path.join(app.getPath("userData"), "wecom-cli", "tmp"),
-    dingTalkCliBinPath: dingTalkCliRuntime?.binaryPath ?? bundledDingTalkCliBinPath,
-    dingTalkCliConfigDir: path.join(app.getPath("userData"), "dingtalk-cli", "config"),
-    dingTalkCliKeychainDir: path.join(app.getPath("userData"), "dingtalk-cli", "keychain"),
+    larkCliBinPath: larkCliRuntime?.binaryPath,
+    larkCliConfigDir: larkCliRuntime ? path.join(app.getPath("userData"), "lark-cli", "config") : undefined,
+    wecomCliBinPath: wecomCliRuntime?.binaryPath,
+    wecomCliConfigDir: wecomCliRuntime ? path.join(app.getPath("userData"), "wecom-cli", "config") : undefined,
+    wecomCliTmpDir: wecomCliRuntime ? path.join(app.getPath("userData"), "wecom-cli", "tmp") : undefined,
+    dingTalkCliBinPath: dingTalkCliRuntime?.binaryPath,
+    dingTalkCliConfigDir: dingTalkCliRuntime ? path.join(app.getPath("userData"), "dingtalk-cli", "config") : undefined,
+    dingTalkCliKeychainDir: dingTalkCliRuntime
+      ? path.join(app.getPath("userData"), "dingtalk-cli", "keychain")
+      : undefined,
     rootDir: path.join(app.getPath("userData"), "agent"),
     customModels: runtimeModels.customModels,
   })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -780,10 +780,8 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
     wecomCliConfigDir: wecomCliRuntime ? path.join(app.getPath("userData"), "wecom-cli", "config") : undefined,
     wecomCliTmpDir: wecomCliRuntime ? path.join(app.getPath("userData"), "wecom-cli", "tmp") : undefined,
     dingTalkCliBinPath: dingTalkCliRuntime?.binaryPath,
-    dingTalkCliConfigDir: dingTalkCliRuntime ? path.join(app.getPath("userData"), "dingtalk-cli", "config") : undefined,
-    dingTalkCliKeychainDir: dingTalkCliRuntime
-      ? path.join(app.getPath("userData"), "dingtalk-cli", "keychain")
-      : undefined,
+    dingTalkCliConfigDir: dingTalkCliRuntime?.configDir,
+    dingTalkCliKeychainDir: dingTalkCliRuntime?.keychainDir,
     rootDir: path.join(app.getPath("userData"), "agent"),
     customModels: runtimeModels.customModels,
   })


### PR DESCRIPTION
## Issue

Wanta packaged and injected the official Lark, WeCom, and DingTalk CLI Skills into every Agent workspace even when the corresponding Direct provider had never been connected. OpenCode therefore discovered all Direct CLI Skill metadata by default, adding unnecessary context and creating ambiguous routing between similar messaging, calendar, document, and task capabilities.

## User impact

Direct CLI capabilities now appear to the Agent only after the matching isolated identity has been verified as connected in Wanta Connections. A user who connects only one provider gets only that provider's Skills and CLI runtime. Disconnecting or expiring the provider removes those capabilities on the next safe Agent refresh, while unrelated providers and built-in Skills remain available.

## Root cause

The three CLI managers exposed an `activeRuntime()` method whose actual contract only checked that a packaged binary and Skill directory existed. Agent assembly treated those available bundles as active regardless of authorization state and fell back unconditionally to every bundled Skill directory. It also always added all three binaries and configuration variables to the sidecar environment. Launcher-level environment variables and globally installed same-name CLIs could additionally bypass an omission made by Agent assembly.

## Fix

- Separate packaged runtime availability from Agent eligibility with `availableRuntime()` and connection-aware `agentRuntime()` methods for Lark, WeCom, and DingTalk.
- Probe all three isolated authorization states in parallel while assembling an Agent runtime.
- Project only connected providers' Skill directories into `.opencode/skill`.
- Scrub launcher-inherited Direct CLI variables before applying the active runtime environment, preventing stale credentials and binary paths from leaking into the sidecar.
- Put Wanta-owned `lark-cli`, `wecom-cli`, and `dws` shims first on the Agent `PATH`; connected shims forward to the managed binary and disconnected shims reject the command, so a global installation cannot bypass activation.
- Observe authorization-state transitions and schedule exactly one idle-gated Agent refresh when a previously active identity expires or disconnects externally.
- Treat disconnected, expired, cancelled, failed, and unavailable states as inactive while preserving packaged runtimes for the Connections authorization flow.
- Document the packaged-versus-activated capability boundary.

## Validation

- `pnpm lint`
- `pnpm ts-check`
- `pnpm test` (full suite)
- `pnpm build`
- Targeted Direct CLI, sidecar-environment, PATH-shim, and lifecycle regression tests
- Targeted `oxfmt --check` for every changed file
- `git diff --check`

The full-repository format check currently reports only three unrelated untracked files under `docs/research/`; every file changed by this PR passes `oxfmt --check`. That unrelated directory remains intentionally excluded from the PR.
