### PR TITLE
fix(agent): route connector workspaces and redact secrets

### DIFF
--- a/electron/agent/event-translator.test.ts
+++ b/electron/agent/event-translator.test.ts
@@ -559,6 +559,35 @@ test("tool events preserve title, metadata and timing for renderer summaries", (
   })
 })
 
+test("tool events redact connector credential fields before they reach the renderer", () => {
+  const out = translateOpencodeEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "p2",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "tool",
+        callID: "c1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: "oo connector run posthog --action list_projects" },
+          output: JSON.stringify({ data: { api_token: "secret", id: 173107, name: "CLI" } }),
+        },
+      },
+    },
+  })
+
+  const event = out[0]
+  assert.equal(event?.event, "toolCallResult")
+  assert.ok(event)
+  const output = (event.data as { output?: string }).output
+  assert.deepEqual(JSON.parse(output ?? "{}"), {
+    data: { api_token: "[redacted]", id: 173107, name: "CLI" },
+  })
+})
+
 test("tool events use input description as title fallback", () => {
   const out = translateOpencodeEvent({
     type: "message.part.updated",
@@ -747,6 +776,31 @@ test("normalizeMessage builds ChatMessage with text + reasoning + tool parts in 
   assert.equal(msg.parts[0].kind, "text")
   assert.equal(msg.parts[1].kind, "reasoning")
   assert.equal(msg.parts[2].kind, "tool")
+})
+
+test("normalizeMessage redacts credential fields from persisted historical tool output", () => {
+  const message = normalizeMessage({
+    info: { id: "m1", role: "assistant", time: { created: 123 } },
+    parts: [
+      {
+        id: "p2",
+        type: "tool",
+        callID: "c1",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: {},
+          output: JSON.stringify({ data: { api_token: "secret", project: "CLI" } }),
+        },
+      },
+    ],
+  })
+
+  const part = message?.parts[0]
+  assert.equal(part?.kind, "tool")
+  assert.deepEqual(JSON.parse(part?.kind === "tool" ? (part.output ?? "{}") : "{}"), {
+    data: { api_token: "[redacted]", project: "CLI" },
+  })
 })
 
 test("normalizeMessage preserves assistant token usage", () => {

--- a/electron/agent/event-translator.ts
+++ b/electron/agent/event-translator.ts
@@ -22,6 +22,7 @@ import type {
 
 import { parseAuthorizationSignal } from "../chat/authorization-signal.ts"
 import { logDiagnostic } from "../diagnostics-log.ts"
+import { redactConnectorOutput } from "./oo-guard-core.ts"
 
 // OpenCode SSE 事件经此翻译为 ChatService ServerEvents。无状态：每个 OpenCode 事件
 // 直接映射为 0..n 个 {event, data}，node.ts 据此 this.send(event, data)。
@@ -582,13 +583,19 @@ function translatePart(part: OpencodePart, delta?: string): ChatEmit[] {
     const state = part.state
     const context = toolContext(state)
     if (state.error && state.status !== "completed") {
-      return [{ event: "toolCallResult", data: { ...base, ...context, status: "error", error: state.error } }]
+      return [
+        {
+          event: "toolCallResult",
+          data: { ...base, ...context, status: "error", error: redactConnectorOutput(state.error) },
+        },
+      ]
     }
     if (state.status === "pending" || state.status === "running") {
       return [{ event: "toolCallStarted", data: { ...base, ...context, status: state.status } }]
     }
     if (state.status === "completed") {
-      const auth = parseToolAuthorization(part.tool, state.output)
+      const output = redactConnectorOutput(state.output ?? "")
+      const auth = parseToolAuthorization(part.tool, output)
       return [
         {
           event: "toolCallResult",
@@ -596,14 +603,19 @@ function translatePart(part: OpencodePart, delta?: string): ChatEmit[] {
             ...base,
             ...context,
             status: "completed",
-            output: state.output,
+            output,
             ...(auth ? { authorization: auth } : {}),
           },
         },
       ]
     }
     if (state.status === "error") {
-      return [{ event: "toolCallResult", data: { ...base, ...context, status: "error", error: state.error } }]
+      return [
+        {
+          event: "toolCallResult",
+          data: { ...base, ...context, status: "error", error: redactConnectorOutput(state.error ?? "") },
+        },
+      ]
     }
   }
   return []
@@ -724,15 +736,18 @@ export function normalizeMessage(message: { info?: unknown; parts?: unknown }): 
         tool: part.tool,
         status: state.error && state.status !== "completed" ? "error" : state.status,
         input: state.input ?? {},
-        output: state.output,
-        error: state.error,
+        output: typeof state.output === "string" ? redactConnectorOutput(state.output) : state.output,
+        error: typeof state.error === "string" ? redactConnectorOutput(state.error) : state.error,
         title: state.title ?? (typeof state.input?.description === "string" ? state.input.description : undefined),
         metadata: state.metadata,
         timing: state.time ? { start: state.time.start, end: state.time.end } : undefined,
         attachmentsCount: Array.isArray(state.attachments) ? state.attachments.length : undefined,
       }
       if (state.status === "completed") {
-        const auth = parseToolAuthorization(part.tool, state.output)
+        const auth = parseToolAuthorization(
+          part.tool,
+          typeof state.output === "string" ? redactConnectorOutput(state.output) : state.output,
+        )
         if (auth) {
           tool.authorization = auth
         }

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -442,10 +442,10 @@ describe("AgentManager", () => {
       const settingsPath = path.join(rootDir, "oo-store", "config", "settings.toml")
 
       await manager.setTeamName("acme-corp")
-      await expect(readFile(settingsPath, "utf8")).resolves.toContain('team = "acme-corp"')
+      await expect(readFile(settingsPath, "utf8")).resolves.toContain('organization = "acme-corp"')
 
       await manager.setTeamName(undefined)
-      await expect(readFile(settingsPath, "utf8")).resolves.not.toContain("team =")
+      await expect(readFile(settingsPath, "utf8")).resolves.not.toContain("organization =")
     } finally {
       await rm(rootDir, { force: true, recursive: true })
     }
@@ -586,8 +586,8 @@ describe("AgentManager", () => {
       expect(settings).toContain("[skills.recommend]")
       expect(settings).toContain("muted = true")
       expect(settings).toContain("[identity]")
-      expect(settings).toContain('team = "team \\"quoted\\""')
-      expect(settings).not.toContain("organization =")
+      expect(settings).toContain('organization = "team \\"quoted\\""')
+      expect(settings).not.toContain("\nteam =")
       expect(settings).toContain('note = "keep"')
     } finally {
       await rm(rootDir, { force: true, recursive: true })

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -31,6 +31,18 @@ describe("AgentManager", () => {
         state: { input: { command: "printf 'password = \"example\"\\n'" } },
       }),
     ).toBe(false)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: "printf 'oo connector run demo'" } },
+      }),
+    ).toBe(false)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: "bash -lc 'oo connector apps posthog --json'" } },
+      }),
+    ).toBe(true)
     expect(isPersistedConnectorToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
   })
 

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -43,6 +43,24 @@ describe("AgentManager", () => {
         state: { input: { command: "bash -lc 'oo connector apps posthog --json'" } },
       }),
     ).toBe(true)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: `printf '%s\\n' "$(oo connector run demo)"` } },
+      }),
+    ).toBe(true)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: `printf '%s\\n' '$(oo connector run demo)'` } },
+      }),
+    ).toBe(false)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: `connector_data="$(oo connector apps posthog --json)"` } },
+      }),
+    ).toBe(true)
     expect(isPersistedConnectorToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
   })
 

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -61,6 +61,12 @@ describe("AgentManager", () => {
         state: { input: { command: `connector_data="$(oo connector apps posthog --json)"` } },
       }),
     ).toBe(true)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: "# $(oo connector run demo)" } },
+      }),
+    ).toBe(false)
     expect(isPersistedConnectorToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
   })
 

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -7,6 +7,7 @@ import {
   buildAgentSidecarEnv,
   buildArtifactSystem,
   buildWorkspaceIdentitySystem,
+  isPersistedConnectorToolPart,
   isUserVisibleSession,
 } from "./manager.ts"
 
@@ -16,6 +17,23 @@ afterEach(() => {
 })
 
 describe("AgentManager", () => {
+  it("limits persisted redaction to connector executions", () => {
+    expect(isPersistedConnectorToolPart({ tool: "call_action" })).toBe(true)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: "oo --lang zh connector run posthog --action list_projects --json" } },
+      }),
+    ).toBe(true)
+    expect(
+      isPersistedConnectorToolPart({
+        tool: "bash",
+        state: { input: { command: "printf 'password = \"example\"\\n'" } },
+      }),
+    ).toBe(false)
+    expect(isPersistedConnectorToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
+  })
+
   it("pins raw connector CLI guidance to the current team", () => {
     const system = buildWorkspaceIdentitySystem('team "quoted"')
     expect(system).toContain('team "team \\"quoted\\""')
@@ -442,10 +460,10 @@ describe("AgentManager", () => {
       const settingsPath = path.join(rootDir, "oo-store", "config", "settings.toml")
 
       await manager.setTeamName("acme-corp")
-      await expect(readFile(settingsPath, "utf8")).resolves.toContain('organization = "acme-corp"')
+      await expect(readFile(settingsPath, "utf8")).resolves.toContain('team = "acme-corp"')
 
       await manager.setTeamName(undefined)
-      await expect(readFile(settingsPath, "utf8")).resolves.not.toContain("organization =")
+      await expect(readFile(settingsPath, "utf8")).resolves.not.toContain("team =")
     } finally {
       await rm(rootDir, { force: true, recursive: true })
     }
@@ -586,8 +604,8 @@ describe("AgentManager", () => {
       expect(settings).toContain("[skills.recommend]")
       expect(settings).toContain("muted = true")
       expect(settings).toContain("[identity]")
-      expect(settings).toContain('organization = "team \\"quoted\\""')
-      expect(settings).not.toContain("\nteam =")
+      expect(settings).toContain('team = "team \\"quoted\\""')
+      expect(settings).not.toContain("organization =")
       expect(settings).toContain('note = "keep"')
     } finally {
       await rm(rootDir, { force: true, recursive: true })

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -27,6 +27,12 @@ import { pathToFileURL } from "node:url"
 import { ActivityMetrics } from "../activity-metrics.ts"
 import { atomicWriteText } from "../atomic-file.ts"
 import { branding } from "../branding.ts"
+import {
+  effectiveShellCommandWords,
+  shellCommandName,
+  shellWords,
+  topLevelShellSegments,
+} from "../chat/shell-syntax.ts"
 import { resolveUserCommandPath } from "../command-path.ts"
 import { logDiagnostic } from "../diagnostics-log.ts"
 import { connectorBaseUrl, llmBaseUrl } from "../domain.ts"
@@ -37,7 +43,7 @@ import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
 import { normalizeMessage, normalizePermissionRequest, normalizeQuestionRequest } from "./event-translator.ts"
 import { normalizeWantaAgentMode } from "./mode.ts"
 import { ensureOoGuardCommandBin } from "./oo-guard-bin.ts"
-import { redactConnectorOutput } from "./oo-guard-core.ts"
+import { isConnectorBusinessCommand, redactConnectorOutput } from "./oo-guard-core.ts"
 import { writeOoIdentitySettings } from "./oo-identity.ts"
 import { buildAgentLinkEnv } from "./oo.ts"
 import { managedPythonEnvironmentPath, managedPythonExecutable } from "./python-environment.ts"
@@ -314,8 +320,40 @@ export function isUserVisibleSession(session: RawSession): boolean {
 }
 
 const persistedConnectorToolNames = new Set(["call_action", "list_apps", "search_actions"])
-const shellConnectorCommandPattern =
-  /(?:^|[\s;&|()])(?:oo|["']?\$\{?WANTA_OO_BIN\}?["']?)\s+(?:(?:--debug|-h|--help|-V|--version)\s+|--lang(?:=\S+|\s+\S+)\s+)*connector(?:\s|$)/u
+const maxConnectorShellDepth = 4
+
+function isOoCommandWord(word: string | undefined): boolean {
+  return word === "oo" || word === "$WANTA_OO_BIN" || word === "${WANTA_OO_BIN}" || shellCommandName(word) === "oo"
+}
+
+function nestedShellCommand(words: readonly string[]): string | undefined {
+  const executable = shellCommandName(words[0])
+  if (["bash", "dash", "fish", "ksh", "sh", "zsh"].includes(executable ?? "")) {
+    const optionIndex = words.findIndex((word, index) => index > 0 && /^-[A-Za-z]*c[A-Za-z]*$/u.test(word))
+    return optionIndex >= 0 ? words[optionIndex + 1] : undefined
+  }
+  if (executable === "cmd" || executable === "cmd.exe") {
+    const optionIndex = words.findIndex((word, index) => index > 0 && /^\/[ck]$/iu.test(word))
+    return optionIndex >= 0 ? words.slice(optionIndex + 1).join(" ") : undefined
+  }
+  if (["powershell", "powershell.exe", "pwsh", "pwsh.exe"].includes(executable ?? "")) {
+    const optionIndex = words.findIndex((word, index) => index > 0 && /^-(?:c|command)$/iu.test(word))
+    return optionIndex >= 0 ? words.slice(optionIndex + 1).join(" ") : undefined
+  }
+  return undefined
+}
+
+function shellExecutesConnectorBusinessCommand(command: string, depth = 0): boolean {
+  if (depth >= maxConnectorShellDepth) return false
+  return topLevelShellSegments(command).some(({ text }) => {
+    const parsed = shellWords(text)
+    if (!parsed?.length) return false
+    const words = effectiveShellCommandWords(parsed)
+    if (isOoCommandWord(words[0])) return isConnectorBusinessCommand(words.slice(1))
+    const nested = nestedShellCommand(words)
+    return nested ? shellExecutesConnectorBusinessCommand(nested, depth + 1) : false
+  })
+}
 
 export function isPersistedConnectorToolPart(part: { state?: { input?: unknown }; tool?: unknown }): boolean {
   if (typeof part.tool !== "string") return false
@@ -324,7 +362,7 @@ export function isPersistedConnectorToolPart(part: { state?: { input?: unknown }
   const input = part.state?.input
   if (!input || typeof input !== "object") return false
   const command = (input as { command?: unknown }).command
-  return typeof command === "string" && shellConnectorCommandPattern.test(command)
+  return typeof command === "string" && shellExecutesConnectorBusinessCommand(command)
 }
 
 /** Agent 内核管理器：编排 OpenCode sidecar + 非编码 agent + 自定义连接器工具。electron-free，便于 headless 测试。 */

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -343,8 +343,73 @@ function nestedShellCommand(words: readonly string[]): string | undefined {
   return undefined
 }
 
+function executableCommandSubstitutions(command: string): string[] {
+  const substitutions: string[] = []
+  let singleQuoted = false
+  let doubleQuoted = false
+  let escaped = false
+
+  for (let index = 0; index < command.length - 1; index += 1) {
+    const char = command[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === "\\" && !singleQuoted) {
+      escaped = true
+      continue
+    }
+    if (char === "'" && !doubleQuoted) {
+      singleQuoted = !singleQuoted
+      continue
+    }
+    if (char === '"' && !singleQuoted) {
+      doubleQuoted = !doubleQuoted
+      continue
+    }
+    if (singleQuoted || char !== "$" || command[index + 1] !== "(") continue
+
+    const bodyStart = index + 2
+    let depth = 1
+    let bodySingleQuoted = false
+    let bodyDoubleQuoted = false
+    let bodyEscaped = false
+    for (let bodyIndex = bodyStart; bodyIndex < command.length; bodyIndex += 1) {
+      const bodyChar = command[bodyIndex]
+      if (bodyEscaped) {
+        bodyEscaped = false
+        continue
+      }
+      if (bodyChar === "\\" && !bodySingleQuoted) {
+        bodyEscaped = true
+        continue
+      }
+      if (bodyChar === "'" && !bodyDoubleQuoted) {
+        bodySingleQuoted = !bodySingleQuoted
+        continue
+      }
+      if (bodyChar === '"' && !bodySingleQuoted) {
+        bodyDoubleQuoted = !bodyDoubleQuoted
+        continue
+      }
+      if (bodySingleQuoted || bodyDoubleQuoted) continue
+      if (bodyChar === "(") depth += 1
+      if (bodyChar !== ")") continue
+      depth -= 1
+      if (depth > 0) continue
+      substitutions.push(command.slice(bodyStart, bodyIndex))
+      index = bodyIndex
+      break
+    }
+  }
+  return substitutions
+}
+
 function shellExecutesConnectorBusinessCommand(command: string, depth = 0): boolean {
   if (depth >= maxConnectorShellDepth) return false
+  if (executableCommandSubstitutions(command).some((body) => shellExecutesConnectorBusinessCommand(body, depth + 1))) {
+    return true
+  }
   return topLevelShellSegments(command).some(({ text }) => {
     const parsed = shellWords(text)
     if (!parsed?.length) return false

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -313,6 +313,20 @@ export function isUserVisibleSession(session: RawSession): boolean {
   return !(session.parentID || session.parentId || session.parent_id)
 }
 
+const persistedConnectorToolNames = new Set(["call_action", "list_apps", "search_actions"])
+const shellConnectorCommandPattern =
+  /(?:^|[\s;&|()])(?:oo|["']?\$\{?WANTA_OO_BIN\}?["']?)\s+(?:(?:--debug|-h|--help|-V|--version)\s+|--lang(?:=\S+|\s+\S+)\s+)*connector(?:\s|$)/u
+
+export function isPersistedConnectorToolPart(part: { state?: { input?: unknown }; tool?: unknown }): boolean {
+  if (typeof part.tool !== "string") return false
+  if (persistedConnectorToolNames.has(part.tool)) return true
+  if (part.tool !== "bash" && part.tool !== "shell") return false
+  const input = part.state?.input
+  if (!input || typeof input !== "object") return false
+  const command = (input as { command?: unknown }).command
+  return typeof command === "string" && shellConnectorCommandPattern.test(command)
+}
+
 /** Agent 内核管理器：编排 OpenCode sidecar + 非编码 agent + 自定义连接器工具。electron-free，便于 headless 测试。 */
 export class AgentManager {
   private options: AgentManagerOptions
@@ -469,7 +483,7 @@ export class AgentManager {
     this.disposed = false
     await this.prepareWorkspace()
     await this.startSidecar()
-    await this.scrubPersistedConnectorOutputs().catch((error: unknown) => {
+    void this.scrubPersistedConnectorOutputs().catch((error: unknown) => {
       console.warn("[wanta] failed to scrub persisted connector outputs:", error)
       logDiagnostic("agent", "persisted connector output scrub failed", { error }, "warn")
     })
@@ -477,7 +491,7 @@ export class AgentManager {
 
   /** One-time defense for tool outputs saved before the managed oo guard existed. */
   private async scrubPersistedConnectorOutputs(): Promise<void> {
-    if (!this.sidecar) return
+    if (!this.sidecar || this.disposed) return
     const markerPath = path.join(this.options.rootDir, ".connector-output-redaction-v1")
     try {
       await readFile(markerPath, "utf8")
@@ -490,11 +504,13 @@ export class AgentManager {
     assertOpencodeSuccess(sessionsResult, "session.list for connector output scrub")
     let redactedPartCount = 0
     for (const session of sessionsResult.data ?? []) {
+      if (this.disposed) return
       const messagesResult = await this.client.session.messages({ sessionID: session.id, limit: 10_000 })
       assertOpencodeSuccess(messagesResult, "session.messages for connector output scrub")
       for (const message of messagesResult.data ?? []) {
         for (const part of message.parts) {
           if (part.type !== "tool" || part.state.status !== "completed") continue
+          if (!isPersistedConnectorToolPart(part)) continue
           const output = redactConnectorOutput(part.state.output)
           if (output === part.state.output) continue
           const updatedPart: OpencodePart = { ...part, state: { ...part.state, output } }
@@ -509,6 +525,7 @@ export class AgentManager {
         }
       }
     }
+    if (this.disposed) return
     await atomicWriteText(markerPath, JSON.stringify({ redactedPartCount, version: 1 }))
     logDiagnostic("agent", "persisted connector output scrub completed", { redactedPartCount })
   }
@@ -566,12 +583,11 @@ export class AgentManager {
     })
     let managedOoBinPath = ooBinPath
     if (linkRuntime && ooBinPath && ooGuardCliPath) {
-      await ensureOoGuardCommandBin({
+      managedOoBinPath = await ensureOoGuardCommandBin({
         binDir: commandBinDir,
         nodeBin: process.execPath,
         ooGuardCliPath,
       })
-      managedOoBinPath = path.join(commandBinDir, process.platform === "win32" ? "oo.cmd" : "oo")
     }
     if (wikiGraphCliPath && wikiGraphStateDir) {
       await ensureWikiGraphCommandBin({

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -12,11 +12,16 @@ import type { RuntimeCustomModel } from "../models/store.ts"
 import type { LinkRuntime, ModelAccess } from "../runtime/agent-runtime.ts"
 import type { GenerateSessionTitleRequest, SessionInfo } from "../session/common.ts"
 import type { GeneratedSessionTitle } from "./session-title-generator.ts"
-import type { FilePartInput, SessionPromptAsyncData, TextPartInput } from "@opencode-ai/sdk/v2/client"
+import type {
+  FilePartInput,
+  Part as OpencodePart,
+  SessionPromptAsyncData,
+  TextPartInput,
+} from "@opencode-ai/sdk/v2/client"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 
 import { randomBytes, randomUUID } from "node:crypto"
-import { lstat, mkdir, realpath } from "node:fs/promises"
+import { lstat, mkdir, readFile, realpath } from "node:fs/promises"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { ActivityMetrics } from "../activity-metrics.ts"
@@ -31,6 +36,8 @@ import { buildOpencodeConfig, customProviderId, WANTA_MODEL_ID, WANTA_PROVIDER_I
 import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
 import { normalizeMessage, normalizePermissionRequest, normalizeQuestionRequest } from "./event-translator.ts"
 import { normalizeWantaAgentMode } from "./mode.ts"
+import { ensureOoGuardCommandBin } from "./oo-guard-bin.ts"
+import { redactConnectorOutput } from "./oo-guard-core.ts"
 import { writeOoIdentitySettings } from "./oo-identity.ts"
 import { buildAgentLinkEnv } from "./oo.ts"
 import { managedPythonEnvironmentPath, managedPythonExecutable } from "./python-environment.ts"
@@ -50,6 +57,8 @@ export interface AgentManagerOptions {
   opencodeBinPath: string
   /** The oo binary is resolved and injected only when a Link runtime is configured. */
   ooBinPath?: string
+  /** Electron-as-Node entrypoint that scopes and redacts Agent-side oo business calls. */
+  ooGuardCliPath?: string
   /** Wanta-owned WikiGraph CLI entrypoint used by the sidecar PATH `wg` shim. */
   wikiGraphCliPath?: string
   wikiGraphStateDir?: string
@@ -460,6 +469,48 @@ export class AgentManager {
     this.disposed = false
     await this.prepareWorkspace()
     await this.startSidecar()
+    await this.scrubPersistedConnectorOutputs().catch((error: unknown) => {
+      console.warn("[wanta] failed to scrub persisted connector outputs:", error)
+      logDiagnostic("agent", "persisted connector output scrub failed", { error }, "warn")
+    })
+  }
+
+  /** One-time defense for tool outputs saved before the managed oo guard existed. */
+  private async scrubPersistedConnectorOutputs(): Promise<void> {
+    if (!this.sidecar) return
+    const markerPath = path.join(this.options.rootDir, ".connector-output-redaction-v1")
+    try {
+      await readFile(markerPath, "utf8")
+      return
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+    }
+
+    const sessionsResult = await this.client.session.list({ limit: 10_000, roots: false })
+    assertOpencodeSuccess(sessionsResult, "session.list for connector output scrub")
+    let redactedPartCount = 0
+    for (const session of sessionsResult.data ?? []) {
+      const messagesResult = await this.client.session.messages({ sessionID: session.id, limit: 10_000 })
+      assertOpencodeSuccess(messagesResult, "session.messages for connector output scrub")
+      for (const message of messagesResult.data ?? []) {
+        for (const part of message.parts) {
+          if (part.type !== "tool" || part.state.status !== "completed") continue
+          const output = redactConnectorOutput(part.state.output)
+          if (output === part.state.output) continue
+          const updatedPart: OpencodePart = { ...part, state: { ...part.state, output } }
+          const updateResult = await this.client.part.update({
+            sessionID: part.sessionID,
+            messageID: part.messageID,
+            partID: part.id,
+            part: updatedPart,
+          })
+          assertOpencodeSuccess(updateResult, "part.update for connector output scrub")
+          redactedPartCount += 1
+        }
+      }
+    }
+    await atomicWriteText(markerPath, JSON.stringify({ redactedPartCount, version: 1 }))
+    logDiagnostic("agent", "persisted connector output scrub completed", { redactedPartCount })
   }
 
   private async prepareWorkspace(): Promise<void> {
@@ -482,6 +533,7 @@ export class AgentManager {
       modelAccess,
       opencodeBinPath,
       ooBinPath,
+      ooGuardCliPath,
       rootDir,
       disableServerAuth,
       customModels,
@@ -512,6 +564,15 @@ export class AgentManager {
       larkCliBinPath,
       wecomCliBinPath,
     })
+    let managedOoBinPath = ooBinPath
+    if (linkRuntime && ooBinPath && ooGuardCliPath) {
+      await ensureOoGuardCommandBin({
+        binDir: commandBinDir,
+        nodeBin: process.execPath,
+        ooGuardCliPath,
+      })
+      managedOoBinPath = path.join(commandBinDir, process.platform === "win32" ? "oo.cmd" : "oo")
+    }
     if (wikiGraphCliPath && wikiGraphStateDir) {
       await ensureWikiGraphCommandBin({
         binDir: commandBinDir,
@@ -526,7 +587,7 @@ export class AgentManager {
       browserControl,
       commandPath,
       linkRuntime,
-      ooBinPath,
+      ooBinPath: managedOoBinPath,
       storeDir,
       teamName: this.teamName,
       teamScopePath,
@@ -539,6 +600,9 @@ export class AgentManager {
       dingTalkCliConfigDir,
       dingTalkCliKeychainDir,
     })
+    if (linkRuntime && ooBinPath && managedOoBinPath !== ooBinPath) {
+      env.WANTA_REAL_OO_BIN = ooBinPath
+    }
 
     const sidecar = new OpencodeSidecar({
       opencodeBinPath,
@@ -1280,7 +1344,10 @@ export function buildWorkspaceIdentitySystem(teamName?: string): string {
   if (!normalizedTeamName) {
     throw new Error("Team workspace identity is unavailable")
   }
-  return `Current-turn Link workspace: team ${JSON.stringify(normalizedTeamName)}; raw oo selector: --team ${JSON.stringify(normalizedTeamName)}.`
+  return (
+    `Current-turn Link workspace: team ${JSON.stringify(normalizedTeamName)}; raw oo selector: --team ${JSON.stringify(normalizedTeamName)}. ` +
+    `Every bare OOMOL oo connector apps/run command MUST keep that exact selector. Never interpret an unscoped connector error as proof that this workspace is disconnected; retry once with the exact selector or use the session-scoped Link tools.`
+  )
 }
 
 async function buildPromptParts(

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -343,6 +343,49 @@ function nestedShellCommand(words: readonly string[]): string | undefined {
   return undefined
 }
 
+function shellWithoutComments(command: string): string {
+  let result = ""
+  let singleQuoted = false
+  let doubleQuoted = false
+  let escaped = false
+  let atWordStart = true
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index] ?? ""
+    if (escaped) {
+      result += char
+      escaped = false
+      atWordStart = false
+      continue
+    }
+    if (char === "\\" && !singleQuoted) {
+      result += char
+      escaped = true
+      atWordStart = false
+      continue
+    }
+    if (char === "'" && !doubleQuoted) {
+      result += char
+      singleQuoted = !singleQuoted
+      atWordStart = false
+      continue
+    }
+    if (char === '"' && !singleQuoted) {
+      result += char
+      doubleQuoted = !doubleQuoted
+      atWordStart = false
+      continue
+    }
+    if (!singleQuoted && !doubleQuoted && char === "#" && atWordStart) {
+      while (index + 1 < command.length && !/[\r\n]/u.test(command[index + 1] ?? "")) index += 1
+      continue
+    }
+    result += char
+    atWordStart = !singleQuoted && !doubleQuoted && /[\s;&|()<>]/u.test(char)
+  }
+  return result
+}
+
 function executableCommandSubstitutions(command: string): string[] {
   const substitutions: string[] = []
   let singleQuoted = false
@@ -407,10 +450,15 @@ function executableCommandSubstitutions(command: string): string[] {
 
 function shellExecutesConnectorBusinessCommand(command: string, depth = 0): boolean {
   if (depth >= maxConnectorShellDepth) return false
-  if (executableCommandSubstitutions(command).some((body) => shellExecutesConnectorBusinessCommand(body, depth + 1))) {
+  const executableCommand = shellWithoutComments(command)
+  if (
+    executableCommandSubstitutions(executableCommand).some((body) =>
+      shellExecutesConnectorBusinessCommand(body, depth + 1),
+    )
+  ) {
     return true
   }
-  return topLevelShellSegments(command).some(({ text }) => {
+  return topLevelShellSegments(executableCommand).some(({ text }) => {
     const parsed = shellWords(text)
     if (!parsed?.length) return false
     const words = effectiveShellCommandWords(parsed)

--- a/electron/agent/oo-guard-bin.test.ts
+++ b/electron/agent/oo-guard-bin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
@@ -14,29 +14,37 @@ describe("managed oo command shim", () => {
   test("creates a POSIX launcher through Electron's Node mode", async () => {
     const binDir = await mkdtemp(path.join(tmpdir(), "wanta-oo-guard-"))
     roots.push(binDir)
-    await ensureOoGuardCommandBin({
+    const commandPath = await ensureOoGuardCommandBin({
       binDir,
-      nodeBin: "/Applications/Wanta.app/Contents/MacOS/Wanta",
+      nodeBin: "/Applications/Wanta's.app/Contents/MacOS/Wanta",
       ooGuardCliPath: "/Applications/Wanta.app/Contents/Resources/app.asar/dist-electron/wanta-oo-guard.js",
       platform: "darwin",
     })
-    const source = await readFile(path.join(binDir, "oo"), "utf8")
+    const source = await readFile(commandPath, "utf8")
+    expect(commandPath).toBe(path.join(binDir, "oo"))
     expect(source).toContain("ELECTRON_RUN_AS_NODE=1")
     expect(source).toContain("wanta-oo-guard.js")
+    expect(source).toContain("Wanta'\\''s.app")
     expect(source).toContain('"$@"')
+    if (process.platform !== "win32") {
+      expect((await stat(commandPath)).mode & 0o777).toBe(0o755)
+    }
   })
 
   test("creates a Windows cmd launcher", async () => {
     const binDir = await mkdtemp(path.join(tmpdir(), "wanta-oo-guard-"))
     roots.push(binDir)
-    await ensureOoGuardCommandBin({
+    const commandPath = await ensureOoGuardCommandBin({
       binDir,
       nodeBin: "C:\\Wanta\\Wanta.exe",
       ooGuardCliPath: "C:\\Wanta\\resources\\wanta-oo-guard.js",
       platform: "win32",
     })
-    const source = await readFile(path.join(binDir, "oo.cmd"), "utf8")
+    const source = await readFile(commandPath, "utf8")
+    expect(commandPath).toBe(path.join(binDir, "oo.cmd"))
+    expect(source).toContain("setlocal")
     expect(source).toContain("set ELECTRON_RUN_AS_NODE=1")
     expect(source).toContain("%*")
+    expect(source).toContain("endlocal & exit /b %ERRORLEVEL%")
   })
 })

--- a/electron/agent/oo-guard-bin.test.ts
+++ b/electron/agent/oo-guard-bin.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+import { ensureOoGuardCommandBin } from "./oo-guard-bin.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
+})
+
+describe("managed oo command shim", () => {
+  test("creates a POSIX launcher through Electron's Node mode", async () => {
+    const binDir = await mkdtemp(path.join(tmpdir(), "wanta-oo-guard-"))
+    roots.push(binDir)
+    await ensureOoGuardCommandBin({
+      binDir,
+      nodeBin: "/Applications/Wanta.app/Contents/MacOS/Wanta",
+      ooGuardCliPath: "/Applications/Wanta.app/Contents/Resources/app.asar/dist-electron/wanta-oo-guard.js",
+      platform: "darwin",
+    })
+    const source = await readFile(path.join(binDir, "oo"), "utf8")
+    expect(source).toContain("ELECTRON_RUN_AS_NODE=1")
+    expect(source).toContain("wanta-oo-guard.js")
+    expect(source).toContain('"$@"')
+  })
+
+  test("creates a Windows cmd launcher", async () => {
+    const binDir = await mkdtemp(path.join(tmpdir(), "wanta-oo-guard-"))
+    roots.push(binDir)
+    await ensureOoGuardCommandBin({
+      binDir,
+      nodeBin: "C:\\Wanta\\Wanta.exe",
+      ooGuardCliPath: "C:\\Wanta\\resources\\wanta-oo-guard.js",
+      platform: "win32",
+    })
+    const source = await readFile(path.join(binDir, "oo.cmd"), "utf8")
+    expect(source).toContain("set ELECTRON_RUN_AS_NODE=1")
+    expect(source).toContain("%*")
+  })
+})

--- a/electron/agent/oo-guard-bin.ts
+++ b/electron/agent/oo-guard-bin.ts
@@ -1,0 +1,44 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+export interface OoGuardCommandBinOptions {
+  binDir: string
+  nodeBin: string
+  ooGuardCliPath: string
+  platform?: NodeJS.Platform
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+export async function ensureOoGuardCommandBin({
+  binDir,
+  nodeBin,
+  ooGuardCliPath,
+  platform = process.platform,
+}: OoGuardCommandBinOptions): Promise<string> {
+  await mkdir(binDir, { recursive: true })
+  if (platform === "win32") {
+    await writeFile(
+      path.join(binDir, "oo.cmd"),
+      ["@echo off", "set ELECTRON_RUN_AS_NODE=1", `"${nodeBin}" "${ooGuardCliPath}" %*`, ""].join("\r\n"),
+      "utf8",
+    )
+    return binDir
+  }
+
+  const commandPath = path.join(binDir, "oo")
+  await writeFile(
+    commandPath,
+    [
+      "#!/bin/sh",
+      "export ELECTRON_RUN_AS_NODE=1",
+      `exec ${shellQuote(nodeBin)} ${shellQuote(ooGuardCliPath)} "$@"`,
+      "",
+    ].join("\n"),
+    "utf8",
+  )
+  await chmod(commandPath, 0o755)
+  return binDir
+}

--- a/electron/agent/oo-guard-bin.ts
+++ b/electron/agent/oo-guard-bin.ts
@@ -20,12 +20,20 @@ export async function ensureOoGuardCommandBin({
 }: OoGuardCommandBinOptions): Promise<string> {
   await mkdir(binDir, { recursive: true })
   if (platform === "win32") {
+    const commandPath = path.join(binDir, "oo.cmd")
     await writeFile(
-      path.join(binDir, "oo.cmd"),
-      ["@echo off", "set ELECTRON_RUN_AS_NODE=1", `"${nodeBin}" "${ooGuardCliPath}" %*`, ""].join("\r\n"),
+      commandPath,
+      [
+        "@echo off",
+        "setlocal",
+        "set ELECTRON_RUN_AS_NODE=1",
+        `"${nodeBin}" "${ooGuardCliPath}" %*`,
+        "endlocal & exit /b %ERRORLEVEL%",
+        "",
+      ].join("\r\n"),
       "utf8",
     )
-    return binDir
+    return commandPath
   }
 
   const commandPath = path.join(binDir, "oo")
@@ -40,5 +48,5 @@ export async function ensureOoGuardCommandBin({
     "utf8",
   )
   await chmod(commandPath, 0o755)
-  return binDir
+  return commandPath
 }

--- a/electron/agent/oo-guard-core.test.ts
+++ b/electron/agent/oo-guard-core.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import { describe, test } from "vitest"
+import {
+  bindOomolWorkspace,
+  hasWorkspaceSelector,
+  isConnectorBusinessCommand,
+  redactConnectorOutput,
+  resolveGuardWorkspaceTeam,
+} from "./oo-guard-core.ts"
+
+describe("OOMOL connector workspace guard", () => {
+  test("binds bare connector business commands to the active team", () => {
+    assert.deepEqual(bindOomolWorkspace(["connector", "apps", "posthog", "--json"], "OOMOL-Internal"), [
+      "connector",
+      "apps",
+      "posthog",
+      "--json",
+      "--team",
+      "OOMOL-Internal",
+    ])
+    assert.deepEqual(bindOomolWorkspace(["connector", "run", "posthog", "--action", "list_projects"], "team-a"), [
+      "connector",
+      "run",
+      "posthog",
+      "--action",
+      "list_projects",
+      "--team",
+      "team-a",
+    ])
+  })
+
+  test("preserves explicit selectors and identity-independent commands", () => {
+    const explicit = ["connector", "run", "posthog", "--team", "team-a"]
+    assert.deepEqual(bindOomolWorkspace(explicit, "team-b"), explicit)
+    assert.deepEqual(bindOomolWorkspace(["connector", "schema", "posthog"], "team-a"), [
+      "connector",
+      "schema",
+      "posthog",
+    ])
+    assert.equal(hasWorkspaceSelector(["connector", "apps", "--personal"]), true)
+    assert.equal(isConnectorBusinessCommand(["connector", "search", "posthog"]), false)
+  })
+
+  test("fails closed when a business command has no usable team", () => {
+    assert.throws(() => bindOomolWorkspace(["connector", "run", "posthog"], " "), /without an active team workspace/u)
+  })
+
+  test("prefers the sole active session workspace over a stale default", () => {
+    assert.equal(
+      resolveGuardWorkspaceTeam({ teamName: "old-team", sessionTeams: { "session-1": "new-team" } }),
+      "new-team",
+    )
+    assert.equal(
+      resolveGuardWorkspaceTeam({
+        teamName: "old-team",
+        sessionTeams: { "session-1": "new-team", "session-2": "new-team" },
+      }),
+      "new-team",
+    )
+  })
+
+  test("fails closed instead of guessing between active session workspaces", () => {
+    assert.throws(
+      () =>
+        resolveGuardWorkspaceTeam({
+          teamName: "team-a",
+          sessionTeams: { "session-1": "team-a", "session-2": "team-b" },
+        }),
+      /active sessions use different workspaces/u,
+    )
+    assert.throws(
+      () => bindOomolWorkspace(["connector", "apps"], resolveGuardWorkspaceTeam({ sessionTeams: { local: "" } })),
+      /without an active team workspace/u,
+    )
+  })
+})
+
+describe("connector output redaction", () => {
+  test("recursively redacts credential fields while preserving business data", () => {
+    const output = redactConnectorOutput(
+      `${JSON.stringify({
+        data: {
+          api_token: "phc_public-looking-but-sensitive",
+          id: 173107,
+          nested: { accessToken: "access", secret_api_token: "private" },
+          name: "CLI",
+        },
+      })}\n`,
+    )
+    assert.deepEqual(JSON.parse(output), {
+      data: {
+        api_token: "[redacted]",
+        id: 173107,
+        nested: { accessToken: "[redacted]", secret_api_token: "[redacted]" },
+        name: "CLI",
+      },
+    })
+  })
+
+  test("redacts credential fields from non-JSON errors", () => {
+    const output = redactConnectorOutput('request failed api_token="secret value", password=hunter2')
+    assert.equal(output.includes("secret value"), false)
+    assert.equal(output.includes("hunter2"), false)
+    assert.match(output, /api_token=\[redacted\]/u)
+    assert.match(output, /password=\[redacted\]/u)
+  })
+})

--- a/electron/agent/oo-guard-core.test.ts
+++ b/electron/agent/oo-guard-core.test.ts
@@ -41,6 +41,26 @@ describe("OOMOL connector workspace guard", () => {
     assert.equal(isConnectorBusinessCommand(["connector", "search", "posthog"]), false)
   })
 
+  test("parses documented global options and inserts selectors before the argument terminator", () => {
+    const args = ["--lang", "zh", "--debug", "connector", "run", "posthog", "--", "--team", "payload"]
+    assert.equal(isConnectorBusinessCommand(args), true)
+    assert.equal(hasWorkspaceSelector(args), false)
+    assert.deepEqual(bindOomolWorkspace(args, "team-a"), [
+      "--lang",
+      "zh",
+      "--debug",
+      "connector",
+      "run",
+      "posthog",
+      "--team",
+      "team-a",
+      "--",
+      "--team",
+      "payload",
+    ])
+    assert.equal(hasWorkspaceSelector(["--lang=en", "connector", "apps", "--team=team-a"]), true)
+  })
+
   test("fails closed when a business command has no usable team", () => {
     assert.throws(() => bindOomolWorkspace(["connector", "run", "posthog"], " "), /without an active team workspace/u)
   })
@@ -48,6 +68,13 @@ describe("OOMOL connector workspace guard", () => {
   test("prefers the sole active session workspace over a stale default", () => {
     assert.equal(
       resolveGuardWorkspaceTeam({ teamName: "old-team", sessionTeams: { "session-1": "new-team" } }),
+      "new-team",
+    )
+    assert.equal(
+      resolveGuardWorkspaceTeam({
+        teamName: "workspace-default",
+        sessionTeams: { local: "", "session-1": "new-team" },
+      }),
       "new-team",
     )
     assert.equal(
@@ -82,7 +109,13 @@ describe("connector output redaction", () => {
         data: {
           api_token: "phc_public-looking-but-sensitive",
           id: 173107,
-          nested: { accessToken: "access", secret_api_token: "private" },
+          nested: {
+            accessToken: "access",
+            APIKey: "uppercase-acronym",
+            posthog_api_key: "vendor-prefixed",
+            secret_api_token: "private",
+            "x-api-key": "header-style",
+          },
           name: "CLI",
         },
       })}\n`,
@@ -91,17 +124,32 @@ describe("connector output redaction", () => {
       data: {
         api_token: "[redacted]",
         id: 173107,
-        nested: { accessToken: "[redacted]", secret_api_token: "[redacted]" },
+        nested: {
+          accessToken: "[redacted]",
+          APIKey: "[redacted]",
+          posthog_api_key: "[redacted]",
+          secret_api_token: "[redacted]",
+          "x-api-key": "[redacted]",
+        },
         name: "CLI",
       },
     })
   })
 
   test("redacts credential fields from non-JSON errors", () => {
-    const output = redactConnectorOutput('request failed api_token="secret value", password=hunter2')
+    const output = redactConnectorOutput(
+      'request failed api_token="secret value", password=hunter2 posthog_api_key=phc_secret x-api-key=header-secret',
+    )
     assert.equal(output.includes("secret value"), false)
     assert.equal(output.includes("hunter2"), false)
     assert.match(output, /api_token=\[redacted\]/u)
     assert.match(output, /password=\[redacted\]/u)
+    assert.match(output, /posthog_api_key=\[redacted\]/u)
+    assert.match(output, /x-api-key=\[redacted\]/u)
+  })
+
+  test("leaves output without credentials byte-for-byte unchanged", () => {
+    const output = `{\n  "data": {\n    "id": 173107,\n    "name": "CLI"\n  }\n}\n`
+    assert.equal(redactConnectorOutput(output), output)
   })
 })

--- a/electron/agent/oo-guard-core.ts
+++ b/electron/agent/oo-guard-core.ts
@@ -18,13 +18,16 @@ const sensitiveConnectorKeys = new Set([
 function normalizedKey(value: string): string {
   return value
     .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/gu, "$1_$2")
     .replace(/([a-z0-9])([A-Z])/gu, "$1_$2")
     .toLowerCase()
     .replaceAll("-", "_")
 }
 
 export function isSensitiveConnectorKey(value: string): boolean {
-  return sensitiveConnectorKeys.has(normalizedKey(value))
+  const key = normalizedKey(value)
+  if (sensitiveConnectorKeys.has(key)) return true
+  return [...sensitiveConnectorKeys].some((sensitiveKey) => key.endsWith(`_${sensitiveKey}`))
 }
 
 function redactConnectorValue(value: unknown): unknown {
@@ -42,30 +45,57 @@ function redactConnectorValue(value: unknown): unknown {
   )
 }
 
-const sensitiveJsonFieldPattern =
-  /("(?:access[_-]?token|api[_-]?key|api[_-]?token|authorization|client[_-]?secret|cookie|credential|password|personal[_-]?api[_-]?key|refresh[_-]?token|secret|secret[_-]?api[_-]?token(?:[_-]?backup)?)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\r\n]+)/giu
+const jsonFieldPattern = /("((?:\\.|[^"\\])*)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\r\n]+)/gu
 const sensitiveAssignmentPattern =
-  /\b(access[_-]?token|api[_-]?key|api[_-]?token|authorization|client[_-]?secret|cookie|credential|password|personal[_-]?api[_-]?key|refresh[_-]?token|secret|secret[_-]?api[_-]?token(?:[_-]?backup)?)\s*[:=]\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)/giu
+  /([A-Za-z][A-Za-z0-9_-]*)\s*[:=]\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)/gu
 
 export function redactConnectorOutput(output: string): string {
   if (!output) return output
   const trailingNewline = output.endsWith("\n")
   try {
     const parsed = JSON.parse(output) as unknown
-    return `${JSON.stringify(redactConnectorValue(parsed))}${trailingNewline ? "\n" : ""}`
+    const redacted = redactConnectorValue(parsed)
+    if (JSON.stringify(redacted) === JSON.stringify(parsed)) return output
+    return `${JSON.stringify(redacted)}${trailingNewline ? "\n" : ""}`
   } catch {
     return output
-      .replace(sensitiveJsonFieldPattern, '$1"[redacted]"')
-      .replace(sensitiveAssignmentPattern, "$1=[redacted]")
+      .replace(jsonFieldPattern, (match, prefix: string, key: string) =>
+        isSensitiveConnectorKey(key) ? `${prefix}"[redacted]"` : match,
+      )
+      .replace(sensitiveAssignmentPattern, (match, key: string) =>
+        isSensitiveConnectorKey(key) ? `${key}=[redacted]` : match,
+      )
   }
 }
 
+function connectorCommandIndex(args: readonly string[]): number {
+  let index = 0
+  while (index < args.length) {
+    const arg = args[index] ?? ""
+    if (arg === "--lang") {
+      index += 2
+      continue
+    }
+    if (arg.startsWith("--lang=") || ["--debug", "-h", "--help", "-V", "--version"].includes(arg)) {
+      index += 1
+      continue
+    }
+    break
+  }
+  return args[index] === "connector" ? index : -1
+}
+
 export function isConnectorBusinessCommand(args: readonly string[]): boolean {
-  return args[0] === "connector" && connectorCommandsRequiringWorkspace.has(args[1] ?? "")
+  const connectorIndex = connectorCommandIndex(args)
+  return connectorIndex >= 0 && connectorCommandsRequiringWorkspace.has(args[connectorIndex + 1] ?? "")
 }
 
 export function hasWorkspaceSelector(args: readonly string[]): boolean {
-  return args.some(
+  const connectorIndex = connectorCommandIndex(args)
+  if (connectorIndex < 0) return false
+  const terminatorIndex = args.indexOf("--", connectorIndex + 2)
+  const commandArgs = args.slice(connectorIndex + 2, terminatorIndex < 0 ? undefined : terminatorIndex)
+  return commandArgs.some(
     (arg) =>
       arg === "--personal" ||
       arg === "--team" ||
@@ -85,7 +115,9 @@ export function bindOomolWorkspace(args: readonly string[], teamName: string): s
   if (!normalizedTeamName) {
     throw new Error("Wanta cannot run an OOMOL connector command without an active team workspace.")
   }
-  return [...args, "--team", normalizedTeamName]
+  const terminatorIndex = args.indexOf("--")
+  if (terminatorIndex < 0) return [...args, "--team", normalizedTeamName]
+  return [...args.slice(0, terminatorIndex), "--team", normalizedTeamName, ...args.slice(terminatorIndex)]
 }
 
 export interface WorkspaceTeamScope {
@@ -99,6 +131,7 @@ export function resolveGuardWorkspaceTeam(scope: WorkspaceTeamScope): string {
     const activeTeams = Object.values(scope.sessionTeams)
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
+      .filter(Boolean)
     if (activeTeams.length > 0) {
       const uniqueTeams = new Set(activeTeams)
       if (uniqueTeams.size > 1) {

--- a/electron/agent/oo-guard-core.ts
+++ b/electron/agent/oo-guard-core.ts
@@ -1,0 +1,113 @@
+const connectorCommandsRequiringWorkspace = new Set(["apps", "run"])
+const sensitiveConnectorKeys = new Set([
+  "access_token",
+  "api_key",
+  "api_token",
+  "authorization",
+  "client_secret",
+  "cookie",
+  "credential",
+  "password",
+  "personal_api_key",
+  "refresh_token",
+  "secret",
+  "secret_api_token",
+  "secret_api_token_backup",
+])
+
+function normalizedKey(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/gu, "$1_$2")
+    .toLowerCase()
+    .replaceAll("-", "_")
+}
+
+export function isSensitiveConnectorKey(value: string): boolean {
+  return sensitiveConnectorKeys.has(normalizedKey(value))
+}
+
+function redactConnectorValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactConnectorValue)
+  }
+  if (!value || typeof value !== "object") {
+    return value
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      isSensitiveConnectorKey(key) ? "[redacted]" : redactConnectorValue(item),
+    ]),
+  )
+}
+
+const sensitiveJsonFieldPattern =
+  /("(?:access[_-]?token|api[_-]?key|api[_-]?token|authorization|client[_-]?secret|cookie|credential|password|personal[_-]?api[_-]?key|refresh[_-]?token|secret|secret[_-]?api[_-]?token(?:[_-]?backup)?)"\s*:\s*)("(?:\\.|[^"\\])*"|[^,}\]\r\n]+)/giu
+const sensitiveAssignmentPattern =
+  /\b(access[_-]?token|api[_-]?key|api[_-]?token|authorization|client[_-]?secret|cookie|credential|password|personal[_-]?api[_-]?key|refresh[_-]?token|secret|secret[_-]?api[_-]?token(?:[_-]?backup)?)\s*[:=]\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;}\]]+)/giu
+
+export function redactConnectorOutput(output: string): string {
+  if (!output) return output
+  const trailingNewline = output.endsWith("\n")
+  try {
+    const parsed = JSON.parse(output) as unknown
+    return `${JSON.stringify(redactConnectorValue(parsed))}${trailingNewline ? "\n" : ""}`
+  } catch {
+    return output
+      .replace(sensitiveJsonFieldPattern, '$1"[redacted]"')
+      .replace(sensitiveAssignmentPattern, "$1=[redacted]")
+  }
+}
+
+export function isConnectorBusinessCommand(args: readonly string[]): boolean {
+  return args[0] === "connector" && connectorCommandsRequiringWorkspace.has(args[1] ?? "")
+}
+
+export function hasWorkspaceSelector(args: readonly string[]): boolean {
+  return args.some(
+    (arg) =>
+      arg === "--personal" ||
+      arg === "--team" ||
+      arg.startsWith("--team=") ||
+      arg === "--organization" ||
+      arg.startsWith("--organization=") ||
+      arg === "--org" ||
+      arg.startsWith("--org="),
+  )
+}
+
+export function bindOomolWorkspace(args: readonly string[], teamName: string): string[] {
+  const normalizedTeamName = teamName.trim()
+  if (!isConnectorBusinessCommand(args) || hasWorkspaceSelector(args)) {
+    return [...args]
+  }
+  if (!normalizedTeamName) {
+    throw new Error("Wanta cannot run an OOMOL connector command without an active team workspace.")
+  }
+  return [...args, "--team", normalizedTeamName]
+}
+
+export interface WorkspaceTeamScope {
+  teamName?: unknown
+  sessionTeams?: unknown
+}
+
+/** Resolve a bare CLI call only when every active session agrees on its workspace. */
+export function resolveGuardWorkspaceTeam(scope: WorkspaceTeamScope): string {
+  if (scope.sessionTeams && typeof scope.sessionTeams === "object") {
+    const activeTeams = Object.values(scope.sessionTeams)
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+    if (activeTeams.length > 0) {
+      const uniqueTeams = new Set(activeTeams)
+      if (uniqueTeams.size > 1) {
+        throw new Error(
+          "Wanta cannot safely route a bare OOMOL connector command while active sessions use different workspaces.",
+        )
+      }
+      return activeTeams[0] ?? ""
+    }
+  }
+  return typeof scope.teamName === "string" ? scope.teamName.trim() : ""
+}

--- a/electron/agent/oo-guard.ts
+++ b/electron/agent/oo-guard.ts
@@ -28,6 +28,13 @@ function appendBounded(chunks: Buffer[], chunk: Buffer, size: number): number {
   return nextSize
 }
 
+function killWithEscalation(child: ReturnType<typeof spawn>): void {
+  child.kill("SIGTERM")
+  const timer = setTimeout(() => child.kill("SIGKILL"), 5_000)
+  timer.unref()
+  child.once("close", () => clearTimeout(timer))
+}
+
 async function runGuarded(command: string, args: string[]): Promise<number> {
   const child = spawn(command, args, { env: process.env, stdio: ["inherit", "pipe", "pipe"] })
   const stdout: Buffer[] = []
@@ -42,7 +49,7 @@ async function runGuarded(command: string, args: string[]): Promise<number> {
       stdoutSize = appendBounded(stdout, chunk, stdoutSize)
     } catch (error) {
       captureError = error instanceof Error ? error : new Error(String(error))
-      child.kill("SIGTERM")
+      killWithEscalation(child)
     }
   })
   child.stderr.on("data", (chunk: Buffer) => {
@@ -51,7 +58,7 @@ async function runGuarded(command: string, args: string[]): Promise<number> {
       stderrSize = appendBounded(stderr, chunk, stderrSize)
     } catch (error) {
       captureError = error instanceof Error ? error : new Error(String(error))
-      child.kill("SIGTERM")
+      killWithEscalation(child)
     }
   })
 

--- a/electron/agent/oo-guard.ts
+++ b/electron/agent/oo-guard.ts
@@ -1,0 +1,98 @@
+import type { WorkspaceTeamScope } from "./oo-guard-core.ts"
+
+import { spawn } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import {
+  bindOomolWorkspace,
+  hasWorkspaceSelector,
+  isConnectorBusinessCommand,
+  redactConnectorOutput,
+  resolveGuardWorkspaceTeam,
+} from "./oo-guard-core.ts"
+
+const maxCapturedOutputBytes = 32 * 1024 * 1024
+
+async function currentWorkspaceTeam(): Promise<string> {
+  const scopePath = process.env.WANTA_TEAM_SCOPE_PATH?.trim()
+  if (!scopePath) return ""
+  const parsed = JSON.parse(await readFile(scopePath, "utf8")) as WorkspaceTeamScope
+  return resolveGuardWorkspaceTeam(parsed)
+}
+
+function appendBounded(chunks: Buffer[], chunk: Buffer, size: number): number {
+  const nextSize = size + chunk.length
+  if (nextSize > maxCapturedOutputBytes) {
+    throw new Error("Connector output exceeded Wanta's 32 MiB safety limit.")
+  }
+  chunks.push(chunk)
+  return nextSize
+}
+
+async function runGuarded(command: string, args: string[]): Promise<number> {
+  const child = spawn(command, args, { env: process.env, stdio: ["inherit", "pipe", "pipe"] })
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  let stdoutSize = 0
+  let stderrSize = 0
+  let captureError: Error | null = null
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    if (captureError) return
+    try {
+      stdoutSize = appendBounded(stdout, chunk, stdoutSize)
+    } catch (error) {
+      captureError = error instanceof Error ? error : new Error(String(error))
+      child.kill("SIGTERM")
+    }
+  })
+  child.stderr.on("data", (chunk: Buffer) => {
+    if (captureError) return
+    try {
+      stderrSize = appendBounded(stderr, chunk, stderrSize)
+    } catch (error) {
+      captureError = error instanceof Error ? error : new Error(String(error))
+      child.kill("SIGTERM")
+    }
+  })
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", (code, signal) => {
+      resolve(code ?? (signal ? 1 : 0))
+    })
+  })
+  if (captureError) throw captureError
+  process.stdout.write(redactConnectorOutput(Buffer.concat(stdout).toString("utf8")))
+  process.stderr.write(redactConnectorOutput(Buffer.concat(stderr).toString("utf8")))
+  return exitCode
+}
+
+async function runPassthrough(command: string, args: string[]): Promise<number> {
+  const child = spawn(command, args, { env: process.env, stdio: "inherit" })
+  return await new Promise<number>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", (code, signal) => resolve(code ?? (signal ? 1 : 0)))
+  })
+}
+
+async function main(): Promise<void> {
+  const command = process.env.WANTA_REAL_OO_BIN?.trim()
+  if (!command) {
+    throw new Error("WANTA_REAL_OO_BIN is required for the managed oo command.")
+  }
+  const originalArgs = process.argv.slice(2)
+  const needsOomolBinding =
+    process.env.WANTA_LINK_RUNTIME === "oomol" &&
+    isConnectorBusinessCommand(originalArgs) &&
+    !hasWorkspaceSelector(originalArgs)
+  const args = needsOomolBinding ? bindOomolWorkspace(originalArgs, await currentWorkspaceTeam()) : originalArgs
+  const exitCode = isConnectorBusinessCommand(args)
+    ? await runGuarded(command, args)
+    : await runPassthrough(command, args)
+  process.exitCode = exitCode
+}
+
+await main().catch((error: unknown) => {
+  process.stderr.write(`Wanta oo guard: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/electron/agent/oo-identity.test.ts
+++ b/electron/agent/oo-identity.test.ts
@@ -5,11 +5,11 @@ import { updateOoIdentitySettings } from "./oo-identity.ts"
 test("updateOoIdentitySettings escapes TOML basic strings directly", () => {
   const updated = updateOoIdentitySettings("", 'team "quoted"\\line\nnext\t\u0001')
 
-  assert.equal(updated, '[identity]\nteam = "team \\"quoted\\"\\\\line\\nnext\\t\\u0001"\n')
+  assert.equal(updated, '[identity]\norganization = "team \\"quoted\\"\\\\line\\nnext\\t\\u0001"\n')
 })
 
-test("updateOoIdentitySettings migrates the legacy organization key to team", () => {
-  const updated = updateOoIdentitySettings('[identity]\norganization = "old"\nnote = "keep"\n', "new")
+test("updateOoIdentitySettings migrates an ignored team key to the CLI organization key", () => {
+  const updated = updateOoIdentitySettings('[identity]\nteam = "old"\nnote = "keep"\n', "new")
 
-  assert.equal(updated, '[identity]\nteam = "new"\nnote = "keep"\n')
+  assert.equal(updated, '[identity]\norganization = "new"\nnote = "keep"\n')
 })

--- a/electron/agent/oo-identity.test.ts
+++ b/electron/agent/oo-identity.test.ts
@@ -5,11 +5,27 @@ import { updateOoIdentitySettings } from "./oo-identity.ts"
 test("updateOoIdentitySettings escapes TOML basic strings directly", () => {
   const updated = updateOoIdentitySettings("", 'team "quoted"\\line\nnext\t\u0001')
 
-  assert.equal(updated, '[identity]\norganization = "team \\"quoted\\"\\\\line\\nnext\\t\\u0001"\n')
+  assert.equal(updated, '[identity]\nteam = "team \\"quoted\\"\\\\line\\nnext\\t\\u0001"\n')
 })
 
-test("updateOoIdentitySettings migrates an ignored team key to the CLI organization key", () => {
-  const updated = updateOoIdentitySettings('[identity]\nteam = "old"\nnote = "keep"\n', "new")
+test("updateOoIdentitySettings migrates a retired organization key to the CLI team key", () => {
+  const updated = updateOoIdentitySettings('[identity]\norganization = "old"\nnote = "keep"\n', "new")
 
-  assert.equal(updated, '[identity]\norganization = "new"\nnote = "keep"\n')
+  assert.equal(updated, '[identity]\nteam = "new"\nnote = "keep"\n')
+})
+
+test("updateOoIdentitySettings collapses every selector regardless of key order", () => {
+  assert.equal(
+    updateOoIdentitySettings('[identity]\nteam = "legacy"\norganization = "current"\nnote = "keep"\n', "new"),
+    '[identity]\nteam = "new"\nnote = "keep"\n',
+  )
+  assert.equal(
+    updateOoIdentitySettings('[identity]\norganization = "current"\nteam = "legacy"\nnote = "keep"\n', "new"),
+    '[identity]\nteam = "new"\nnote = "keep"\n',
+  )
+})
+
+test("updateOoIdentitySettings removes every selector when clearing identity", () => {
+  const source = '[identity]\norganization = "current"\nnote = "keep"\nteam = "legacy"\n'
+  assert.equal(updateOoIdentitySettings(source, undefined), '[identity]\nnote = "keep"\n')
 })

--- a/electron/agent/oo-identity.ts
+++ b/electron/agent/oo-identity.ts
@@ -51,9 +51,8 @@ function sectionName(line: string): string | undefined {
 }
 
 function identityTeamLine(teamName: string): string {
-  // The CLI reads identity.organization; --team is only the command-line product term/alias.
-  // Writing identity.team is silently ignored and makes bare Provider Skill calls fall back to personal scope.
-  return `organization = ${tomlString(teamName)}`
+  // Current oo versions read identity.team. Remove the retired organization key during migration.
+  return `team = ${tomlString(teamName)}`
 }
 
 function ensureTrailingNewline(value: string): string {
@@ -92,24 +91,15 @@ export function updateOoIdentitySettings(source: string, teamName: string | unde
     return `${prefix}${prefix.trim() ? "\n" : ""}[${identitySection}]\n${identityTeamLine(normalized)}\n`
   }
 
-  const nextLines = [...lines]
-  let teamLine = -1
-  for (let index = identityStart + 1; index < identityEnd; index += 1) {
-    if (teamKeyPattern.test(nextLines[index] ?? "")) {
-      teamLine = index
-      break
-    }
-  }
-
-  if (normalized) {
-    if (teamLine >= 0) {
-      nextLines[teamLine] = identityTeamLine(normalized)
-    } else {
-      nextLines.splice(identityEnd, 0, identityTeamLine(normalized))
-    }
-  } else if (teamLine >= 0) {
-    nextLines.splice(teamLine, 1)
-  }
+  const identityBody = lines.slice(identityStart + 1, identityEnd)
+  const firstSelector = identityBody.findIndex((line) => teamKeyPattern.test(line))
+  const insertionOffset =
+    firstSelector < 0
+      ? identityBody.length
+      : identityBody.slice(0, firstSelector).filter((line) => !teamKeyPattern.test(line)).length
+  const nextIdentityBody = identityBody.filter((line) => !teamKeyPattern.test(line))
+  if (normalized) nextIdentityBody.splice(insertionOffset, 0, identityTeamLine(normalized))
+  const nextLines = [...lines.slice(0, identityStart + 1), ...nextIdentityBody, ...lines.slice(identityEnd)]
 
   return `${nextLines.join("\n")}\n`
 }

--- a/electron/agent/oo-identity.ts
+++ b/electron/agent/oo-identity.ts
@@ -51,7 +51,9 @@ function sectionName(line: string): string | undefined {
 }
 
 function identityTeamLine(teamName: string): string {
-  return `team = ${tomlString(teamName)}`
+  // The CLI reads identity.organization; --team is only the command-line product term/alias.
+  // Writing identity.team is silently ignored and makes bare Provider Skill calls fall back to personal scope.
+  return `organization = ${tomlString(teamName)}`
 }
 
 function ensureTrailingNewline(value: string): string {

--- a/electron/agent/tool-sources.test.ts
+++ b/electron/agent/tool-sources.test.ts
@@ -289,6 +289,38 @@ describe("call_action embedded runtime", () => {
     expect(commands[1]).not.toContain("--team")
   })
 
+  it("refreshes connection inventory immediately after an account switch", async () => {
+    process.env.WANTA_LINK_RUNTIME = "openconnector"
+    process.env.WANTA_CONNECTOR_URL = "http://127.0.0.1:3000"
+    const commands: string[][] = []
+    let inventoryRead = 0
+    const runtime = loadCallActionTool(async (...args) => {
+      const argv = args[1] as string[]
+      commands.push(argv)
+      if (argv[1] === "apps") {
+        inventoryRead += 1
+        const alias = inventoryRead === 1 ? "old-account" : "new-account"
+        return { stdout: JSON.stringify([{ alias, service: "posthog", status: "active" }]) }
+      }
+      return { stdout: JSON.stringify({ data: { ok: true } }) }
+    })
+
+    await runtime.execute(
+      { service: "posthog", action: "list_projects", connectionName: "old-account" },
+      { sessionID: "session-1" },
+    )
+    const switched = JSON.parse(
+      await runtime.execute(
+        { service: "posthog", action: "list_projects", connectionName: "new-account" },
+        { sessionID: "session-1" },
+      ),
+    ) as { data?: { ok?: boolean } }
+
+    expect(inventoryRead).toBe(2)
+    expect(commands).toHaveLength(4)
+    expect(switched).toEqual({ data: { ok: true } })
+  })
+
   it("runs one canary and skips matching queued calls after an authorization block", async () => {
     process.env.WANTA_CONSOLE_URL = "https://console.example.test"
     let calls = 0

--- a/electron/agent/tool-sources.ts
+++ b/electron/agent/tool-sources.ts
@@ -387,18 +387,13 @@ const AUTH_BLOCKING = new Set([
   "authorization_failed",
 ])
 
-const CONNECTION_NAME_CACHE_MS = 5 * 1000
 const ACTION_PROBE_CACHE_MS = 5 * 1000
 const CONNECTION_BLOCK_MS = 10 * 1000
 const MAX_PARALLEL_ACTION_CALLS = 2
-const connectionNameLookups = new Map()
 const actionProbeStates = new Map()
 const connectionBlocks = new Map()
 
 function pruneExpiredRuntimeState(now = Date.now()) {
-  for (const [key, cached] of connectionNameLookups) {
-    if (now - cached.createdAt >= CONNECTION_NAME_CACHE_MS) connectionNameLookups.delete(key)
-  }
   for (const [key, state] of actionProbeStates) {
     if (!state.probePromise && state.active === 0 && now - state.createdAt >= ACTION_PROBE_CACHE_MS) {
       actionProbeStates.delete(key)
@@ -430,35 +425,24 @@ function appConnectionName(app) {
 }
 
 async function knownConnectionNames(service, identity) {
-  const key = identity.cacheKey + ":" + service
-  const now = Date.now()
-  pruneExpiredRuntimeState(now)
-  const cached = connectionNameLookups.get(key)
-  if (cached && now - cached.createdAt < CONNECTION_NAME_CACHE_MS) {
-    return await cached.promise
-  }
-  const promise = (async () => {
-    const argv = ["connector", "apps", service]
-    await appendIdentityArgs(argv, identity)
-    argv.push("--json")
-    try {
-      const result = await execFileAsync(OO_BIN, argv, OO_EXEC_OPTIONS)
-      const apps = parseApps(result.stdout)
-      return {
-        names: new Set(
-          apps
-            .filter((app) => !app || typeof app !== "object" || app.status !== "disconnected")
-            .map(appConnectionName)
-            .filter(Boolean),
-        ),
-      }
-    } catch (error) {
-      const e = error || {}
-      return { names: null, message: String(e.stderr || e.message || "connection inventory lookup failed").trim() }
+  const argv = ["connector", "apps", service]
+  await appendIdentityArgs(argv, identity)
+  argv.push("--json")
+  try {
+    const result = await execFileAsync(OO_BIN, argv, OO_EXEC_OPTIONS)
+    const apps = parseApps(result.stdout)
+    return {
+      names: new Set(
+        apps
+          .filter((app) => !app || typeof app !== "object" || app.status !== "disconnected")
+          .map(appConnectionName)
+          .filter(Boolean),
+      ),
     }
-  })()
-  connectionNameLookups.set(key, { createdAt: now, promise: promise })
-  return await promise
+  } catch (error) {
+    const e = error || {}
+    return { names: null, message: String(e.stderr || e.message || "connection inventory lookup failed").trim() }
+  }
 }
 
 function authorizationResult(output) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -158,6 +158,7 @@ const modelsStore = new ModelsStore(app.getPath("userData"), modelCredentialStor
 const wikiGraphStateDir = path.join(app.getPath("userData"), "wikigraph-state")
 const wikiGraphLibraryDir = path.join(wikiGraphStateDir, "library")
 const wikiGraphCliPath = path.join(dirname, "wanta-wg.js")
+const ooGuardCliPath = path.join(dirname, "wanta-oo-guard.js")
 // 二进制解析：生产从打包 Resources/bin（extraResources），dev 从 node_modules（opencode）与 .oo-bin（oo）。
 const opencodeBinPath = app.isPackaged
   ? resolveBundledBin(process.resourcesPath, opencodeBinaryName())
@@ -761,6 +762,7 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
     modelAccess: runtime.modelAccess,
     opencodeBinPath,
     ooBinPath,
+    ooGuardCliPath,
     wikiGraphCliPath,
     wikiGraphStateDir,
     listOpenConnectorAuthorizedServices: async (signal) =>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -148,6 +148,7 @@ export default defineConfig(({ command, mode }) => {
                   main: path.join(dirname, "electron/main.ts"),
                   "spreadsheet-preview-worker": path.join(dirname, "electron/chat/spreadsheet-preview-worker.ts"),
                   "wanta-wg": path.join(dirname, "electron/knowledge/wg.ts"),
+                  "wanta-oo-guard": path.join(dirname, "electron/agent/oo-guard.ts"),
                 },
                 // @opencode-ai/sdk 依赖 cross-spawn（CJS require("child_process")）、electron-updater 走
                 // CJS 动态 require，playwright-core 需要保留其运行时模块结构，都不能打进 ESM 主进程包；


### PR DESCRIPTION
## Problem

The Connections page could show a provider such as PostHog as connected while a chat call intermittently returned `app_not_found` or `connection_required`. The behavior appeared probabilistic because Wanta's session-scoped Link tools selected the active team correctly, while Provider Skills could invoke a bare `oo connector apps/run` command that fell back to a different CLI identity.

Provider/account switching also had a short stale-inventory window: explicit `connectionName` validation cached the previous account list for five seconds, so a newly connected or selected account could be rejected until that cache expired.

## Root cause

- Raw Provider Skill commands were not guaranteed to carry the active OOMOL `--team` selector.
- Leading global oo options could hide a connector command from the guard.
- The raw CLI compatibility path only had a mutable workspace default and could silently route incorrectly when concurrent sessions used different workspaces.
- Explicit connection-name validation reused a short-lived inventory cache across account switches.
- Connector tool output could persist credential-shaped fields such as API tokens in OpenCode history and expose them again through the renderer.

## Fix

- Add a managed `oo` guard executable and shim for Agent-side calls.
  - Bind bare OOMOL `connector apps/run` commands to the active session workspace.
  - Parse documented global options and insert the selector before `--` terminators.
  - Prefer the sole active session scope over a stale workspace default.
  - Ignore empty session scopes and fail closed when non-empty active scopes disagree.
  - Preserve explicit selectors and leave OpenConnector commands unscoped.
  - Escalate oversized-output termination from `SIGTERM` to `SIGKILL` after a bounded delay.
- Preserve the current oo CLI `identity.team` key while collapsing retired or duplicate identity selectors into exactly one entry.
- Strengthen the per-turn workspace contract for raw connector commands.
- Refresh connection inventory on every explicit `connectionName` validation so newly switched accounts are immediately visible.
- Redact exact, vendor-prefixed, and header-style credential fields before stdout/stderr reaches the Agent and before live/history tool results reach the renderer.
- Run the persisted-history scrub in the background, restrict it to connector executions, preserve unchanged JSON byte-for-byte, and stop safely when the Agent is disposed.
- Cap captured connector output at 32 MiB and fail closed when the guard cannot inspect it safely.

## User impact

Connected providers should no longer intermittently appear disconnected because two invocation paths used different workspace identities. Rapid provider/account switching no longer waits for the old connection-name cache to expire. Ambiguous cross-team raw CLI calls now stop safely instead of reaching the wrong workspace.

## Safety and Compatibility

- [x] No credential values are added to source, logs, renderer state, or the PR.
- [x] OpenConnector keeps its existing endpoint-scoped behavior and receives no team selector.
- [x] Explicit OOMOL selectors remain unchanged; only bare `connector apps/run` commands are bound.
- [x] Current oo CLI 1.7.1 compatibility was checked locally: the persisted key remains `identity.team` and the command-line selector remains `--team`.
- [x] Historical mutation is restricted to completed connector execution outputs containing credential-shaped values; unrelated tool history is not rewritten.
- [x] The history scrub is non-blocking and aborts without writing its completion marker if the Agent is disposed.
- [x] POSIX and Windows launchers preserve argument forwarding and child exit status; Windows environment changes are scoped with `setlocal`.
- [x] No database schema, IPC contract, network endpoint, or renderer API changes are introduced.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm test` — 295 files, 2208 tests passed
- `pnpm run build:app`
- Targeted formatting checks for every changed file
- `git diff --check`

The production build includes `dist-electron/wanta-oo-guard.js`; only the existing bundle-size and deprecated `inlineDynamicImports` warnings remain.
