### PR TITLE
feat(agent): deliver attachments to external agents as file references

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -99,6 +99,13 @@ External agents build on `electron/agent/external/`:
   `warmCatalog()` pass (throwaway ACP session closed right away, or an idle
   Claude query) fills the catalog before the first user session so draft-time
   pickers show the real lists.
+- **Attachments**: delivered as file references the agent resolves with its
+  own tools and permission model — never inlined into the payload. The ACP
+  adapter appends one `resource_link` block per attachment (baseline prompt
+  capability, so no capability negotiation is needed); the Claude adapter
+  appends a path-note text block (the CLI's Read tool handles images too).
+  Display rides the kernel's `userAttachmentStore` record keyed by the
+  synthesized user message id.
 - **Usage reporting**: adapters emit `usageUpdated` (normalized
   `ChatTokenUsage` + optional `contextWindow`) — Claude from result-frame
   usage/modelUsage, ACP from `usage_update`. The recorder attaches it to the

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -368,6 +368,37 @@ describe("AcpAgentAdapter", () => {
     expect(harness.fake.promptRequests[0]!.prompt).toEqual([{ type: "text", text: "hello agent" }])
   })
 
+  test("attachments ride the prompt as resource_link blocks after the text", async () => {
+    const harness = await createHarness()
+    await harness.adapter.send({
+      type: "prompt",
+      sessionId: WANTA_SESSION_ID,
+      text: "read the notes",
+      attachments: [
+        { id: "att-1", name: "notes.md", mime: "text/markdown", size: 12, path: "/tmp/notes.md" },
+        {
+          id: "att-2",
+          name: "shot.png",
+          mime: "image/png",
+          size: 99,
+          path: "/tmp/raw.png",
+          agentPath: "/tmp/optimized.png",
+          agentName: "optimized.png",
+          agentMime: "image/png",
+        },
+      ],
+    })
+    await harness.waitFor((event) => event.event === "messageCompleted")
+
+    // The agent-optimized copy wins when present; the uri is a file URL the
+    // agent resolves with its own tools.
+    expect(harness.fake.promptRequests[0]!.prompt).toEqual([
+      { type: "text", text: "read the notes" },
+      { type: "resource_link", uri: "file:///tmp/notes.md", name: "notes.md", mimeType: "text/markdown" },
+      { type: "resource_link", uri: "file:///tmp/optimized.png", name: "optimized.png", mimeType: "image/png" },
+    ])
+  })
+
   test.each([
     ["once", "opt-allow-once"],
     ["always", "opt-allow-always"],

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -14,6 +14,7 @@ import type { AcpAgentKind, AcpAgentRegistration } from "./registry.ts"
 import type { AcpSessionTranslator } from "./translator.ts"
 import type {
   ClientConnection,
+  ContentBlock,
   InitializeResponse,
   PermissionOption,
   PromptResponse,
@@ -28,6 +29,7 @@ import { spawn } from "node:child_process"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { Readable, Writable } from "node:stream"
+import { pathToFileURL } from "node:url"
 import { errorMessage, logDiagnostic } from "../../diagnostics-log.ts"
 import { AGENT_PROFILES } from "../contract/profile.ts"
 import { ExternalAgentAdapter } from "../external/adapter-base.ts"
@@ -268,6 +270,26 @@ function requestErrorCode(error: unknown): number | undefined {
  * same-direction kinds only; when no option matches the direction the outcome
  * degrades to "cancelled" rather than picking an opposite-direction option.
  */
+/**
+ * The prompt as ACP content blocks: the user text plus one resource_link per
+ * attachment. resource_link is baseline prompt capability (unlike image/audio,
+ * which need a capability declaration), so the agent resolves the file with
+ * its own tools regardless of what it advertised at initialize.
+ */
+function promptContentBlocks(input: PromptAgentInput): ContentBlock[] {
+  const blocks: ContentBlock[] = [{ type: "text", text: input.text }]
+  for (const attachment of input.attachments ?? []) {
+    const target = attachment.agentPath?.trim() || attachment.path
+    blocks.push({
+      type: "resource_link",
+      uri: pathToFileURL(target).href,
+      name: attachment.agentName?.trim() || attachment.name,
+      ...(attachment.agentMime || attachment.mime ? { mimeType: attachment.agentMime ?? attachment.mime } : {}),
+    })
+  }
+  return blocks
+}
+
 function selectPermissionOptionId(
   options: readonly PermissionOption[],
   reply: ChatPermissionReply,
@@ -462,7 +484,7 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     session.activeTurn = turn
     const promptPromise = handle.connection.agent.request("session/prompt", {
       sessionId: session.acpSessionId,
-      prompt: [{ type: "text", text: input.text }],
+      prompt: promptContentBlocks(input),
     })
     this.trackTurn(session, turn, promptPromise, options?.signal)
     // Resolve on dispatch (submission ack); completion arrives as messageCompleted.

--- a/electron/agent/claude/adapter.test.ts
+++ b/electron/agent/claude/adapter.test.ts
@@ -201,6 +201,37 @@ describe("ClaudeCodeAgentAdapter", () => {
     await vi.waitFor(() => expect(calls[0].fake.promptMessages).toHaveLength(2))
   })
 
+  it("appends attachments as a path-note text block the CLI resolves itself", async () => {
+    const { adapter, calls } = await createHarness()
+    await adapter.send({
+      type: "prompt",
+      sessionId,
+      text: "read the notes",
+      attachments: [
+        { id: "att-1", name: "notes.md", mime: "text/markdown", size: 12, path: "/tmp/notes.md" },
+        {
+          id: "att-2",
+          name: "assets",
+          mime: "inode/directory",
+          size: 0,
+          path: "/tmp/raw-assets",
+          kind: "directory",
+          agentPath: "/tmp/assets",
+        },
+      ],
+    })
+
+    await vi.waitFor(() => expect(calls[0].fake.promptMessages).toHaveLength(1))
+    const content = calls[0].fake.promptMessages[0].message.content
+    expect(Array.isArray(content) && content).toEqual([
+      { type: "text", text: "read the notes" },
+      {
+        type: "text",
+        text: "The user attached the following files for this message. Read them as needed:\n- /tmp/notes.md\n- /tmp/assets (directory)",
+      },
+    ])
+  })
+
   it("resumes the native session when persisted history exists, instead of recreating the id", async () => {
     // A restored session already owns its deterministic uuid on the CLI side;
     // creating it again fails with "Session ID already in use".

--- a/electron/agent/claude/adapter.ts
+++ b/electron/agent/claude/adapter.ts
@@ -1,4 +1,4 @@
-import type { AgentPermissionMode, ChatMessage, ChatPermissionRequest } from "../../chat/common.ts"
+import type { AgentPermissionMode, ChatAttachment, ChatMessage, ChatPermissionRequest } from "../../chat/common.ts"
 import type {
   AgentSendOptions,
   CancelAgentInput,
@@ -199,6 +199,15 @@ function isAuthenticationFailureMessage(message: string): boolean {
   return /authentication/iu.test(message)
 }
 
+/** Attachment paths as a prompt note the CLI resolves with its own file tools. */
+function attachmentPathNote(attachments: readonly ChatAttachment[]): string {
+  const lines = attachments.map((attachment) => {
+    const target = attachment.agentPath?.trim() || attachment.path
+    return `- ${target}${attachment.kind === "directory" ? " (directory)" : ""}`
+  })
+  return `The user attached the following files for this message. Read them as needed:\n${lines.join("\n")}`
+}
+
 export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
   public readonly kind = "claude-code" as const
   public readonly profile = AGENT_PROFILES["claude-code"]
@@ -284,11 +293,18 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       return
     }
     this.emitUserTurn(input)
+    // Attachments ride as a separate text block of path references: the CLI's
+    // own file tools resolve them (Read handles images too), which keeps large
+    // files out of the prompt payload and inside the agent's permission model.
+    const content: Array<{ type: "text"; text: string }> = [{ type: "text", text: input.text }]
+    if (input.attachments?.length) {
+      content.push({ type: "text", text: attachmentPathNote(input.attachments) })
+    }
     // Submission ack semantics: resolve once the message is enqueued for the
     // subprocess; turn progress flows back through the event channel.
     session.inputQueue.push({
       type: "user",
-      message: { role: "user", content: [{ type: "text", text: input.text }] },
+      message: { role: "user", content },
       parent_tool_use_id: null,
       session_id: session.sessionUuid,
     })

--- a/electron/agent/contract/profile.ts
+++ b/electron/agent/contract/profile.ts
@@ -78,10 +78,12 @@ export interface AgentProfile {
 
 /**
  * External agents own their models, auth, and system prompts; Wanta reflects
- * them and never routes models or injects prompt tails.
+ * them and never routes models or injects prompt tails. Attachments are
+ * delivered as file references (ACP resource_link blocks, path notes for the
+ * Claude SDK) that the agent resolves with its own file tools.
  */
 const externalAgentInputs: AgentInputCapabilityFlags = {
-  attachments: false,
+  attachments: true,
   modes: false,
   reasoningLevels: false,
   systemPrompt: false,

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -60,6 +60,8 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   public readonly permissionResponses: PermissionResponseAgentInput[] = []
   public readonly setModels: SetModelAgentInput[] = []
   public readonly setEfforts: SetEffortAgentInput[] = []
+  /** When set, the next prompt throws this error instead of dispatching. */
+  public failNextPrompt: Error | undefined
   private readonly nativePendingPermissionIds = new Set<string>()
 
   public constructor(kind: ExternalAgentKind) {
@@ -74,6 +76,11 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   protected async handlePrompt(input: PromptAgentInput, options?: AgentSendOptions): Promise<void> {
     if (options?.signal?.aborted) {
       return
+    }
+    if (this.failNextPrompt) {
+      const error = this.failNextPrompt
+      this.failNextPrompt = undefined
+      throw error
     }
     this.prompts.push(input)
     const userMessageId = input.messageId ?? `user-${this.prompts.length}`
@@ -228,7 +235,7 @@ async function waitForTurnCompletion(service: ChatServiceImpl): Promise<void> {
 // Edge 1: attachments into an external session
 // ---------------------------------------------------------------------------
 
-test("edge1: attachment send into an external session rejects cleanly and leaves zero run residue", async () => {
+test("edge1: attachment send into an external session records the attachment and forwards it to the adapter", async () => {
   const record = vi.fn(async () => undefined)
   const removeMessage = vi.fn(async () => undefined)
   const attachmentStore = {
@@ -248,34 +255,55 @@ test("edge1: attachment send into an external session rejects cleanly and leaves
     path: "/tmp/notes.md",
   }
 
-  await assert.rejects(
-    service.sendMessage(sendRequest(sessionId, "please read this", { attachments: [attachment] })),
-    /Attachments are not supported for this agent yet\./,
-  )
+  await service.sendMessage(sendRequest(sessionId, "please read this", { attachments: [attachment] }))
 
-  // No half-created generation: no active run, no adapter dispatch, no
-  // optimistic user message in the transcript, no attachment record written.
-  assert.equal(service.hasActiveGeneration(), false)
-  assert.equal(await service.getActiveRun(sessionId), null)
-  assert.equal(adapter.prompts.length, 0)
-  assert.deepEqual(await service.getMessages(sessionId), [])
-  assert.equal(record.mock.calls.length, 0)
-  assert.equal(removeMessage.mock.calls.length, 0)
-  assert.deepEqual(
-    events.filter((entry) => entry.event === "messageError"),
-    [],
-  )
-
-  // A follow-up plain-text send into the same session works end to end.
-  await service.sendMessage(sendRequest(sessionId, "hello without attachments"))
+  // The adapter receives the attachments on the prompt, and the display
+  // record ties them to the same user message id the adapter echoes back.
   assert.equal(adapter.prompts.length, 1)
-  adapter.completeAssistantTurn(sessionId, "reply-1", "hi")
+  assert.deepEqual(adapter.prompts[0]?.attachments, [attachment])
+  assert.equal(record.mock.calls.length, 1)
+  const [recordedSessionId, recordedMessageId] = record.mock.calls[0] as unknown as [string, string]
+  assert.equal(recordedSessionId, sessionId)
+  assert.equal(recordedMessageId, adapter.prompts[0]?.messageId)
+  assert.equal(removeMessage.mock.calls.length, 0)
+
+  adapter.completeAssistantTurn(sessionId, "reply-1", "read it")
   await waitForTurnCompletion(service)
   const messages = await service.getMessages(sessionId)
   assert.equal(messages.length, 2)
   assert.equal(messages[0]?.role, "user")
   assert.equal(messages[1]?.role, "assistant")
-  assert.ok(events.some((entry) => entry.event === "messageCompleted"))
+  assert.deepEqual(
+    events.filter((entry) => entry.event === "messageError"),
+    [],
+  )
+})
+
+test("edge1b: a failed attachment send rolls the display record back", async () => {
+  const record = vi.fn(async () => undefined)
+  const removeMessage = vi.fn(async () => undefined)
+  const attachmentStore = {
+    read: async () => new Map(),
+    record,
+    removeMessage,
+  } as unknown as UserAttachmentStore
+  const { service, adapters } = createHarness(["claude-code"], { userAttachmentStore: attachmentStore })
+  const adapter = adapters.get("claude-code")
+  assert.ok(adapter)
+  adapter.failNextPrompt = new Error("agent exploded")
+  const sessionId = mintExternalSessionId("claude-code")
+  const attachment: ChatAttachment = {
+    id: "att-1",
+    name: "notes.md",
+    mime: "text/markdown",
+    size: 12,
+    path: "/tmp/notes.md",
+  }
+
+  await service.sendMessage(sendRequest(sessionId, "please read this", { attachments: [attachment] }))
+  await waitForCondition(() => removeMessage.mock.calls.length === 1, "attachment record rollback")
+  assert.equal(record.mock.calls.length, 1)
+  assert.equal(service.hasActiveGeneration(), false)
 })
 
 // ---------------------------------------------------------------------------

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -17,6 +17,9 @@ import type { UserAttachmentStore } from "./user-attachments.ts"
 
 import assert from "node:assert/strict"
 import { randomUUID } from "node:crypto"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import { test, vi } from "vitest"
 import { AGENT_PROFILES } from "../agent/contract/profile.ts"
 import { ExternalAgentAdapter } from "../agent/external/adapter-base.ts"
@@ -235,6 +238,14 @@ async function waitForTurnCompletion(service: ChatServiceImpl): Promise<void> {
 // Edge 1: attachments into an external session
 // ---------------------------------------------------------------------------
 
+/** A real on-disk attachment: the trust boundary realpath()s every candidate. */
+async function createProbeAttachment(): Promise<ChatAttachment> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "wanta-dx-attach-"))
+  const filePath = path.join(dir, "notes.md")
+  await writeFile(filePath, "probe", "utf8")
+  return { id: "att-1", name: "notes.md", mime: "text/markdown", size: 5, path: filePath }
+}
+
 test("edge1: attachment send into an external session records the attachment and forwards it to the adapter", async () => {
   const record = vi.fn(async () => undefined)
   const removeMessage = vi.fn(async () => undefined)
@@ -243,17 +254,16 @@ test("edge1: attachment send into an external session records the attachment and
     record,
     removeMessage,
   } as unknown as UserAttachmentStore
-  const { service, events, adapters } = createHarness(["claude-code"], { userAttachmentStore: attachmentStore })
+  const attachment = await createProbeAttachment()
+  const { service, events, adapters } = createHarness(["claude-code"], {
+    userAttachmentStore: attachmentStore,
+    // Picker authorization: attachment paths are trusted only when the user
+    // selected them, mirrored here the way main.ts wires the shared set.
+    trustedAttachmentPaths: new Set([attachment.path]),
+  })
   const adapter = adapters.get("claude-code")
   assert.ok(adapter)
   const sessionId = mintExternalSessionId("claude-code")
-  const attachment: ChatAttachment = {
-    id: "att-1",
-    name: "notes.md",
-    mime: "text/markdown",
-    size: 12,
-    path: "/tmp/notes.md",
-  }
 
   await service.sendMessage(sendRequest(sessionId, "please read this", { attachments: [attachment] }))
 
@@ -287,22 +297,53 @@ test("edge1b: a failed attachment send rolls the display record back", async () 
     record,
     removeMessage,
   } as unknown as UserAttachmentStore
-  const { service, adapters } = createHarness(["claude-code"], { userAttachmentStore: attachmentStore })
+  const attachment = await createProbeAttachment()
+  const { service, adapters } = createHarness(["claude-code"], {
+    userAttachmentStore: attachmentStore,
+    trustedAttachmentPaths: new Set([attachment.path]),
+  })
   const adapter = adapters.get("claude-code")
   assert.ok(adapter)
   adapter.failNextPrompt = new Error("agent exploded")
   const sessionId = mintExternalSessionId("claude-code")
-  const attachment: ChatAttachment = {
-    id: "att-1",
-    name: "notes.md",
-    mime: "text/markdown",
-    size: 12,
-    path: "/tmp/notes.md",
-  }
 
   await service.sendMessage(sendRequest(sessionId, "please read this", { attachments: [attachment] }))
   await waitForCondition(() => removeMessage.mock.calls.length === 1, "attachment record rollback")
   assert.equal(record.mock.calls.length, 1)
+  assert.equal(service.hasActiveGeneration(), false)
+})
+
+test("edge1c: an attachment path the user never authorized is rejected at the IPC boundary", async () => {
+  // Attachment paths are renderer-supplied; without picker authorization a
+  // compromised renderer could hand the agent any local file. The external
+  // path must enforce the same trust boundary as the kernel path.
+  const record = vi.fn(async () => undefined)
+  const attachmentStore = {
+    read: async () => new Map(),
+    record,
+    removeMessage: vi.fn(async () => undefined),
+  } as unknown as UserAttachmentStore
+  const { service, adapters } = createHarness(["claude-code"], {
+    userAttachmentStore: attachmentStore,
+    trustedAttachmentPaths: new Set<string>(),
+  })
+  const adapter = adapters.get("claude-code")
+  assert.ok(adapter)
+  const sessionId = mintExternalSessionId("claude-code")
+  const attachment: ChatAttachment = {
+    id: "att-evil",
+    name: "id_rsa",
+    mime: "application/octet-stream",
+    size: 1,
+    path: "/Users/someone/.ssh/id_rsa",
+  }
+
+  await assert.rejects(
+    service.sendMessage(sendRequest(sessionId, "leak this", { attachments: [attachment] })),
+    /not selected or previously authorized/,
+  )
+  assert.equal(adapter.prompts.length, 0)
+  assert.equal(record.mock.calls.length, 0)
   assert.equal(service.hasActiveGeneration(), false)
 })
 

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1850,6 +1850,12 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       if (trustedProjectRoot) {
         this.trustedAccess.setProjectRoot(req.sessionId, trustedProjectRoot)
       }
+      if (req.attachments?.length) {
+        // Same display path as the kernel: the store record is what getMessages
+        // folds back onto the synthesized user turn.
+        await this.deps.userAttachmentStore?.record(req.sessionId, userMessageId, req.attachments, req.text)
+        this.rememberTrustedAttachments(req.sessionId, req.attachments)
+      }
       await this.projectPermissionMode(req.sessionId, this.sessionPermissionMode(req.sessionId))
       this.activeRuns.update(req.sessionId, { phase: "submitted" })
       this.scheduleGenerationSubmitWatchdog(req.sessionId, generation.id)
@@ -1860,6 +1866,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             sessionId: req.sessionId,
             text: req.text,
             messageId: userMessageId,
+            ...(req.attachments?.length ? { attachments: req.attachments } : {}),
             ...(trustedProjectRoot ? { outputProjectRoot: trustedProjectRoot } : {}),
             ...(req.agentModelId ? { agentModelId: req.agentModelId } : {}),
             ...(req.agentEffortId ? { agentEffortId: req.agentEffortId } : {}),
@@ -1876,6 +1883,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           }
         })
         .catch((error: unknown) => {
+          if (req.attachments?.length) {
+            // The prompt never reached the agent; a record without a user turn
+            // would resurface as an orphaned attachment bubble on reload.
+            void this.rollbackUnsubmittedUserAttachments(req.sessionId, userMessageId, req.attachments)
+          }
           if (!this.isCurrentGeneration(req.sessionId, generation.id) || generation.controller.signal.aborted) {
             this.clearSessionGeneration(req.sessionId, generation.id)
             return

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1826,6 +1826,12 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (!req.text.trim()) {
       throw new Error("Message text is empty.")
     }
+    // Same trust boundary as the kernel path: attachment paths cross the IPC
+    // boundary, so only picker-authorized or previously trusted paths may be
+    // recorded and handed to the agent. Asserted BEFORE the single-generation
+    // check: the await would otherwise open a same-tick window where two sends
+    // both pass the check and spawn duplicate generations.
+    await this.assertTrustedAttachments(req.attachments)
     if (this.generations.has(req.sessionId)) {
       throw new Error("A generation is already active for this session.")
     }
@@ -1855,6 +1861,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         // folds back onto the synthesized user turn.
         await this.deps.userAttachmentStore?.record(req.sessionId, userMessageId, req.attachments, req.text)
         this.rememberTrustedAttachments(req.sessionId, req.attachments)
+        // One-shot picker authorization is consumed on submit, kernel-style.
+        this.discardTrustedAttachmentPaths(req.attachments)
       }
       await this.projectPermissionMode(req.sessionId, this.sessionPermissionMode(req.sessionId))
       this.activeRuns.update(req.sessionId, { phase: "submitted" })

--- a/src/routes/Chat/agent-control-options.test.ts
+++ b/src/routes/Chat/agent-control-options.test.ts
@@ -38,11 +38,14 @@ describe("composerCapabilitiesForProfile", () => {
     })
   })
 
-  it("disables model routing, modes, and attachments for external profiles", () => {
+  it("disables model routing and modes but keeps attachments for external profiles", () => {
+    // Attachments are delivered as file references the agent resolves itself,
+    // so every external agent supports them; model routing and Wanta modes
+    // stay agent-owned.
     for (const kind of EXTERNAL_AGENT_KINDS) {
       expect(composerCapabilitiesForProfile(AGENT_PROFILES[kind])).toEqual({
         agentModesEnabled: false,
-        attachmentsEnabled: false,
+        attachmentsEnabled: true,
         modelRoutingEnabled: false,
       })
     }


### PR DESCRIPTION
External agents (Claude Code, Codex, Grok) declared `attachments: false`, so the composer hid the attachment picker even though all three CLIs can consume files, and linkcode already ships image support for claude and codex. This PR delivers attachments as file references the agent resolves with its own tools: the ACP adapter appends one `resource_link` block per attachment (baseline prompt capability, no negotiation needed) and the Claude adapter appends a path-note text block, whose Read tool handles text and images alike. Inlining file bytes was rejected on purpose, since it bloats the payload for large files and bypasses the agent's own permission model.

Display reuses the kernel path unchanged: `sendExternalMessage` records attachments in `userAttachmentStore` under the synthesized user message id, which `getMessages` already folds back for any backend, and the record rolls back when the prompt never reaches the agent. Verified live against all three agents, each reading a probe file's content back through its own file tools.
