### PR TITLE
fix(skills): streamline Skill publishing workflow

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -185,8 +185,10 @@
   oo business operations. Safe shell wrappers are inspected; unrecognized ordinary wrappers,
   pipelines, and output filtering fall through to the normal Default Access policy instead of
   creating a parser-only prompt. Pipes/redirection are not by themselves a reason to prompt —
-  prompt only on a genuine baseline security risk; `sudo`, piping into a shell, writes to sensitive
-  paths, etc. still require confirmation. Full Access bypasses every local prompt after the
+  prompt only on a genuine baseline security risk. A `curl`/`wget` response piped into bare Python
+  or `python -` is executable input and remains protected; piping JSON into an explicit local
+  `python -m ...` or `python -c ...` data processor is ordinary filtering. `sudo`, piping into a
+  shell, writes to sensitive paths, etc. still require confirmation. Full Access bypasses every local prompt after the
   OpenConnector credential and injected-runtime hard-deny checks.
 - **Permission gates only built-in tools**: `bash: deny` and the like do not constrain `.opencode`
   custom tools (their permission gate lives inside each built-in tool's execute) — when

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -256,6 +256,7 @@ describe("AgentManager", () => {
 
   it("exposes OOMOL authentication and the managed Node runtime to Skill commands", () => {
     const env = buildAgentSidecarEnv({
+      accountName: "alwaysmavs",
       commandPath: "/usr/bin:/bin",
       linkRuntime: { kind: "oomol", sessionToken: "session-token" },
       ooBinPath: "/tmp/oo",
@@ -269,6 +270,7 @@ describe("AgentManager", () => {
       PATH: "/usr/bin:/bin",
       WANTA_NODE_BIN: process.execPath,
       WANTA_OO_BIN: "/tmp/oo",
+      WANTA_ACCOUNT_NAME: "alwaysmavs",
     })
     expect(env.OO_ENDPOINT).toBeTruthy()
   })

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -63,6 +63,8 @@ import { ensureAgentWorkspace } from "./workspace.ts"
 export type { GeneratedSessionTitle } from "./session-title-generator.ts"
 
 export interface AgentManagerOptions {
+  /** Signed-in account name exposed as non-secret Skill publishing context. */
+  accountName?: string
   browserControl?: () => Promise<AgentBrowserControlConnection | undefined>
   linkRuntime: LinkRuntime | null
   modelAccess: ModelAccess
@@ -155,6 +157,7 @@ export function buildManagedSkillRuntimeEnv(nodeBin: string = process.execPath):
 }
 
 export interface AgentSidecarEnvOptions {
+  accountName?: string
   browserControl?: AgentBrowserControlConnection
   commandPath: string
   linkRuntime: LinkRuntime | null
@@ -173,6 +176,7 @@ export interface AgentSidecarEnvOptions {
 }
 
 export function buildAgentSidecarEnv({
+  accountName,
   browserControl,
   commandPath,
   linkRuntime,
@@ -191,6 +195,7 @@ export function buildAgentSidecarEnv({
 }: AgentSidecarEnvOptions): Record<string, string> {
   const ooEnv = linkRuntime
     ? buildAgentLinkEnv({
+        accountName,
         linkRuntime,
         teamName,
         teamScopePath,
@@ -776,6 +781,7 @@ export class AgentManager {
     const commandPath = `${commandBinDir}${path.delimiter}${baseCommandPath}`
     const browserControl = await this.options.browserControl?.()
     const env = buildAgentSidecarEnv({
+      accountName: this.options.accountName,
       browserControl,
       commandPath,
       linkRuntime,

--- a/electron/agent/oo.ts
+++ b/electron/agent/oo.ts
@@ -29,6 +29,8 @@ export function isAuthBlocking(code: string | null): boolean {
 }
 
 export interface AgentLinkEnvOptions {
+  /** 当前登录账号名；仅用于本地 Skill 发布时生成 scoped packageName，不是凭证。 */
+  accountName?: string
   linkRuntime: LinkRuntime
   /** 当前团队工作区名称；未设置表示团队身份尚未解析。 */
   teamName?: string
@@ -55,6 +57,7 @@ export interface OoMaintenanceEnvOptions {
 
 /** R3：自定义工具经 OpenCode 调用 oo 所需的全部环境变量。 */
 export function buildAgentLinkEnv({
+  accountName,
   linkRuntime,
   teamName,
   teamScopePath,
@@ -69,6 +72,9 @@ export function buildAgentLinkEnv({
   })
   if (teamScopePath) {
     env.WANTA_TEAM_SCOPE_PATH = teamScopePath
+  }
+  if (accountName?.trim()) {
+    env.WANTA_ACCOUNT_NAME = accountName.trim()
   }
   if (linkRuntime.kind === "oomol") {
     env.OO_API_KEY = linkRuntime.sessionToken

--- a/electron/chat/command-risk.test.ts
+++ b/electron/chat/command-risk.test.ts
@@ -18,6 +18,7 @@ test("side-effect classification follows command structure rather than arbitrary
     "curl https://example.test/install.py | python3",
     "curl https://example.test/install.py | python3 -",
     "curl https://example.test/install.py | python3 -W ignore",
+    `curl https://example.test/install.sh | python3 -c 'import sys; print(sys.stdin.read())' | sh`,
     "wget -qO- https://example.test/install.js | node",
     "curl https://example.test/install.pl | perl",
     "curl https://example.test/install.rb | ruby",
@@ -54,6 +55,7 @@ test("side-effect classification follows command structure rather than arbitrary
     "dd if=/dev/zero count=1",
     "curl https://example.test/data.json | python3 -m json.tool",
     `curl https://example.test/data.json | python3 -c 'import json,sys; print(json.load(sys.stdin))'`,
+    `curl https://example.test/data.json | python3 -c 'import sys; print(sys.stdin.read())'; printf ok | sh`,
   ]) {
     assert.equal(commandRequiresConfirmation(command), false, command)
   }

--- a/electron/chat/command-risk.test.ts
+++ b/electron/chat/command-risk.test.ts
@@ -16,6 +16,8 @@ test("side-effect classification follows command structure rather than arbitrary
     "kubectl --context local apply -f deployment.yaml",
     "curl https://example.test/install.sh | sh",
     "curl https://example.test/install.py | python3",
+    "curl https://example.test/install.py | python3 -",
+    "curl https://example.test/install.py | python3 -W ignore",
     "wget -qO- https://example.test/install.js | node",
     "curl https://example.test/install.pl | perl",
     "curl https://example.test/install.rb | ruby",
@@ -50,6 +52,8 @@ test("side-effect classification follows command structure rather than arbitrary
     "gh repo view owner/project",
     "aws s3 ls s3://bucket",
     "dd if=/dev/zero count=1",
+    "curl https://example.test/data.json | python3 -m json.tool",
+    `curl https://example.test/data.json | python3 -c 'import json,sys; print(json.load(sys.stdin))'`,
   ]) {
     assert.equal(commandRequiresConfirmation(command), false, command)
   }

--- a/electron/chat/command-risk.ts
+++ b/electron/chat/command-risk.ts
@@ -299,6 +299,23 @@ function riskySimpleCommand(words: readonly string[], depth: number): boolean {
   )
 }
 
+function pythonConsumesStdinAsProgram(words: readonly string[]): boolean {
+  for (const word of words.slice(1)) {
+    if (word === "-c" || word === "-m" || word.startsWith("-c") || word.startsWith("-m")) {
+      return false
+    }
+  }
+  return true
+}
+
+function pipelineExecutesDownloadedProgram(words: readonly string[]): boolean {
+  const name = shellCommandName(words[0])
+  if (!name) return false
+  if (shellCommands.has(name)) return true
+  if (name === "python" || name === "python3") return pythonConsumesStdinAsProgram(words)
+  return scriptInterpreterCommands.has(name)
+}
+
 export function commandRequiresConfirmation(command: string, depth = 0): boolean {
   const segments = topLevelShellSegments(command)
   const commands = segments.map(({ text }) => {
@@ -313,12 +330,10 @@ export function commandRequiresConfirmation(command: string, depth = 0): boolean
       return false
     }
     const source = shellCommandName(words[0])
-    const target = shellCommandName(commands[index + 1]?.[0])
     return Boolean(
       source &&
-      target &&
       ["curl", "wget"].includes(source) &&
-      (shellCommands.has(target) || scriptInterpreterCommands.has(target)),
+      pipelineExecutesDownloadedProgram(commands[index + 1] ?? []),
     )
   })
 }

--- a/electron/chat/command-risk.ts
+++ b/electron/chat/command-risk.ts
@@ -331,9 +331,7 @@ export function commandRequiresConfirmation(command: string, depth = 0): boolean
     }
     const source = shellCommandName(words[0])
     return Boolean(
-      source &&
-      ["curl", "wget"].includes(source) &&
-      pipelineExecutesDownloadedProgram(commands[index + 1] ?? []),
+      source && ["curl", "wget"].includes(source) && pipelineExecutesDownloadedProgram(commands[index + 1] ?? []),
     )
   })
 }

--- a/electron/chat/command-risk.ts
+++ b/electron/chat/command-risk.ts
@@ -316,6 +316,18 @@ function pipelineExecutesDownloadedProgram(words: readonly string[]): boolean {
   return scriptInterpreterCommands.has(name)
 }
 
+function downloadedPipelineExecutesProgram(
+  commands: readonly (readonly string[])[],
+  segments: ReturnType<typeof topLevelShellSegments>,
+  sourceIndex: number,
+): boolean {
+  for (let index = sourceIndex + 1; index < commands.length; index += 1) {
+    if (segments[index - 1]?.operatorAfter !== "pipe") return false
+    if (pipelineExecutesDownloadedProgram(commands[index] ?? [])) return true
+  }
+  return false
+}
+
 export function commandRequiresConfirmation(command: string, depth = 0): boolean {
   const segments = topLevelShellSegments(command)
   const commands = segments.map(({ text }) => {
@@ -331,7 +343,7 @@ export function commandRequiresConfirmation(command: string, depth = 0): boolean
     }
     const source = shellCommandName(words[0])
     return Boolean(
-      source && ["curl", "wget"].includes(source) && pipelineExecutesDownloadedProgram(commands[index + 1] ?? []),
+      source && ["curl", "wget"].includes(source) && downloadedPipelineExecutesProgram(commands, segments, index),
     )
   })
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -792,6 +792,7 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   ])
   const nextAgent = new OpencodeAgentAdapter(
     new AgentManager({
+      accountName: account?.name,
       browserControl: browserControlConnection,
       defaultModel: runtime.defaultModel,
       linkRuntime,

--- a/resources/skill-overrides/oo-publish-skill.md
+++ b/resources/skill-overrides/oo-publish-skill.md
@@ -1,0 +1,12 @@
+## Wanta fast path for publishing a new version
+
+When the user asks to publish a new version of an existing local Skill, keep the workflow deterministic and short:
+
+1. Resolve the concrete source path once. If multiple installed copies are identical, use the current runtime copy; ask only when their contents differ and no source is already clear.
+2. Read `SKILL.md` frontmatter once. If `metadata.version` exists, increment its patch component unless the user requested another bump. If it is missing, use `0.0.1`.
+3. Keep an existing `metadata.packageName`. If it is missing, create `@<account>/<skill-name>` from the non-secret `WANTA_ACCOUNT_NAME` environment value and the frontmatter `name`. If that value is unavailable, run the publish command once and apply only the smallest correction named by its error.
+4. For an existing package whose visibility should remain unchanged, omit `--visibility`. For a genuinely new package with no requested visibility, ask exactly once whether it should be private or public.
+5. In a non-interactive agent session, run `oo skills publish <path> -y` with `--visibility` only when visibility is explicitly chosen for a new package or explicitly changed by the user.
+6. On a version-conflict error, increment patch once and retry once. For any other failure, report the exact error and smallest next fix; do not begin an open-ended investigation.
+
+Do not search logs, shell history, SQLite databases, unrelated Skill metadata, registry caches, or alternate guessed package names to infer version or visibility. Do not infer this Skill's visibility from other packages. Before the first publish attempt, use at most the source resolution and frontmatter read above.

--- a/scripts/skills.test.ts
+++ b/scripts/skills.test.ts
@@ -1,12 +1,27 @@
-import { access } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
-import { wantaBundledSkillIds, wantaSkillsDir } from "./skills.ts"
+import { applyBundledSkillOverrides, skillOverridesDir, wantaBundledSkillIds, wantaSkillsDir } from "./skills.ts"
 
 describe("Wanta bundled skills", () => {
   it("keeps a tracked SKILL.md source for every bundled Wanta skill", async () => {
     await expect(
       Promise.all(wantaBundledSkillIds.map((skillId) => access(path.join(wantaSkillsDir, skillId, "SKILL.md")))),
     ).resolves.toBeDefined()
+  })
+
+  it("adds the tracked Wanta fast path to the exported publish skill", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wanta-skill-overrides-"))
+    const outDir = path.join(root, "skills")
+    const publishDir = path.join(outDir, "oo-publish-skill")
+    await mkdir(publishDir, { recursive: true })
+    await writeFile(path.join(publishDir, "SKILL.md"), "# Upstream publish skill\n")
+
+    await applyBundledSkillOverrides(outDir, skillOverridesDir)
+
+    const content = await readFile(path.join(publishDir, "SKILL.md"), "utf8")
+    expect(content).toContain("## Wanta fast path for publishing a new version")
+    expect(content).toContain("Do not search logs, shell history, SQLite databases")
   })
 })

--- a/scripts/skills.test.ts
+++ b/scripts/skills.test.ts
@@ -2,7 +2,7 @@ import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
-import { applyBundledSkillOverrides, skillOverridesDir, wantaBundledSkillIds, wantaSkillsDir } from "./skills.ts"
+import { exportBundledSkills, wantaBundledSkillIds, wantaSkillsDir } from "./skills.ts"
 
 describe("Wanta bundled skills", () => {
   it("keeps a tracked SKILL.md source for every bundled Wanta skill", async () => {
@@ -11,16 +11,23 @@ describe("Wanta bundled skills", () => {
     ).resolves.toBeDefined()
   })
 
-  it("adds the tracked Wanta fast path to the exported publish skill", async () => {
+  it("adds the tracked Wanta fast path through the bundled Skill export", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "wanta-skill-overrides-"))
     const outDir = path.join(root, "skills")
-    const publishDir = path.join(outDir, "oo-publish-skill")
-    await mkdir(publishDir, { recursive: true })
-    await writeFile(path.join(publishDir, "SKILL.md"), "# Upstream publish skill\n")
+    await exportBundledSkills(outDir, async (directory) => {
+      const publishDir = path.join(directory, "oo-publish-skill")
+      await mkdir(publishDir, { recursive: true })
+      await writeFile(path.join(publishDir, "SKILL.md"), "# Upstream publish skill\n")
+      return JSON.stringify({
+        skills: ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"].map((skillId) => ({
+          skillId,
+          status: "exported",
+        })),
+        summary: { failed: 0 },
+      })
+    })
 
-    await applyBundledSkillOverrides(outDir, skillOverridesDir)
-
-    const content = await readFile(path.join(publishDir, "SKILL.md"), "utf8")
+    const content = await readFile(path.join(outDir, "oo-publish-skill", "SKILL.md"), "utf8")
     expect(content).toContain("## Wanta fast path for publishing a new version")
     expect(content).toContain("Do not search logs, shell history, SQLite databases")
   })

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -34,16 +34,33 @@ interface SkillsInstallExport {
   skills?: Array<{ skillId?: string; status?: string }>
 }
 
+export type BundledSkillsInstaller = (outDir: string) => Promise<string>
+
 /**
  * 把 oo bundled skill 导出到 outDir（默认 resources/skills/）。幂等：先清空目录再导出，避免旧版本残留。
  * 返回导出目录绝对路径。导出失败或 oo skills 未全部导出则抛错。
  */
-export async function exportBundledSkills(outDir: string = bundledSkillsDir): Promise<string> {
-  const ooBin = await downloadOoBinary()
-  const storeDir = path.join(os.tmpdir(), "wanta-oo-skill-export-store")
-
+export async function exportBundledSkills(
+  outDir: string = bundledSkillsDir,
+  installOoSkills: BundledSkillsInstaller = installBundledOoSkills,
+): Promise<string> {
   await rm(outDir, { force: true, recursive: true })
   await mkdir(outDir, { recursive: true })
+
+  const stdout = await installOoSkills(outDir)
+  assertSkillsExported(stdout, outDir)
+  await applyBundledSkillOverrides(outDir)
+  await Promise.all(
+    wantaBundledSkillIds.map((skillId) =>
+      cp(path.join(wantaSkillsDir, skillId), path.join(outDir, skillId), { recursive: true }),
+    ),
+  )
+  return outDir
+}
+
+async function installBundledOoSkills(outDir: string): Promise<string> {
+  const ooBin = await downloadOoBinary()
+  const storeDir = path.join(os.tmpdir(), "wanta-oo-skill-export-store")
 
   const result = spawnSync(ooBin, ["skills", "install", `--out-dir=${outDir}`, "--agent-format=universal", "--json"], {
     encoding: "utf-8",
@@ -65,15 +82,7 @@ export async function exportBundledSkills(outDir: string = bundledSkillsDir): Pr
   if (result.status !== 0) {
     throw new Error(`oo skills install --out-dir failed (code ${result.status}): ${result.stderr || result.stdout}`)
   }
-
-  assertSkillsExported(result.stdout, outDir)
-  await applyBundledSkillOverrides(outDir)
-  await Promise.all(
-    wantaBundledSkillIds.map((skillId) =>
-      cp(path.join(wantaSkillsDir, skillId), path.join(outDir, skillId), { recursive: true }),
-    ),
-  )
-  return outDir
+  return result.stdout
 }
 
 export async function applyBundledSkillOverrides(

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -1,5 +1,6 @@
 // 静态内置 agent skill：构建期用 oo 二进制把 oo bundled skill 导出到 resources/skills/（gitignore），
-// 再补入 Wanta 自带的只读工作流 skills（resources/wanta-skills/）。
+// 再叠加 Wanta 的 tracked skill 补充规则（resources/skill-overrides/），并补入 Wanta 自带的只读工作流
+// skills（resources/wanta-skills/）。
 // 供 dev 与打包共用。运行时由 electron/agent/workspace.ts 拷进 OpenCode workspace 的 .opencode/skill/，
 // 使 Wanta 自己的 agent 直接读到这些 skill——不再像旧 oo-cli 那样把 skill 释放到其他 AI agent 家目录。
 //
@@ -7,7 +8,7 @@
 // `--out-dir` 只写指定目录；仍隔离 OO_CONFIG/DATA/LOG 到临时目录并禁用 sync，避免污染开发机家目录。
 
 import { spawnSync } from "node:child_process"
-import { cp, mkdir, rm } from "node:fs/promises"
+import { appendFile, cp, mkdir, readFile, readdir, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -19,6 +20,7 @@ const repoRoot = path.join(dirname, "..")
 // 导出落地目录（gitignore）。dev 运行时与生产打包都以此为源；运行时路径解析见 electron/agent/binaries.ts。
 export const bundledSkillsDir = path.join(repoRoot, "resources", "skills")
 export const wantaSkillsDir = path.join(repoRoot, "resources", "wanta-skills")
+export const skillOverridesDir = path.join(repoRoot, "resources", "skill-overrides")
 
 const ooBundledSkillIds = ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"] as const
 export const wantaBundledSkillIds = ["browser", "wikigraph-knowledge"] as const
@@ -65,12 +67,31 @@ export async function exportBundledSkills(outDir: string = bundledSkillsDir): Pr
   }
 
   assertSkillsExported(result.stdout, outDir)
+  await applyBundledSkillOverrides(outDir)
   await Promise.all(
     wantaBundledSkillIds.map((skillId) =>
       cp(path.join(wantaSkillsDir, skillId), path.join(outDir, skillId), { recursive: true }),
     ),
   )
   return outDir
+}
+
+export async function applyBundledSkillOverrides(
+  outDir: string,
+  overridesDir: string = skillOverridesDir,
+): Promise<void> {
+  const overrideFiles = await readdirMarkdownFiles(overridesDir)
+  await Promise.all(
+    overrideFiles.map(async (filename) => {
+      const skillId = path.basename(filename, ".md")
+      const supplement = (await readFile(path.join(overridesDir, filename), "utf8")).trim()
+      await appendFile(path.join(outDir, skillId, "SKILL.md"), `\n\n${supplement}\n`, "utf8")
+    }),
+  )
+}
+
+async function readdirMarkdownFiles(directory: string): Promise<string[]> {
+  return (await readdir(directory)).filter((name) => name.endsWith(".md"))
 }
 
 /** 校验 oo skills install --json 的导出结果：oo 内置 skill 全部 exported、无失败。 */


### PR DESCRIPTION
## Summary

Streamline the chat-driven OO Skill publishing workflow so publishing a new version follows a short, deterministic path and ordinary JSON processing does not trigger repeated permission confirmations.

## Problem

A request to publish a new version of a local Skill could expand into dozens of shell calls that searched logs, registry caches, SQLite databases, unrelated Skill metadata, and historical sessions. The workflow was slow, could fail to publish, and repeatedly interrupted the user while querying registry JSON.

The user-visible permission prompts were caused by the command-risk classifier treating every `curl`/`wget` pipeline into Python as downloaded code execution. This conflated genuinely risky commands such as `curl URL | python3` with explicit local data processors such as `python3 -m json.tool` and `python3 -c '...json.load(sys.stdin)...'`.

The bundled upstream `oo-publish-skill` guidance also did not provide Wanta-specific account context or sufficiently strict bounds on pre-publish investigation, so the agent could keep exploring instead of applying the smallest metadata correction and publishing.

## Changes

- Refine downloaded-program detection for Python pipelines:
  - continue protecting bare Python, `python -`, shells, and other interpreter pipelines;
  - allow explicit local Python `-m` and `-c` data processors.
- Expose the signed-in account name to the Agent as the non-secret `WANTA_ACCOUNT_NAME` value so it can derive a scoped Skill package name without searching local state.
- Add a tracked Wanta override for the bundled `oo-publish-skill` workflow that requires:
  - one source resolution and one frontmatter read;
  - patch version bumping by default;
  - preservation of an existing package name and visibility;
  - non-interactive `oo skills publish <path> -y` execution;
  - at most one targeted version-conflict retry;
  - no log, shell-history, SQLite, registry-cache, unrelated-Skill, or guessed-package investigation.
- Apply tracked Skill overrides whenever bundled OO Skills are exported, so future upstream Skill refreshes retain the Wanta fast path.
- Document the refined permission boundary.

## User impact

Normal OO Skill publishing should now proceed from source resolution to frontmatter update and publish in a few bounded steps. JSON formatting and parsing used during ordinary registry reads no longer creates spurious high-risk prompts, while actual downloaded-code execution remains protected.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm vitest run electron/chat/command-risk.test.ts electron/chat/local-access-policy.test.ts scripts/skills.test.ts electron/agent/manager.test.ts`
  - 4 test files passed
  - 76 tests passed
- `git diff --check`

The branch was rebased onto `origin/main` at `df22d753` before the final validation and commit.
