### PR TITLE
fix(agent): close BYOA permission and session-race gaps

### DIFF
--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -578,8 +578,18 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     if (!session || !handle || handle.lost) {
       return
     }
-    const target = value ?? session.configSelects[axis]?.initialValue
-    if (target === undefined || session.configSelects[axis]?.currentValue === target) {
+    const select = session.configSelects[axis]
+    const target = value ?? select?.initialValue
+    if (target === undefined || select?.currentValue === target) {
+      return
+    }
+    // A reset (value === undefined) targets the creation-time default. A later
+    // cross-axis clamp (e.g. a model switch narrowing the effort space) may have
+    // dropped that value from the options; the agent already sits on a valid
+    // clamped default, so re-sending the vanished value would only draw a
+    // -32602 and leave the user unable to pick "Default". The stash is already
+    // cleared above, so skipping the wire call adopts the agent's default.
+    if (value === undefined && select !== undefined && !select.options.some((option) => option.id === target)) {
       return
     }
     try {
@@ -1007,6 +1017,17 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       }
       const desiredMode = this.desiredPermissionModes.get(input.sessionId)
       if (desiredMode !== undefined) await this.applyPermissionMode(input.sessionId, desiredMode)
+      // The one-shot guard above only covered the session/new round-trip. A forget
+      // (or stop) can still land during the post-registration awaits above without
+      // throwing; re-check so the catch below closes the native session instead of
+      // leaking a deleted session that handlePrompt would still dispatch a turn into.
+      if (!this.isStarted || this.isSessionForgotten(input.sessionId)) {
+        throw new Error(
+          this.isSessionForgotten(input.sessionId)
+            ? `${this.kind}: session was deleted while being created`
+            : `${this.kind}: adapter stopped while creating the session`,
+        )
+      }
       return session
     } catch (error) {
       this.sessionsByWantaId.delete(input.sessionId)

--- a/electron/agent/acp/selection-edge.test.ts
+++ b/electron/agent/acp/selection-edge.test.ts
@@ -247,6 +247,14 @@ function promptInput(text = "hello agent") {
   return { type: "prompt", sessionId: WANTA_SESSION_ID, text } as const
 }
 
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
 function modelsShape(currentModelId: string, ids: string[]): NewSessionResponse {
   return {
     sessionId: "acp-session-x",
@@ -354,6 +362,87 @@ describe("acp selection: stash-revert on live rejection", () => {
       configId: "reasoning_effort",
       value: "high",
     })
+  })
+
+  test("resetting effort to Default after a model switch narrows the option space does not re-send the vanished value", async () => {
+    // Opens on effort "ultra" (initialValue), then a model switch clamps effort
+    // to [low,medium,high] currentValue "medium". Picking Default must NOT send
+    // the now-invalid "ultra" (which the agent would reject), leaving the user
+    // unable to select Default; it should adopt the agent's clamped default.
+    const effortWithUltra = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        category: "model",
+        currentValue: "gpt-a",
+        options: [
+          { value: "gpt-a", name: "GPT A" },
+          { value: "gpt-b", name: "GPT B" },
+        ],
+      },
+      {
+        id: "reasoning_effort",
+        name: "Reasoning effort",
+        type: "select",
+        category: "thought_level",
+        currentValue: "ultra",
+        options: [
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+          { value: "ultra", name: "Ultra" },
+        ],
+      },
+    ]
+    const narrowedEffort = [
+      { ...effortWithUltra[0], currentValue: "gpt-b" },
+      { ...effortWithUltra[1], currentValue: "medium", options: effortWithUltra[1]!.options.slice(0, 3) },
+    ]
+    const harness = await createHarness({
+      newSession: () => ({ sessionId: "acp-session-1", configOptions: effortWithUltra }) as never,
+      setConfigOption: (params) =>
+        params.configId === "model" ? ({ configOptions: narrowedEffort } as never) : ({ configOptions: [] } as never),
+    })
+    await harness.adapter.send(promptInput())
+    await harness.waitFor((event) => event.event === "messageCompleted")
+
+    await harness.adapter.send({ type: "set-model", sessionId: WANTA_SESSION_ID, modelId: "gpt-b" })
+    // Reset effort to Default (no effortId): must not throw and must not send "ultra".
+    await harness.adapter.send({ type: "set-effort", sessionId: WANTA_SESSION_ID })
+
+    const ultraSends = harness.fake.setConfigOptionRequests.filter(
+      (request) => request.configId === "reasoning_effort" && request.value === "ultra",
+    )
+    expect(ultraSends).toHaveLength(0)
+    // The stash no longer pins an effort, so read-back reports the agent default.
+    expect(harness.adapter.sessionSelection(WANTA_SESSION_ID).effortId).toBeUndefined()
+  })
+
+  test("a delete landing during post-registration setup closes the native session and never prompts", async () => {
+    // The one-shot guard only covers session/new. A forget can still land during
+    // the post-registration setConfigValue await; without a second re-check the
+    // native session leaks on the shared subprocess and a turn could dispatch.
+    const gate = deferred<void>()
+    const harness = await createHarness({
+      newSession: () => ({ sessionId: "acp-session-late", configOptions: MODEL_EFFORT_CONFIG_OPTIONS }) as never,
+      setConfigOption: (params) =>
+        params.configId === "model" ? (gate.promise.then(() => ({ configOptions: [] })) as never) : ({} as never),
+    })
+    // Stash a desired model so createAcpSession applies it (a gated await) after
+    // it has already registered the session mappings.
+    await harness.adapter.send({ type: "set-model", sessionId: WANTA_SESSION_ID, modelId: "gpt-b" })
+
+    const sendPromise = harness.adapter.send(promptInput("delete me"))
+    await vi.waitFor(() => expect(harness.fake.setConfigOptionRequests.length).toBeGreaterThanOrEqual(1))
+    harness.adapter.forgetSession(WANTA_SESSION_ID)
+    gate.resolve()
+
+    await expect(sendPromise).rejects.toThrow(/session was deleted while being created/u)
+    expect(harness.fake.promptRequests).toHaveLength(0)
+    expect(harness.fake.closedSessionIds).toContain("acp-session-late")
+    const sessions = (harness.adapter as unknown as { sessionsByWantaId: Map<string, unknown> }).sessionsByWantaId
+    expect(sessions.has(WANTA_SESSION_ID)).toBe(false)
   })
 
   test("an accepted set_model followed by a session/new with a different current model follows the agent", async () => {

--- a/electron/agent/claude/adapter.test.ts
+++ b/electron/agent/claude/adapter.test.ts
@@ -522,7 +522,11 @@ describe("ClaudeCodeAgentAdapter", () => {
   })
 
   it("marks Claude Wanta MCP permission requests as host-owned", async () => {
-    const { adapter, events, calls } = await createHarness()
+    const { adapter, events, calls } = await createHarness(detectedStatus(), {
+      hostMcpServers: async () => [
+        { name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: { Authorization: "Bearer opaque" } },
+      ],
+    })
     await adapter.send({ type: "prompt", sessionId, text: "load a Wanta skill" })
     const canUseTool = calls[0].options.canUseTool
     const permission = canUseTool!(
@@ -541,6 +545,54 @@ describe("ClaudeCodeAgentAdapter", () => {
       behavior: "allow",
       updatedInput: { skill_id: "oo-posthog" },
     })
+  })
+
+  it("does not trust an agent-supplied Wanta-like MCP server name that Wanta never registered", async () => {
+    // The CLI also loads project/user/plugin MCP config, so a non-host server
+    // named `wanta_forged` must NOT inherit the host-tool auto-approve marker:
+    // its permission ask has to reach the user like any other external tool.
+    const { adapter, events, calls } = await createHarness(detectedStatus(), {
+      hostMcpServers: async () => [{ name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: {} }],
+    })
+    await adapter.send({ type: "prompt", sessionId, text: "run a forged tool" })
+    const canUseTool = calls[0].options.canUseTool
+    void canUseTool!(
+      "mcp__wanta_forged__run_anything",
+      { cmd: "rm -rf /" },
+      { signal: new AbortController().signal, requestId: "req-forged", toolUseID: "toolu-forged" },
+    )
+
+    const asked = findPermissionAsked(events)
+    expect(asked?.data.request.metadata).not.toHaveProperty("wantaHostTool")
+    expect(asked?.data.request.action).toBe("mcp__wanta_forged__run_anything")
+  })
+
+  it("does not trust foreign MCP servers that embed a registered host name as a prefix", async () => {
+    // None of these is the registered `wanta_skills`, so none may be attributed
+    // to it by a prefix match:
+    // - `wanta_skills__evil`  -> mcp__wanta_skills__evil__do  (tool tail has `__`)
+    // - `wanta_skills_`       -> mcp__wanta_skills___do       (tool tail starts `_`)
+    // - `wanta_skillsx`       -> mcp__wanta_skillsx__do       (not a `__` boundary)
+    const { adapter, events, calls } = await createHarness(detectedStatus(), {
+      hostMcpServers: async () => [{ name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: {} }],
+    })
+    await adapter.send({ type: "prompt", sessionId, text: "run embedded-prefix tools" })
+    const canUseTool = calls[0].options.canUseTool
+    const forged = ["mcp__wanta_skills__evil__do", "mcp__wanta_skills___do", "mcp__wanta_skillsx__do"]
+    forged.forEach((toolName, index) => {
+      void canUseTool!(
+        toolName,
+        { cmd: "exfiltrate" },
+        { signal: new AbortController().signal, requestId: `req-embed-${index}`, toolUseID: `toolu-embed-${index}` },
+      )
+    })
+
+    for (const toolName of forged) {
+      const asked = events.find(
+        (event) => event.event === "permissionAsked" && event.data.request.action === toolName,
+      ) as Extract<AgentEvent, { event: "permissionAsked" }> | undefined
+      expect(asked?.data.request.metadata).not.toHaveProperty("wantaHostTool")
+    }
   })
 
   it("resolves a parked permission with deny and permissionReplied when the SDK aborts it", async () => {

--- a/electron/agent/claude/adapter.ts
+++ b/electron/agent/claude/adapter.ts
@@ -145,14 +145,37 @@ function salientResources(toolInput: Record<string, unknown>): string[] {
   return resources
 }
 
+// Wanta host tool names are snake_case identifiers: a lowercase letter start,
+// single `_` separators, no leading/trailing/double underscore. Validating the
+// tool segment against this grammar is what makes the server attribution exact:
+// `mcp__<server>__<tool>` is ambiguous by string alone (a foreign server named
+// `<registered>_` yields `mcp__<registered>___<tool>`, indistinguishable from
+// `<registered>` with tool `_<tool>`), and only the registered server produces
+// a grammar-valid tail, so a `_`-prefixed or `__`-bearing tail is rejected.
+const WANTA_HOST_TOOL_NAME = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/u
+
 /**
  * Claude exposes Wanta MCP calls as `mcp__<server>__<tool>`. Keep this
  * deliberately narrow so only tools from Wanta's generated host servers can
  * skip the redundant external-agent transport prompt.
  */
-function wantaHostToolName(toolName: string): string | undefined {
-  const match = /^mcp__wanta_[a-z0-9_-]+__([a-z0-9_-]+)$/u.exec(toolName)
-  return match?.[1]
+function wantaHostToolName(toolName: string, hostServerNames: ReadonlySet<string>): string | undefined {
+  // Trust the tool only when its MCP server was actually registered for THIS
+  // session by Wanta — never the `wanta_*` name shape alone. A foreign MCP
+  // server (from project/user/plugin config the CLI also loads), whether named
+  // `wanta_helper`, `wanta_skills__evil`, or `wanta_skills_`, must not inherit
+  // the host-tool auto-approve. Mirrors the ACP translator's registration check.
+  for (const name of hostServerNames) {
+    const prefix = `mcp__${name}__`
+    if (!toolName.startsWith(prefix)) {
+      continue
+    }
+    const tool = toolName.slice(prefix.length)
+    if (WANTA_HOST_TOOL_NAME.test(tool)) {
+      return tool
+    }
+  }
+  return undefined
 }
 
 function sdkPermissionMode(
@@ -682,6 +705,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
     }
     const commandPathValue = await this.commandPath()
     const hostMcpServers = await this.hostMcpServers?.(input)
+    const hostServerNames = new Set((hostMcpServers ?? []).map((server) => server.name))
     const inputQueue = new AsyncInputQueue<SDKUserMessage>()
     const abortController = new AbortController()
     const stderrTail: string[] = []
@@ -711,7 +735,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
         allowDangerouslySkipPermissions: true,
         includePartialMessages: true,
         ...(startMode === "resume" ? { resume: sessionUuid } : { sessionId: sessionUuid }),
-        canUseTool: this.createCanUseTool(sessionId),
+        canUseTool: this.createCanUseTool(sessionId, hostServerNames),
         stderr: (data: string) => {
           stderrTail.push(data)
           if (stderrTail.length > MAX_STDERR_CHUNKS) {
@@ -830,7 +854,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
    * permission-response round trip. The returned promise stays parked until
    * the user replies, the prompt is aborted by the SDK, or the adapter stops.
    */
-  private createCanUseTool(sessionId: string): CanUseTool {
+  private createCanUseTool(sessionId: string, hostServerNames: ReadonlySet<string>): CanUseTool {
     return (toolName, toolInput, opts) => {
       // `Skill` only loads Claude's local Skill instructions. It is a
       // read-only discovery operation, not a shell/file mutation, and should
@@ -840,7 +864,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
         return Promise.resolve({ behavior: "allow", updatedInput: toolInput })
       }
       const requestId = opts.requestId ?? opts.toolUseID
-      const wantaHostTool = wantaHostToolName(toolName)
+      const wantaHostTool = wantaHostToolName(toolName, hostServerNames)
       const request: ChatPermissionRequest = {
         id: requestId,
         sessionId,

--- a/electron/agent/claude/translator.test.ts
+++ b/electron/agent/claude/translator.test.ts
@@ -406,6 +406,37 @@ describe("createClaudeTurnTranslator", () => {
     })
   })
 
+  it("uses the main-loop model's context window after a mid-session downswitch, not the max", () => {
+    // modelUsage is cumulative and multi-model; after switching opus[1m] -> sonnet
+    // the stale 1M entry lingers. The window must track the main-loop model
+    // (sonnet, 200k) so the occupancy meter is not silently under-reported.
+    const translator = createClaudeTurnTranslator(sessionId)
+    translator.translate({
+      type: "assistant",
+      message: {
+        id: "msg_1",
+        model: "claude-sonnet-5",
+        content: [{ type: "text", text: "answer" }],
+        usage: { input_tokens: 150_000, output_tokens: 100, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      },
+      parent_tool_use_id: null,
+      session_id: "sdk-session",
+    } as unknown as SDKMessage)
+    const events = translator.translate({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      usage: { input_tokens: 150_000, output_tokens: 100, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      modelUsage: {
+        "claude-opus-5": { contextWindow: 1_000_000 },
+        "claude-sonnet-5": { contextWindow: 200_000 },
+      },
+    } as unknown as SDKMessage)
+    const usageEvent = events.find((event) => event.event === "usageUpdated")
+    expect(usageEvent?.data.tokenUsage.contextWindow).toBe(200_000)
+  })
+
   it("maps result usage and context window to a usageUpdated event before completion", () => {
     const translator = createClaudeTurnTranslator(sessionId)
     const events = translator.translate({

--- a/electron/agent/claude/translator.test.ts
+++ b/electron/agent/claude/translator.test.ts
@@ -417,7 +417,12 @@ describe("createClaudeTurnTranslator", () => {
         id: "msg_1",
         model: "claude-sonnet-5",
         content: [{ type: "text", text: "answer" }],
-        usage: { input_tokens: 150_000, output_tokens: 100, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        usage: {
+          input_tokens: 150_000,
+          output_tokens: 100,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
       },
       parent_tool_use_id: null,
       session_id: "sdk-session",

--- a/electron/agent/claude/translator.ts
+++ b/electron/agent/claude/translator.ts
@@ -89,6 +89,7 @@ function translateResultUsage(
   sessionId: string,
   message: SDKMessage,
   lastApiUsage: Record<string, unknown> | undefined,
+  lastApiModel: string | undefined,
 ): AgentEvent | null {
   const frame = message as {
     usage?: Record<string, unknown>
@@ -100,9 +101,20 @@ function translateResultUsage(
   const cacheRead = numberOrZero(usage?.["cache_read_input_tokens"])
   const cacheWrite = numberOrZero(usage?.["cache_creation_input_tokens"])
   const total = input + output + cacheRead + cacheWrite
-  let contextWindow = 0
-  for (const entry of Object.values(frame.modelUsage ?? {})) {
-    contextWindow = Math.max(contextWindow, numberOrZero(entry.contextWindow))
+  // modelUsage is CUMULATIVE and spans every model the pipeline touched (main
+  // loop, subagents, compaction). Occupancy comes from the main-loop frame, so
+  // the window must be that same model's — Math.max over all entries would keep
+  // a larger stale window after a mid-session downswitch (e.g. 1M -> 200k) and
+  // silently under-report the meter. Fall back to the max only when the
+  // main-loop model is unknown or absent from modelUsage (the SDK may report a
+  // frame model alias not equal to the modelUsage key).
+  const modelUsage = frame.modelUsage ?? {}
+  const mainLoopWindow = lastApiModel ? numberOrZero(modelUsage[lastApiModel]?.contextWindow) : 0
+  let contextWindow = mainLoopWindow
+  if (contextWindow <= 0) {
+    for (const entry of Object.values(modelUsage)) {
+      contextWindow = Math.max(contextWindow, numberOrZero(entry.contextWindow))
+    }
   }
   if (total <= 0 && contextWindow <= 0) {
     return null
@@ -136,6 +148,8 @@ export function createClaudeTurnTranslator(sessionId: string): ClaudeTurnTransla
   const deliveredBlockCounts = new Map<string, number>()
   /** Per-call usage of the latest MAIN-LOOP assistant frame (context occupancy source). */
   let lastApiUsage: Record<string, unknown> | undefined
+  /** Model of the latest MAIN-LOOP assistant frame (context-window source; may change mid-session). */
+  let lastApiModel: string | undefined
 
   function ensureAssistantMessageStarted(messageId: string, events: AgentEvent[]): void {
     if (startedAssistantMessages.has(messageId)) {
@@ -238,6 +252,8 @@ export function createClaudeTurnTranslator(sessionId: string): ClaudeTurnTransla
     const frameUsage = (message.message as { usage?: unknown }).usage
     if (message.parent_tool_use_id === null && frameUsage && typeof frameUsage === "object") {
       lastApiUsage = frameUsage as Record<string, unknown>
+      const frameModel = (message.message as { model?: unknown }).model
+      lastApiModel = typeof frameModel === "string" ? frameModel : undefined
     }
     // The CLI emits one complete assistant message PER content block, all
     // sharing the same API message id, so a block's true index is its offset
@@ -341,8 +357,9 @@ export function createClaudeTurnTranslator(sessionId: string): ClaudeTurnTransla
         // receive further complete-message frames.
         deliveredBlockCounts.clear()
         const events: AgentEvent[] = []
-        const usageEvent = translateResultUsage(sessionId, message, lastApiUsage)
+        const usageEvent = translateResultUsage(sessionId, message, lastApiUsage, lastApiModel)
         lastApiUsage = undefined
+        lastApiModel = undefined
         if (usageEvent) {
           // Usage precedes completion so the transcript's completion flush
           // already carries it.

--- a/electron/agent/external/adapter-base-edge.test.ts
+++ b/electron/agent/external/adapter-base-edge.test.ts
@@ -562,6 +562,33 @@ describe("forgetSession and stop() races", () => {
     expect(await fileExists(transcriptPath(transcriptDir, SESSION_A))).toBe(false)
   })
 
+  it("an already-aborted prompt after forgetSession must not clear the tombstone and resurrect the file", async () => {
+    // The delete flow aborts the generation, then a resumed sendExternalMessage
+    // dispatches the prompt with an aborted signal. That send must NOT reopen the
+    // late-event gate, or a still-draining native frame would rewrite the file.
+    const transcriptDir = await makeTranscriptDir()
+    const adapter = await makeAdapter(transcriptDir)
+    for (const event of assistantTurn(SESSION_A, "m1", "will be deleted")) {
+      adapter.emitForTest(event)
+    }
+    adapter.forgetSession(SESSION_A)
+    await vi.waitFor(async () => {
+      expect(await fileExists(transcriptPath(transcriptDir, SESSION_A))).toBe(false)
+    })
+
+    const controller = new AbortController()
+    controller.abort()
+    await adapter.send({ type: "prompt", sessionId: SESSION_A, text: "reopen?" }, { signal: controller.signal })
+
+    // A straggler frame lands after the aborted send; the tombstone must still hold.
+    adapter.emitForTest({
+      event: "messageDelta",
+      data: { sessionId: SESSION_A, messageId: "m-late", partId: "m-late:0", text: "zombie" },
+    })
+    await sleep(TRANSCRIPT_DEBOUNCE_WAIT_MS)
+    expect(await fileExists(transcriptPath(transcriptDir, SESSION_A))).toBe(false)
+  })
+
   it("stop() completes in-flight and pending saves without unhandled rejections or late writes", async () => {
     const unhandled: unknown[] = []
     const onUnhandled = (reason: unknown): void => {

--- a/electron/agent/external/adapter-base-edge.test.ts
+++ b/electron/agent/external/adapter-base-edge.test.ts
@@ -12,6 +12,15 @@ import { ClaudeCodeAgentAdapter } from "../claude/adapter.ts"
 import { AGENT_PROFILES } from "../contract/profile.ts"
 import { ExternalAgentAdapter } from "./adapter-base.ts"
 import { externalSessionUuid } from "./session-id.ts"
+import { ExternalTranscriptStore } from "./transcript-store.ts"
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
 
 // Adversarial edge-case coverage for external transcript persistence and
 // hydration: corrupted on-disk files, sanitizer interplay on restored
@@ -880,5 +889,53 @@ describe("hydration races", () => {
     adapter.forgetSession(SESSION_A)
     const ghost = await adapter.getMessages(SESSION_A)
     expect(ghost).toEqual([])
+  })
+
+  it("a delete + reopen while the original load is in flight must not restore deleted history", async () => {
+    // The tombstone alone is not enough: a valid prompt can reopen the id and
+    // clear the tombstone BEFORE an already-started store.load resolves, so the
+    // stale load would restore the deleted messages (and sessionsWithDiskHistory).
+    // A per-session deletion generation invalidates that superseded load.
+    const transcriptDir = await makeTranscriptDir()
+    await writeTranscriptFile(
+      transcriptDir,
+      SESSION_A,
+      validTranscriptJson([userMessage("u1", "secret"), assistantMessage("a1", "deleted")]),
+    )
+    const adapter = await makeAdapter(transcriptDir)
+    adapter.promptEmitsUserTurn = true
+
+    // Hold the first load in flight so the delete + reopen interleave before it
+    // resolves; on release it delegates to the real load (the file still exists).
+    const realLoad = ExternalTranscriptStore.prototype.load
+    const gate = deferred()
+    let gated = false
+    const loadSpy = vi.spyOn(ExternalTranscriptStore.prototype, "load").mockImplementation(function (
+      this: ExternalTranscriptStore,
+      sessionId: string,
+    ) {
+      if (sessionId === SESSION_A && !gated) {
+        gated = true
+        return gate.promise.then(() => realLoad.call(this, sessionId))
+      }
+      return realLoad.call(this, sessionId)
+    })
+
+    const hydrating = adapter.getMessages(SESSION_A) // op1
+    // Wait until the load is genuinely IN FLIGHT (op1's body reached store.load)
+    // before deleting, so this exercises the post-load race, not the pre-load guard.
+    await vi.waitFor(() => expect(gated).toBe(true))
+    adapter.forgetSession(SESSION_A) // bumps the deletion generation, queues remove
+    const sending = adapter.send({ type: "prompt", sessionId: SESSION_A, text: "new turn" }) // clears the tombstone
+    gate.resolve() // original load resolves; the generation check must reject its result
+    await hydrating
+    await sending
+    loadSpy.mockRestore()
+    await adapter.stop()
+
+    // Reopened from disk: only the new turn, never the deleted history.
+    const reopened = await makeAdapter(transcriptDir)
+    const messages = await reopened.getMessages(SESSION_A)
+    expect(messages.map((message) => message.id)).toEqual(["prompt-user-1"])
   })
 })

--- a/electron/agent/external/adapter-base.ts
+++ b/electron/agent/external/adapter-base.ts
@@ -44,6 +44,13 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
    * scrubbed as noise, so resume decisions must use this, not the survivors.
    */
   private readonly sessionsWithDiskHistory = new Set<string>()
+  /**
+   * sessionId -> monotonically increasing count of forgets. A hydration
+   * captures it before `store.load` and rejects its own result if it changed,
+   * so a delete that lands mid-load can never restore deleted history even
+   * when a later prompt reopened the id and cleared the tombstone first.
+   */
+  private readonly forgetGenerations = new Map<string, number>()
 
   private userTurnSeq = 0
 
@@ -166,6 +173,7 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
   /** Release all in-memory state of a deleted session and its on-disk transcript. */
   public forgetSession(sessionId: string): void {
     this.forgottenSessions.add(sessionId)
+    this.forgetGenerations.set(sessionId, (this.forgetGenerations.get(sessionId) ?? 0) + 1)
     this.sessionsWithDiskHistory.delete(sessionId)
     this.transcript.forgetSession(sessionId)
     this.transcriptHydrations.delete(sessionId)
@@ -238,15 +246,20 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
       // a queued removal and resurrect a deleted session's history. The chain
       // also swallows and logs failures, so a broken disk state degrades to an
       // empty history instead of poisoning every later getMessages/send.
+      // Snapshot the deletion generation for THIS hydration; a forget landing
+      // any time after it invalidates the load's result.
+      const generation = this.forgetGenerations.get(sessionId) ?? 0
       hydration = this.queueTranscriptOp(sessionId, async () => {
-        if (this.forgottenSessions.has(sessionId)) {
+        if (this.forgottenSessions.has(sessionId) || (this.forgetGenerations.get(sessionId) ?? 0) !== generation) {
           return
         }
         const messages = await store.load(sessionId)
-        // A forget (and its queued remove) may have landed during the load; if
-        // the tombstone is now set, neither mark disk history nor restore, so a
-        // racing send-reopen that cleared the tombstone cannot resurrect it.
-        if (this.forgottenSessions.has(sessionId)) {
+        // A forget (and its queued remove) may have landed during the load.
+        // Compare the generation, NOT just the tombstone: a later prompt can
+        // reopen the id and clear the tombstone before this load resolves, so
+        // the tombstone alone would let the stale load resurrect deleted history
+        // (and sessionsWithDiskHistory). The generation stays bumped regardless.
+        if (this.forgottenSessions.has(sessionId) || (this.forgetGenerations.get(sessionId) ?? 0) !== generation) {
           return
         }
         if (messages && messages.length > 0) {

--- a/electron/agent/external/adapter-base.ts
+++ b/electron/agent/external/adapter-base.ts
@@ -95,7 +95,11 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
   }
 
   public override async send(input: AgentInput, options?: AgentSendOptions): Promise<void> {
-    if (input.type === "prompt" && typeof input.sessionId === "string") {
+    // An already-aborted prompt never dispatches (the concrete handlePrompt
+    // short-circuits), so it must NOT clear the tombstone: doing so would reopen
+    // the late-event gate and let a deleted session's still-draining native
+    // frames resurrect its transcript on disk.
+    if (input.type === "prompt" && typeof input.sessionId === "string" && !options?.signal?.aborted) {
       // An explicit new prompt reopens a forgotten session id; the tombstone
       // only exists to block LATE events from a still-draining native process.
       this.forgottenSessions.delete(input.sessionId)
@@ -239,11 +243,17 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
           return
         }
         const messages = await store.load(sessionId)
+        // A forget (and its queued remove) may have landed during the load; if
+        // the tombstone is now set, neither mark disk history nor restore, so a
+        // racing send-reopen that cleared the tombstone cannot resurrect it.
+        if (this.forgottenSessions.has(sessionId)) {
+          return
+        }
         if (messages && messages.length > 0) {
           this.sessionsWithDiskHistory.add(sessionId)
         }
         const sanitized = messages && messages.length > 0 ? this.sanitizeRestoredMessages(messages) : messages
-        if (sanitized && sanitized.length > 0 && !this.forgottenSessions.has(sessionId)) {
+        if (sanitized && sanitized.length > 0) {
           this.transcript.restore(sessionId, sanitized)
         }
       })

--- a/electron/agent/external/session-id.ts
+++ b/electron/agent/external/session-id.ts
@@ -29,7 +29,11 @@ export function externalAgentKindForSessionId(sessionId: string): ExternalAgentK
     return undefined
   }
   const kind = rest.slice(0, separator)
-  if (kind in AGENT_PROFILES && isExternalAgentKind(kind as AgentKind)) {
+  // Own-property check only: `in` walks the prototype chain, so a hostile id
+  // whose kind segment is an inherited Object.prototype key ("constructor",
+  // "toString", "__proto__", ...) would otherwise pass as a valid kind and
+  // defeat the drop-on-read guards that route on this function.
+  if (Object.hasOwn(AGENT_PROFILES, kind) && isExternalAgentKind(kind as AgentKind)) {
     return kind as ExternalAgentKind
   }
   return undefined

--- a/electron/agent/oo-command-permission.test.ts
+++ b/electron/agent/oo-command-permission.test.ts
@@ -55,3 +55,35 @@ test("OpenConnector policy keeps credential and runtime boundary protections", (
     assert.equal(openConnectorCommandPolicy(command), "deny", command)
   }
 })
+
+test("OpenConnector policy denies mutations hidden behind leading oo global flags", () => {
+  // A leading global flag (--debug / --lang <v> / -V / --help) must not smuggle
+  // a credential/config/auth mutation past the deny-list into a silent allow.
+  for (const command of [
+    "oo --debug config set endpoint https://evil.example.test",
+    "oo --lang zh connector logout",
+    "oo --lang=zh connector login https://attacker.example.test",
+    "oo -V connector logout",
+    "oo --debug auth logout",
+    "oo -h auth login",
+    "${WANTA_OO_BIN} --debug config set endpoint https://evil.example.test",
+    "echo hi; oo config set endpoint https://evil.example.test",
+    // Global flags can also sit BETWEEN `connector` and its subcommand (commander
+    // accepts --lang/--debug after the connector token), so these must deny too.
+    "oo connector --lang zh logout",
+    "oo connector --debug logout",
+    "oo connector --lang zh login https://attacker.example.test",
+    "oo --lang zh connector --debug logout",
+  ]) {
+    assert.equal(openConnectorCommandPolicy(command), "deny", command)
+  }
+  // Legitimate business commands with the same flags still resolve to allow,
+  // including config/logout appearing only as an action arg or data value.
+  for (const command of [
+    "oo --lang zh connector run gmail list --json",
+    "oo connector --lang zh run app --action logout",
+    "oo connector run app --action config --json",
+  ]) {
+    assert.equal(openConnectorCommandPolicy(command), "allow", command)
+  }
+})

--- a/electron/agent/oo-command-permission.ts
+++ b/electron/agent/oo-command-permission.ts
@@ -167,6 +167,62 @@ function shellWrapperCommand(command: string): ShellWrapper {
   return { kind: "command", command: wrappedCommand }
 }
 
+// oo global flags that may precede the subcommand. Kept in sync with
+// oo-guard-core.ts connectorCommandIndex so a leading `--debug` / `--lang zh`
+// can never smuggle a forbidden subcommand past forbiddenOoMutation.
+const ooGlobalFlagWithValue = "--lang"
+const ooGlobalBooleanFlags = new Set(["--debug", "-h", "--help", "-V", "--version"])
+
+/** Advance past oo global flags (commander accepts them before AND between subcommands). */
+function skipOoGlobalFlags(tokens: readonly string[], start: number): number {
+  let index = start
+  while (index < tokens.length) {
+    const arg = tokens[index] ?? ""
+    if (arg === ooGlobalFlagWithValue) {
+      index += 2
+      continue
+    }
+    if (arg.startsWith(`${ooGlobalFlagWithValue}=`) || ooGlobalBooleanFlags.has(arg)) {
+      index += 1
+      continue
+    }
+    break
+  }
+  return index
+}
+
+/** Tokens of a single `oo ...` command after skipping leading global flags, or null if not a bare oo call. */
+function ooSubcommandTokens(command: string): string[] | null {
+  const words = shellWords(command.trim())
+  if (!words || !isOoExecutable(words[0] ?? "")) {
+    return null
+  }
+  return words.slice(skipOoGlobalFlags(words, 1))
+}
+
+/**
+ * Whether a single `oo` invocation mutates host-managed connector auth or
+ * configuration. Unlike the regex forbiddenOoMutation this is flag-aware, so
+ * `oo --lang zh connector logout` and `oo connector --lang zh logout` (global
+ * flags may sit before AND between subcommands) are still denied.
+ */
+export function isForbiddenOoMutationCommand(command: string): boolean {
+  const tokens = ooSubcommandTokens(command)
+  if (!tokens || tokens.length === 0) {
+    return false
+  }
+  const subcommand = tokens[0]
+  if (subcommand === "auth" || subcommand === "login" || subcommand === "logout" || subcommand === "config") {
+    return true
+  }
+  if (subcommand !== "connector") {
+    return false
+  }
+  // Global flags can also appear between `connector` and its subcommand.
+  const connectorSubcommand = tokens[skipOoGlobalFlags(tokens, 1)]
+  return connectorSubcommand === "login" || connectorSubcommand === "logout"
+}
+
 export function isPureOoCliCommand(command: string): boolean {
   const trimmed = command.trim()
   if (!trimmed || hasUnsafeShellSyntax(trimmed)) {
@@ -201,6 +257,7 @@ export function openConnectorCommandPolicy(command: string): "allow" | "deny" | 
       isEnvironmentDump(current) ||
       linkEnvironmentAssignment.test(current) ||
       forbiddenOoMutation.test(current) ||
+      isForbiddenOoMutationCommand(current) ||
       (ooCommandSegment.test(current) && forbiddenOoOption.test(current))
     ) {
       return "deny"

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -754,6 +754,27 @@ test("edge7: unknown backends degrade to empty reads and named send errors, neve
   )
 })
 
+test("edge7b: prototype-chain kind segments are not valid external kinds (in-operator spoof)", async () => {
+  // `kind in AGENT_PROFILES` would treat inherited Object.prototype keys as
+  // valid kinds; the parse must reject every one so a hostile id cannot defeat
+  // the drop-on-read guard or route anywhere.
+  for (const kind of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__", "isPrototypeOf"]) {
+    assert.equal(externalAgentKindForSessionId(`wanta-ext:${kind}:${randomUUID()}`), undefined, kind)
+  }
+
+  // And such an id behaves like an unknown backend end-to-end: empty reads, no route.
+  const { service } = createHarness(["claude-code"])
+  const spoofed = `wanta-ext:constructor:${randomUUID()}`
+  assert.deepEqual(await service.getMessages(spoofed), [])
+  assert.deepEqual(await service.getSessionSnapshot(spoofed), {
+    activeRun: null,
+    messages: [],
+    pendingPermissions: [],
+    pendingQuestions: [],
+    sessionId: spoofed,
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Edge 8: model/effort knobs against an agent that declares setEffort false
 // ---------------------------------------------------------------------------

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -85,6 +85,27 @@ test("external-agent OOCLI parity stays narrow and fails closed", () => {
   )
 })
 
+test("external-agent oo_cli auto-approve requires an active Link runtime, not the truthy 'none'", () => {
+  // "none" is the production default when no Link runtime is connected and is a
+  // truthy string; it must NOT satisfy the oo_cli gate, or a BYOA agent could run
+  // the user's own unguarded oo binary with no approval card.
+  assert.deepEqual(
+    evaluateLocalAccessRequest(
+      permission({ metadata: { command: "oo connector run gmail --action send_email --json" } }),
+      { isExternalSession: true, linkRuntime: "none", permissionMode: "default" },
+    ),
+    { type: "prompt", kind: "command", highRisk: false },
+  )
+  // With a real runtime the same command still auto-approves (parity preserved).
+  assert.equal(
+    evaluateLocalAccessRequest(
+      permission({ metadata: { command: "oo connector run gmail --action send_email --json" } }),
+      { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
+    ).type,
+    "allow",
+  )
+})
+
 test("external agents auto-approve Wanta host MCP dispatch without weakening native local permissions", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(

--- a/electron/chat/local-access-policy.ts
+++ b/electron/chat/local-access-policy.ts
@@ -74,6 +74,13 @@ export interface LocalAccessPolicyContext {
   trustedProjectRoot?: string
 }
 
+// "none" is a valid ActiveLinkRuntime value and is truthy, so a bare truthiness
+// check would treat "no Link runtime" as active and auto-approve oo_cli parity
+// commands. Only a real runtime backs a Wanta-owned Link transport.
+function hasActiveLinkRuntime(linkRuntime: ActiveLinkRuntime | undefined): boolean {
+  return linkRuntime === "oomol" || linkRuntime === "openconnector"
+}
+
 export function localAccessPromptReason(request: ChatPermissionRequest): LocalPermissionPromptReason {
   if (permissionRequestHasSensitiveResource(request)) return "sensitive_resource"
   if (isHighRiskPermissionRequest(request)) return "high_risk_command"
@@ -136,7 +143,7 @@ export function evaluateLocalAccessRequest(
   // commands continue into the external agent's native permission flow.
   if (
     context.isExternalSession &&
-    context.linkRuntime &&
+    hasActiveLinkRuntime(context.linkRuntime) &&
     isOoCliPermissionRequest(request) &&
     !permissionRequestHasSensitiveResource(request) &&
     !highRisk
@@ -220,7 +227,7 @@ export function evaluateLocalAccessRequest(
   if (permissionRequestNeedsDefaultPrompt(request)) {
     return { type: "prompt", kind, highRisk }
   }
-  if (context.linkRuntime && isOoCliPermissionRequest(request)) {
+  if (hasActiveLinkRuntime(context.linkRuntime) && isOoCliPermissionRequest(request)) {
     return { type: "allow", reason: "oo_cli", kind, highRisk }
   }
   if (context.trustedProjectRoot && projectPermissionRequestInsideRoot(request, context.trustedProjectRoot)) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -942,6 +942,14 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
   const runtimeVersionAtStart = agentRuntimeVersion
   const runtimeModels = await modelsStore.runtimeModels()
   const runtime = resolveAgentRuntime(account, runtimeModels.selected, runtimeModels.customModels)
+  // On a cross-account switch, drop the previous account's team BEFORE it is
+  // baked into linkRuntime (and thus the new sidecar's oo identity/team-scope);
+  // otherwise a personal-workspace account inherits the old team and defeats the
+  // oo-guard fail-closed check. The renderer re-asserts the team after login.
+  // The later reset at the account-switch branch below stays for attention state.
+  if (appliedAccount && appliedAccount.id !== account?.id) {
+    activeAgentTeamName = undefined
+  }
   const linkRuntime =
     (await linkRuntimeManager.selectedRuntime()) === "oomol"
       ? account

--- a/electron/session/external-sessions.test.ts
+++ b/electron/session/external-sessions.test.ts
@@ -73,6 +73,24 @@ test("external sessions are created and listed when no kernel adapter exists", a
   )
 })
 
+test("an unregistered agentKind never mints an external session id (create gate)", async () => {
+  // RPC types are erased at runtime; a junk kind must not reach mintExternalSessionId.
+  // With no kernel adapter it falls to the kernel path and fails closed instead.
+  const external = externalStore()
+  const service = new SessionServiceImpl(null, {
+    externalSessionStore: external.store,
+    metadataStore: metadataStore(),
+  })
+  ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
+
+  await assert.rejects(
+    service.create({ agentKind: "gemini" as never, scope: localScope }),
+    /Agent not configured/,
+  )
+  // No wanta-ext:gemini record was persisted.
+  assert.equal(external.current().size, 0)
+})
+
 test("external archived sessions and projects remain available when no kernel adapter exists", async () => {
   const external = externalStore()
   const service = new SessionServiceImpl(null, {

--- a/electron/session/external-sessions.test.ts
+++ b/electron/session/external-sessions.test.ts
@@ -83,10 +83,7 @@ test("an unregistered agentKind never mints an external session id (create gate)
   })
   ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
 
-  await assert.rejects(
-    service.create({ agentKind: "gemini" as never, scope: localScope }),
-    /Agent not configured/,
-  )
+  await assert.rejects(service.create({ agentKind: "gemini" as never, scope: localScope }), /Agent not configured/)
   // No wanta-ext:gemini record was persisted.
   assert.equal(external.current().size, 0)
 })

--- a/electron/session/node.ts
+++ b/electron/session/node.ts
@@ -27,7 +27,7 @@ import type { IConnectionService } from "@oomol/connection"
 import { ConnectionService } from "@oomol/connection"
 import { randomUUID } from "node:crypto"
 import path from "node:path"
-import { isExternalAgentKind } from "../agent/contract/profile.ts"
+import { EXTERNAL_AGENT_KINDS, isExternalAgentKind } from "../agent/contract/profile.ts"
 import {
   externalAgentKindForSessionId,
   isExternalSessionId,
@@ -217,7 +217,10 @@ export class SessionServiceImpl
   }
 
   private async createMutation(req: CreateSessionRequest, revision: number): Promise<SessionInfo> {
-    if (req.agentKind && isExternalAgentKind(req.agentKind)) {
+    // Only a REGISTERED external kind mints an external session id; isExternalAgentKind
+    // alone is `!== "opencode"`, so RPC-erased junk (unknown or prototype-chain kinds)
+    // must not reach mintExternalSessionId. Unknown kinds fall through to the kernel.
+    if (req.agentKind && isExternalAgentKind(req.agentKind) && EXTERNAL_AGENT_KINDS.includes(req.agentKind)) {
       return this.createExternalMutation(req, req.agentKind, revision)
     }
     const agent = this.agent


### PR DESCRIPTION
## Summary

Several BYOA paths still trusted truthy defaults, name shapes, or intermediate states that an agent or a race could exploit. Host MCP auto-approve now requires a session-registered server (not a `wanta_*` name alone), `oo_cli` parity requires a real Link runtime rather than the truthy `"none"`, aborted prompts keep the forget tombstone so late frames cannot resurrect a deleted transcript, OpenConnector policy denies auth/config mutations hidden behind oo global flags, and create/parse paths reject unregistered and prototype-chain kinds. Also closes smaller ACP races (delete during post-registration setup, effort Default after a model clamp drops the initial value) and pins Claude context-window reporting to the main-loop model so a mid-session downswitch is not under-reported.

## Verification

Regression coverage is in the adapter, session, and local-access policy edge tests on this branch (forged host MCP names, aborted-prompt tombstone, prototype-chain session ids, unregistered create, flag-smuggled oo mutations, and the ACP reset/delete races). Full suite not re-run in this PR step.

- [ ] `corepack pnpm run ts-check`
- [ ] `corepack pnpm run lint`
- [ ] `corepack pnpm run format`
- [ ] `corepack pnpm test`
- [ ] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.
