### PR TITLE
fix(agent): bundle Codex ACP bridge

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -19,6 +19,15 @@ Wanta is not a fork of OpenCode. It embeds the pinned OpenCode runtime and build
 security isolation, model configuration, permissions, sessions, Connector tools, and artifact UI
 around it.
 
+## Codex ACP Bridge
+
+Wanta packages `@agentclientprotocol/codex-acp@1.1.14` as the local ACP bridge used to connect a
+user-installed Codex CLI to the common external-agent adapter.
+
+Source: [agentclientprotocol/codex-acp](https://github.com/agentclientprotocol/codex-acp).
+License: Apache License 2.0. Copyright 2025 JetBrains s.r.o. The complete license text is included
+in this repository's [`LICENSE`](LICENSE) file.
+
 ## oo CLI and Bundled Skills
 
 Wanta downloads and packages `@oomol-lab/oo-cli@1.7.1` platform binaries from the public npm

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -32,9 +32,11 @@ import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { Readable, Writable } from "node:stream"
 import { pathToFileURL } from "node:url"
+import { resolveUserCommandPath } from "../../command-path.ts"
 import { errorMessage, logDiagnostic } from "../../diagnostics-log.ts"
 import { AGENT_PROFILES } from "../contract/profile.ts"
 import { ExternalAgentAdapter } from "../external/adapter-base.ts"
+import { externalExecutableNeedsShell } from "../external/executable.ts"
 import { externalAgentPromptText } from "../external/prompt.ts"
 import { externalSessionUuid } from "../external/session-id.ts"
 import { createAcpSessionTranslator } from "./translator.ts"
@@ -886,9 +888,13 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       const detail = status.binary.status === "error" ? ` (${status.binary.message})` : ""
       throw new Error(`${registration.displayName} CLI was not found on this machine${detail}.`)
     }
+    // Finder/desktop launches do not inherit the user's shell PATH. Reuse the
+    // recovered PATH so the bridge can find both Node and the user's agent CLI.
+    const pathEnv = await resolveUserCommandPath()
     const child = spawn(status.binary.path, [...registration.acpArgs], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: process.env,
+      env: { ...process.env, PATH: pathEnv, WANTA_NODE_RUNTIME: process.execPath },
+      shell: externalExecutableNeedsShell(status.binary.path),
     })
     if (!child.stdin || !child.stdout) {
       child.kill()

--- a/electron/agent/external/executable.test.ts
+++ b/electron/agent/external/executable.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+import { externalExecutableNeedsShell } from "./executable.ts"
+
+test("only Windows command shims require a shell", () => {
+  assert.equal(externalExecutableNeedsShell("C:\\app\\codex-acp.cmd", "win32"), true)
+  assert.equal(externalExecutableNeedsShell("C:\\app\\codex-acp.BAT", "win32"), true)
+  assert.equal(externalExecutableNeedsShell("C:\\app\\codex-acp.exe", "win32"), false)
+  assert.equal(externalExecutableNeedsShell("/app/codex-acp", "darwin"), false)
+})

--- a/electron/agent/external/executable.ts
+++ b/electron/agent/external/executable.ts
@@ -1,0 +1,12 @@
+import path from "node:path"
+
+export function externalExecutableNeedsShell(
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "win32") {
+    return false
+  }
+  const extension = path.win32.extname(executablePath).toLowerCase()
+  return extension === ".cmd" || extension === ".bat"
+}

--- a/electron/agent/external/probe.ts
+++ b/electron/agent/external/probe.ts
@@ -11,6 +11,7 @@ import { resolveUserCommandPath } from "../../command-path.ts"
 import { errorMessage, logDiagnosticOnChange } from "../../diagnostics-log.ts"
 import { ACP_AGENT_REGISTRY } from "../acp/registry.ts"
 import { AGENT_PROFILES, agentLoginHint } from "../contract/profile.ts"
+import { externalExecutableNeedsShell } from "./executable.ts"
 
 // BYOA runtime probing: binary detection (PATH scan + --version verification)
 // and best-effort login-state detection, exposed to the UI as a resource.
@@ -57,7 +58,8 @@ async function probeBinary(
     const { stdout } = await execFileAsync(detected.executablePath, [...versionArgs], {
       timeout: versionProbeTimeoutMs,
       maxBuffer: 64 * 1024,
-      env: { ...env, PATH: pathEnv },
+      env: { ...env, PATH: pathEnv, WANTA_NODE_RUNTIME: process.execPath },
+      shell: externalExecutableNeedsShell(detected.executablePath),
     })
     const firstLine = stdout
       .split(/\r?\n/u)

--- a/scripts/codex-acp.test.ts
+++ b/scripts/codex-acp.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { test } from "vitest"
+import { bundleCodexAcp } from "./codex-acp.ts"
+
+test("bundles a runnable POSIX codex-acp bridge entry", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-codex-acp-"))
+  try {
+    const bundled = bundleCodexAcp(directory, "darwin")
+    assert.equal(path.basename(bundled.entryPath), "codex-acp")
+    assert.equal(path.basename(bundled.scriptPath), "codex-acp.js")
+    assert.match(bundled.version, /^\d+\.\d+\.\d+/u)
+    assert.match(await readFile(bundled.entryPath, "utf8"), /WANTA_NODE_RUNTIME/u)
+    assert.notEqual((await stat(bundled.entryPath)).mode & 0o111, 0)
+    assert.ok((await stat(bundled.scriptPath)).size > 0)
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+})
+
+test("bundles a Windows command shim for codex-acp", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-codex-acp-"))
+  try {
+    const bundled = bundleCodexAcp(directory, "win32")
+    assert.equal(path.basename(bundled.entryPath), "codex-acp.cmd")
+    assert.match(await readFile(bundled.entryPath, "utf8"), /ELECTRON_RUN_AS_NODE=1/u)
+    assert.ok((await stat(bundled.scriptPath)).size > 0)
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+})

--- a/scripts/codex-acp.ts
+++ b/scripts/codex-acp.ts
@@ -1,0 +1,64 @@
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import path from "node:path"
+
+const require = createRequire(import.meta.url)
+
+interface CodexAcpManifest {
+  version: string
+}
+
+export interface BundledCodexAcp {
+  entryPath: string
+  scriptPath: string
+  version: string
+}
+
+function codexAcpPackageRoot(): string {
+  return path.dirname(require.resolve("@agentclientprotocol/codex-acp/package.json"))
+}
+
+export function bundleCodexAcp(
+  destinationDirectory: string,
+  platform: NodeJS.Platform = process.platform,
+): BundledCodexAcp {
+  const packageRoot = codexAcpPackageRoot()
+  const manifest = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")) as CodexAcpManifest
+  const sourceScript = path.join(packageRoot, "dist", "index.js")
+  const scriptPath = path.join(destinationDirectory, "codex-acp.js")
+  const entryPath = path.join(destinationDirectory, platform === "win32" ? "codex-acp.cmd" : "codex-acp")
+
+  mkdirSync(destinationDirectory, { recursive: true })
+  copyFileSync(sourceScript, scriptPath)
+
+  if (platform === "win32") {
+    writeFileSync(
+      entryPath,
+      [
+        "@echo off",
+        "if defined WANTA_NODE_RUNTIME goto wanta_node",
+        'node "%~dp0codex-acp.js" %*',
+        "exit /b %ERRORLEVEL%",
+        ":wanta_node",
+        "set ELECTRON_RUN_AS_NODE=1",
+        '"%WANTA_NODE_RUNTIME%" "%~dp0codex-acp.js" %*',
+        "exit /b %ERRORLEVEL%",
+        "",
+      ].join("\r\n"),
+    )
+  } else {
+    writeFileSync(
+      entryPath,
+      [
+        "#!/bin/sh",
+        'script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
+        'node_runtime=${WANTA_NODE_RUNTIME:-node}',
+        'ELECTRON_RUN_AS_NODE=1 exec "$node_runtime" "$script_dir/codex-acp.js" "$@"',
+        "",
+      ].join("\n"),
+    )
+    chmodSync(entryPath, 0o755)
+  }
+
+  return { entryPath, scriptPath, version: manifest.version }
+}

--- a/scripts/codex-acp.ts
+++ b/scripts/codex-acp.ts
@@ -52,7 +52,7 @@ export function bundleCodexAcp(
       [
         "#!/bin/sh",
         'script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
-        'node_runtime=${WANTA_NODE_RUNTIME:-node}',
+        "node_runtime=${WANTA_NODE_RUNTIME:-node}",
         'ELECTRON_RUN_AS_NODE=1 exec "$node_runtime" "$script_dir/codex-acp.js" "$@"',
         "",
       ].join("\n"),

--- a/scripts/open-source-readiness.test.ts
+++ b/scripts/open-source-readiness.test.ts
@@ -69,6 +69,7 @@ describe("open-source installation contract", () => {
     expect(readme).toContain("Agent Engine: OpenCode")
     expect(readme).toContain("opencode-ai@1.18.10")
     expect(notices).toContain("@opencode-ai/sdk@1.18.10")
+    expect(notices).toContain("@agentclientprotocol/codex-acp@1.1.14")
     expect(notices).toContain("@oomol-lab/oo-cli@1.7.1")
     for (const fileName of ["LICENSE", "NOTICE", "TRADEMARKS.md", "THIRD_PARTY_NOTICES.md"]) {
       expect(existsSync(path.join(repoRoot, fileName))).toBe(true)

--- a/scripts/prepare-binaries.ts
+++ b/scripts/prepare-binaries.ts
@@ -10,6 +10,7 @@ import { chmodSync, copyFileSync, mkdirSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { buildAgentToolRuntime } from "./build-agent-tool-runtime.ts"
+import { bundleCodexAcp } from "./codex-acp.ts"
 import { dingTalkCliBinaryName, downloadDingTalkCliBinary, exportDingTalkCliSkills } from "./dingtalk-cli.ts"
 import { downloadLarkCliBinary, exportLarkCliSkills, larkCliBinaryName } from "./lark-cli.ts"
 import { downloadOoBinary, ooExecutableName } from "./oo-cli.ts"
@@ -38,6 +39,11 @@ bundle(
   path.join(repoRoot, "node_modules", "opencode-ai", "bin", "opencode.exe"),
   `opencode${exe}`,
 )
+
+// Codex 通过 ACP bridge 接入。开发态从 node_modules/.bin 解析；打包态必须把同版本的
+// 自包含 JS bundle 和启动 shim 放进 Resources/bin，不能依赖构建机的 pnpm shim。
+const bundledCodexAcp = bundleCodexAcp(binDir, platform)
+console.log(`[wanta] bundled codex-acp: ${path.basename(bundledCodexAcp.entryPath)}@${bundledCodexAcp.version}`)
 
 // oo 不再依赖 node_modules：确保 .oo-bin/ 已就绪（缺失则下载当前平台的二进制）后复制。
 const ooSrc = await downloadOoBinary()


### PR DESCRIPTION
## Issue

The packaged Wanta app reports Codex as unavailable even when the user has the Codex CLI installed and authenticated. Development builds do not reproduce the problem because they resolve `codex-acp` from the repository's `node_modules/.bin` directory.

## Root cause

The Codex adapter speaks ACP through the `codex-acp` bridge rather than invoking `codex` directly. Packaged builds search `Resources/bin`, but the binary preparation step did not place the bridge there. In addition, an ACP subprocess launched from a desktop app inherited the minimal GUI process environment instead of the recovered login-shell PATH, so the bridge could still fail to find a Codex CLI installed through NVM or another shell-managed location.

## Fix

This change packages the pinned `@agentclientprotocol/codex-acp` JavaScript bundle together with platform-specific launch shims. The shim uses Electron's executable in `ELECTRON_RUN_AS_NODE` mode, avoiding a separate system Node requirement. Windows command shims are detected and launched through a shell where required.

ACP subprocess startup now uses the same recovered user command PATH as binary probing, allowing the packaged bridge to find the user's installed agent CLI. The third-party notice is also updated for the newly redistributed bridge.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm run build:app`
- `pnpm exec vitest run scripts/codex-acp.test.ts scripts/open-source-readiness.test.ts electron/agent/external/executable.test.ts electron/agent/external/probe.test.ts electron/agent/acp/adapter.test.ts`
- Verified the generated bridge reports `@agentclientprotocol/codex-acp 1.1.14` with both Node and Electron's Node mode.
- Verified `probeExternalAgent("codex")` detects the generated `resources/bin/codex-acp` bridge and reports the existing Codex login.
