### PR TITLE
fix(skills): finish updates before version recheck

### DIFF
--- a/src/routes/Skills/registry-skill-update.test.ts
+++ b/src/routes/Skills/registry-skill-update.test.ts
@@ -1,0 +1,86 @@
+import type { SkillInventory } from "../../../electron/skills/common.ts"
+
+import assert from "node:assert/strict"
+import { test } from "vitest"
+import { runRegistrySkillUpdate } from "./registry-skill-update.ts"
+
+const inventory: SkillInventory = {
+  groups: [],
+  summary: {
+    localSkills: 0,
+    managedSkills: 0,
+    modifiedHosts: 0,
+    needsAttention: 0,
+    publishableSkills: 0,
+    registrySkills: 0,
+    sourceMissingHosts: 0,
+    skills: [],
+  },
+  updatedAt: "2026-08-11T00:00:00.000Z",
+}
+
+test("runRegistrySkillUpdate finishes without waiting for the background version refresh", async () => {
+  let resolveRefresh: (() => void) | undefined
+  const refresh = new Promise<void>((resolve) => {
+    resolveRefresh = resolve
+  })
+  const events: string[] = []
+
+  const result = await runRegistrySkillUpdate({
+    invalidateVersions: () => events.push("versions-invalidated"),
+    refreshVersions: () => {
+      events.push("version-refresh-started")
+      return refresh
+    },
+    reportVersionRefreshError: () => events.push("version-refresh-failed"),
+    setInventory: () => events.push("inventory-set"),
+    update: async () => {
+      events.push("update-completed")
+      return inventory
+    },
+  })
+
+  assert.equal(result, inventory)
+  assert.deepEqual(events, ["update-completed", "inventory-set", "versions-invalidated", "version-refresh-started"])
+
+  resolveRefresh?.()
+  await refresh
+})
+
+test("runRegistrySkillUpdate reports a background refresh failure without rejecting the update", async () => {
+  const refreshError = new Error("version check timed out")
+  const reported: unknown[] = []
+
+  await assert.doesNotReject(() =>
+    runRegistrySkillUpdate({
+      invalidateVersions: () => undefined,
+      refreshVersions: () => Promise.reject(refreshError),
+      reportVersionRefreshError: (cause) => reported.push(cause),
+      setInventory: () => undefined,
+      update: async () => inventory,
+    }),
+  )
+  await Promise.resolve()
+
+  assert.deepEqual(reported, [refreshError])
+})
+
+test("runRegistrySkillUpdate rejects when the actual update fails and does not start a version refresh", async () => {
+  const updateError = new Error("update failed")
+  let refreshStarted = false
+
+  await assert.rejects(
+    runRegistrySkillUpdate({
+      invalidateVersions: () => undefined,
+      refreshVersions: async () => {
+        refreshStarted = true
+      },
+      reportVersionRefreshError: () => undefined,
+      setInventory: () => undefined,
+      update: async () => Promise.reject(updateError),
+    }),
+    updateError,
+  )
+
+  assert.equal(refreshStarted, false)
+})

--- a/src/routes/Skills/registry-skill-update.ts
+++ b/src/routes/Skills/registry-skill-update.ts
@@ -1,0 +1,26 @@
+import type { SkillInventory } from "../../../electron/skills/common.ts"
+
+export interface RegistrySkillUpdateOperation {
+  invalidateVersions(): void
+  refreshVersions(): Promise<unknown>
+  reportVersionRefreshError(cause: unknown): void
+  setInventory(inventory: SkillInventory): void
+  update(): Promise<SkillInventory>
+}
+
+/**
+ * The mutation is complete once the main process returns its freshly scanned inventory.
+ * A full registry version check is only a background consistency refresh and must not
+ * keep the update action busy or turn a successful update into a failure.
+ */
+export async function runRegistrySkillUpdate(operation: RegistrySkillUpdateOperation): Promise<SkillInventory> {
+  const inventory = await operation.update()
+
+  operation.setInventory(inventory)
+  operation.invalidateVersions()
+  void operation.refreshVersions().catch((cause: unknown) => {
+    operation.reportVersionRefreshError(cause)
+  })
+
+  return inventory
+}

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -98,10 +98,7 @@ test("getSkillVersionCheck keeps reports when either trimmed version is incomple
     currentCheck,
   )
   currentCheck.currentVersion = "1.0.0"
-  assert.equal(
-    getSkillVersionCheck(checks, managedSkillGroup("demo", "@alice/demo", { version: " " })),
-    currentCheck,
-  )
+  assert.equal(getSkillVersionCheck(checks, managedSkillGroup("demo", "@alice/demo", { version: " " })), currentCheck)
 })
 
 test("isEmojiIcon excludes numeric strings", () => {

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -64,9 +64,9 @@ test("getSkillVersionCheck ignores a report that predates the installed inventor
 })
 
 test("getSkillVersionCheck keeps a report matching the installed inventory version", () => {
-  const group = managedSkillGroup("demo", "@alice/demo", { version: "2.0.0" })
+  const group = managedSkillGroup("demo", "@alice/demo", { version: " 2.0.0 " })
   const currentCheck = {
-    currentVersion: "2.0.0",
+    currentVersion: "2.0.0 ",
     id: "demo",
     kind: "registry" as const,
     latestVersion: "2.0.0",
@@ -78,6 +78,30 @@ test("getSkillVersionCheck keeps a report matching the installed inventory versi
   const checks = new Map([[getSkillVersionCheckKey("demo", "@alice/demo"), currentCheck]])
 
   assert.equal(getSkillVersionCheck(checks, group), currentCheck)
+})
+
+test("getSkillVersionCheck keeps reports when either trimmed version is incomplete", () => {
+  const currentCheck = {
+    currentVersion: " ",
+    id: "demo",
+    kind: "registry" as const,
+    latestVersion: "2.0.0",
+    name: "demo",
+    packageName: "@alice/demo",
+    skillId: "demo",
+    status: "unknown" as const,
+  }
+  const checks = new Map([[getSkillVersionCheckKey("demo", "@alice/demo"), currentCheck]])
+
+  assert.equal(
+    getSkillVersionCheck(checks, managedSkillGroup("demo", "@alice/demo", { version: "2.0.0" })),
+    currentCheck,
+  )
+  currentCheck.currentVersion = "1.0.0"
+  assert.equal(
+    getSkillVersionCheck(checks, managedSkillGroup("demo", "@alice/demo", { version: " " })),
+    currentCheck,
+  )
 })
 
 test("isEmojiIcon excludes numeric strings", () => {

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -11,6 +11,8 @@ import {
   getPublicPackageInstallState,
   getRuntimeHosts,
   getSkillDocumentRevision,
+  getSkillVersionCheck,
+  getSkillVersionCheckKey,
   getRuntimeSkillRemoveTarget,
   getSelectedManagedSkillGroup,
   initialPublicPackageCatalogState,
@@ -42,6 +44,40 @@ test("getSkillDocumentRevision follows the selected installed host content", () 
     path: "/wanta/skills/demo",
   })
   assert.equal(getSkillDocumentRevision(updated), "content-v2")
+})
+
+test("getSkillVersionCheck ignores a report that predates the installed inventory version", () => {
+  const group = managedSkillGroup("demo", "@alice/demo", { version: "2.0.0" })
+  const staleCheck = {
+    currentVersion: "1.0.0",
+    id: "demo",
+    kind: "registry" as const,
+    latestVersion: "2.0.0",
+    name: "demo",
+    packageName: "@alice/demo",
+    skillId: "demo",
+    status: "update-available" as const,
+  }
+  const checks = new Map([[getSkillVersionCheckKey("demo", "@alice/demo"), staleCheck]])
+
+  assert.equal(getSkillVersionCheck(checks, group), undefined)
+})
+
+test("getSkillVersionCheck keeps a report matching the installed inventory version", () => {
+  const group = managedSkillGroup("demo", "@alice/demo", { version: "2.0.0" })
+  const currentCheck = {
+    currentVersion: "2.0.0",
+    id: "demo",
+    kind: "registry" as const,
+    latestVersion: "2.0.0",
+    name: "demo",
+    packageName: "@alice/demo",
+    skillId: "demo",
+    status: "current" as const,
+  }
+  const checks = new Map([[getSkillVersionCheckKey("demo", "@alice/demo"), currentCheck]])
+
+  assert.equal(getSkillVersionCheck(checks, group), currentCheck)
 })
 
 test("isEmojiIcon excludes numeric strings", () => {

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -319,7 +319,12 @@ export function getSkillVersionCheck(
     return undefined
   }
 
-  return versionCheckByKey.get(getSkillVersionCheckKey(group.id, group.packageName))
+  const versionCheck = versionCheckByKey.get(getSkillVersionCheckKey(group.id, group.packageName))
+  if (versionCheck?.currentVersion && group.version && versionCheck.currentVersion.trim() !== group.version.trim()) {
+    return undefined
+  }
+
+  return versionCheck
 }
 
 export function hasSkillUpdateAvailable(versionCheck: SkillVersionReport["skills"][number] | undefined): boolean {

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -320,7 +320,9 @@ export function getSkillVersionCheck(
   }
 
   const versionCheck = versionCheckByKey.get(getSkillVersionCheckKey(group.id, group.packageName))
-  if (versionCheck?.currentVersion && group.version && versionCheck.currentVersion.trim() !== group.version.trim()) {
+  const reportedVersion = versionCheck?.currentVersion?.trim()
+  const installedVersion = group.version?.trim()
+  if (reportedVersion && installedVersion && reportedVersion !== installedVersion) {
     return undefined
   }
 

--- a/src/routes/Skills/use-registry-skill-update.test.ts
+++ b/src/routes/Skills/use-registry-skill-update.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import type { SkillInventory, SkillVersionReport } from "../../../electron/skills/common.ts"
+import type { useSkillService } from "@/components/AppContext"
+import type { ResourceView } from "@/lib/resource-store"
+import type { Root } from "react-dom/client"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useRegistrySkillUpdate } from "./use-registry-skill-update.ts"
+
+const inventory: SkillInventory = {
+  groups: [],
+  summary: {
+    localSkills: 0,
+    managedSkills: 0,
+    modifiedHosts: 0,
+    needsAttention: 0,
+    publishableSkills: 0,
+    registrySkills: 0,
+    sourceMissingHosts: 0,
+    skills: [],
+  },
+  updatedAt: "2026-08-11T00:00:00.000Z",
+}
+
+const versionReport: SkillVersionReport = {
+  checkedAt: "2026-08-11T00:00:00.000Z",
+  cli: {
+    command: [],
+    status: "up-to-date",
+  },
+  skills: [],
+  summary: {
+    cliUpdates: 0,
+    errors: 0,
+    registrySkillUpdates: 0,
+    totalUpdates: 0,
+  },
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (cause: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+function createResourceView<T>(overrides: Partial<ResourceView<T>> = {}): ResourceView<T> {
+  return {
+    data: null,
+    error: null,
+    invalidate: vi.fn(),
+    isInitialLoading: false,
+    isRefreshing: false,
+    refresh: vi.fn(),
+    reset: vi.fn(),
+    setData: vi.fn(),
+    status: "ready",
+    updatedAt: null,
+    ...overrides,
+  } as ResourceView<T>
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe("useRegistrySkillUpdate", () => {
+  it("clears the updating state when installation finishes without waiting for version refresh", async () => {
+    const update = createDeferred<SkillInventory>()
+    const refresh = createDeferred<SkillVersionReport>()
+    const inventoryResource = createResourceView<SkillInventory>()
+    const versionResource = createResourceView<SkillVersionReport>({
+      refresh: vi.fn(() => refresh.promise),
+    })
+    const skillService = {
+      invoke: vi.fn(() => update.promise),
+    } as unknown as ReturnType<typeof useSkillService>
+    let updatePromise: Promise<void> | undefined
+
+    function Harness() {
+      const { updateRegistrySkill, updatingRegistrySkillId } = useRegistrySkillUpdate({
+        inventoryResource,
+        onError: vi.fn(),
+        skillService,
+        versionResource,
+      })
+
+      return React.createElement(
+        "button",
+        {
+          "data-state": updatingRegistrySkillId ? "updating" : "idle",
+          onClick: () => {
+            updatePromise = updateRegistrySkill({ id: "oo-github", kind: "registry", packageName: "oo-github" })
+          },
+        },
+        "Update",
+      )
+    }
+
+    const host = document.createElement("div")
+    document.body.append(host)
+    const root: Root = createRoot(host)
+    await act(async () => root.render(React.createElement(Harness)))
+    const button = host.querySelector<HTMLButtonElement>("button")
+
+    await act(async () => button?.click())
+    expect(button?.dataset.state).toBe("updating")
+
+    await act(async () => {
+      update.resolve(inventory)
+      await updatePromise
+    })
+
+    expect(button?.dataset.state).toBe("idle")
+    expect(inventoryResource.setData).toHaveBeenCalledWith(inventory)
+    expect(versionResource.invalidate).toHaveBeenCalledOnce()
+    expect(versionResource.refresh).toHaveBeenCalledWith({ forceRefresh: true, silent: true })
+
+    refresh.resolve(versionReport)
+    await refresh.promise
+    act(() => root.unmount())
+  })
+})

--- a/src/routes/Skills/use-registry-skill-update.ts
+++ b/src/routes/Skills/use-registry-skill-update.ts
@@ -3,6 +3,8 @@ import type { useSkillService } from "@/components/AppContext"
 import type { useSkillInventoryResource, useSkillVersionReportResource } from "@/components/AppDataHooks"
 
 import * as React from "react"
+import { runRegistrySkillUpdate } from "./registry-skill-update.ts"
+import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 
 interface UseRegistrySkillUpdateOptions {
   inventoryResource: ReturnType<typeof useSkillInventoryResource>
@@ -42,9 +44,14 @@ export function useRegistrySkillUpdate({
       setUpdatingRegistrySkillId(skill.id)
       onStart?.()
       try {
-        const nextInventory = await skillService.invoke("updateRegistrySkill", { packageName, skillId: skill.id })
-        inventoryResource.setData(nextInventory)
-        await versionResource.refresh({ forceRefresh: true, silent: true })
+        await runRegistrySkillUpdate({
+          invalidateVersions: versionResource.invalidate,
+          refreshVersions: () => versionResource.refresh({ forceRefresh: true, silent: true }),
+          reportVersionRefreshError: (cause) =>
+            reportRendererHandledError("skills", "silent skill version refresh failed after update", cause),
+          setInventory: inventoryResource.setData,
+          update: () => skillService.invoke("updateRegistrySkill", { packageName, skillId: skill.id }),
+        })
       } catch (cause) {
         onError(cause, skill.id)
       } finally {


### PR DESCRIPTION
## 问题

技能更新安装实际完成后，界面仍持续显示“更新中”，并继续展示旧版本的升级提示；重启应用后才会显示新版本。

## 原因

- 更新流程把完整的 registry 版本复查当成更新操作的一部分同步等待。版本复查会执行多个外部命令，耗时较长或超时时会让 UI 长时间停留在“更新中”。
- 版本资源失效时仍保留旧报告。新 inventory 已返回新版本后，旧报告里的 `currentVersion` 仍可能让界面继续显示过期的升级状态。

## 修改

- 以更新 RPC 返回的新 inventory 作为安装完成的边界，立即更新界面并结束 busy 状态。
- 将完整版本复查改为后台一致性刷新；刷新失败只记录诊断，不会把已成功的更新改判为失败。
- 当版本报告的当前版本与最新 inventory 不一致时，忽略该过期报告，避免继续显示旧升级提示。
- 增加 helper、route model 和 React hook 回归测试，覆盖后台刷新未完成时 UI 仍能退出“更新中”的真实状态切换。

## 验证

- `pnpm run lint`
- `pnpm test`（299 个测试文件，2246 个测试）
- `pnpm run build`
