### PR TITLE
fix(agent): close BYOA selection review races

### DIFF
--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -448,19 +448,19 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       return
     }
     const previousSelection = { ...this.desiredSelections.get(input.sessionId) }
-    const appliedAxes: Array<keyof AcpConfigSelects> = []
+    const appliedSelections: Partial<Record<keyof AcpConfigSelects, string>> = {}
     try {
       if (input.agentModelId !== undefined) {
         await this.applyConfigSelection(input.sessionId, "model", input.agentModelId)
-        appliedAxes.push("model")
+        appliedSelections.model = input.agentModelId
       }
       if (input.agentEffortId !== undefined) {
         await this.applyConfigSelection(input.sessionId, "effort", input.agentEffortId)
-        appliedAxes.push("effort")
+        appliedSelections.effort = input.agentEffortId
       }
       await this.dispatchPrompt(input, options)
     } catch (error) {
-      await this.restorePromptSelections(input.sessionId, previousSelection, appliedAxes)
+      await this.restorePromptSelections(input.sessionId, previousSelection, appliedSelections)
       throw error
     }
   }
@@ -520,9 +520,14 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
   private async restorePromptSelections(
     sessionId: string,
     previous: { model?: string; effort?: string },
-    appliedAxes: Array<keyof AcpConfigSelects>,
+    applied: Partial<Record<keyof AcpConfigSelects, string>>,
   ): Promise<void> {
-    for (const axis of appliedAxes.reverse()) {
+    const appliedAxes = (Object.keys(applied) as Array<keyof AcpConfigSelects>).reverse()
+    for (const axis of appliedAxes) {
+      // A picker or newer prompt may have changed this axis while the failed
+      // prompt was still setting up. Only the prompt's own value may be
+      // restored; otherwise this rollback would clobber the newer selection.
+      if (this.desiredSelections.get(sessionId)?.[axis] !== applied[axis]) continue
       try {
         await this.applyConfigSelection(sessionId, axis, previous[axis])
       } catch (error) {

--- a/electron/agent/acp/selection-edge.test.ts
+++ b/electron/agent/acp/selection-edge.test.ts
@@ -649,6 +649,36 @@ describe("acp selection: prompt-borne selections", () => {
     ])
     expect(harness.adapter.sessionSelection(WANTA_SESSION_ID)).toEqual({})
   })
+
+  test("an earlier prompt failure does not restore over a newer model selection", async () => {
+    let rejectEffort: ((error: Error) => void) | undefined
+    const harness = await createHarness({
+      newSession: () => ({ sessionId: "acp-session-1", configOptions: MODEL_EFFORT_CONFIG_OPTIONS }) as never,
+      setConfigOption: (params) => {
+        if (params.configId === "reasoning_effort" && params.value === "high") {
+          return new Promise((_resolve, reject) => {
+            rejectEffort = reject
+          })
+        }
+        return { configOptions: MODEL_EFFORT_CONFIG_OPTIONS }
+      },
+    })
+    await harness.adapter.send(promptInput())
+    await harness.waitFor((event) => event.event === "messageCompleted")
+
+    const failedPrompt = harness.adapter.send({
+      ...promptInput("prompt with stale model"),
+      agentModelId: "gpt-b",
+      agentEffortId: "high",
+    })
+    await vi.waitFor(() => expect(rejectEffort).toBeDefined())
+    await harness.adapter.send({ type: "set-model", sessionId: WANTA_SESSION_ID, modelId: "gpt-a" })
+
+    rejectEffort?.(new Error("effort rejected"))
+    await expect(failedPrompt).rejects.toThrow()
+    expect(harness.adapter.sessionSelection(WANTA_SESSION_ID)).toEqual({ modelId: "gpt-a" })
+    expect(harness.fake.promptRequests).toHaveLength(1)
+  })
 })
 
 describe("acp selection: permission-mode projection", () => {

--- a/electron/agent/claude/adapter.ts
+++ b/electron/agent/claude/adapter.ts
@@ -333,7 +333,15 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       }
       await this.dispatchPrompt(input, options)
     } catch (error) {
-      await this.restorePromptSelections(input.sessionId, previousModel, previousEffort, modelApplied, effortApplied)
+      await this.restorePromptSelections(
+        input.sessionId,
+        previousModel,
+        previousEffort,
+        input.agentModelId,
+        input.agentEffortId,
+        modelApplied,
+        effortApplied,
+      )
       throw error
     }
   }
@@ -366,10 +374,12 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
     sessionId: string,
     previousModel: string | undefined,
     previousEffort: ClaudeEffortId | undefined,
+    appliedModel: string | undefined,
+    appliedEffort: string | undefined,
     modelApplied: boolean,
     effortApplied: boolean,
   ): Promise<void> {
-    if (effortApplied) {
+    if (effortApplied && this.desiredEfforts.get(sessionId) === appliedEffort) {
       await this.applyEffort(sessionId, previousEffort).catch((error: unknown) => {
         logDiagnostic(
           "claude-code-adapter",
@@ -379,7 +389,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
         )
       })
     }
-    if (modelApplied) {
+    if (modelApplied && this.desiredModels.get(sessionId) === appliedModel) {
       await this.applyModel(sessionId, previousModel).catch((error: unknown) => {
         logDiagnostic(
           "claude-code-adapter",

--- a/electron/agent/claude/selection-edge.test.ts
+++ b/electron/agent/claude/selection-edge.test.ts
@@ -402,6 +402,34 @@ describe("claude selection: prompt-borne selections", () => {
     expect(adapter.sessionSelection(sessionId)).toEqual({})
   })
 
+  it("an earlier prompt failure does not restore over a newer model selection", async () => {
+    const { adapter, calls } = await createHarness()
+    await adapter.send({ type: "prompt", sessionId, text: "hello" })
+
+    let rejectEffort: ((error: Error) => void) | undefined
+    calls[0]!.fake.applyFlagSettings.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectEffort = reject
+        }),
+    )
+    const failedPrompt = adapter.send({
+      type: "prompt",
+      sessionId,
+      text: "prompt with stale model",
+      agentModelId: "sonnet",
+      agentEffortId: "high",
+    })
+    await vi.waitFor(() => expect(rejectEffort).toBeDefined())
+    await adapter.send({ type: "set-model", sessionId, modelId: "haiku" })
+
+    rejectEffort?.(new Error("effort rejected"))
+    await expect(failedPrompt).rejects.toThrow("effort rejected")
+    expect(adapter.sessionSelection(sessionId)).toEqual({ modelId: "haiku" })
+    expect(calls[0]!.fake.setModel.mock.calls).toEqual([["sonnet"], ["haiku"]])
+    expect(calls[0]!.fake.promptMessages).toHaveLength(1)
+  })
+
   it("an unknown prompt-borne effort id is rejected loudly", async () => {
     const { adapter, calls } = await createHarness()
     await expect(adapter.send({ type: "prompt", sessionId, text: "hello", agentEffortId: "ultra" })).rejects.toThrow(

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -953,6 +953,46 @@ test("forgetSession waits for pending selection persistence and removes its muta
   }
 })
 
+test("a prompt failure after session deletion cannot enqueue a late selection rollback", async () => {
+  const persisted: Array<{ modelId?: string | null; effortId?: string | null }> = []
+  const { service, adapters } = createHarness(["claude-code"], {
+    onExternalSessionSelectionChanged: (_sessionId, patch) => {
+      persisted.push(patch)
+    },
+  })
+  const adapter = adapters.get("claude-code")
+  assert.ok(adapter)
+  const sessionId = mintExternalSessionId("claude-code")
+  let releasePromptFailure!: () => void
+  adapter.promptFailureBarrier = new Promise<void>((resolve) => (releasePromptFailure = resolve))
+  adapter.failNextPrompt = new Error("prompt rejected after deletion")
+
+  await service.sendMessage(sendRequest(sessionId, "use sonnet", { agentModelId: "sonnet" }))
+  await waitForCondition(() => persisted.length === 1, "prompt selection persistence")
+  // Prompt selection persistence has settled, so deletion observes an idle
+  // queue. The native prompt rejection is deliberately released afterwards.
+  await service.forgetSession(sessionId)
+  releasePromptFailure()
+  await waitForCondition(() => adapter.promptFailureBarrier === undefined, "late prompt rejection")
+
+  assert.deepEqual(persisted, [{ modelId: "sonnet" }])
+  await assert.rejects(
+    service.setExternalSessionModel({ sessionId, modelId: "haiku" }),
+    /external agent session was deleted/u,
+  )
+  const internals = service as unknown as {
+    externalSelectionMutationTails: Map<string, Promise<void>>
+    externalSelectionMutationTokens: Map<string, number>
+    externalSelectionMutationSequences: Map<string, number>
+  }
+  for (const axis of ["model", "effort"] as const) {
+    const key = `${sessionId}\0${axis}`
+    assert.equal(internals.externalSelectionMutationTails.has(key), false)
+    assert.equal(internals.externalSelectionMutationTokens.has(key), false)
+    assert.equal(internals.externalSelectionMutationSequences.has(key), false)
+  }
+})
+
 test("external model and effort updates stay ordered when persistence overlaps", async () => {
   let releaseModelPersistence!: () => void
   let releaseEffortPersistence!: () => void

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -69,6 +69,9 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   public failNextPrompt: Error | undefined
   /** Optional fence used to race a rejected prompt against a newer selection. */
   public promptFailureBarrier: Promise<void> | undefined
+  /** Optional fence used to pause a turn before prompt selections persist. */
+  public permissionModeBarrier: Promise<void> | undefined
+  public permissionModeBarrierEntries = 0
   /** When set, the next native permission-mode projection rejects. */
   public failNextPermissionMode: Error | undefined
   private readonly modelSelections = new Map<string, string>()
@@ -163,6 +166,9 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   }
 
   public override async applyPermissionMode(sessionId: string, mode: AgentPermissionMode): Promise<void> {
+    this.permissionModeBarrierEntries += 1
+    await this.permissionModeBarrier
+    this.permissionModeBarrier = undefined
     if (this.failNextPermissionMode) {
       const error = this.failNextPermissionMode
       this.failNextPermissionMode = undefined
@@ -882,6 +888,69 @@ test("a rejected prompt rollback cannot overwrite a newer model selection", asyn
 
   assert.deepEqual(persisted, [{ modelId: "sonnet" }, { modelId: "haiku" }])
   assert.deepEqual(adapter.sessionSelection(sessionId), { modelId: "haiku" })
+})
+
+test("prompt rollback captures a direct selection that completed before prompt persistence", async () => {
+  const persisted: Array<{ modelId?: string | null; effortId?: string | null }> = []
+  const { service, adapters } = createHarness(["claude-code"], {
+    onExternalSessionSelectionChanged: (_sessionId, patch) => {
+      persisted.push(patch)
+    },
+  })
+  const adapter = adapters.get("claude-code")
+  assert.ok(adapter)
+  const sessionId = mintExternalSessionId("claude-code")
+  let releasePermissionMode!: () => void
+  adapter.permissionModeBarrier = new Promise<void>((resolve) => (releasePermissionMode = resolve))
+  adapter.failNextPrompt = new Error("prompt rejected")
+
+  const prompt = service.sendMessage(sendRequest(sessionId, "use sonnet", { agentModelId: "sonnet" }))
+  await waitForCondition(() => adapter.permissionModeBarrierEntries === 1, "permission-mode projection barrier")
+  await service.setExternalSessionModel({ sessionId, modelId: "haiku" })
+  releasePermissionMode()
+  await prompt
+  await waitForCondition(() => !service.hasActiveGeneration(), "rejected prompt cleanup")
+
+  assert.deepEqual(persisted, [{ modelId: "haiku" }, { modelId: "sonnet" }, { modelId: "haiku" }])
+  assert.deepEqual(adapter.sessionSelection(sessionId), { modelId: "haiku" })
+})
+
+test("forgetSession waits for pending selection persistence and removes its mutation bookkeeping", async () => {
+  let releasePersistence!: () => void
+  const persistenceBarrier = new Promise<void>((resolve) => (releasePersistence = resolve))
+  let persistenceStarted = false
+  const { service } = createHarness(["claude-code"], {
+    onExternalSessionSelectionChanged: async (_sessionId, patch) => {
+      if (patch.modelId === "sonnet") {
+        persistenceStarted = true
+        await persistenceBarrier
+      }
+    },
+  })
+  const sessionId = mintExternalSessionId("claude-code")
+  const selection = service.setExternalSessionModel({ sessionId, modelId: "sonnet" })
+  await waitForCondition(() => persistenceStarted, "pending selection persistence")
+
+  let deletionSettled = false
+  const deletion = service.forgetSession(sessionId).then(() => {
+    deletionSettled = true
+  })
+  await Promise.resolve()
+  assert.equal(deletionSettled, false)
+  releasePersistence()
+  await Promise.all([selection, deletion])
+
+  const internals = service as unknown as {
+    externalSelectionMutationTails: Map<string, Promise<void>>
+    externalSelectionMutationTokens: Map<string, number>
+    externalSelectionMutationSequences: Map<string, number>
+  }
+  for (const axis of ["model", "effort"] as const) {
+    const key = `${sessionId}\0${axis}`
+    assert.equal(internals.externalSelectionMutationTails.has(key), false)
+    assert.equal(internals.externalSelectionMutationTokens.has(key), false)
+    assert.equal(internals.externalSelectionMutationSequences.has(key), false)
+  }
 })
 
 test("external model and effort updates stay ordered when persistence overlaps", async () => {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -578,6 +578,24 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     return next
   }
 
+  private async settleExternalSelectionMutations(sessionId: string): Promise<void> {
+    for (const axis of ["model", "effort"] as const) {
+      const key = `${sessionId}\0${axis}`
+      // A mutation can enqueue another mutation while the current tail is
+      // settling. Re-read the tail until the axis is genuinely idle, then the
+      // deletion cleanup can remove its bookkeeping without a late callback
+      // recreating tokens for the deleted session.
+      for (;;) {
+        const tail = this.externalSelectionMutationTails.get(key)
+        if (!tail) break
+        await tail.catch(() => undefined)
+      }
+      this.externalSelectionMutationTails.delete(key)
+      this.externalSelectionMutationTokens.delete(key)
+      this.externalSelectionMutationSequences.delete(key)
+    }
+  }
+
   public async getExternalSessionSelection(sessionId: string): Promise<{ modelId?: string; effortId?: string }> {
     return this.externalAdapterFor(sessionId).sessionSelection(sessionId)
   }
@@ -644,6 +662,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   /** 会话永久删除后释放运行态索引，并删除授权/停止 overlay。 */
   public async forgetSession(sessionId: string): Promise<void> {
     this.generations.get(sessionId)?.controller.abort()
+    const selectionMutationsSettled = this.settleExternalSelectionMutations(sessionId)
     this.turnOutputs.delete(sessionId)
     this.turnOutputs.clearPending(sessionId)
     this.clearSessionGeneration(sessionId)
@@ -656,10 +675,6 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.compactingSessions.delete(sessionId)
     this.permissions.deleteSession(sessionId)
     this.permissionModeMutationTokens.delete(sessionId)
-    this.externalSelectionMutationTokens.delete(`${sessionId}\0model`)
-    this.externalSelectionMutationTokens.delete(`${sessionId}\0effort`)
-    this.externalSelectionMutationSequences.delete(`${sessionId}\0model`)
-    this.externalSelectionMutationSequences.delete(`${sessionId}\0effort`)
     this.trustedAccess.deleteSession(sessionId)
     const messageIds = this.managedUserMessageIdsBySession.get(sessionId)
     for (const messageId of messageIds ?? []) {
@@ -667,6 +682,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       this.internalAttachmentPathsByMessage.delete(messageId)
     }
     this.managedUserMessageIdsBySession.delete(sessionId)
+    await selectionMutationsSettled
     await this.outputPersistence.removeSession(sessionId)
   }
 
@@ -1972,7 +1988,10 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     )
     const userMessageId = createOpencodeMessageId()
     const generation = this.beginChatTurn(req, userMessageId)
-    const previousSelection = adapter.sessionSelection(req.sessionId)
+    const previousSelection: { modelId: string | undefined; effortId: string | undefined } = {
+      modelId: undefined,
+      effortId: undefined,
+    }
     const promptSelectionOwners: Partial<Record<"model" | "effort", number>> = {}
     let artifactDir: string | undefined
     let processDir: string | undefined
@@ -2038,11 +2057,13 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       await this.projectPermissionMode(req.sessionId, this.sessionPermissionMode(req.sessionId))
       if (req.agentModelId) {
         promptSelectionOwners.model = await this.runExternalSelectionMutation(req.sessionId, "model", async () => {
+          previousSelection.modelId = adapter.sessionSelection(req.sessionId).modelId
           await this.deps.onExternalSessionSelectionChanged?.(req.sessionId, { modelId: req.agentModelId })
         })
       }
       if (req.agentEffortId) {
         promptSelectionOwners.effort = await this.runExternalSelectionMutation(req.sessionId, "effort", async () => {
+          previousSelection.effortId = adapter.sessionSelection(req.sessionId).effortId
           await this.deps.onExternalSessionSelectionChanged?.(req.sessionId, { effortId: req.agentEffortId })
         })
       }
@@ -2120,7 +2141,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private async rollbackPromptSelectionPersistence(
     sessionId: string,
     owners: Partial<Record<"model" | "effort", number>>,
-    previous: { modelId?: string; effortId?: string },
+    previous: { modelId: string | undefined; effortId: string | undefined },
   ): Promise<void> {
     const rollbacks: Promise<void>[] = []
     if (owners.model !== undefined) {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -326,6 +326,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private readonly externalSelectionMutationTokens = new Map<string, number>()
   /** Monotonic token source; reservations are distinct even when an earlier mutation fails. */
   private readonly externalSelectionMutationSequences = new Map<string, number>()
+  /** Permanent tombstones: external session UUIDs are never reused after deletion. */
+  private readonly deletedExternalSelectionSessions = new Set<string>()
   /** Permission changes serialize so a duplicate same-mode request can retry a failed projection. */
   private readonly permissionModeMutationTails = new Map<string, Promise<void>>()
   /** Ownership token for async permission persistence/projection and rollback. */
@@ -528,6 +530,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     axis: "model" | "effort",
     mutation: () => Promise<void>,
   ): Promise<number> {
+    if (this.deletedExternalSelectionSessions.has(sessionId)) {
+      return Promise.reject(new Error("The external agent session was deleted."))
+    }
     const key = `${sessionId}\0${axis}`
     const token = (this.externalSelectionMutationSequences.get(key) ?? 0) + 1
     this.externalSelectionMutationSequences.set(key, token)
@@ -554,6 +559,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     ownerToken: number,
     mutation: () => Promise<void>,
   ): Promise<void> {
+    // A rejected prompt may finish after forgetSession observed an idle queue.
+    // Its rollback no longer owns any durable state and must stay a no-op.
+    if (this.deletedExternalSelectionSessions.has(sessionId)) return Promise.resolve()
     const key = `${sessionId}\0${axis}`
     const rollbackToken = (this.externalSelectionMutationSequences.get(key) ?? 0) + 1
     this.externalSelectionMutationSequences.set(key, rollbackToken)
@@ -661,6 +669,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
 
   /** 会话永久删除后释放运行态索引，并删除授权/停止 overlay。 */
   public async forgetSession(sessionId: string): Promise<void> {
+    this.deletedExternalSelectionSessions.add(sessionId)
     this.generations.get(sessionId)?.controller.abort()
     const selectionMutationsSettled = this.settleExternalSelectionMutations(sessionId)
     this.turnOutputs.delete(sessionId)


### PR DESCRIPTION
## Summary

Follow up on the late CodeRabbit findings from #322 by closing three BYOA selection races that arrived as the original PR was being merged.

When an ACP or Claude prompt applied a model/effort and later failed, its rollback could overwrite a newer picker or prompt selection. The adapters now retain the values applied by that prompt and restore an axis only while that prompt still owns the desired value.

The chat selection persistence layer now captures each rollback baseline inside the serialized per-axis mutation, immediately before persistence. This preserves a direct model/effort choice that completes while an external turn is still preparing. Session deletion also waits for pending per-axis persistence tails before removing their tail, token, and sequence bookkeeping, preventing late callbacks from recreating selection state for a deleted session while keeping the rest of session cleanup synchronous. A permanent tombstone for the non-reusable external session UUID blocks direct mutations and delayed prompt rollbacks after deletion begins.

Regression coverage exercises both adapters, the direct-selection/prompt-persistence race, and deletion during pending selection persistence.

## Verification

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run format`
- [x] `corepack pnpm test` — 332 files passed, 2 skipped; 2702 tests passed, 4 skipped
- [x] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable — concurrency and persistence behavior is covered by adapter and chat-service regression tests; no UI rendering changed

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately. This change is limited to external BYOA agent selection state and does not alter authentication modes.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them. Only model/effort rollback ownership and persistence ordering changed.
- [x] Migration, packaging, endpoint, and update implications were considered. No persisted schema, package, endpoint, or update format changed.
- [x] Relevant documentation and tests were updated. No contract documentation change is required; regression tests cover all three races.
