### PR TITLE
fix(agent): unify BYOA permission behavior

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -82,10 +82,14 @@ External agents build on `electron/agent/external/`:
   `permissionModeMap`). Enforcement is always agent-side. Applying a declared
   mode is fail-closed: a missing or rejected native mode blocks the turn rather
   than silently continuing under a stale, potentially broader mode.
-- **Native permission ownership is agent-side, host capability permission is
-  host-side**: the external agent's CLI decides WHEN native file, shell, and
-  network work needs approval, and Wanta relays those asks to the user. The one
-  deliberate exception is dispatch to a generated `wanta_*` MCP server:
+- **Native enforcement is agent-side; user-visible approval semantics are
+  host-owned**: an external CLI keeps its sandbox and decides when it needs an
+  interactive native permission response. Every such request is normalized and
+  evaluated by the same Wanta local-access policy used for the built-in kernel.
+  Ordinary operations are answered automatically; protected or consequential
+  boundaries reach the user. Switching agents must not change the decision for
+  the same normalized operation, permission mode, and host context. Dispatch to
+  a generated `wanta_*` MCP server is also auto-approved at the transport layer:
   Wanta auto-approves that redundant ACP transport prompt because the call
   enters the same host-owned capability kernel used directly by OpenCode,
   where identity, credentials, validation, and auditing are already enforced.
@@ -105,9 +109,11 @@ External agents build on `electron/agent/external/`:
   policy: Wanta MCP capabilities take precedence over CLI examples, so the raw
   CLI remains a fallback rather than an agent-specific primary transport.
   Explicit session grants still never cross sensitive-resource or high-risk
-  boundaries. The kernel's other blanket defaults (`default_local` /
-  `default_command`, trusted-project allows, host-side `full_access`) continue
-  to apply only to built-in kernel sessions.
+  boundaries. The shared defaults (`default_local` / `default_command`,
+  trusted-project allows, and host-side `full_access`) apply to every adapter.
+  External sessions also register Wanta's stable artifact/process roots with
+  their native runtime so ordinary managed-output writes do not create a
+  redundant sandbox escalation.
 - **Transcript persistence**: every emitted event is folded into
   `ExternalTranscriptRecorder` and mirrored to one JSON file per session under
   `<scratchRoot>/<kind>/transcripts/` (atomic replace, debounced writes,

--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -88,11 +88,13 @@ External agents build on `electron/agent/external/`:
   evaluated by the same Wanta local-access policy used for the built-in kernel.
   Ordinary operations are answered automatically; protected or consequential
   boundaries reach the user. Switching agents must not change the decision for
-  the same normalized operation, permission mode, and host context. Dispatch to
-  a generated `wanta_*` MCP server is also auto-approved at the transport layer:
-  Wanta auto-approves that redundant ACP transport prompt because the call
-  enters the same host-owned capability kernel used directly by OpenCode,
-  where identity, credentials, validation, and auditing are already enforced.
+  the same normalized operation, permission mode, and host context. A
+  non-sensitive, non-high-risk dispatch to a generated `wanta_*` MCP server is
+  also auto-approved at the transport layer: Wanta auto-approves that redundant
+  ACP transport prompt because the call enters the same host-owned capability
+  kernel used directly by OpenCode, where identity, credentials, validation,
+  and auditing are already enforced. Sensitive or high-risk host-tool requests
+  still continue through the shared prompt-or-deny policy.
   Claude's native `Skill` discovery tool is also auto-approved because it only
   loads local instructions; any file, shell, or network operation instructed
   by that Skill remains subject to Claude's normal permission flow. Claude MCP

--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -12,11 +12,16 @@ The target split is:
 | Owner         | Responsibilities                                                                                                                                                             |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Wanta host    | session identity, team/workspace scope, Link connections, browser and knowledge services, artifacts, redaction, authorization signals, audit records, and normalized tool UI |
-| Agent adapter | native session lifecycle, model/effort selection, reasoning loop, native local-tool permissions, and translation to/from the normalized adapter contract                     |
+| Agent adapter | native session lifecycle, model/effort selection, reasoning loop, native local-tool enforcement, and translation to/from the normalized adapter contract                     |
 | Model         | intent understanding, planning, tool choice, synthesis, and response generation                                                                                              |
 
 Agent-native behavior is not expected to be identical. Host capability
 identity, business safety, and result semantics are expected to be identical.
+For local interactive permissions, Wanta also owns the user-visible decision:
+the same normalized operation, permission mode, and host context must produce
+the same allow/prompt/deny result for every adapter. Native sandboxes remain a
+defense-in-depth execution boundary and may fail an operation they cannot
+support, but they do not define a separate Wanta approval experience.
 
 ## Runtime-context contract
 

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -403,6 +403,23 @@ describe("AcpAgentAdapter", () => {
     ])
   })
 
+  test("registers the host working directory and stable managed roots on session creation", async () => {
+    const harness = await createHarness()
+    const projectRoot = path.join(harness.scratchRootDir, "project")
+    const artifactRoot = path.join(harness.scratchRootDir, "artifacts", WANTA_SESSION_ID)
+    const processRoot = path.join(harness.scratchRootDir, "process", WANTA_SESSION_ID)
+    await harness.adapter.send({
+      type: "prompt",
+      sessionId: WANTA_SESSION_ID,
+      text: "create a file",
+      workingDirectory: projectRoot,
+      additionalDirectories: [projectRoot, artifactRoot, processRoot, artifactRoot],
+    })
+
+    expect(harness.fake.newSessionRequests[0]?.cwd).toBe(projectRoot)
+    expect(harness.fake.newSessionRequests[0]?.additionalDirectories).toEqual([artifactRoot, processRoot])
+  })
+
   test("registers Wanta host MCP servers on the external ACP session", async () => {
     const harness = await createHarness({}, "codex", async () => [
       {

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -1004,9 +1004,16 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
   }
 
   private async createAcpSession(handle: AcpConnectionHandle, input: PromptAgentInput): Promise<AcpSessionState> {
-    const cwd = input.outputProjectRoot ?? (await this.ensureScratchDir(input.sessionId))
+    const cwd = input.workingDirectory ?? input.outputProjectRoot ?? (await this.ensureScratchDir(input.sessionId))
     const mcpServers = await this.hostMcpServers(input)
-    const response = await handle.connection.agent.request("session/new", { cwd, mcpServers })
+    const additionalDirectories = [...new Set(input.additionalDirectories ?? [])].filter(
+      (directory) => directory !== cwd,
+    )
+    const response = await handle.connection.agent.request("session/new", {
+      cwd,
+      ...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
+      mcpServers,
+    })
     if (!this.isStarted || this.isSessionForgotten(input.sessionId)) {
       await handle.connection.agent
         .request("session/close" as never, { sessionId: response.sessionId } as never)

--- a/electron/agent/claude/adapter.test.ts
+++ b/electron/agent/claude/adapter.test.ts
@@ -322,6 +322,22 @@ describe("ClaudeCodeAgentAdapter", () => {
     expect(calls[0].options.cwd).toBe(scratchRootDir)
   })
 
+  it("passes stable host-authorized directories to the native CLI", async () => {
+    const { adapter, calls, scratchRootDir } = await createHarness()
+    const projectRoot = path.join(scratchRootDir, "project")
+    const artifactRoot = path.join(scratchRootDir, "artifacts")
+    const processRoot = path.join(scratchRootDir, "process")
+    await adapter.send({
+      type: "prompt",
+      sessionId,
+      text: "create a file",
+      workingDirectory: projectRoot,
+      additionalDirectories: [projectRoot, artifactRoot, processRoot, artifactRoot],
+    })
+    expect(calls[0].options.cwd).toBe(projectRoot)
+    expect(calls[0].options.additionalDirectories).toEqual([artifactRoot, processRoot])
+  })
+
   it("does nothing when the prompt signal is already aborted", async () => {
     const { adapter, calls } = await createHarness()
     const controller = new AbortController()

--- a/electron/agent/claude/adapter.ts
+++ b/electron/agent/claude/adapter.ts
@@ -738,7 +738,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
     // (verified against 2.1.226: resume replays nothing and keeps the same id).
     const startMode =
       this.nativeStartOverride.get(sessionId) ?? (this.hasPersistedHistory(sessionId) ? "resume" : "fresh")
-    let cwd = input.outputProjectRoot
+    let cwd = input.workingDirectory ?? input.outputProjectRoot
     if (!cwd) {
       cwd = path.join(this.scratchRootDir, sessionUuid)
       await mkdir(cwd, { recursive: true })
@@ -753,6 +753,11 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       prompt: inputQueue,
       options: {
         cwd,
+        ...(input.additionalDirectories?.length
+          ? {
+              additionalDirectories: [...new Set(input.additionalDirectories)].filter((directory) => directory !== cwd),
+            }
+          : {}),
         pathToClaudeCodeExecutable: status.binary.path,
         // Options.env REPLACES the subprocess env entirely (verified against
         // sdk.d.ts 0.3.226), so the current env is spread in explicitly.

--- a/electron/agent/contract/input.ts
+++ b/electron/agent/contract/input.ts
@@ -37,6 +37,10 @@ export interface PromptAgentInput {
   system?: string
   /** Managed output directories assigned by the chat layer for this turn. */
   artifactDir?: string
+  /** Host-selected project cwd. Kept separate from artifact placement. */
+  workingDirectory?: string
+  /** Stable host-authorized local roots available in addition to the cwd. */
+  additionalDirectories?: string[]
   outputProjectRoot?: string
   processDir?: string
   /**
@@ -131,6 +135,8 @@ const promptInputSchema = z.object({
   teamName: z.string().optional(),
   system: z.string().optional(),
   artifactDir: z.string().optional(),
+  workingDirectory: z.string().optional(),
+  additionalDirectories: z.array(z.string().min(1)).optional(),
   outputProjectRoot: z.string().optional(),
   processDir: z.string().optional(),
   // Same floor as the dedicated set-model/set-effort inputs: an empty id would

--- a/electron/agent/managed-turn-directories.ts
+++ b/electron/agent/managed-turn-directories.ts
@@ -26,6 +26,11 @@ export class ManagedTurnDirectories {
     return this.createTurnDir("process", sessionId)
   }
 
+  /** Stable parent of every process directory created for this session. */
+  public processSessionDir(sessionId: string): string {
+    return this.sessionTurnRoot("process", sessionId)
+  }
+
   private async createTurnDir(kind: "artifacts" | "process", sessionId: string): Promise<string> {
     const root = this.sessionTurnRoot(kind, sessionId)
     await mkdir(root, { recursive: true })

--- a/electron/chat/context-system.test.ts
+++ b/electron/chat/context-system.test.ts
@@ -98,12 +98,13 @@ test("buildPermissionModeSystem describes default access", () => {
   assert.doesNotMatch(prompt, /user has enabled Full Access/)
 })
 
-test("buildExternalPermissionModeSystem preserves agent-native enforcement", () => {
+test("buildExternalPermissionModeSystem describes shared Wanta decisions over native enforcement", () => {
   const defaultPrompt = buildExternalPermissionModeSystem("default", true)
   const fullAccessPrompt = buildExternalPermissionModeSystem("full_access", true)
 
-  assert.match(defaultPrompt, /Default Access through the external agent's native permission policy/)
-  assert.match(defaultPrompt, /will not silently answer it on the agent's behalf/)
+  assert.match(defaultPrompt, /Default Access with Wanta's shared approval policy/)
+  assert.match(defaultPrompt, /same local permission policy to every agent/)
+  assert.match(defaultPrompt, /approved automatically/)
   assert.doesNotMatch(defaultPrompt, /Local permission requests are auto-approved/)
   assert.match(fullAccessPrompt, /projected onto the external agent's native permission mode when supported/)
   assert.match(fullAccessPrompt, /external agent runtime remains the enforcement authority/)

--- a/electron/chat/context-system.ts
+++ b/electron/chat/context-system.ts
@@ -216,9 +216,9 @@ export function buildExternalPermissionModeSystem(
     return lines.join("\n")
   }
   const lines = [
-    "Permission mode for this turn: Default Access through the external agent's native permission policy.",
+    "Permission mode for this turn: Default Access with Wanta's shared approval policy and the external agent's native enforcement.",
     "- Use local tools normally when they are useful; do not ask for conversational confirmation before the native runtime requests it.",
-    "- If the native runtime emits a permission request, Wanta will surface that exact request to the user and will not silently answer it on the agent's behalf.",
+    "- Wanta applies the same local permission policy to every agent. Ordinary shell, file, project, and managed-output operations are approved automatically; only protected or consequential boundaries should interrupt the user.",
     "- Wanta-managed business capabilities separately enforce their own confirmation, identity, and data-safety rules.",
   ]
   if (browserAvailable) {

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -206,8 +206,8 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
     const request: ChatPermissionRequest = {
       id: requestId,
       sessionId,
-      action: "write_file",
-      resources: [`/fake/${requestId}.txt`],
+      action: "read_file",
+      resources: [`/Users/example/.ssh/${requestId}`],
     }
     this.nativePendingPermissionIds.add(requestId)
     this.emit({ event: "permissionAsked", data: { sessionId, request } })
@@ -298,6 +298,11 @@ test("external turns receive managed output directories and finalize against the
   const prompt = adapter.prompts[0]
   assert.ok(prompt?.artifactDir)
   assert.ok(prompt.processDir)
+  assert.equal(prompt.additionalDirectories?.length, 2)
+  assert.equal(
+    prompt.additionalDirectories?.every((root) => path.isAbsolute(root)),
+    true,
+  )
 
   adapter.completeAssistantTurn(sessionId, "reply-managed", "done")
   await waitForTurnCompletion(service)
@@ -341,6 +346,7 @@ test("external plan turns keep the registered project read-only and use managed 
 
   const prompt = adapter.prompts[0]
   assert.equal(prompt?.outputProjectRoot, undefined)
+  assert.equal(prompt?.workingDirectory, undefined)
   assert.ok(prompt?.artifactDir)
   assert.equal(prompt.artifactDir.startsWith(projectRoot), false)
 
@@ -980,7 +986,7 @@ test("external turns receive the same Wanta team and Link identity instead of fa
   assert.match(codex.prompts[0]?.system ?? "", /Current-turn Wanta Link workspace: team "OOMOL-Internal"/)
   assert.match(codex.prompts[0]?.system ?? "", /--team "OOMOL-Internal"/)
   assert.match(codex.prompts[0]?.system ?? "", /Team-configured skills for the active workspace/)
-  assert.match(codex.prompts[0]?.system ?? "", /Default Access through the external agent's native permission policy/)
+  assert.match(codex.prompts[0]?.system ?? "", /Default Access with Wanta's shared approval policy/)
   assert.match(codex.prompts[0]?.system ?? "", /application interface language: Simplified Chinese/)
 
   codex.completeAssistantTurn(sessionId, "reply", "done")

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -56,11 +56,19 @@ test("OpenCode, Claude, and ACP agents share the guarded OOCLI allow path", () =
   }
 })
 
-test("external-agent OOCLI parity stays narrow and fails closed", () => {
+test("OOCLI parity stays narrow and fails closed for every agent", () => {
+  for (const command of ["oo auth login", "oo connector logout", "oo connector apps --connector-token secret"]) {
+    assert.equal(
+      evaluateLocalAccessRequest(permission({ metadata: { command } }), {
+        isExternalSession: true,
+        linkRuntime: "oomol",
+        permissionMode: "default",
+      }).type,
+      "deny",
+      command,
+    )
+  }
   for (const command of [
-    "oo auth login",
-    "oo connector logout",
-    "oo connector apps --connector-token secret",
     'oo connector run "posthog" --action "list_projects" --json | tee /tmp/projects.json',
     'oo connector run "posthog" --action "list_projects" --json && echo done',
     'oo connector run "posthog" --action "list_projects" --json > /tmp/projects.json',
@@ -81,28 +89,35 @@ test("external-agent OOCLI parity stays narrow and fails closed", () => {
       isExternalSession: true,
       permissionMode: "default",
     }),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
 })
 
-test("external-agent oo_cli auto-approve requires an active Link runtime, not the truthy 'none'", () => {
-  // "none" is the production default when no Link runtime is connected and is a
-  // truthy string; it must NOT satisfy the oo_cli gate, or a BYOA agent could run
-  // the user's own unguarded oo binary with no approval card.
+test("safe OOCLI classification is agent-independent even without an active Link runtime", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(
       permission({ metadata: { command: "oo connector run gmail --action send_email --json" } }),
       { isExternalSession: true, linkRuntime: "none", permissionMode: "default" },
     ),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
-  // With a real runtime the same command still auto-approves (parity preserved).
+  // A real runtime produces the same Wanta decision.
   assert.equal(
     evaluateLocalAccessRequest(
       permission({ metadata: { command: "oo connector run gmail --action send_email --json" } }),
       { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
     ).type,
     "allow",
+  )
+  assert.deepEqual(
+    evaluateLocalAccessRequest(
+      permission({
+        metadata: { command: "oo connector apps --json" },
+        resources: ["/Users/example/.ssh/id_rsa"],
+      }),
+      { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
+    ),
+    { type: "prompt", kind: "command", highRisk: false },
   )
 })
 
@@ -128,14 +143,14 @@ test("external agents auto-approve Wanta host MCP dispatch without weakening nat
       }),
       { isExternalSession: true, permissionMode: "default" },
     ),
-    { type: "prompt", kind: "local", highRisk: false },
+    { type: "allow", reason: "default_local", kind: "local", highRisk: false },
   )
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "permission", metadata: { rawInput: { tool: "call_action" } } }), {
       isExternalSession: true,
       permissionMode: "default",
     }),
-    { type: "prompt", kind: "local", highRisk: false },
+    { type: "allow", reason: "default_local", kind: "local", highRisk: false },
   )
 })
 
@@ -164,7 +179,7 @@ test("local access policy allows direct and standard wrapped oo commands under O
         linkRuntime: "openconnector",
         permissionMode: "full_access",
       }),
-      { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
+      { type: "allow", reason: "full_access", kind: "command", highRisk: false },
       command,
     )
   }
@@ -180,7 +195,7 @@ test("local access policy allows direct and standard wrapped oo commands under O
       linkRuntime: "openconnector",
       permissionMode: "default",
     }),
-    { type: "allow", reason: "default_command", kind: "command", highRisk: false },
+    { type: "prompt", kind: "command", highRisk: false },
   )
   for (const command of ["oo connector apps --json 2>&1", "oo connector apps --json 2>&1 | head -80"]) {
     assert.deepEqual(
@@ -901,25 +916,23 @@ test("local access policy keeps project dev grants compatible but prompts unsafe
   )
 })
 
-// External (BYOA) sessions: permission policy is owned by the agent's own
-// CLI (linkcode-style pass-through). Every ask the agent surfaces reaches the
-// user; the only automatic answers are the user's explicit session grants.
+// External (BYOA) sessions use the same Wanta policy as the built-in kernel.
+// Native CLIs retain their sandbox/enforcement boundary; Wanta owns whether an
+// interactive request interrupts the user.
 
 const EXTERNAL_ROOT = path.join("/tmp", "wanta-agent-external", "claude-code", "uuid-1")
 
-test("external sessions prompt for file writes even inside the scratch cwd", () => {
-  // The agent asking means its own policy wants explicit approval; Wanta must
-  // not answer on its behalf, not even inside the session's working directory.
+test("external sessions auto-approve ordinary file writes like OpenCode", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "Write", resources: [path.join(EXTERNAL_ROOT, "hello.txt")] }), {
       permissionMode: "default",
       isExternalSession: true,
     }),
-    { type: "prompt", kind: "edit", highRisk: false },
+    { type: "allow", reason: "default_local", kind: "edit", highRisk: false },
   )
 })
 
-test("external sessions prompt for edits inside the trusted project root", () => {
+test("external sessions auto-approve trusted-project edits like OpenCode", () => {
   const projectRoot = path.join("/tmp", "my-project")
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "Edit", resources: [path.join(projectRoot, "src", "index.ts")] }), {
@@ -927,21 +940,21 @@ test("external sessions prompt for edits inside the trusted project root", () =>
       isExternalSession: true,
       trustedProjectRoot: projectRoot,
     }),
-    { type: "prompt", kind: "edit", highRisk: false },
+    { type: "allow", reason: "trusted_project", kind: "edit", highRisk: false },
   )
 })
 
-test("external sessions prompt for commands instead of the blanket default allow", () => {
+test("external sessions auto-approve ordinary commands like OpenCode", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "Bash", metadata: { command: "echo hi > ~/anywhere" } }), {
       permissionMode: "default",
       isExternalSession: true,
     }),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "default_command", kind: "command", highRisk: false },
   )
 })
 
-test("external Bash cannot spoof a Wanta host tool through raw MCP metadata", () => {
+test("external Bash metadata cannot change the shared ordinary-command decision reason", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(
       permission({
@@ -950,19 +963,17 @@ test("external Bash cannot spoof a Wanta host tool through raw MCP metadata", ()
       }),
       { permissionMode: "default", isExternalSession: true },
     ),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "default_command", kind: "command", highRisk: false },
   )
 })
 
-test("external sessions prompt even in full access mode", () => {
-  // full_access projects onto the agent's own bypass mode, so the agent stops
-  // asking on its own; an ask that still arrives is surfaced, never answered.
+test("external sessions share OpenCode full-access auto-approval", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "Bash", metadata: { command: "echo hi" } }), {
       permissionMode: "full_access",
       isExternalSession: true,
     }),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "full_access", kind: "command", highRisk: false },
   )
 })
 
@@ -1006,12 +1017,29 @@ test("external session grants cannot cross sensitive or high-risk boundaries", (
   )
 })
 
-test("external sessions with no resolvable context still fail closed to a prompt", () => {
+test("external sessions with no project context share OpenCode default-local behavior", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ action: "Write", resources: ["/tmp/anywhere.txt"] }), {
       permissionMode: "default",
       isExternalSession: true,
     }),
-    { type: "prompt", kind: "edit", highRisk: false },
+    { type: "allow", reason: "default_local", kind: "edit", highRisk: false },
   )
+})
+
+test("built-in and external sessions receive identical decisions for normalized local operations", () => {
+  const root = path.join("/tmp", "permission-parity-project")
+  const requests = [
+    permission({ action: "Write", resources: [path.join(root, "src", "new.ts")] }),
+    permission({ action: "Bash", metadata: { command: "pnpm test" } }),
+    permission({ action: "Read", resources: ["/Users/someone/.ssh/id_rsa"] }),
+    permission({ action: "Bash", metadata: { command: "git push origin main" } }),
+  ]
+  for (const request of requests) {
+    const shared = { permissionMode: "default" as const, trustedProjectRoot: root }
+    assert.deepEqual(
+      evaluateLocalAccessRequest(request, { ...shared, isExternalSession: true }),
+      evaluateLocalAccessRequest(request, shared),
+    )
+  }
 })

--- a/electron/chat/local-access-policy.ts
+++ b/electron/chat/local-access-policy.ts
@@ -2,7 +2,7 @@ import type { ActiveLinkRuntime } from "../link-runtime/common.ts"
 import type { AgentPermissionMode, ChatPermissionRequest, LocalPermissionPromptReason } from "./common.ts"
 import type { PermissionRequestKind, SessionPermissionGrant } from "./permission-request.ts"
 
-import { openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
+import { isOoCliCommand, openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
 import { isLowConsequenceCleanupCommand } from "./bounded-cleanup.ts"
 import {
   createSessionPermissionGrant,
@@ -60,11 +60,10 @@ export type LocalAccessDecision =
 export interface LocalAccessPolicyContext {
   activeGenerationId?: string
   /**
-   * The request comes from an external (BYOA) agent session. Permission policy
-   * for those sessions is owned by the agent's own CLI: it decides when to
-   * ask, and Wanta relays every ask to the user instead of answering through
-   * host-side policy. Must be derived from the session id's kind, never from
-   * whether a scratch root could be resolved.
+   * The request comes from an external (BYOA) agent session. This only affects
+   * transport-specific duplicate approvals (for example Wanta MCP dispatch).
+   * It must never change Wanta's user-visible local permission policy: the
+   * same normalized operation receives the same decision for every agent.
    */
   isExternalSession?: boolean
   linkRuntime?: ActiveLinkRuntime
@@ -72,13 +71,6 @@ export interface LocalAccessPolicyContext {
   sessionGrants?: readonly SessionPermissionGrant[]
   taskProcessRoot?: string
   trustedProjectRoot?: string
-}
-
-// "none" is a valid ActiveLinkRuntime value and is truthy, so a bare truthiness
-// check would treat "no Link runtime" as active and auto-approve oo_cli parity
-// commands. Only a real runtime backs a Wanta-owned Link transport.
-function hasActiveLinkRuntime(linkRuntime: ActiveLinkRuntime | undefined): boolean {
-  return linkRuntime === "oomol" || linkRuntime === "openconnector"
 }
 
 export function localAccessPromptReason(request: ChatPermissionRequest): LocalPermissionPromptReason {
@@ -124,6 +116,7 @@ export function evaluateLocalAccessRequest(
 ): LocalAccessDecision {
   const kind = permissionRequestKind(request)
   const highRisk = isHighRiskPermissionRequest(request)
+  const command = kind === "command" ? permissionCommand(request) : undefined
   // Wanta host MCP tools are the external-agent transport for the same
   // capability kernel that OpenCode invokes directly. Their identity,
   // credentials, validation, and audit boundary remain host-owned; do not add
@@ -140,45 +133,10 @@ export function evaluateLocalAccessRequest(
   // host MCP path. Apply the same narrow command classifier to every adapter
   // so switching from OpenCode to Claude/Codex does not add a redundant shell
   // approval. Unknown shell composition, sensitive resources, and high-risk
-  // commands continue into the external agent's native permission flow.
-  if (
-    context.isExternalSession &&
-    hasActiveLinkRuntime(context.linkRuntime) &&
-    isOoCliPermissionRequest(request) &&
-    !permissionRequestHasSensitiveResource(request) &&
-    !highRisk
-  ) {
-    return { type: "allow", reason: "oo_cli", kind, highRisk }
-  }
-  if (context.isExternalSession) {
-    // linkcode-style pass-through: the external agent's own CLI policy decides
-    // WHEN to ask (its native permission modes: acceptEdits, auto classifier,
-    // sandbox levels, ...), and Wanta relays every ask to the user instead of
-    // answering through host-side policy. The only automatic answers are the
-    // user's own explicit "allow for this session" grants, and even those
-    // cannot cross credential boundaries or approve high-risk commands.
-    if (permissionRequestHasSensitiveResource(request) || highRisk) {
-      return { type: "prompt", kind, highRisk }
-    }
-    if (
-      hasMatchingNarrowSessionGrant(
-        request,
-        context.sessionGrants,
-        context.trustedProjectRoot,
-        context.activeGenerationId,
-      ) ||
-      hasMatchingGenericSessionGrant(request, context.sessionGrants)
-    ) {
-      return { type: "allow", reason: "session_grant", kind, highRisk }
-    }
-    return { type: "prompt", kind, highRisk }
-  }
+  // commands continue through the shared Wanta permission flow.
   const openConnectorPolicy =
-    context.linkRuntime === "openconnector" && kind === "command"
-      ? openConnectorCommandPolicy(permissionCommand(request) ?? request.resources.join(" "))
-      : null
+    kind === "command" ? openConnectorCommandPolicy(command ?? request.resources.join(" ")) : null
   if (openConnectorPolicy === "deny") return { type: "deny", kind, highRisk }
-  if (openConnectorPolicy === "allow") return { type: "allow", reason: "oo_cli", kind, highRisk }
   if (context.permissionMode === "full_access") {
     return { type: "allow", reason: "full_access", kind, highRisk }
   }
@@ -187,7 +145,6 @@ export function evaluateLocalAccessRequest(
   if (permissionRequestHasSensitiveResource(request)) {
     return { type: "prompt", kind, highRisk }
   }
-  const command = kind === "command" ? permissionCommand(request) : undefined
   if (
     highRisk &&
     command &&
@@ -201,6 +158,11 @@ export function evaluateLocalAccessRequest(
   if (highRisk) {
     return { type: "prompt", kind, highRisk }
   }
+  if (isOoCliPermissionRequest(request)) return { type: "allow", reason: "oo_cli", kind, highRisk }
+  // The Wanta policy is agent-independent: an unclassified/compound oo command
+  // never falls through to the blanket ordinary-command allow path, regardless
+  // of which CLI surfaced it.
+  if (command && isOoCliCommand(command)) return { type: "prompt", kind, highRisk }
   if (
     (context.taskProcessRoot &&
       (isTaskScopedPythonDependencyInstallRequest(request, context.taskProcessRoot) ||
@@ -226,9 +188,6 @@ export function evaluateLocalAccessRequest(
   }
   if (permissionRequestNeedsDefaultPrompt(request)) {
     return { type: "prompt", kind, highRisk }
-  }
-  if (hasActiveLinkRuntime(context.linkRuntime) && isOoCliPermissionRequest(request)) {
-    return { type: "allow", reason: "oo_cli", kind, highRisk }
   }
   if (context.trustedProjectRoot && projectPermissionRequestInsideRoot(request, context.trustedProjectRoot)) {
     return { type: "allow", reason: "trusted_project", kind, highRisk }

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -2002,6 +2002,10 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         },
       )
       if (!artifactDir || !processDir) throw new Error("Turn directory creation returned an empty path")
+      const additionalDirectories = [
+        directories.artifactSessionDir(req.sessionId, artifactProjectRoot),
+        directories.processSessionDir(req.sessionId),
+      ]
       if (!this.isCurrentGeneration(req.sessionId, generation.id) || generation.controller.signal.aborted) {
         this.clearSessionGeneration(req.sessionId, generation.id)
         await removeUnsubmittedTurnDirectories(artifactDir, processDir)
@@ -2056,6 +2060,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             text: req.text,
             messageId: userMessageId,
             ...(req.attachments?.length ? { attachments: req.attachments } : {}),
+            ...(artifactProjectRoot ? { workingDirectory: artifactProjectRoot } : {}),
+            additionalDirectories,
             ...(artifactProjectRoot ? { outputProjectRoot: artifactProjectRoot } : {}),
             artifactDir,
             processDir,


### PR DESCRIPTION
## Summary

This change makes Wanta's user-visible local permission behavior consistent across the built-in OpenCode kernel and every external CLI adapter, including Claude Code, Codex, Grok, and future ACP agents.

Previously, external sessions used their CLI's native approval policy as the user-interruption policy. Once an external CLI emitted a permission request, Wanta prompted the user for nearly every ordinary file or shell operation. This made switching agents change the meaning of Default Access and caused routine actions such as creating a file to interrupt autonomous runs.

## Root cause

The local-access policy returned `prompt` early for external sessions, so those requests never reached the existing OpenCode rules for ordinary commands, local file operations, trusted projects, project-scoped dependencies, session grants, bounded cleanup, and Full Access.

External sessions also received only one native working directory while Wanta instructed them to write artifacts and temporary process files into separate managed directories. Since those managed roots were not registered with the native runtime, otherwise ordinary writes could appear as workspace escapes and generate redundant permission requests.

## Changes

- Route normalized permission requests from every adapter through the same Wanta local-access policy.
- Keep native CLI sandboxes as the execution and enforcement boundary while making Wanta responsible for the shared allow/prompt/deny experience.
- Preserve prompts for sensitive resources and high-risk operations, and preserve fail-closed native permission-mode projection.
- Apply the guarded `oo` classifier consistently across adapters, including denial of authentication/configuration mutations and prompts for unclassified compound commands.
- Add normalized `workingDirectory` and `additionalDirectories` prompt fields.
- Register stable artifact and process session roots with generic ACP agents and Claude Code so managed writes do not trigger redundant sandbox escalations.
- Keep plan-mode project handling scoped to managed output directories.
- Update BYOA host-contract documentation and external-agent permission guidance.
- Add cross-adapter parity, workspace-root, sensitive-resource, lifecycle, and native adapter regression coverage.

## User impact

Under Default Access, ordinary project file creation and edits, managed artifact/process writes, and normal local commands now behave consistently when switching between OpenCode and external CLI agents. Sensitive local data, destructive or consequential commands, privilege escalation, publishing/deployment boundaries, and unsafe connector commands continue to prompt or deny according to the shared Wanta policy.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm run format`
- `pnpm test` — 332 test files passed, 2 skipped; 2700 tests passed, 4 skipped

