### PR TITLE
build: upgrade bundled collaboration CLIs

### DIFF
--- a/scripts/dingtalk-cli.ts
+++ b/scripts/dingtalk-cli.ts
@@ -14,17 +14,17 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 const maxDownloadBytes = 128 * 1024 * 1024
 const DINGTALK_CLI_NPM_INTEGRITY =
-  "0h4qxnHT3KUgNgzgUzwczZfnS0oKv9hc9mUPphJUZerqYjg6LtWtOvJRgFiMMCo9TfSmcx5/NfoItO7d1xmeVQ=="
+  "9sYkNwfBuT/FM6IYgLEZCJZJItUq6/5dP7+rWXQt/Mbhxty8HPK7rxNepUbmhjfRPI34ZFMT6PSnetfvkTTO3g=="
 
-export const DINGTALK_CLI_VERSION = "1.0.55"
+export const DINGTALK_CLI_VERSION = "1.0.58"
 const DINGTALK_CLI_CHECKSUMS: Readonly<Record<string, string>> = {
-  "dws-darwin-amd64.tar.gz": "f465eb7ac38a8a84eac4eb821fd15424bfc6f6245a60fa695ba97a639970dd77",
-  "dws-darwin-arm64.tar.gz": "dd753bbd051e5dd007cf433b8aa211c4a221dd73dfcb0b3783fa924d09f12351",
-  "dws-linux-amd64.tar.gz": "051ba404a5f6a8fb15def0e0f5d9d273cf9d63f881df2fffe159f2c4ea3366e7",
-  "dws-linux-arm64.tar.gz": "5961be0fd551ec8e69b6fff2b1609f73486f7e6c3ffe8eb4bb99fa1ed691b401",
-  "dws-windows-amd64.zip": "9e273fa5f069a2606921aa5d325849a2245a1bb6d81329f5aa02376421c2330c",
-  "dws-windows-arm64.zip": "2c417f8957b683d5e354fefeb9f06115bb020f957dbb3c4dbe078b2d1275e3f0",
-  "dws-skills.zip": "bd35f674f184001f5a03c7b5fa6029ebcda54f0054e15cd608b5b5e213ce2d05",
+  "dws-darwin-amd64.tar.gz": "4c12e35e5bf7e0905812cd42dc94a5345068a2c16e306bb50b13c5c78b5cb95d",
+  "dws-darwin-arm64.tar.gz": "7d98599f90cae9d42b51ff2863efc87dbfb4a3176ff3c84fc2216110c0157a70",
+  "dws-linux-amd64.tar.gz": "3ccadcc6f070a39d2b2ba20429a4fcdc2f21639bf79f34361dc7d16f501bfda6",
+  "dws-linux-arm64.tar.gz": "5ef6bde24bc3db6a11a0f1d0b3343a048956b2cbcf6cd3409a037fb6ba425489",
+  "dws-windows-amd64.zip": "b8c50d9111115eafdb466978f1dd8f9421bcc2d5fac848023108353dc5a236cb",
+  "dws-windows-arm64.zip": "e1303ded8a863be9affc41c89ac1a889a14374888702b749c8d0507ad6abd202",
+  "dws-skills.zip": "2626debc21c3daadfd155b4c167b2219b97e801398fe4441a8b48138960ab264",
 }
 
 export const localDingTalkCliBinDir = path.join(repoRoot, ".dingtalk-cli-bin")

--- a/scripts/lark-cli.test.ts
+++ b/scripts/lark-cli.test.ts
@@ -5,22 +5,22 @@ import { resolveLarkCliTarget } from "./lark-cli.ts"
 test("resolveLarkCliTarget maps supported platforms and architectures to release assets", () => {
   assert.deepEqual(resolveLarkCliTarget("darwin", "x64"), {
     archiveKind: "tar.gz",
-    assetName: "lark-cli-1.0.81-darwin-amd64.tar.gz",
+    assetName: "lark-cli-1.0.87-darwin-amd64.tar.gz",
     binaryName: "lark-cli",
   })
   assert.deepEqual(resolveLarkCliTarget("darwin", "arm64"), {
     archiveKind: "tar.gz",
-    assetName: "lark-cli-1.0.81-darwin-arm64.tar.gz",
+    assetName: "lark-cli-1.0.87-darwin-arm64.tar.gz",
     binaryName: "lark-cli",
   })
   assert.deepEqual(resolveLarkCliTarget("linux", "riscv64"), {
     archiveKind: "tar.gz",
-    assetName: "lark-cli-1.0.81-linux-riscv64.tar.gz",
+    assetName: "lark-cli-1.0.87-linux-riscv64.tar.gz",
     binaryName: "lark-cli",
   })
   assert.deepEqual(resolveLarkCliTarget("win32", "arm64"), {
     archiveKind: "zip",
-    assetName: "lark-cli-1.0.81-windows-arm64.zip",
+    assetName: "lark-cli-1.0.87-windows-arm64.zip",
     binaryName: "lark-cli.exe",
   })
 })

--- a/scripts/lark-cli.ts
+++ b/scripts/lark-cli.ts
@@ -13,15 +13,15 @@ const execFileAsync = promisify(execFile)
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 
-export const LARK_CLI_VERSION = "1.0.81"
+export const LARK_CLI_VERSION = "1.0.87"
 const LARK_CLI_CHECKSUMS: Readonly<Record<string, string>> = {
-  "lark-cli-1.0.81-darwin-amd64.tar.gz": "8efdf2706a98c22d6ee4600f6c4656b1f9924c2e277821753199c5f4f8486b29",
-  "lark-cli-1.0.81-darwin-arm64.tar.gz": "0693846b129044a8c1312999f04ff26343b9a2fdb41615343e33fe67cea9dea5",
-  "lark-cli-1.0.81-linux-amd64.tar.gz": "4c783dc4bb7dd9829184058f09e1953ad5016c2fea6a38b5ae2966b191907a33",
-  "lark-cli-1.0.81-linux-arm64.tar.gz": "31691d8391d2a2cc64203b3fe4a4dd595da8f03b6c86a8be53af1f3bdb15dc64",
-  "lark-cli-1.0.81-linux-riscv64.tar.gz": "4323e7111a5a3a53187a4efdf0644852e18dde9bac24a267fe028c5baa6e533d",
-  "lark-cli-1.0.81-windows-amd64.zip": "d6ba5f4794dde63ed1b5f2373ab6cb2fcdcabf8b9dcdf0a701362a78c1ed1c74",
-  "lark-cli-1.0.81-windows-arm64.zip": "c4305ddb55cf1b9e06cb33b7c9c2289a5632e313254c5edea3c84306bce732cd",
+  "lark-cli-1.0.87-darwin-amd64.tar.gz": "40f005dc39e955ad3fa51a05b1a91619f0ccec1e781038fa247058e4c85b02a7",
+  "lark-cli-1.0.87-darwin-arm64.tar.gz": "b4cf7b1b7ff9c3d8c9ac3dd577fd178f3c8a84ec82184a82de809335840d5b20",
+  "lark-cli-1.0.87-linux-amd64.tar.gz": "6027b1ddc12440400581bbdf9554850d8e119c7dd400439b1220e7a87b9673c5",
+  "lark-cli-1.0.87-linux-arm64.tar.gz": "fade9a22d363172a9c18a8287c99c80d6d106a2900f3fce4015e4e156c5fc776",
+  "lark-cli-1.0.87-linux-riscv64.tar.gz": "c567a9b9848b1c8497a995e1fb1b1e76042315d9f80f6dfc431f9e136bcf08fa",
+  "lark-cli-1.0.87-windows-amd64.zip": "5cb039b20502d02d93f2829f82dd5a30eae8ed7674c1c5a229a7f93563526518",
+  "lark-cli-1.0.87-windows-arm64.zip": "01730490c52fbf69843cc9a57c69fe641578e99cb86bc7f04c02f9c37cef01a2",
 }
 export const localLarkCliBinDir = path.join(repoRoot, ".lark-cli-bin")
 export const bundledLarkSkillsDir = path.join(repoRoot, "resources", "lark-skills")

--- a/scripts/wecom-cli.ts
+++ b/scripts/wecom-cli.ts
@@ -12,8 +12,9 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 const maxDownloadBytes = 128 * 1024 * 1024
 
-export const WECOM_CLI_VERSION = "0.1.9"
-export const WECOM_CLI_GIT_HEAD = "72e14f7695f34d28f1ff23ea504ddd2210a87c13"
+export const WECOM_CLI_VERSION = "1.1.0"
+export const WECOM_CLI_GIT_HEAD = "889c555c527b26aa4ffece9bb03f0ec624bfa0b1"
+export const WECOM_CLI_SOURCE_COMMIT = "cd0480e0e4013c99cc9e7bb4a3247ec949a052d8"
 export const localWecomCliBinDir = path.join(repoRoot, ".wecom-cli-bin")
 export const bundledWecomSkillsDir = path.join(repoRoot, "resources", "wecom-skills")
 
@@ -167,7 +168,7 @@ export function safeSkillPath(value: string): boolean {
 }
 
 export async function exportWecomCliSkills(outputRoot: string = bundledWecomSkillsDir): Promise<string> {
-  const commit = WECOM_CLI_GIT_HEAD
+  const commit = WECOM_CLI_SOURCE_COMMIT
   const expectedMarker = `${WECOM_CLI_VERSION}@${commit}`
   try {
     if ((await readFile(path.join(outputRoot, ".version"), "utf-8")).trim() === expectedMarker) return outputRoot


### PR DESCRIPTION
## Summary

Upgrade the collaboration CLIs bundled with Wanta to their latest stable releases:

- Lark CLI from 1.0.81 to 1.0.87
- DingTalk Workspace CLI from 1.0.55 to 1.0.58
- WeCom CLI from 0.1.9 to 1.1.0

## Problem and user impact

Wanta pinned older CLI binaries and embedded Skill exports, so packaged applications did not receive the latest collaboration commands, fixes, and Skill definitions available from the upstream stable releases.

## Root cause

Each integration intentionally pins the upstream version and integrity metadata for reproducible packaging. Those pins had not yet been advanced. WeCom 1.1.0 also publishes platform binaries with a build `gitHead` that is not present in the public source repository, while the bundled Skills must be exported from the public release commit. The previous implementation used one SHA for both purposes.

## Changes

- Update Lark release asset names and SHA-256 checksums for 1.0.87.
- Update DingTalk npm integrity and embedded release asset checksums for 1.0.58.
- Update WeCom binary metadata for 1.1.0.
- Track the WeCom npm binary build SHA separately from the public 1.1.0 source commit used to export Skills, preserving both binary integrity verification and reproducible Skill exports.
- Update Lark release-target expectations in unit tests.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run format`
- `corepack pnpm run ts-check`
- `corepack pnpm test` — 335 test files passed, 2 skipped; 2722 tests passed, 4 skipped
- `corepack pnpm run build`
- `corepack pnpm run prepare:binaries`
- Executed all three CLI download and Skill export scripts successfully.
- Verified the staged package binaries report Lark 1.0.87, DingTalk 1.0.58, and WeCom 1.1.0.
