### PR TITLE
build: upgrade pnpm from 9.14.4 to 11.21.0

### DIFF
--- a/docs/ai/bootstrap.md
+++ b/docs/ai/bootstrap.md
@@ -6,7 +6,7 @@ machine-level prerequisites.
 ## Preconditions
 
 - Node.js `>=22.22.2`
-- pnpm `9.14.4` via `corepack`
+- pnpm `11.21.0` via `corepack`
 - screen recording permission on macOS if visual verification will be needed
 - any required hardware or OS permissions already granted by the operator
 

--- a/package.json
+++ b/package.json
@@ -112,5 +112,5 @@
   "engines": {
     "node": ">=22.22.2"
   },
-  "packageManager": "pnpm@9.14.4"
+  "packageManager": "pnpm@11.21.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# pnpm 10+ blocks dependency install/postinstall scripts by default. This list
+# allows the dependencies that actually ran build scripts under pnpm 9 (sqlite3
+# is a native module required for packaging; the rest keep behavior unchanged).
+allowBuilds:
+  electron-winstaller: true
+  msgpackr-extract: true
+  opencode-ai: true
+  protobufjs: true
+  sqlite3: true

--- a/scripts/dingtalk-cli.ts
+++ b/scripts/dingtalk-cli.ts
@@ -77,7 +77,10 @@ export function resolveDingTalkCliTarget(
 }
 
 async function fetchBytes(url: string): Promise<Buffer> {
-  const response = await fetchWithRetry(url)
+  // The dingtalk-workspace-cli npm package is ~66MB. The default 30s timeout
+  // also aborts the body read, so it always fails on slow networks (~2MB/s).
+  // Extend to 180s.
+  const response = await fetchWithRetry(url, {}, { timeoutMs: 180_000 })
   if (!response.ok) throw new Error(`download DingTalk CLI failed: HTTP ${response.status} ${url}`)
   const contentLength = Number(response.headers.get("content-length") ?? "0")
   if (contentLength > maxDownloadBytes) throw new Error(`DingTalk CLI download exceeded ${maxDownloadBytes} bytes`)

--- a/scripts/open-source-readiness.test.ts
+++ b/scripts/open-source-readiness.test.ts
@@ -33,7 +33,7 @@ describe("open-source installation contract", () => {
     expect(manifest.homepage).toBe("https://wanta.ai/")
     expect(manifest.bugs?.url).toBe("https://github.com/oomol-lab/wanta/issues")
     expect(manifest.engines?.node).toBe(">=22.22.2")
-    expect(manifest.packageManager).toBe("pnpm@9.14.4")
+    expect(manifest.packageManager).toBe("pnpm@11.21.0")
   })
 
   test("does not depend on a repository-local private npm registry", () => {


### PR DESCRIPTION
## Summary

Upgrades the pinned package manager from pnpm 9.14.4 to 11.21.0. pnpm 10+ stopped running dependency install/postinstall scripts by default, so the new _pnpm-workspace.yaml_ carries an `allowBuilds` list approving the five packages that actually built under pnpm 9, `sqlite3` being the native module the packaged app ships in `app.asar.unpacked`. The lockfile stays on format v9.0 with no changes, and CI already resolves the pnpm version from the `packageManager` field, so no workflow changes are needed.

Also extends the DingTalk CLI download timeout from 30s to 180s. The default timeout also bounds the response body read, which made the ~66MB `dingtalk-workspace-cli` npm tarball fail deterministically on slow networks and blocked `prepare:binaries`.

## Verification

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run format`
- [x] `corepack pnpm test`
- [x] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable

`CSC_IDENTITY_AUTO_DISCOVERY=false corepack pnpm run build:mac` produces the unsigned dmg and zip, with `node_sqlite3.node` present in `app.asar.unpacked` and all six bundled CLI binaries in place. `corepack pnpm install --frozen-lockfile` passes against the untouched lockfile.

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.
