### PR TITLE
fix(external-agents): improve runtime startup diagnostics

### DIFF
--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -44,6 +44,8 @@ interface FakePromptTurn {
 
 interface FakeAgentBehavior {
   initialize?: Partial<InitializeResponse>
+  initializeError?: Error
+  failureDetail?: string
   /** Override session/new; may throw (for auth_required scenarios). */
   newSession?: (params: NewSessionRequest) => NewSessionResponse
   /** Drive a prompt turn; defaults to an immediate end_turn. */
@@ -79,7 +81,12 @@ function createFakeAgent(behavior: FakeAgentBehavior = {}): FakeAgent {
   const permissionResponses: RequestPermissionResponse[] = []
 
   const app = agent({ name: "fake-acp-agent" })
-    .onRequest("initialize", () => ({ protocolVersion: PROTOCOL_VERSION, ...behavior.initialize }))
+    .onRequest("initialize", () => {
+      if (behavior.initializeError) {
+        throw behavior.initializeError
+      }
+      return { protocolVersion: PROTOCOL_VERSION, ...behavior.initialize }
+    })
     .onRequest("session/new", ({ params }) => {
       newSessionRequests.push(params)
       if (behavior.newSession) {
@@ -158,6 +165,7 @@ function createFakeAgent(behavior: FakeAgentBehavior = {}): FakeAgent {
         dispose: () => {
           agentConnection.close()
         },
+        failureDetail: behavior.failureDetail ? () => behavior.failureDetail : undefined,
         onExit: (callback) => {
           exitCallbacks.push(callback)
         },
@@ -623,6 +631,27 @@ describe("AcpAgentAdapter", () => {
     expect(message).toContain(`${PROTOCOL_VERSION}`)
     expect(harness.fake.newSessionRequests).toHaveLength(0)
   })
+
+  test.each(["codex", "grok"] as const)(
+    "%s initialize failure includes the captured subprocess detail",
+    async (kind) => {
+      const registration = ACP_AGENT_REGISTRY[kind]
+      const harness = await createHarness(
+        {
+          initializeError: new Error("ACP connection closed"),
+          failureDetail: "Error: native ACP process failed during startup",
+        },
+        kind,
+      )
+
+      await expect(harness.adapter.send(promptInput())).rejects.toThrow(
+        "ACP subprocess: Error: native ACP process failed during startup",
+      )
+      const error = await harness.waitFor((event) => event.event === "agentError")
+      expect(eventData(error, "agentError").message).toContain(registration.displayName)
+      expect(eventData(error, "agentError").message).toContain("native ACP process failed during startup")
+    },
+  )
 
   test("an unknown permission requestId is rejected loudly", async () => {
     const harness = await createHarness()

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -32,6 +32,7 @@ import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { Readable, Writable } from "node:stream"
 import { pathToFileURL } from "node:url"
+import { detectCliExecutable } from "../../agents/catalog.ts"
 import { resolveUserCommandPath } from "../../command-path.ts"
 import { errorMessage, logDiagnostic } from "../../diagnostics-log.ts"
 import { AGENT_PROFILES } from "../contract/profile.ts"
@@ -39,6 +40,7 @@ import { ExternalAgentAdapter } from "../external/adapter-base.ts"
 import { externalExecutableNeedsShell } from "../external/executable.ts"
 import { externalAgentPromptText } from "../external/prompt.ts"
 import { externalSessionUuid } from "../external/session-id.ts"
+import { appendStderrTail, subprocessFailureSummary } from "../external/subprocess-diagnostics.ts"
 import { createAcpSessionTranslator } from "./translator.ts"
 
 // Generic ACP agent adapter (BYOA phase 2).
@@ -68,6 +70,8 @@ export interface AcpTransport {
   stream: Stream
   dispose: () => void
   onExit?: (cb: (info: { code: number | null }) => void) => void
+  /** Best-effort subprocess failure detail captured without mixing stderr into ACP stdout. */
+  failureDetail?: () => string | undefined
 }
 
 export interface AcpAdapterOptions {
@@ -93,6 +97,38 @@ interface AcpConnectionHandle {
   dispose: () => void
   /** Set once the connection is torn down so loss handling runs exactly once. */
   lost: boolean
+}
+
+/** Resolve bridge-specific native executables without adding per-agent branches. */
+export async function acpSubprocessEnvironment(
+  registration: AcpAgentRegistration,
+  pathEnv: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<NodeJS.ProcessEnv> {
+  const subprocessEnv: NodeJS.ProcessEnv = {
+    ...env,
+    PATH: pathEnv,
+    WANTA_NODE_RUNTIME: process.execPath,
+  }
+  const runtime = registration.runtimeExecutable
+  if (!runtime) {
+    return subprocessEnv
+  }
+
+  const configuredPath = env[runtime.envVar]?.trim()
+  if (configuredPath) {
+    subprocessEnv[runtime.envVar] = configuredPath
+    return subprocessEnv
+  }
+
+  const detected = await detectCliExecutable(runtime.cliCommands, { env, pathEnv })
+  if (!detected) {
+    throw new Error(
+      `${registration.displayName} CLI was not found on this machine. Install it or set ${runtime.envVar} to its executable path.`,
+    )
+  }
+  subprocessEnv[runtime.envVar] = detected.executablePath
+  return subprocessEnv
 }
 
 /** In-flight prompt marker; settled exactly once by resolve/reject/loss. */
@@ -854,8 +890,12 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
         clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
       })
     } catch (error) {
+      const failureDetail = transport.failureDetail?.()
       this.teardownHandle(handle)
-      throw new Error(`${displayName} failed to initialize the ACP connection: ${errorMessage(error)}`)
+      throw new Error(
+        `${displayName} failed to initialize the ACP connection: ${errorMessage(error)}` +
+          (failureDetail ? `. ACP subprocess: ${failureDetail}` : ""),
+      )
     }
     if (initialize.protocolVersion !== PROTOCOL_VERSION) {
       this.teardownHandle(handle)
@@ -891,18 +931,22 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     // Finder/desktop launches do not inherit the user's shell PATH. Reuse the
     // recovered PATH so the bridge can find both Node and the user's agent CLI.
     const pathEnv = await resolveUserCommandPath()
+    const subprocessEnv = await acpSubprocessEnvironment(registration, pathEnv)
     const child = spawn(status.binary.path, [...registration.acpArgs], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PATH: pathEnv, WANTA_NODE_RUNTIME: process.execPath },
+      env: subprocessEnv,
       shell: externalExecutableNeedsShell(status.binary.path),
     })
     if (!child.stdin || !child.stdout) {
       child.kill()
       throw new Error(`${registration.displayName} subprocess did not expose stdio pipes.`)
     }
-    // ACP traffic is stdout-only; stderr must be drained so the CLI never
-    // blocks on a full pipe.
-    child.stderr?.resume()
+    // ACP traffic is stdout-only. Keep a bounded stderr tail for diagnostics
+    // while continuously draining the pipe so a noisy CLI cannot block.
+    let stderrTail = ""
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrTail = appendStderrTail(stderrTail, chunk.toString())
+    })
     // Node web-stream declarations are structurally compatible with the DOM
     // globals the SDK types reference, but nominally distinct; cast once here.
     const stream = ndJsonStream(
@@ -911,16 +955,25 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     )
     const exitCallbacks: Array<(info: { code: number | null }) => void> = []
     let exited = false
+    let disposed = false
     const fireExit = (code: number | null): void => {
       if (exited) {
         return
       }
       exited = true
+      if (!disposed && (code !== 0 || stderrTail.trim())) {
+        logDiagnostic(
+          "acp-adapter",
+          "ACP subprocess exited",
+          { adapter: this.kind, code, stderrTail: stderrTail.trim() },
+          code === 0 ? "warn" : "error",
+        )
+      }
       for (const callback of exitCallbacks) {
         callback({ code })
       }
     }
-    child.once("exit", (code) => fireExit(code))
+    child.once("close", (code) => fireExit(code))
     child.once("error", (error) => {
       logDiagnostic("acp-adapter", "ACP subprocess error", { adapter: this.kind, error: errorMessage(error) }, "error")
       fireExit(null)
@@ -929,9 +982,11 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       stream,
       dispose: () => {
         if (!exited) {
+          disposed = true
           child.kill()
         }
       },
+      failureDetail: () => subprocessFailureSummary(stderrTail),
       onExit: (callback) => {
         exitCallbacks.push(callback)
       },

--- a/electron/agent/acp/registry.ts
+++ b/electron/agent/acp/registry.ts
@@ -38,6 +38,15 @@ export interface AcpAgentRegistration {
    * for npm-distributed ACP bridges such as codex-acp.
    */
   bundledBinName?: string
+  /**
+   * Optional native CLI launched by the ACP bridge. Wanta resolves it from the
+   * recovered desktop PATH and passes the absolute path through this env var,
+   * so a packaged bridge never depends on an omitted node_modules tree.
+   */
+  runtimeExecutable?: {
+    cliCommands: readonly string[]
+    envVar: string
+  }
 }
 
 export const ACP_AGENT_REGISTRY = {
@@ -55,6 +64,7 @@ export const ACP_AGENT_REGISTRY = {
     selection: { model: true, effort: true },
     loginMarkerPath: ".codex/auth.json",
     bundledBinName: "codex-acp",
+    runtimeExecutable: { cliCommands: ["codex"], envVar: "CODEX_PATH" },
   },
   grok: {
     displayName: "Grok",

--- a/electron/agent/acp/runtime-environment.test.ts
+++ b/electron/agent/acp/runtime-environment.test.ts
@@ -1,0 +1,49 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+import { acpSubprocessEnvironment } from "./adapter.ts"
+import { ACP_AGENT_REGISTRY } from "./registry.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })))
+})
+
+describe("ACP subprocess environment", () => {
+  test.runIf(process.platform !== "win32")("injects the resolved Codex CLI path for the packaged bridge", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-acp-runtime-"))
+    temporaryDirectories.push(directory)
+    const codexPath = path.join(directory, "codex")
+    await writeFile(codexPath, "#!/bin/sh\nexit 0\n", "utf8")
+    await chmod(codexPath, 0o755)
+
+    const env = await acpSubprocessEnvironment(ACP_AGENT_REGISTRY.codex, directory, {})
+
+    expect(env.CODEX_PATH).toBe(codexPath)
+    expect(env.PATH).toBe(directory)
+    expect(env.WANTA_NODE_RUNTIME).toBe(process.execPath)
+  })
+
+  test("preserves an explicit bridge runtime override", async () => {
+    const env = await acpSubprocessEnvironment(ACP_AGENT_REGISTRY.codex, "", {
+      CODEX_PATH: "/custom/codex",
+    })
+
+    expect(env.CODEX_PATH).toBe("/custom/codex")
+  })
+
+  test("fails clearly when the bridge runtime is unavailable", async () => {
+    await expect(acpSubprocessEnvironment(ACP_AGENT_REGISTRY.codex, "", {})).rejects.toThrow(
+      "Codex CLI was not found on this machine",
+    )
+  })
+
+  test("leaves agents without a delegated runtime unchanged", async () => {
+    const env = await acpSubprocessEnvironment(ACP_AGENT_REGISTRY.grok, "/bin", { SAMPLE: "value" })
+
+    expect(env).toMatchObject({ PATH: "/bin", SAMPLE: "value", WANTA_NODE_RUNTIME: process.execPath })
+    expect(env.CODEX_PATH).toBeUndefined()
+  })
+})

--- a/electron/agent/claude/adapter.test.ts
+++ b/electron/agent/claude/adapter.test.ts
@@ -703,6 +703,21 @@ describe("ClaudeCodeAgentAdapter", () => {
     expect(errorEvent?.data.message).toBe("process exited with code 1")
   })
 
+  it("adds bounded subprocess stderr detail to a generic process failure", async () => {
+    const { adapter, events, calls } = await createHarness()
+    await adapter.send({ type: "prompt", sessionId, text: "hello" })
+    calls[0].options.stderr?.("Error: failed to load Claude runtime dependency\n")
+    calls[0].fake.fail(new Error("Claude Code process exited with code 1"))
+
+    await vi.waitFor(() => expect(events.some((event) => event.event === "agentError")).toBe(true))
+    const errorEvent = events.find(
+      (event): event is Extract<AgentEvent, { event: "agentError" }> => event.event === "agentError",
+    )
+    expect(errorEvent?.data.message).toBe(
+      "Claude Code process exited with code 1. Claude subprocess: Error: failed to load Claude runtime dependency",
+    )
+  })
+
   it("caches the runtime probe for 30 seconds", async () => {
     const { adapter, probe } = await createHarness()
     await adapter.runtimeStatus()

--- a/electron/agent/claude/adapter.ts
+++ b/electron/agent/claude/adapter.ts
@@ -28,6 +28,7 @@ import { AGENT_PROFILES, agentLoginHint } from "../contract/profile.ts"
 import { ExternalAgentAdapter } from "../external/adapter-base.ts"
 import { externalAgentPromptText } from "../external/prompt.ts"
 import { externalSessionUuid } from "../external/session-id.ts"
+import { appendStderrTail, subprocessFailureSummary } from "../external/subprocess-diagnostics.ts"
 import { createClaudeTurnTranslator, isLocalCommandText } from "./translator.ts"
 
 // Claude Code native adapter (BYOA phase 1).
@@ -41,7 +42,6 @@ import { createClaudeTurnTranslator, isLocalCommandText } from "./translator.ts"
 // `allowDangerouslySkipPermissions: true` at query creation.
 
 const PROBE_CACHE_TTL_MS = 30_000
-const MAX_STDERR_CHUNKS = 40
 const LOGIN_HINT = agentLoginHint("claude-code")
 
 export interface ClaudeCodeAdapterOptions {
@@ -114,7 +114,7 @@ interface ClaudeSessionState {
   inputQueue: AsyncInputQueue<SDKUserMessage>
   queryHandle: Query
   /** Bounded ring buffer of recent subprocess stderr chunks for diagnostics. */
-  stderrTail: string[]
+  stderrTail: string
   loop: Promise<void>
   /** How the native CLI session was started; drives the retry fallback. */
   startMode: "fresh" | "resume"
@@ -758,7 +758,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
     const hostServerNames = new Set((hostMcpServers ?? []).map((server) => server.name))
     const inputQueue = new AsyncInputQueue<SDKUserMessage>()
     const abortController = new AbortController()
-    const stderrTail: string[] = []
+    let stderrTail = ""
     const queryHandle = this.queryFn({
       prompt: inputQueue,
       options: {
@@ -792,10 +792,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
         ...(startMode === "resume" ? { resume: sessionUuid } : { sessionId: sessionUuid }),
         canUseTool: this.createCanUseTool(sessionId, hostServerNames),
         stderr: (data: string) => {
-          stderrTail.push(data)
-          if (stderrTail.length > MAX_STDERR_CHUNKS) {
-            stderrTail.shift()
-          }
+          stderrTail = appendStderrTail(stderrTail, data)
         },
         abortController,
       },
@@ -805,7 +802,9 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       sessionUuid,
       inputQueue,
       queryHandle,
-      stderrTail,
+      get stderrTail() {
+        return stderrTail
+      },
       loop: Promise.resolve(),
       startMode,
     }
@@ -858,12 +857,14 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       }
     } catch (error) {
       const raw = errorMessage(error)
-      const message = isAuthenticationFailureMessage(raw) ? `${raw} ${LOGIN_HINT}` : raw
+      const stderrSummary = subprocessFailureSummary(session.stderrTail)
+      const detail = stderrSummary && !raw.includes(stderrSummary) ? `. Claude subprocess: ${stderrSummary}` : ""
+      const message = isAuthenticationFailureMessage(raw) ? `${raw} ${LOGIN_HINT}` : `${raw}${detail}`
       // A startup failure means the start mode itself was wrong (resume of a
       // vanished CLI session, or a fresh start rejected as duplicate); flip it
       // so the user's retry takes the other path instead of dead-ending.
       if (!receivedAnyMessage) {
-        const failureText = raw + session.stderrTail.join("")
+        const failureText = raw + session.stderrTail
         if (session.startMode === "resume") {
           this.nativeStartOverride.set(session.sessionId, "fresh")
         } else if (/already in use/iu.test(failureText)) {
@@ -874,7 +875,7 @@ export class ClaudeCodeAgentAdapter extends ExternalAgentAdapter {
       logDiagnostic(
         "claude-code-adapter",
         "query loop failed",
-        { sessionId: session.sessionId, error: raw, stderrTail: session.stderrTail.join("") },
+        { sessionId: session.sessionId, error: raw, stderrTail: session.stderrTail },
         "error",
       )
     } finally {

--- a/electron/agent/external/probe.ts
+++ b/electron/agent/external/probe.ts
@@ -171,6 +171,7 @@ export async function probeExternalAgent(
     kind,
     binaryStatus: status.binary.status,
     ...(status.binary.status === "detected" ? { version: status.binary.version ?? null } : {}),
+    ...(status.binary.status === "error" ? { binaryError: status.binary.message } : {}),
     loginStatus: status.login.status,
   })
   return status

--- a/electron/agent/external/subprocess-diagnostics.test.ts
+++ b/electron/agent/external/subprocess-diagnostics.test.ts
@@ -14,6 +14,16 @@ describe("subprocess diagnostics", () => {
     ).toBe("Error: Cannot find module 'runtime'")
   })
 
+  test("recognizes a Node error with a bracketed error code", () => {
+    expect(
+      subprocessFailureSummary(
+        "node:internal/modules/esm/resolve:999\n" +
+          "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'runtime'\n" +
+          "Node.js v24.16.0\n",
+      ),
+    ).toBe("Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'runtime'")
+  })
+
   test("falls back to the final non-empty line", () => {
     expect(subprocessFailureSummary("warning\nprocess stopped\n")).toBe("process stopped")
   })

--- a/electron/agent/external/subprocess-diagnostics.test.ts
+++ b/electron/agent/external/subprocess-diagnostics.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest"
+import { appendStderrTail, subprocessFailureSummary } from "./subprocess-diagnostics.ts"
+
+describe("subprocess diagnostics", () => {
+  test("bounds retained stderr by characters", () => {
+    expect(appendStderrTail("1234", "5678", 5)).toBe("45678")
+  })
+
+  test("prefers an explicit error line over runtime boilerplate", () => {
+    expect(
+      subprocessFailureSummary(
+        "node:internal/modules/cjs/loader:1507\nError: Cannot find module 'runtime'\nNode.js v24.16.0\n",
+      ),
+    ).toBe("Error: Cannot find module 'runtime'")
+  })
+
+  test("falls back to the final non-empty line", () => {
+    expect(subprocessFailureSummary("warning\nprocess stopped\n")).toBe("process stopped")
+  })
+})

--- a/electron/agent/external/subprocess-diagnostics.ts
+++ b/electron/agent/external/subprocess-diagnostics.ts
@@ -1,0 +1,15 @@
+const DEFAULT_STDERR_TAIL_CHARS = 4 * 1024
+
+/** Append subprocess stderr while keeping memory and diagnostic payloads bounded. */
+export function appendStderrTail(current: string, chunk: string, maxChars = DEFAULT_STDERR_TAIL_CHARS): string {
+  return `${current}${chunk}`.slice(-maxChars)
+}
+
+/** Pick the most useful single line from a bounded stderr tail for a user-facing error. */
+export function subprocessFailureSummary(stderrTail: string): string | undefined {
+  const lines = stderrTail
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  return lines.find((line) => /^(?:Error|TypeError|ReferenceError|SyntaxError):/u.test(line)) ?? lines.at(-1)
+}

--- a/electron/agent/external/subprocess-diagnostics.ts
+++ b/electron/agent/external/subprocess-diagnostics.ts
@@ -11,5 +11,8 @@ export function subprocessFailureSummary(stderrTail: string): string | undefined
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter(Boolean)
-  return lines.find((line) => /^(?:Error|TypeError|ReferenceError|SyntaxError):/u.test(line)) ?? lines.at(-1)
+  return (
+    lines.find((line) => /^(?:Error|TypeError|ReferenceError|SyntaxError)(?:\s+\[[^\]]+\])?:/u.test(line)) ??
+    lines.at(-1)
+  )
 }


### PR DESCRIPTION
## Summary

Fix packaged Codex ACP startup by resolving the user's installed Codex CLI and passing its absolute path to the bundled `codex-acp` bridge through `CODEX_PATH`.

Unify bounded subprocess stderr diagnostics across ACP agents and Claude Code so generic connection/process-closed errors retain a useful underlying failure line. Improve external-agent probe logging to include the concrete `--version` failure when a detected binary cannot be executed.

## User impact

Packaged Wanta builds previously copied `codex-acp.js` without its `@openai/codex` dependency. Because the bridge received no `CODEX_PATH`, it attempted to resolve `@openai/codex/bin/codex.js`, exited before the ACP handshake, and users only saw `Codex failed to initialize the ACP connection: ACP connection closed`.

After this change, Wanta resolves the user's authenticated `codex` executable from the recovered desktop PATH and injects it into the bridge. If the native CLI is absent, startup fails before the ACP handshake with an actionable install/`CODEX_PATH` message.

Claude Code and Grok do not share the missing-package topology: Claude already receives the detected `claude` path through the SDK, while Grok speaks ACP natively through `grok agent stdio`. Both now benefit from the same bounded stderr summarization and richer probe diagnostics, and Codex/Grok initialization-failure behavior is covered together.

## Implementation

- Add registry-driven ACP runtime executable metadata instead of agent-name conditionals.
- Resolve and inject bridge runtime paths while preserving explicit environment overrides.
- Capture at most 4 KiB of stderr without mixing it into ACP stdout.
- Include the salient subprocess error line in ACP and Claude Code user-facing failures.
- Suppress crash diagnostics for deliberate ACP adapter teardown.
- Record binary probe error details in diagnostics.
- Add tests for packaged Codex runtime resolution, missing runtimes, explicit overrides, both ACP registrations, Claude stderr propagation, and bounded stderr parsing.

## Safety and compatibility

- **Credentials and authentication:** No credentials are copied, logged, or stored. Wanta resolves only the native CLI executable path; authentication remains owned by each user's CLI.
- **Diagnostic data:** Captured stderr is bounded to the final 4 KiB and normal diagnostic serialization applies its existing field-length limit. ACP stdout remains isolated for JSON-RPC traffic.
- **Backward compatibility:** The new ACP runtime metadata is optional. Native ACP agents such as Grok keep their existing command and environment behavior.
- **Platform compatibility:** Executable discovery reuses Wanta's existing cross-platform PATH/PATHEXT resolution, including Windows command shims. Explicit runtime environment overrides remain supported.
- **Lifecycle safety:** Deliberate adapter teardown is excluded from crash diagnostics, and existing connection/session cleanup behavior is preserved.
- **Data and migrations:** No persisted schema, transcript format, or user data migration is introduced.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm run format`
- `corepack pnpm test` — 337 test files passed, 2 skipped; 2733 tests passed, 4 skipped
- `corepack pnpm run build:app`
- Real Codex ACP smoke test passed against the installed `codex-acp` bridge and Codex CLI.
- Real Claude Code smoke test passed against the installed Claude CLI.
- Grok is not installed on the test machine; its not-found probe path and generic ACP behavior are covered by automated tests.
