### PR TITLE
Improve connection category layout

### DIFF
--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -1248,6 +1248,9 @@ export const enMessages = {
   "connections.scenario.aiDescription": "Bring models, search, and media generation into agents and automation.",
   "connections.scenario.communicationTitle": "Team communication",
   "connections.scenario.communicationDescription": "Keep work in sync through chat, email, and notification services.",
+  "connections.scenario.developmentTitle": "Development & data",
+  "connections.scenario.developmentDescription":
+    "Connect code, deployment, database, and analytics tools to build faster and troubleshoot issues.",
   "connections.scenario.explore": "Explore connections",
   "connections.scenario.current": "Current",
   "connections.scenario.connectionCount": "{count} connections",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -1194,6 +1194,8 @@ export const zhCNMessages = {
   "connections.scenario.aiDescription": "将模型、搜索和媒体生成能力接入 Agent 与自动化。",
   "connections.scenario.communicationTitle": "团队沟通",
   "connections.scenario.communicationDescription": "通过聊天、邮件和通知服务同步进展、协同工作。",
+  "connections.scenario.developmentTitle": "研发与数据",
+  "connections.scenario.developmentDescription": "连接代码、部署、数据库与分析工具，加速产品开发和问题排查。",
   "connections.scenario.explore": "查看相关连接",
   "connections.scenario.current": "当前",
   "connections.scenario.connectionCount": "{count} 个连接",

--- a/src/routes/Connections/ConnectionCatalog.tsx
+++ b/src/routes/Connections/ConnectionCatalog.tsx
@@ -847,10 +847,18 @@ const ProviderCard = React.memo(function ProviderCard({
       onKeyDown={onKeyDown}
       className={cn(
         "group/card relative grid min-w-0 cursor-pointer overflow-hidden border-r border-b bg-card px-4 py-3 text-left text-card-foreground transition-[background-color,box-shadow,transform] outline-none hover:bg-[var(--oo-row-hover)] focus-visible:z-10 focus-visible:ring-[3px] focus-visible:ring-ring/40 active:translate-y-px",
+        index === 0 && "rounded-tl-[calc(var(--radius-lg)_-_1px)]",
+        index < columnCount &&
+          (index === itemCount - 1 || index % columnCount === columnCount - 1) &&
+          "rounded-tr-[calc(var(--radius-lg)_-_1px)]",
         index % columnCount === columnCount - 1 && "border-r-0",
-        index >= itemCount - (itemCount % columnCount || columnCount) && "border-b-0",
-        selected &&
-          "bg-[var(--accent-soft)] shadow-[inset_0_0_0_1px_var(--accent-ring)] before:absolute before:inset-y-2 before:left-0 before:w-1 before:rounded-r-full before:bg-[var(--accent-strong)] hover:bg-[var(--accent-soft)]",
+        index >= itemCount - (itemCount % columnCount || columnCount) && [
+          "border-b-0",
+          index % columnCount === 0 && "rounded-bl-[calc(var(--radius-lg)_-_1px)]",
+          (index === itemCount - 1 || index % columnCount === columnCount - 1) &&
+            "rounded-br-[calc(var(--radius-lg)_-_1px)]",
+        ],
+        selected && "bg-[var(--accent-soft)] shadow-[inset_0_0_0_1px_var(--accent-ring)] hover:bg-[var(--accent-soft)]",
       )}
       style={{ height: providerGridCardHeightPx }}
     >

--- a/src/routes/Connections/ConnectionScenarioShowcase.tsx
+++ b/src/routes/Connections/ConnectionScenarioShowcase.tsx
@@ -1,6 +1,6 @@
 import type { ConnectionProviderSummary } from "../../../electron/connections/common.ts"
 
-import { ArrowRight, Bot, Check, MessagesSquare, ShoppingBag } from "lucide-react"
+import { ArrowRight, Bot, Check, DatabaseZap, MessagesSquare, ShoppingBag } from "lucide-react"
 import { crossBorderEcommerceCategory, getProviderCategoryRawLabels } from "./connection-route-model.ts"
 import { ProviderIcon } from "./ProviderIcon.tsx"
 import { useT } from "@/i18n/i18n"
@@ -11,8 +11,7 @@ const scenarios = [
     category: crossBorderEcommerceCategory,
     descriptionKey: "connections.scenario.crossBorderDescription",
     icon: ShoppingBag,
-    activeClassName:
-      "border-[var(--warning)] bg-[color-mix(in_oklab,var(--warning)_9%,var(--card))] shadow-[inset_3px_0_0_var(--warning)]",
+    activeClassName: "border-[var(--warning)] bg-[color-mix(in_oklab,var(--warning)_9%,var(--card))]",
     iconClassName: "bg-[color-mix(in_oklab,var(--warning)_12%,transparent)] text-[var(--warning)]",
     titleKey: "connections.scenario.crossBorderTitle",
   },
@@ -20,7 +19,7 @@ const scenarios = [
     category: "AI",
     descriptionKey: "connections.scenario.aiDescription",
     icon: Bot,
-    activeClassName: "border-[var(--accent-ring)] bg-[var(--accent-soft)] shadow-[inset_3px_0_0_var(--accent-strong)]",
+    activeClassName: "border-[var(--accent-ring)] bg-[var(--accent-soft)]",
     iconClassName: "bg-[var(--accent-soft)] text-[var(--accent-strong)]",
     titleKey: "connections.scenario.aiTitle",
   },
@@ -28,10 +27,17 @@ const scenarios = [
     category: "Communication",
     descriptionKey: "connections.scenario.communicationDescription",
     icon: MessagesSquare,
-    activeClassName:
-      "border-[var(--success)] bg-[color-mix(in_oklab,var(--success)_8%,var(--card))] shadow-[inset_3px_0_0_var(--success)]",
+    activeClassName: "border-[var(--success)] bg-[color-mix(in_oklab,var(--success)_8%,var(--card))]",
     iconClassName: "bg-[color-mix(in_oklab,var(--success)_12%,transparent)] text-[var(--success)]",
     titleKey: "connections.scenario.communicationTitle",
+  },
+  {
+    category: "Developer Tools",
+    descriptionKey: "connections.scenario.developmentDescription",
+    icon: DatabaseZap,
+    activeClassName: "border-violet-500/60 bg-violet-500/[0.08]",
+    iconClassName: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+    titleKey: "connections.scenario.developmentTitle",
   },
 ] as const
 
@@ -47,72 +53,67 @@ export function ConnectionScenarioShowcase({
   const t = useT()
 
   return (
-    <div className="min-w-0 overflow-x-auto pb-0.5">
-      <div className="grid min-w-[780px] grid-cols-3 items-stretch gap-2">
-        {scenarios.map((scenario, index) => {
-          const Icon = scenario.icon
-          const active = activeCategory === scenario.category
-          const scenarioProviders = providers.filter((provider) =>
-            getProviderCategoryRawLabels(provider).includes(scenario.category),
-          )
+    <div className="grid min-w-0 grid-cols-1 items-stretch gap-2 min-[720px]:grid-cols-2">
+      {scenarios.map((scenario) => {
+        const Icon = scenario.icon
+        const active = activeCategory === scenario.category
+        const scenarioProviders = providers.filter((provider) =>
+          getProviderCategoryRawLabels(provider).includes(scenario.category),
+        )
 
-          return (
-            <button
-              key={scenario.category}
-              type="button"
-              aria-pressed={active}
-              onClick={() => onSelect(scenario.category)}
-              className={cn(
-                "group relative flex min-h-[116px] min-w-0 flex-col gap-1.5 rounded-lg border bg-card p-3 text-left transition-[background-color,border-color,box-shadow,transform] outline-none hover:border-[var(--selection-ring)] hover:bg-[var(--oo-row-hover)] focus-visible:ring-[3px] focus-visible:ring-ring/40 active:translate-y-px",
-                active && scenario.activeClassName,
+        return (
+          <button
+            key={scenario.category}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onSelect(scenario.category)}
+            className={cn(
+              "group relative flex min-h-[116px] min-w-0 flex-col gap-1.5 rounded-lg border bg-card p-3 text-left transition-[background-color,border-color,box-shadow,transform] outline-none hover:border-[var(--selection-ring)] hover:bg-[var(--oo-row-hover)] focus-visible:ring-[3px] focus-visible:ring-ring/40 active:translate-y-px",
+              active && scenario.activeClassName,
+            )}
+          >
+            <span className="flex min-w-0 items-center justify-between gap-2">
+              <span className="flex min-w-0 items-center gap-2.5">
+                <span
+                  className={cn("flex size-8 shrink-0 items-center justify-center rounded-md", scenario.iconClassName)}
+                >
+                  <Icon className="size-4" />
+                </span>
+                <span className="oo-text-control min-w-0 truncate font-semibold">{t(scenario.titleKey)}</span>
+              </span>
+              {active ? (
+                <span className="flex shrink-0 items-center gap-1 rounded-full bg-background/70 px-1.5 py-0.5 text-[11px] font-medium text-foreground">
+                  <Check className="size-3" />
+                  {t("connections.scenario.current")}
+                </span>
+              ) : (
+                <ArrowRight className="oo-text-muted size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
               )}
+            </span>
+            <span
+              className="oo-text-caption oo-text-muted block min-h-5 truncate leading-5"
+              title={t(scenario.descriptionKey)}
             >
-              <span className="flex min-w-0 items-center justify-between gap-2">
-                <span className="flex min-w-0 items-center gap-2.5">
-                  <span
-                    className={cn(
-                      "flex size-8 shrink-0 items-center justify-center rounded-md",
-                      scenario.iconClassName,
-                    )}
-                  >
-                    <Icon className="size-4" />
-                  </span>
-                  <span className="oo-text-control min-w-0 truncate font-semibold">{t(scenario.titleKey)}</span>
-                </span>
-                {active ? (
-                  <span className="flex shrink-0 items-center gap-1 rounded-full bg-background/70 px-1.5 py-0.5 text-[11px] font-medium text-foreground">
-                    <Check className="size-3" />
-                    {t("connections.scenario.current")}
-                  </span>
-                ) : (
-                  <ArrowRight className="oo-text-muted size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
-                )}
+              {t(scenario.descriptionKey)}
+            </span>
+            <span className="mt-auto flex min-w-0 items-center justify-between gap-2">
+              <span className="flex -space-x-1" aria-hidden="true">
+                {scenarioProviders.slice(0, 3).map((provider) => (
+                  <ProviderIcon
+                    key={provider.service}
+                    iconUrl={provider.iconUrl}
+                    displayName={provider.displayName}
+                    size="showcase"
+                  />
+                ))}
               </span>
-              <span
-                className="oo-text-caption oo-text-muted block min-h-5 truncate leading-5"
-                title={t(scenario.descriptionKey)}
-              >
-                {t(scenario.descriptionKey)}
+              <span className={cn("oo-text-micro oo-text-muted shrink-0 font-medium", active && "text-foreground")}>
+                {t("connections.scenario.connectionCount", { count: scenarioProviders.length })}
               </span>
-              <span className="mt-auto flex min-w-0 items-center justify-between gap-2">
-                <span className="flex -space-x-1" aria-hidden="true">
-                  {scenarioProviders.slice(0, index === 0 ? 4 : 3).map((provider) => (
-                    <ProviderIcon
-                      key={provider.service}
-                      iconUrl={provider.iconUrl}
-                      displayName={provider.displayName}
-                      size="showcase"
-                    />
-                  ))}
-                </span>
-                <span className={cn("oo-text-micro oo-text-muted shrink-0 font-medium", active && "text-foreground")}>
-                  {t("connections.scenario.connectionCount", { count: scenarioProviders.length })}
-                </span>
-              </span>
-            </button>
-          )
-        })}
-      </div>
+            </span>
+          </button>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The connection catalog previously presented three scenario cards in a horizontally scrollable strip. At common desktop widths, the last card could be partially hidden, which made the area look clipped and reduced category discoverability. Selected scenario cards and provider rows also used a heavy left-side accent that made the selection treatment visually unbalanced.

This change replaces the horizontal strip with a responsive four-category grid. It adds a localized Development & data category backed by Developer Tools providers, uses two columns at normal desktop widths and one column in narrow layouts, and keeps all category cards fully visible without horizontal scrolling.

The selected states retain their colored border and subtle background while removing the heavy left-side accent. Provider cards at the outside corners now receive matching inner corner radii so their selected inset outline follows the rounded catalog container instead of appearing clipped.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm test -- src/routes/Connections/connection-route-model.test.ts` (20 tests passed)
- Full test suite previously passed during implementation (295 files, 2212 tests)
- `git diff --check`
