### PR TITLE
fix(skills): refresh details after updates

### DIFF
--- a/electron/skills/common.ts
+++ b/electron/skills/common.ts
@@ -38,6 +38,7 @@ export interface SkillSummary {
 export interface ManagedSkillHostCoverage {
   agentId: string
   agentName: string
+  contentHash?: string
   kind?: ManagedSkillKind
   packageName?: string
   path?: string

--- a/electron/skills/inventory.test.ts
+++ b/electron/skills/inventory.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict"
 import { test } from "vitest"
 import { manifestSchemaVersion } from "./constants.ts"
 import { buildSummary, groupInstalledSkills } from "./inventory.ts"
+import { wantaRuntimeAgent } from "./scan.ts"
 
 const agents = [
   {
@@ -149,4 +150,47 @@ test("buildSummary reports an empty inventory with no managed skills", () => {
   assert.equal(summary.managedSkills, 0)
   assert.equal(summary.needsAttention, 0)
   assert.deepEqual(summary.skills, [])
+})
+
+test("groupInstalledSkills uses Wanta runtime metadata as the canonical group version", () => {
+  const groups = groupInstalledSkills(
+    [
+      {
+        agent: agents[1],
+        hash: "external-old-hash",
+        metadata: {
+          description: "Old external description",
+          kind: "registry",
+          packageName: "@oomol/example",
+          version: "1.0.0",
+        },
+        name: "example",
+        path: "/claude/skills/example",
+        sourceHash: "external-old-hash",
+        sourcePath: "/oo/skills/registry/example",
+      },
+      {
+        agent: wantaRuntimeAgent,
+        hash: "wanta-new-hash",
+        metadata: {
+          description: "Current Wanta description",
+          kind: "registry",
+          packageName: "@oomol/example",
+          version: "2.0.0",
+        },
+        name: "example",
+        path: "/wanta/skills/example",
+        sourceHash: "wanta-new-hash",
+        sourcePath: "/wanta/store/registry/example",
+      },
+    ],
+    manifestStore,
+    [wantaRuntimeAgent, agents[1]],
+  )
+  const example = groups.find((group) => group.id === "example")
+
+  assert.equal(example?.version, "2.0.0")
+  assert.equal(example?.description, "Current Wanta description")
+  assert.equal(example?.runtimeHosts[0]?.contentHash, "wanta-new-hash")
+  assert.equal(example?.externalHosts[0]?.version, "1.0.0")
 })

--- a/electron/skills/inventory.ts
+++ b/electron/skills/inventory.ts
@@ -31,6 +31,7 @@ function createHostCoverage(
     return {
       agentId: agent.id,
       agentName: agent.name,
+      contentHash: installedSkill.hash,
       controlState: readControlState(installedSkill, manifestStore),
       kind: installedSkill.metadata.kind,
       packageName: installedSkill.metadata.packageName,
@@ -53,10 +54,12 @@ export function groupInstalledSkills(
 
   return skillNames.map((skillName) => {
     const matchedSkills = installedSkills.filter((skill) => skill.name === skillName)
-    const firstMetadata = matchedSkills[0]?.metadata
+    const canonicalMetadata =
+      matchedSkills.find((skill) => isWantaRuntimeAgent(skill.agent))?.metadata ?? matchedSkills[0]?.metadata
     const resolvedKind = resolveGroupKind(matchedSkills)
-    const description = matchedSkills.find((skill) => skill.metadata.description)?.metadata.description
-    const icon = matchedSkills.find((skill) => skill.metadata.icon)?.metadata.icon
+    const description =
+      canonicalMetadata?.description ?? matchedSkills.find((skill) => skill.metadata.description)?.metadata.description
+    const icon = canonicalMetadata?.icon ?? matchedSkills.find((skill) => skill.metadata.icon)?.metadata.icon
 
     const coveredHosts = createHostCoverage(skillName, installedSkills, manifestStore, coverageAgents)
     const externalHosts = coveredHosts.filter((host) => host.scope === "external")
@@ -67,8 +70,8 @@ export function groupInstalledSkills(
       id: skillName,
       name: skillName,
       kind: resolvedKind,
-      packageName: firstMetadata?.packageName,
-      version: firstMetadata?.version,
+      packageName: canonicalMetadata?.packageName,
+      version: canonicalMetadata?.version,
       externalHosts,
       hosts: coveredHosts,
       runtimeHosts,

--- a/src/routes/Skills/SkillDetailContent.tsx
+++ b/src/routes/Skills/SkillDetailContent.tsx
@@ -505,7 +505,7 @@ function SkillPeek({
               {t("skills.installedLocationsHelper")}
             </CardDescription>
           </div>
-          <div className="grid max-h-56 gap-1.5 overflow-auto pr-1">
+          <div className={cn("grid max-h-56 overflow-auto pr-1", installedHosts.length >= 4 ? "gap-0" : "gap-1.5")}>
             {installedHosts.map((host) => (
               <SkillInstallLocationRow
                 key={`${host.agentId}:${host.scope}:${host.path ?? host.sourcePath ?? host.agentName}`}

--- a/src/routes/Skills/SkillDetailContent.tsx
+++ b/src/routes/Skills/SkillDetailContent.tsx
@@ -16,6 +16,7 @@ import {
   getLocalSkillPublishPath,
   getRuntimeHosts,
   getSkillDocumentRootPath,
+  getSkillDocumentRevision,
   getSkillKindLabel,
   getStatusBadgeClassName,
   hasSkillUpdateAvailable,
@@ -259,6 +260,7 @@ function SkillPeek({
   const runtimeHosts = getRuntimeHosts(selectedSkill)
   const installedHosts = selectedSkill.hosts.filter((host) => host.status === "installed")
   const skillDocumentRootPath = getSkillDocumentRootPath(selectedSkill)
+  const skillDocumentRevision = getSkillDocumentRevision(selectedSkill)
   const hasPublishedUpdate = hasSkillUpdateAvailable(selectedVersionCheck)
   const canUpdatePublishedSkill = hasPublishedUpdate && shouldUpdatePublishedSkill(selectedSkill)
   const canRestoreRegistrySkill =
@@ -327,7 +329,7 @@ function SkillPeek({
     return () => {
       cancelled = true
     }
-  }, [skillDocumentRootPath, skillService, t])
+  }, [skillDocumentRevision, skillDocumentRootPath, skillService, t])
 
   const openSkillDocument = React.useCallback(async () => {
     if (!skillDocumentRootPath) {

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -10,6 +10,7 @@ import {
   getPublicSkillInstallState,
   getPublicPackageInstallState,
   getRuntimeHosts,
+  getSkillDocumentRevision,
   getRuntimeSkillRemoveTarget,
   getSelectedManagedSkillGroup,
   initialPublicPackageCatalogState,
@@ -26,6 +27,21 @@ test("skillDocumentPreviewSource strips frontmatter only when a closing delimite
   assert.equal(skillDocumentPreviewSource("---\nname: demo\n# Demo\n"), "---\nname: demo\n# Demo\n")
   assert.equal(skillDocumentPreviewSource("# Demo\n"), "# Demo\n")
   assert.equal(skillDocumentPreviewSource("\uFEFF# Demo\n"), "# Demo\n")
+})
+
+test("getSkillDocumentRevision follows the selected installed host content", () => {
+  const group = managedSkillGroup("demo", "@alice/demo", {
+    contentHash: "content-v1",
+    path: "/wanta/skills/demo",
+  })
+
+  assert.equal(getSkillDocumentRevision(group), "content-v1")
+
+  const updated = managedSkillGroup("demo", "@alice/demo", {
+    contentHash: "content-v2",
+    path: "/wanta/skills/demo",
+  })
+  assert.equal(getSkillDocumentRevision(updated), "content-v2")
 })
 
 test("isEmojiIcon excludes numeric strings", () => {
@@ -351,17 +367,21 @@ function managedSkillGroup(
   name: string,
   packageName: string | undefined,
   options: {
+    contentHash?: string
     controlState?: "controlled" | "modified" | "source-missing" | "unknown"
     kind?: "local" | "registry" | "unknown"
+    path?: string
     version?: string
   } = {},
 ): ManagedSkillGroup {
   const host = {
     agentId: "wanta",
     agentName: "Wanta",
+    ...(options.contentHash ? { contentHash: options.contentHash } : {}),
     ...(options.controlState ? { controlState: options.controlState } : {}),
     kind: options.kind ?? ("registry" as const),
     ...(packageName ? { packageName } : {}),
+    ...(options.path ? { path: options.path } : {}),
     scope: "runtime" as const,
     status: "installed" as const,
     ...(options.version ? { version: options.version } : {}),

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -270,8 +270,16 @@ export function getLocalSkillPublishPath(group: ManagedSkillGroup): string | und
 }
 
 export function getSkillDocumentRootPath(group: ManagedSkillGroup): string | undefined {
-  const installedHost = getInstalledSkillHosts(group).find((host) => host.path || host.sourcePath)
+  const installedHost = getSkillDocumentHost(group)
   return installedHost?.path ?? installedHost?.sourcePath
+}
+
+export function getSkillDocumentRevision(group: ManagedSkillGroup): string | undefined {
+  return getSkillDocumentHost(group)?.contentHash
+}
+
+function getSkillDocumentHost(group: ManagedSkillGroup): ManagedSkillHostCoverage | undefined {
+  return getInstalledSkillHosts(group).find((host) => host.path || host.sourcePath)
 }
 
 export function isPublishableLocalSkill(group: ManagedSkillGroup): boolean {


### PR DESCRIPTION
## Summary

Skill updates were written to disk correctly, but the open Skill details view could continue showing the previously loaded document until Wanta restarted. The document reader was keyed only by the installation path, and registry updates replace content at the same path, so React had no signal to load the new file. In multi-host installations, the aggregate Skill version could also come from an older external host because it depended on scan order.

This change exposes the existing scanned content hash on each installed host and uses the selected document host's hash as a revision. When an update changes the Skill contents, the open details view now reloads the document immediately without requiring a restart. Aggregate package metadata now prefers the Wanta runtime host while retaining the true per-host versions for external installations.

The installation-location list is also compacted when four or more hosts are visible. This removes the vertical gaps in the four-host layout so Wanta, Claude Code, Hermes, and Universal can be shown completely within the existing panel height; lists with three or fewer hosts preserve the current spacing.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm test` — 297 test files and 2,240 tests passed
- `git diff --check`
- Production build was verified before the final layout-only adjustment

Regression coverage verifies that the Wanta runtime metadata is canonical when an external host is on an older version, and that a same-path document receives a new content revision when its hash changes.
