### PR TITLE
Fix sidebar pinned section ordering

### DIFF
--- a/src/components/app-shell/AppShellNavigationSidebar.tsx
+++ b/src/components/app-shell/AppShellNavigationSidebar.tsx
@@ -215,6 +215,59 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
       onArchive={() => onArchiveSessionRequest(session)}
     />
   )
+  const renderTaskSectionHeader = () => (
+    <div className="group mb-2 flex h-7 items-center justify-between px-3">
+      <div className="oo-sidebar-section-heading oo-text-caption">{t("sidebar.tasks")}</div>
+      <div className="pointer-events-none -mr-1 flex items-center gap-0.5 text-sidebar-foreground/45 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              title={t("tasks.moreActions")}
+              aria-label={t("tasks.moreActions")}
+              className="flex size-6 items-center justify-center rounded hover:bg-sidebar-accent/60 hover:text-sidebar-foreground/75"
+            >
+              <Ellipsis className="size-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-48">
+            <DropdownMenuItem onSelect={onManageTasks}>
+              <ListChecks className="size-4" />
+              {t("tasks.organize")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onNavigate("archived")}>
+              <Archive className="size-4" />
+              {t("tasks.viewArchived")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>{t("tasks.sortLabel")}</DropdownMenuLabel>
+            {(
+              [
+                ["updatedAt", t("tasks.sortUpdated")],
+                ["createdAt", t("tasks.sortCreated")],
+                ["title", t("tasks.sortTitle")],
+              ] satisfies Array<[SidebarTaskSortMode, string]>
+            ).map(([value, label]) => (
+              <DropdownMenuItem key={value} onSelect={() => onSetTaskSortMode(value)}>
+                <span>{label}</span>
+                {taskSortMode === value ? <Check className="ml-auto size-4" /> : null}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <button
+          type="button"
+          title={newChatLabel}
+          aria-label={newChatLabel}
+          aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.newChat)}
+          onClick={onNewSession}
+          className="flex size-6 items-center justify-center rounded hover:bg-sidebar-accent/60 hover:text-sidebar-foreground/75"
+        >
+          <SquarePen className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  )
 
   return (
     <aside
@@ -302,61 +355,11 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
             <SidebarSegmentControl value={sidebarSegment} onChange={onSetSidebarSegment} />
           </div>
           <div className="oo-sidebar-session-scroll -mx-3 flex min-h-0 flex-1 flex-col overflow-y-auto px-3 pb-2">
-            {sidebarSegment === "tasks" ? (
-              <div className="group mb-2 flex h-7 items-center justify-between px-3">
-                <div className="oo-sidebar-section-heading oo-text-caption">{t("sidebar.tasks")}</div>
-                <div className="pointer-events-none -mr-1 flex items-center gap-0.5 text-sidebar-foreground/45 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        title={t("tasks.moreActions")}
-                        aria-label={t("tasks.moreActions")}
-                        className="flex size-6 items-center justify-center rounded hover:bg-sidebar-accent/60 hover:text-sidebar-foreground/75"
-                      >
-                        <Ellipsis className="size-3.5" />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="min-w-48">
-                      <DropdownMenuItem onSelect={onManageTasks}>
-                        <ListChecks className="size-4" />
-                        {t("tasks.organize")}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={() => onNavigate("archived")}>
-                        <Archive className="size-4" />
-                        {t("tasks.viewArchived")}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuLabel>{t("tasks.sortLabel")}</DropdownMenuLabel>
-                      {(
-                        [
-                          ["updatedAt", t("tasks.sortUpdated")],
-                          ["createdAt", t("tasks.sortCreated")],
-                          ["title", t("tasks.sortTitle")],
-                        ] satisfies Array<[SidebarTaskSortMode, string]>
-                      ).map(([value, label]) => (
-                        <DropdownMenuItem key={value} onSelect={() => onSetTaskSortMode(value)}>
-                          <span>{label}</span>
-                          {taskSortMode === value ? <Check className="ml-auto size-4" /> : null}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                  <button
-                    type="button"
-                    title={newChatLabel}
-                    aria-label={newChatLabel}
-                    aria-keyshortcuts={appCommandAriaShortcut(APP_COMMANDS.newChat)}
-                    onClick={onNewSession}
-                    className="flex size-6 items-center justify-center rounded hover:bg-sidebar-accent/60 hover:text-sidebar-foreground/75"
-                  >
-                    <SquarePen className="size-3.5" />
-                  </button>
-                </div>
-              </div>
-            ) : null}
             {sessionsError ? (
-              <ErrorNotice error={sessionsError} compact className="mx-0" />
+              <>
+                {sidebarSegment === "tasks" ? renderTaskSectionHeader() : null}
+                <ErrorNotice error={sessionsError} compact className="mx-0" />
+              </>
             ) : sidebarSegment === "projects" ? (
               projectSidebarGroups.length > 0 ? (
                 <div className="grid gap-2">
@@ -365,8 +368,8 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
                       <div className="oo-sidebar-section-heading oo-text-caption px-3 pt-1 pb-1">
                         {t("sidebar.pinned")}
                       </div>
-                      {projectPinnedGroups.map(renderProjectGroup)}
                       {projectPinnedSessions.map(renderSession)}
+                      {projectPinnedGroups.map(renderProjectGroup)}
                     </div>
                   ) : null}
                   {projectRegularGroups.length > 0 ? (
@@ -403,9 +406,10 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
                     {visibleTaskSessionGroups.pinned.map(renderSession)}
                   </div>
                 ) : null}
-                {visibleTaskSessionGroups.regular.length > 0 ? (
-                  <div className="grid gap-0.5">{visibleTaskSessionGroups.regular.map(renderSession)}</div>
-                ) : null}
+                <div className="grid gap-0.5">
+                  {renderTaskSectionHeader()}
+                  {visibleTaskSessionGroups.regular.map(renderSession)}
+                </div>
                 {visibleTaskSessionGroups.hiddenCount > 0 ? (
                   <button
                     type="button"
@@ -419,7 +423,10 @@ export const AppShellNavigationSidebar = React.memo(function AppShellNavigationS
                 ) : null}
               </div>
             ) : (
-              <SidebarEmptyState />
+              <>
+                {renderTaskSectionHeader()}
+                <SidebarEmptyState />
+              </>
             )}
           </div>
 

--- a/src/components/app-shell/app-sidebar-model.test.ts
+++ b/src/components/app-shell/app-sidebar-model.test.ts
@@ -122,15 +122,17 @@ test("buildProjectSidebarGroups hoists pinned sessions out of pinned and regular
 })
 
 test("pinnedProjectSidebarSessions includes every active pinned project session", () => {
+  const projects = [project("pinned-project", 2_000), project("regular-project", 1_000)]
   const sessions = [
     { ...session("old-pin", "pinned-project", 1_000), pinnedAt: 4_000 },
     { ...session("new-pin", "regular-project", 2_000), pinnedAt: 5_000 },
     { ...session("archived-pin", "regular-project", 3_000), pinnedAt: 6_000, archivedAt: 7_000 },
+    { ...session("missing-project-pin", "missing-project", 4_000), pinnedAt: 7_000 },
     { ...session("root-pin", "", 4_000), pinnedAt: 8_000 },
   ]
 
   assert.deepEqual(
-    pinnedProjectSidebarSessions(sessions).map((item) => item.id),
+    pinnedProjectSidebarSessions(projects, sessions).map((item) => item.id),
     ["new-pin", "old-pin"],
   )
 })

--- a/src/components/app-shell/app-sidebar-model.test.ts
+++ b/src/components/app-shell/app-sidebar-model.test.ts
@@ -2,7 +2,11 @@ import type { SessionInfo, SessionProject } from "../../../electron/session/comm
 
 import assert from "node:assert/strict"
 import { test } from "vitest"
-import { buildProjectSidebarGroups, projectSidebarSessionsInRenderOrder } from "./app-sidebar-model.ts"
+import {
+  buildProjectSidebarGroups,
+  pinnedProjectSidebarSessions,
+  projectSidebarSessionsInRenderOrder,
+} from "./app-sidebar-model.ts"
 
 function project(id: string, updatedAt: number): SessionProject {
   return {
@@ -94,6 +98,43 @@ test("buildProjectSidebarGroups keeps project order while a child session is run
   )
 })
 
+test("buildProjectSidebarGroups hoists pinned sessions out of pinned and regular projects", () => {
+  const groups = buildProjectSidebarGroups(
+    [{ ...project("pinned-project", 2_000), pinnedAt: 3_000 }, project("regular-project", 1_000)],
+    [
+      { ...session("pinned-child", "pinned-project", 4_000), pinnedAt: 5_000 },
+      session("pinned-project-regular-child", "pinned-project", 3_000),
+      { ...session("regular-project-pinned-child", "regular-project", 2_000), pinnedAt: 4_000 },
+      session("regular-child", "regular-project", 1_000),
+    ],
+  )
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      project: group.project.id,
+      sessions: group.sessions.map((item) => item.id),
+    })),
+    [
+      { project: "pinned-project", sessions: ["pinned-project-regular-child"] },
+      { project: "regular-project", sessions: ["regular-child"] },
+    ],
+  )
+})
+
+test("pinnedProjectSidebarSessions includes every active pinned project session", () => {
+  const sessions = [
+    { ...session("old-pin", "pinned-project", 1_000), pinnedAt: 4_000 },
+    { ...session("new-pin", "regular-project", 2_000), pinnedAt: 5_000 },
+    { ...session("archived-pin", "regular-project", 3_000), pinnedAt: 6_000, archivedAt: 7_000 },
+    { ...session("root-pin", "", 4_000), pinnedAt: 8_000 },
+  ]
+
+  assert.deepEqual(
+    pinnedProjectSidebarSessions(sessions).map((item) => item.id),
+    ["new-pin", "old-pin"],
+  )
+})
+
 test("projectSidebarSessionsInRenderOrder mirrors the project sidebar sections", () => {
   const pinnedGroup = {
     hiddenCount: 0,
@@ -113,6 +154,6 @@ test("projectSidebarSessionsInRenderOrder mirrors the project sidebar sections",
       pinnedSessions: [pinnedSession],
       regularGroups: [regularGroup],
     }).map((item) => item.id),
-    ["pinned-child", "pinned-session", "regular-child"],
+    ["pinned-session", "pinned-child", "regular-child"],
   )
 })

--- a/src/components/app-shell/app-sidebar-model.ts
+++ b/src/components/app-shell/app-sidebar-model.ts
@@ -1,7 +1,7 @@
 import type { SessionInfo, SessionProject } from "../../../electron/session/common.ts"
 import type { SidebarSessionOrder } from "./sidebar-sessions.ts"
 
-import { compareSidebarSessions } from "./sidebar-sessions.ts"
+import { compareRunningSessions, compareSidebarSessions } from "./sidebar-sessions.ts"
 
 export interface ProjectSidebarGroup {
   hiddenCount: number
@@ -42,7 +42,7 @@ export function buildProjectSidebarGroups(
       continue
     }
     const project = projectById.get(session.projectId)
-    if (!project || (session.pinnedAt && !project.pinnedAt)) {
+    if (!project || session.pinnedAt) {
       continue
     }
     const current = sessionsByProject.get(session.projectId) ?? []
@@ -64,6 +64,12 @@ export function buildProjectSidebarGroups(
     .sort(compareProjectSidebarGroups)
 }
 
+export function pinnedProjectSidebarSessions(sessions: SessionInfo[], order: SidebarSessionOrder = {}): SessionInfo[] {
+  return sessions
+    .filter((session) => session.projectId && session.pinnedAt && !session.archivedAt)
+    .sort((a, b) => compareRunningSessions(a, b, order) || (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0))
+}
+
 export function projectSidebarSessionsInRenderOrder({
   pinnedGroups,
   pinnedSessions,
@@ -74,8 +80,8 @@ export function projectSidebarSessionsInRenderOrder({
   regularGroups: ProjectSidebarGroup[]
 }): SessionInfo[] {
   return [
-    ...pinnedGroups.flatMap((group) => group.sessions),
     ...pinnedSessions,
+    ...pinnedGroups.flatMap((group) => group.sessions),
     ...regularGroups.flatMap((group) => group.sessions),
   ]
 }

--- a/src/components/app-shell/app-sidebar-model.ts
+++ b/src/components/app-shell/app-sidebar-model.ts
@@ -64,9 +64,16 @@ export function buildProjectSidebarGroups(
     .sort(compareProjectSidebarGroups)
 }
 
-export function pinnedProjectSidebarSessions(sessions: SessionInfo[], order: SidebarSessionOrder = {}): SessionInfo[] {
+export function pinnedProjectSidebarSessions(
+  projects: SessionProject[],
+  sessions: SessionInfo[],
+  order: SidebarSessionOrder = {},
+): SessionInfo[] {
+  const projectIds = new Set(projects.map((project) => project.id))
   return sessions
-    .filter((session) => session.projectId && session.pinnedAt && !session.archivedAt)
+    .filter(
+      (session) => session.projectId && projectIds.has(session.projectId) && session.pinnedAt && !session.archivedAt,
+    )
     .sort((a, b) => compareRunningSessions(a, b, order) || (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0))
 }
 

--- a/src/components/app-shell/use-app-shell-sidebar-sessions.ts
+++ b/src/components/app-shell/use-app-shell-sidebar-sessions.ts
@@ -2,8 +2,12 @@ import type { SessionInfo, SessionProject } from "../../../electron/session/comm
 import type { SidebarSegment, SidebarTaskSortMode } from "./sidebar-persistence.ts"
 
 import * as React from "react"
-import { buildProjectSidebarGroups, projectSidebarSessionsInRenderOrder } from "./app-sidebar-model.ts"
-import { compareRunningSessions, groupSidebarSessions } from "./sidebar-sessions.ts"
+import {
+  buildProjectSidebarGroups,
+  pinnedProjectSidebarSessions,
+  projectSidebarSessionsInRenderOrder,
+} from "./app-sidebar-model.ts"
+import { groupSidebarSessions } from "./sidebar-sessions.ts"
 
 export function useAppShellSidebarSessions({
   getSessionRunStartedAt,
@@ -33,15 +37,10 @@ export function useAppShellSidebarSessions({
     [getSessionRunStartedAt, isSessionRunning],
   )
   const taskGroups = React.useMemo(() => groupSidebarSessions(taskSessions, sessionOrder), [sessionOrder, taskSessions])
-  const pinnedProjectSessions = React.useMemo(() => {
-    const pinnedProjectIds = new Set(projects.filter((project) => project.pinnedAt).map((project) => project.id))
-    return projectSessions
-      .filter(
-        (session) =>
-          session.projectId && !pinnedProjectIds.has(session.projectId) && session.pinnedAt && !session.archivedAt,
-      )
-      .sort((a, b) => compareRunningSessions(a, b, projectSessionOrder) || (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0))
-  }, [projectSessionOrder, projectSessions, projects])
+  const pinnedProjectSessions = React.useMemo(
+    () => pinnedProjectSidebarSessions(projectSessions, projectSessionOrder),
+    [projectSessionOrder, projectSessions],
+  )
   const projectGroups = React.useMemo(
     () => buildProjectSidebarGroups(projects, projectSessions, projectSessionOrder, { selectedSessionId }),
     [projectSessionOrder, projectSessions, projects, selectedSessionId],

--- a/src/components/app-shell/use-app-shell-sidebar-sessions.ts
+++ b/src/components/app-shell/use-app-shell-sidebar-sessions.ts
@@ -38,8 +38,8 @@ export function useAppShellSidebarSessions({
   )
   const taskGroups = React.useMemo(() => groupSidebarSessions(taskSessions, sessionOrder), [sessionOrder, taskSessions])
   const pinnedProjectSessions = React.useMemo(
-    () => pinnedProjectSidebarSessions(projectSessions, projectSessionOrder),
-    [projectSessionOrder, projectSessions],
+    () => pinnedProjectSidebarSessions(projects, projectSessions, projectSessionOrder),
+    [projectSessionOrder, projectSessions, projects],
   )
   const projectGroups = React.useMemo(
     () => buildProjectSidebarGroups(projects, projectSessions, projectSessionOrder, { selectedSessionId }),


### PR DESCRIPTION
## Summary

This PR fixes the sidebar hierarchy for pinned tasks and project conversations.

Previously, the Tasks tab rendered its general “Tasks” heading above the “Pinned” category, which made the pinned group appear as a subsection of the regular task list. In the Projects tab, pinning a conversation inside an already pinned project updated the pin state but left the conversation nested under the project, so there was no visible promotion and the same action behaved differently depending on whether the parent project was pinned.

The root cause was split presentation logic: the task section heading was rendered outside the grouped task content, while project-session grouping deliberately excluded pinned conversations from the top-level pinned list when their parent project was also pinned. The project group builder then kept those conversations inside pinned projects.

The sidebar now renders pinned tasks before the regular Tasks section. All active pinned project conversations are also promoted to the top-level Pinned section regardless of the parent project’s pin state, removed from the nested project list to prevent duplication, and rendered before pinned project folders. Their project association remains unchanged. The selectable-session order was updated to match the visible order so keyboard and automatic navigation remain consistent.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run src/components/app-shell/app-sidebar-model.test.ts src/components/app-shell/sidebar-sessions.test.ts` (18 tests passed)
- `corepack pnpm exec oxfmt --check src/components/app-shell/AppShellNavigationSidebar.tsx src/components/app-shell/app-sidebar-model.ts src/components/app-shell/app-sidebar-model.test.ts src/components/app-shell/use-app-shell-sidebar-sessions.ts`
- `git diff --check`

The updated behavior was also exercised in the running Electron development build through Vite hot reload.
