### PR TITLE
Fix duplicate connection access modal

### DIFF
--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -2236,6 +2236,7 @@ export function AppShell({ auth }: { auth: UseAuth }) {
                 />
               ) : route === "teams" && oomolEnabled ? (
                 <TeamManagementRoute
+                  connectionProviders={activeProviders}
                   connectedProvidersLoading={activeProvidersLoading}
                   onOpenConnection={handleOpenTeamConnection}
                   teamSkills={teamSkills}

--- a/src/routes/Connections/ConnectionAccountsList.test.tsx
+++ b/src/routes/Connections/ConnectionAccountsList.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import type { ConnectionAppSummary, ConnectionProviderSummary } from "../../../electron/connections/common.ts"
+import type { UseConnections } from "@/hooks/useConnections"
+import type { Root } from "react-dom/client"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ConnectionAccountsList } from "./ConnectionAccountsList.tsx"
+import { I18nContext, translate } from "@/i18n/i18n"
+
+const app: ConnectionAppSummary = {
+  authType: null,
+  createdAt: 1,
+  id: "app-1",
+  isDefault: true,
+  service: "github",
+  status: "active",
+  updatedAt: 1,
+}
+
+const provider: ConnectionProviderSummary = {
+  actionKind: "oauth2",
+  appCount: 1,
+  apps: [app],
+  authTypes: ["oauth2"],
+  canDisconnect: false,
+  categoryLabels: [],
+  displayName: "GitHub",
+  service: "github",
+  status: "connected",
+}
+
+function listElement(onOpenAccess: (target: ConnectionAppSummary) => void): React.ReactElement {
+  return React.createElement(ConnectionAccountsList, {
+    accessContext: {} as never,
+    busy: null,
+    canManageConnections: false,
+    connections: {} as UseConnections,
+    onConnect: async () => undefined,
+    onDisconnect: () => undefined,
+    onOpenAccess,
+    polling: null,
+    provider,
+  })
+}
+
+async function renderDuplicatedLists(onOpenAccess: (target: ConnectionAppSummary) => void): Promise<Root> {
+  const host = document.createElement("div")
+  document.body.append(host)
+  const root = createRoot(host)
+  await act(async () => {
+    root.render(
+      <I18nContext.Provider
+        value={{ locale: "en", setLocale: () => undefined, t: (key, vars) => translate("en", key, vars) }}
+      >
+        {listElement(onOpenAccess)}
+        {listElement(onOpenAccess)}
+      </I18nContext.Provider>,
+    )
+  })
+  return root
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+describe("ConnectionAccountsList access dialog ownership", () => {
+  it("delegates access opening without mounting a modal from duplicated responsive lists", async () => {
+    const onOpenAccess = vi.fn()
+    const root = await renderDuplicatedLists(onOpenAccess)
+    const accessButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).filter(
+      (button) => button.textContent?.trim() === "View access",
+    )
+
+    expect(accessButtons).toHaveLength(2)
+    await act(async () => accessButtons[0]?.click())
+
+    expect(onOpenAccess).toHaveBeenCalledOnce()
+    expect(onOpenAccess).toHaveBeenCalledWith(app)
+    expect(document.querySelectorAll('[aria-modal="true"]')).toHaveLength(0)
+
+    act(() => root.unmount())
+  })
+})

--- a/src/routes/Connections/ConnectionAccountsList.tsx
+++ b/src/routes/Connections/ConnectionAccountsList.tsx
@@ -16,7 +16,6 @@ import {
   normalizeConnectionAliasInput,
   supportsManagedConnectionAccountActions,
 } from "./connection-route-model.ts"
-import { ConnectionAccessDialog } from "./ConnectionAccessDialog.tsx"
 import { AccountExecutionLogsButton } from "./ConnectionExecutionLogs.tsx"
 import { authTypeLabel } from "./shared.ts"
 import { Loader } from "@/components/ai-elements/loader"
@@ -35,9 +34,9 @@ export function ConnectionAccountsList({
   connections,
   onConnect,
   onDisconnect,
+  onOpenAccess,
   polling,
   provider,
-  selectedAppId,
   reconnectBlocked,
 }: {
   accessContext?: ConnectionAccessContext
@@ -50,9 +49,9 @@ export function ConnectionAccountsList({
     appId?: string,
   ) => Promise<void>
   onDisconnect: (target: DisconnectTarget) => void
+  onOpenAccess: (app: ConnectionAppSummary) => void
   polling: string | null
   provider: ConnectionProviderSummary
-  selectedAppId?: string | null
   reconnectBlocked?: boolean
 }) {
   const t = useT()
@@ -76,9 +75,9 @@ export function ConnectionAccountsList({
           index={index}
           onConnect={onConnect}
           onDisconnect={onDisconnect}
+          onOpenAccess={onOpenAccess}
           polling={polling}
           provider={provider}
-          selectedAppId={selectedAppId}
           reconnectBlocked={Boolean(reconnectBlocked)}
           servicePolling={servicePolling}
         />
@@ -96,9 +95,9 @@ function ConnectionAccountItem({
   index,
   onConnect,
   onDisconnect,
+  onOpenAccess,
   polling,
   provider,
-  selectedAppId,
   reconnectBlocked,
   servicePolling,
 }: {
@@ -114,17 +113,15 @@ function ConnectionAccountItem({
     appId?: string,
   ) => Promise<void>
   onDisconnect: (target: DisconnectTarget) => void
+  onOpenAccess: (app: ConnectionAppSummary) => void
   polling: string | null
   provider: ConnectionProviderSummary
-  selectedAppId?: string | null
   reconnectBlocked: boolean
   servicePolling: boolean
 }) {
   const t = useT()
   const supportsManagedAccount = supportsManagedConnectionAccountActions(provider)
   const managedAccountActions = canManageConnections && supportsManagedAccount
-  const [accessOpen, setAccessOpen] = React.useState(false)
-  const handledSelectedAppIdRef = React.useRef<string | null>(null)
   const [aliasDraft, setAliasDraft] = React.useState(app.alias ?? "")
   const [aliasEditing, setAliasEditing] = React.useState(false)
   const [aliasBusy, setAliasBusy] = React.useState(false)
@@ -154,16 +151,6 @@ function ConnectionAccountItem({
     setAliasEditing(false)
     setAliasBusy(false)
   }, [app.id, app.alias, app.isDefault])
-
-  React.useEffect(() => {
-    if (selectedAppId !== app.id) {
-      handledSelectedAppIdRef.current = null
-      return
-    }
-    if (!accessContext || handledSelectedAppIdRef.current === selectedAppId) return
-    handledSelectedAppIdRef.current = selectedAppId
-    setAccessOpen(true)
-  }, [accessContext, app.id, selectedAppId])
 
   async function saveAlias() {
     if (!aliasDirty || aliasDisabled) return
@@ -276,7 +263,7 @@ function ConnectionAccountItem({
               variant="outline"
               size="sm"
               className={accountActionButtonClassName}
-              onClick={() => setAccessOpen(true)}
+              onClick={() => onOpenAccess(app)}
             >
               <ShieldCheck className="size-3.5" />
               {t(canManageConnections ? "connections.manageAccess" : "connections.viewAccess")}
@@ -320,14 +307,6 @@ function ConnectionAccountItem({
           ) : null}
         </div>
       </article>
-      {accessContext ? (
-        <ConnectionAccessDialog
-          app={app}
-          context={accessContext}
-          open={accessOpen}
-          onClose={() => setAccessOpen(false)}
-        />
-      ) : null}
     </>
   )
 }

--- a/src/routes/Connections/ConnectionProviderDetailPane.tsx
+++ b/src/routes/Connections/ConnectionProviderDetailPane.tsx
@@ -1,4 +1,5 @@
 import type {
+  ConnectionAppSummary,
   ConnectionAuthType,
   ConnectionProviderDetail,
   ConnectionProviderSummary,
@@ -87,12 +88,12 @@ export function ProviderDetail({
   onClose,
   onConnect,
   onDisconnect,
+  onOpenAccess,
   onReopenPolling,
   polling,
   progressLabel,
   reopenPollingLabel,
   provider,
-  selectedAppId,
   showCloseButton = false,
 }: {
   accessContext?: ConnectionAccessContext
@@ -113,12 +114,12 @@ export function ProviderDetail({
     appId?: string,
   ) => Promise<void>
   onDisconnect: (target: DisconnectTarget) => void
+  onOpenAccess: (app: ConnectionAppSummary) => void
   onReopenPolling?: () => void
   polling: string | null
   progressLabel?: string
   reopenPollingLabel?: string
   provider: ConnectionProviderSummary
-  selectedAppId?: string | null
   showCloseButton?: boolean
 }) {
   const t = useT()
@@ -178,9 +179,9 @@ export function ProviderDetail({
               connections={connections}
               onConnect={onConnect}
               onDisconnect={onDisconnect}
+              onOpenAccess={onOpenAccess}
               polling={polling}
               provider={provider}
-              selectedAppId={selectedAppId}
               reconnectBlocked
             />
           ) : null
@@ -197,12 +198,12 @@ export function ProviderDetail({
             onCancelPolling={onCancelPolling}
             onConnect={onConnect}
             onDisconnect={onDisconnect}
+            onOpenAccess={onOpenAccess}
             onReopenPolling={onReopenPolling}
             polling={polling}
             progressLabel={progressLabel}
             reopenPollingLabel={reopenPollingLabel}
             provider={provider}
-            selectedAppId={selectedAppId}
           />
         )}
       </section>
@@ -301,12 +302,12 @@ function ConnectionPanel({
   onCancelPolling,
   onConnect,
   onDisconnect,
+  onOpenAccess,
   onReopenPolling,
   polling,
   progressLabel,
   reopenPollingLabel,
   provider,
-  selectedAppId,
 }: {
   accessContext?: ConnectionAccessContext
   actionsPending?: boolean
@@ -323,12 +324,12 @@ function ConnectionPanel({
     appId?: string,
   ) => Promise<void>
   onDisconnect: (target: DisconnectTarget) => void
+  onOpenAccess: (app: ConnectionAppSummary) => void
   onReopenPolling?: () => void
   polling: string | null
   progressLabel?: string
   reopenPollingLabel?: string
   provider: ConnectionProviderSummary
-  selectedAppId?: string | null
 }) {
   const t = useT()
   const [selectedAuthType, setSelectedAuthType] = React.useState<Exclude<ConnectionAuthType, null> | null>(
@@ -451,9 +452,9 @@ function ConnectionPanel({
           connections={connections}
           onConnect={onConnect}
           onDisconnect={onDisconnect}
+          onOpenAccess={onOpenAccess}
           polling={polling}
           provider={provider}
-          selectedAppId={selectedAppId}
           reconnectBlocked={authorizationBlocked}
         />
       ) : null}

--- a/src/routes/Connections/index.tsx
+++ b/src/routes/Connections/index.tsx
@@ -1,4 +1,5 @@
 import type {
+  ConnectionAppSummary,
   ConnectionAuthType,
   ConnectionAppDetail,
   ConnectionConnectInput,
@@ -32,6 +33,7 @@ import {
   matchesProviderQuery,
   shouldShowConnectionState,
 } from "./connection-route-model.ts"
+import { ConnectionAccessDialog } from "./ConnectionAccessDialog.tsx"
 import {
   ConnectionDrawerSkeleton,
   ConnectionListToolbar,
@@ -153,9 +155,11 @@ export function ConnectionsPanel({
     oauthClientConfig?: ConnectionUserOAuthClientConfigSummary | null
   } | null>(null)
   const [confirmDisconnect, setConfirmDisconnect] = React.useState<DisconnectTarget | null>(null)
+  const [accessApp, setAccessApp] = React.useState<ConnectionAppSummary | null>(null)
   const detailCloseTimerRef = React.useRef<number | null>(null)
   const connectionActionRequestIdRef = React.useRef(0)
   const detailWorkspaceKeyRef = React.useRef<string | null>(summaryWorkspaceKey)
+  const handledSelectedAccessAppIdRef = React.useRef<string | null>(null)
   const listPaneRef = React.useRef<HTMLDivElement | null>(null)
 
   const larkCliProvider = React.useMemo(
@@ -330,6 +334,17 @@ export function ConnectionsPanel({
   const selectedProvider = selectedProviderService
     ? (filteredProviders.find((provider) => provider.service === selectedProviderService) ?? null)
     : null
+  React.useEffect(() => {
+    if (!selectedAppId) {
+      handledSelectedAccessAppIdRef.current = null
+      return
+    }
+    if (!accessContext || handledSelectedAccessAppIdRef.current === selectedAppId) return
+    const app = selectedProvider?.apps.find((item) => item.id === selectedAppId)
+    if (!app) return
+    handledSelectedAccessAppIdRef.current = selectedAppId
+    setAccessApp(app)
+  }, [accessContext, selectedAppId, selectedProvider])
   const selectedDirectProvider = selectedProvider ? directProviderByService[selectedProvider.service] : undefined
   const selectedProviderIsDirect = selectedDirectProvider !== undefined
   const selectedProviderActionsEnabled = selectedProviderIsDirect ? true : connectionActionsEnabled
@@ -385,7 +400,14 @@ export function ConnectionsPanel({
     connectionActionRequestIdRef.current += 1
     setDialog(null)
     setConfirmDisconnect(null)
+    setAccessApp(null)
+    handledSelectedAccessAppIdRef.current = null
   }, [summaryWorkspaceKey])
+
+  const accessDialog =
+    accessContext && accessApp ? (
+      <ConnectionAccessDialog app={accessApp} context={accessContext} open onClose={() => setAccessApp(null)} />
+    ) : null
 
   React.useEffect(() => {
     if (connectionActionsEnabled) return
@@ -682,12 +704,12 @@ export function ConnectionsPanel({
             onClose={onClose ?? closeDetail}
             onConnect={connectProvider}
             onDisconnect={requestDisconnectTarget}
+            onOpenAccess={setAccessApp}
             onReopenPolling={reopenSelectedProviderPolling}
             polling={selectedProviderPolling}
             progressLabel={selectedProviderProgressLabel}
             reopenPollingLabel={reopenSelectedProviderPollingLabel}
             provider={selectedProvider}
-            selectedAppId={selectedAppId}
             showCloseButton
           />
         ) : (
@@ -735,6 +757,7 @@ export function ConnectionsPanel({
           onClose={() => setConfirmDisconnect(null)}
           onConfirm={confirmDisconnectTarget}
         />
+        {accessDialog}
       </div>
     )
   }
@@ -832,12 +855,12 @@ export function ConnectionsPanel({
               onClose={closeDetail}
               onConnect={connectProvider}
               onDisconnect={requestDisconnectTarget}
+              onOpenAccess={setAccessApp}
               onReopenPolling={reopenSelectedProviderPolling}
               polling={selectedProviderPolling}
               progressLabel={selectedProviderProgressLabel}
               reopenPollingLabel={reopenSelectedProviderPollingLabel}
               provider={selectedProvider}
-              selectedAppId={selectedAppId}
             />
           </SplitViewMobileDetailPane>
         ) : null}
@@ -866,12 +889,12 @@ export function ConnectionsPanel({
               onClose={closeDetail}
               onConnect={connectProvider}
               onDisconnect={requestDisconnectTarget}
+              onOpenAccess={setAccessApp}
               onReopenPolling={reopenSelectedProviderPolling}
               polling={selectedProviderPolling}
               progressLabel={selectedProviderProgressLabel}
               reopenPollingLabel={reopenSelectedProviderPollingLabel}
               provider={selectedProvider}
-              selectedAppId={selectedAppId}
             />
           </SplitViewDesktopDetailPane>
         ) : null}
@@ -896,6 +919,7 @@ export function ConnectionsPanel({
         onClose={() => setConfirmDisconnect(null)}
         onConfirm={confirmDisconnectTarget}
       />
+      {accessDialog}
     </SplitViewRoot>
   )
 }

--- a/src/routes/Skills/TeamManagement.tsx
+++ b/src/routes/Skills/TeamManagement.tsx
@@ -1,5 +1,6 @@
+import type { ConnectionProviderSummary } from "../../../electron/connections/common.ts"
 import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
-import type { BusyAction } from "./team-management-model.ts"
+import type { BusyAction, MemberView } from "./team-management-model.ts"
 import type { MemberConnectionAccessDelta } from "./team-member-connection-access-model.ts"
 import type { ProviderSkillRecommendationsState } from "@/hooks/useProviderSkillRecommendations"
 import type { UseTeamSkills } from "@/hooks/useTeamSkills"
@@ -28,6 +29,7 @@ import {
   TeamSkillGuidePanel,
   TeamSwitcherPanel,
 } from "./TeamManagementPanels.tsx"
+import { TeamMemberConnectionAccessPanel } from "./TeamMemberConnectionAccessDialog.tsx"
 import {
   AddMemberDialog,
   CreateTeamDialog,
@@ -55,13 +57,20 @@ import { useTeamMemberActions } from "@/routes/Skills/use-team-member-actions"
 import { useTeamMemberSearch } from "@/routes/Skills/use-team-member-search"
 import { useTeamSkillActions } from "@/routes/Skills/use-team-skill-actions"
 
+type TeamManagementOverlay =
+  | { kind: "none" }
+  | { kind: "settings" }
+  | { kind: "memberConnectionAccess"; member: MemberView }
+
 export function TeamManagementRoute({
+  connectionProviders,
   connectedProvidersLoading = false,
   onOpenConnection,
   teamSkills,
   providerSkillRecommendationsState,
   workspace,
 }: {
+  connectionProviders: ConnectionProviderSummary[]
   connectedProvidersLoading?: boolean
   onOpenConnection: (target: { appId: string; service: string }) => void
   teamSkills?: UseTeamSkills
@@ -85,7 +94,7 @@ export function TeamManagementRoute({
   const [busyAction, setBusyAction] = React.useState<BusyAction | null>(null)
   const [addMemberOpen, setAddMemberOpen] = React.useState(false)
   const [addMemberError, setAddMemberError] = React.useState<string | null>(null)
-  const [teamSettingsOpen, setTeamSettingsOpen] = React.useState(false)
+  const [overlay, setOverlay] = React.useState<TeamManagementOverlay>({ kind: "none" })
   const [managedSkillId, setManagedSkillId] = React.useState<string | null>(null)
   const [selectedPackage, setSelectedPackage] = React.useState<PublicSkillPackage | null>(null)
   const [managedSkillError, setManagedSkillError] = React.useState<{ cause: unknown; skillId: string } | null>(null)
@@ -211,7 +220,7 @@ export function TeamManagementRoute({
     setBusyAction(null)
     setAddMemberOpen(false)
     setAddMemberError(null)
-    setTeamSettingsOpen(false)
+    setOverlay({ kind: "none" })
     setManagedSkillId(null)
     setManagedSkillError(null)
     setSelectedPackage(null)
@@ -241,8 +250,12 @@ export function TeamManagementRoute({
       return
     }
     teamForms.edit.close()
-    setTeamSettingsOpen(false)
+    setOverlay({ kind: "none" })
   }, [busyAction, teamForms.edit])
+
+  const openMemberConnectionAccess = React.useCallback((member: MemberView) => {
+    setOverlay({ kind: "memberConnectionAccess", member })
+  }, [])
 
   const handleSelectTeamWorkspace = React.useCallback(
     (teamId: string) => {
@@ -310,7 +323,7 @@ export function TeamManagementRoute({
                   selectedTeamId={selectedTeamId}
                   onCreate={teamForms.create.openDialog}
                   onAddMember={() => setAddMemberOpen(true)}
-                  onOpenSettings={() => setTeamSettingsOpen(true)}
+                  onOpenSettings={() => setOverlay({ kind: "settings" })}
                   onRemoteAvatarLoad={clearTeamAvatarPreview}
                   onSelect={handleSelectTeamWorkspace}
                 />
@@ -346,56 +359,82 @@ export function TeamManagementRoute({
                 ) : null}
                 {selectedTeam ? (
                   <TeamSettingsSheet
-                    open={teamSettingsOpen}
-                    title={t(canManage ? "teams.teamSettings" : "teams.viewMembers")}
+                    open={overlay.kind !== "none"}
+                    title={
+                      overlay.kind === "memberConnectionAccess"
+                        ? t("teams.memberConnectionAccessTitle")
+                        : t(canManage ? "teams.teamSettings" : "teams.viewMembers")
+                    }
+                    onBack={
+                      overlay.kind === "memberConnectionAccess" ? () => setOverlay({ kind: "settings" }) : undefined
+                    }
                     onClose={closeTeamSettings}
                   >
-                    <div className="grid min-w-0 gap-3">
-                      {canManage ? (
-                        <TeamProfileSettingsPanel
-                          avatar={teamForms.edit.avatar}
-                          avatarFile={teamForms.edit.avatarFile}
-                          busy={busyAction === "updateTeam"}
-                          editing={teamForms.edit.open}
-                          name={teamForms.edit.name}
-                          nameError={teamForms.edit.nameError}
-                          team={selectedTeam}
-                          onAvatarChange={teamForms.edit.setAvatar}
-                          onAvatarFileChange={teamForms.edit.changeAvatarFile}
-                          onClose={teamForms.edit.close}
-                          onEdit={() => teamForms.edit.openDialog(selectedTeam)}
-                          onNameChange={teamForms.edit.setName}
-                          onSubmit={teamForms.edit.submit}
-                        />
-                      ) : null}
-                      <TeamDetailPanel
-                        actorRole={activeWorkspace.role}
-                        actorUserId={activeAccountId}
-                        busyAction={busyAction}
-                        canManage={canManage}
-                        connectionAccess={{
+                    {overlay.kind === "memberConnectionAccess" ? (
+                      <TeamMemberConnectionAccessPanel
+                        data={{
                           access: appAccessState.data,
                           apps: connectionAppsState.data,
                           error: appAccessState.error ?? connectionAppsState.error,
                           loading: appAccessState.status === "loading" || connectionAppsState.status === "loading",
+                          providers: connectionProviders,
                         }}
-                        members={memberViews}
-                        membersComplete={membersComplete}
-                        membersError={membersError}
-                        membersForbidden={membersForbidden}
-                        membersLoading={membersState.status === "loading"}
-                        team={selectedTeam}
-                        onAddMember={() => setAddMemberOpen(true)}
-                        onDisableMembers={memberActions.disableMembers}
-                        onEnableMembers={memberActions.enableMembers}
-                        onOpenConnection={onOpenConnection}
-                        onRemoveMember={memberActions.removeMember}
-                        onRetryMembers={() => void reload()}
-                        onRetryConnectionAccess={() => void reload()}
-                        onSaveMemberConnectionAccess={saveMemberConnectionAccess}
-                        onUpdateMemberRole={memberActions.updateMemberRole}
+                        member={overlay.member}
+                        onClose={() => setOverlay({ kind: "settings" })}
+                        onOpenConnection={(target) => {
+                          setOverlay({ kind: "none" })
+                          onOpenConnection(target)
+                        }}
+                        onRetry={() => void reload()}
+                        onSave={saveMemberConnectionAccess}
                       />
-                    </div>
+                    ) : (
+                      <div className="grid min-w-0 gap-3">
+                        {canManage ? (
+                          <TeamProfileSettingsPanel
+                            avatar={teamForms.edit.avatar}
+                            avatarFile={teamForms.edit.avatarFile}
+                            busy={busyAction === "updateTeam"}
+                            editing={teamForms.edit.open}
+                            name={teamForms.edit.name}
+                            nameError={teamForms.edit.nameError}
+                            team={selectedTeam}
+                            onAvatarChange={teamForms.edit.setAvatar}
+                            onAvatarFileChange={teamForms.edit.changeAvatarFile}
+                            onClose={teamForms.edit.close}
+                            onEdit={() => teamForms.edit.openDialog(selectedTeam)}
+                            onNameChange={teamForms.edit.setName}
+                            onSubmit={teamForms.edit.submit}
+                          />
+                        ) : null}
+                        <TeamDetailPanel
+                          actorRole={activeWorkspace.role}
+                          actorUserId={activeAccountId}
+                          busyAction={busyAction}
+                          canManage={canManage}
+                          connectionAccess={{
+                            access: appAccessState.data,
+                            apps: connectionAppsState.data,
+                            error: appAccessState.error ?? connectionAppsState.error,
+                            loading: appAccessState.status === "loading" || connectionAppsState.status === "loading",
+                            providers: connectionProviders,
+                          }}
+                          members={memberViews}
+                          membersComplete={membersComplete}
+                          membersError={membersError}
+                          membersForbidden={membersForbidden}
+                          membersLoading={membersState.status === "loading"}
+                          team={selectedTeam}
+                          onAddMember={() => setAddMemberOpen(true)}
+                          onDisableMembers={memberActions.disableMembers}
+                          onEnableMembers={memberActions.enableMembers}
+                          onOpenMemberConnectionAccess={openMemberConnectionAccess}
+                          onRemoveMember={memberActions.removeMember}
+                          onRetryMembers={() => void reload()}
+                          onUpdateMemberRole={memberActions.updateMemberRole}
+                        />
+                      </div>
+                    )}
                   </TeamSettingsSheet>
                 ) : null}
               </>

--- a/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
+++ b/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
@@ -1,4 +1,4 @@
-import type { ConnectionAppSummary } from "../../../electron/connections/common.ts"
+import type { ConnectionAppSummary, ConnectionProviderSummary } from "../../../electron/connections/common.ts"
 import type { TeamAppAccess } from "../../../electron/teams/common.ts"
 import type { MemberView } from "./team-management-model.ts"
 import type {
@@ -30,10 +30,10 @@ import {
   ConfirmDialogHeader,
   ConfirmDialogTitle,
 } from "@/components/ui/confirm-dialog"
-import { Dialog } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { useAppI18n } from "@/i18n"
 import { cn } from "@/lib/utils"
+import { ProviderIcon } from "@/routes/Connections/ProviderIcon"
 import { teamErrorMessage } from "@/routes/Skills/team-errors"
 
 export interface TeamMemberConnectionAccessData {
@@ -41,9 +41,10 @@ export interface TeamMemberConnectionAccessData {
   apps: ConnectionAppSummary[]
   error: string | null
   loading: boolean
+  providers: ConnectionProviderSummary[]
 }
 
-export function TeamMemberConnectionAccessDialog({
+export function TeamMemberConnectionAccessPanel({
   data,
   member,
   onClose,
@@ -52,7 +53,7 @@ export function TeamMemberConnectionAccessDialog({
   onSave,
 }: {
   data: TeamMemberConnectionAccessData
-  member: MemberView | null
+  member: MemberView
   onClose: () => void
   onOpenConnection: (target: { appId: string; service: string }) => void
   onRetry: () => void
@@ -65,6 +66,10 @@ export function TeamMemberConnectionAccessDialog({
   const [draftAppIds, setDraftAppIds] = React.useState<Set<string>>(() => new Set())
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   const [saving, setSaving] = React.useState(false)
+  const providersByService = React.useMemo(
+    () => new Map(data.providers.map((provider) => [provider.service, provider])),
+    [data.providers],
+  )
   const projection = React.useMemo(
     () => (member && data.access ? projectMemberConnectionAccess(data.access, data.apps, member.user_id) : null),
     [data.access, data.apps, member],
@@ -86,9 +91,9 @@ export function TeamMemberConnectionAccessDialog({
         .filter((appId) => !baseline.has(appId))
         .sort(),
       removeAppIds: explicitAppIds.filter((appId) => !draftAppIds.has(appId)).sort(),
-      userId: member?.user_id ?? "",
+      userId: member.user_id,
     }
-  }, [draftAppIds, explicitAppIds, member?.user_id])
+  }, [draftAppIds, explicitAppIds, member.user_id])
   const hasChanges = delta.addAppIds.length > 0 || delta.removeAppIds.length > 0
   const hasEditableConnections = Boolean(
     projection?.ok && projection.items.some((item) => item.provenance === "explicit" || item.provenance === "none"),
@@ -100,7 +105,7 @@ export function TeamMemberConnectionAccessDialog({
     setEditing(false)
     setConfirmOpen(false)
     setSaving(false)
-  }, [member?.user_id])
+  }, [member.user_id])
 
   React.useEffect(() => {
     if (!editing) setDraftAppIds(new Set(explicitAppIds))
@@ -123,15 +128,69 @@ export function TeamMemberConnectionAccessDialog({
 
   return (
     <>
-      <Dialog
-        open={Boolean(member)}
-        onClose={saving ? () => undefined : onClose}
-        title={t("teams.memberConnectionAccessTitle")}
-        description={t("teams.memberConnectionAccessDescription")}
-        className="max-w-3xl"
-        contentClassName="grid gap-3"
-        footer={
-          editing ? (
+      <div className="grid gap-3">
+        <div className="oo-text-caption text-muted-foreground">{t("teams.memberConnectionAccessDescription")}</div>
+        <MemberHeader member={member} projection={projection} />
+        {data.loading && !data.access ? (
+          <AccessListSkeleton />
+        ) : data.error ? (
+          <AccessLoadError error={data.error} onRetry={onRetry} />
+        ) : projection && !projection.ok ? (
+          <AccessLoadError error={t("teams.memberConnectionAccessInvalid")} onRetry={onRetry} />
+        ) : projection?.ok ? (
+          <>
+            {editing ? (
+              <div className="oo-text-caption rounded-md border bg-muted/30 px-3 py-2 text-muted-foreground">
+                {t("teams.memberConnectionAccessEditHint")}
+              </div>
+            ) : null}
+            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+              <div className="relative min-w-0">
+                <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  className="pl-8"
+                  placeholder={t("teams.memberConnectionAccessSearch")}
+                  aria-label={t("teams.memberConnectionAccessSearch")}
+                  onChange={(event) => setQuery(event.target.value)}
+                />
+              </div>
+              <AccessFilters filter={filter} projection={projection} onChange={setFilter} />
+            </div>
+            {visibleItems.length > 0 ? (
+              <div className="max-h-[46vh] overflow-y-auto rounded-md border">
+                <div className="divide-y">
+                  {visibleItems.map((item) => (
+                    <ConnectionAccessRow
+                      key={item.appId}
+                      checked={draftAppIds.has(item.appId)}
+                      editing={editing}
+                      item={item}
+                      provider={item.service ? providersByService.get(item.service) : undefined}
+                      onCheckedChange={(checked) =>
+                        setDraftAppIds((current) => {
+                          const next = new Set(current)
+                          if (checked) next.add(item.appId)
+                          else next.delete(item.appId)
+                          return next
+                        })
+                      }
+                      onOpenConnection={onOpenConnection}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="oo-text-caption flex min-h-28 items-center justify-center rounded-md border border-dashed px-4 text-center text-muted-foreground">
+                {projection.items.length === 0
+                  ? t("teams.memberConnectionAccessEmpty")
+                  : t("teams.memberConnectionAccessNoMatches")}
+              </div>
+            )}
+          </>
+        ) : null}
+        <div className="oo-border-divider flex justify-end gap-2 border-t pt-3">
+          {editing ? (
             <>
               <Button
                 type="button"
@@ -160,72 +219,9 @@ export function TeamMemberConnectionAccessDialog({
                 {t("common.close")}
               </Button>
             </>
-          )
-        }
-      >
-        {member ? (
-          <>
-            <MemberHeader member={member} projection={projection} />
-            {data.loading && !data.access ? (
-              <AccessListSkeleton />
-            ) : data.error ? (
-              <AccessLoadError error={data.error} onRetry={onRetry} />
-            ) : projection && !projection.ok ? (
-              <AccessLoadError error={t("teams.memberConnectionAccessInvalid")} onRetry={onRetry} />
-            ) : projection?.ok ? (
-              <>
-                {editing ? (
-                  <div className="oo-text-caption rounded-md border bg-muted/30 px-3 py-2 text-muted-foreground">
-                    {t("teams.memberConnectionAccessEditHint")}
-                  </div>
-                ) : null}
-                <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-                  <div className="relative min-w-0">
-                    <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                    <Input
-                      value={query}
-                      className="pl-8"
-                      placeholder={t("teams.memberConnectionAccessSearch")}
-                      aria-label={t("teams.memberConnectionAccessSearch")}
-                      onChange={(event) => setQuery(event.target.value)}
-                    />
-                  </div>
-                  <AccessFilters filter={filter} projection={projection} onChange={setFilter} />
-                </div>
-                {visibleItems.length > 0 ? (
-                  <div className="max-h-[46vh] overflow-y-auto rounded-md border">
-                    <div className="divide-y">
-                      {visibleItems.map((item) => (
-                        <ConnectionAccessRow
-                          key={item.appId}
-                          checked={draftAppIds.has(item.appId)}
-                          editing={editing}
-                          item={item}
-                          onCheckedChange={(checked) =>
-                            setDraftAppIds((current) => {
-                              const next = new Set(current)
-                              if (checked) next.add(item.appId)
-                              else next.delete(item.appId)
-                              return next
-                            })
-                          }
-                          onOpenConnection={onOpenConnection}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="oo-text-caption flex min-h-28 items-center justify-center rounded-md border border-dashed px-4 text-center text-muted-foreground">
-                    {projection.items.length === 0
-                      ? t("teams.memberConnectionAccessEmpty")
-                      : t("teams.memberConnectionAccessNoMatches")}
-                  </div>
-                )}
-              </>
-            ) : null}
-          </>
-        ) : null}
-      </Dialog>
+          )}
+        </div>
+      </div>
       <ConfirmDialog open={confirmOpen} onOpenChange={(open) => !saving && setConfirmOpen(open)}>
         <ConfirmDialogContent>
           <ConfirmDialogHeader>
@@ -328,12 +324,14 @@ function ConnectionAccessRow({
   checked,
   editing,
   item,
+  provider,
   onCheckedChange,
   onOpenConnection,
 }: {
   checked: boolean
   editing: boolean
   item: MemberConnectionAccessItem
+  provider?: ConnectionProviderSummary
   onCheckedChange: (checked: boolean) => void
   onOpenConnection: (target: { appId: string; service: string }) => void
 }) {
@@ -357,9 +355,7 @@ function ConnectionAccessRow({
           onChange={(event) => onCheckedChange(event.currentTarget.checked)}
         />
       ) : null}
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted text-xs font-semibold text-muted-foreground uppercase">
-        {(item.service ?? item.label).slice(0, 1)}
-      </span>
+      <ProviderIcon iconUrl={provider?.iconUrl} displayName={provider?.displayName ?? item.service ?? item.label} />
       <div className="min-w-0">
         <div className="flex min-w-0 flex-wrap items-center gap-1.5">
           <span className="oo-text-control min-w-0 truncate font-medium">{item.label}</span>

--- a/src/routes/Skills/TeamMembersPanel.tsx
+++ b/src/routes/Skills/TeamMembersPanel.tsx
@@ -1,6 +1,5 @@
 import type { EditableTeamMemberRole, Team, TeamMember, TeamRole } from "../../../electron/teams/common.ts"
 import type { BusyAction, MemberView } from "./team-management-model.ts"
-import type { MemberConnectionAccessDelta } from "./team-member-connection-access-model.ts"
 import type { TeamMemberConnectionAccessData } from "./TeamMemberConnectionAccessDialog.tsx"
 
 import { PlusIcon, RefreshCwIcon, UsersIcon } from "lucide-react"
@@ -106,11 +105,9 @@ export function TeamDetailPanel({
   onAddMember,
   onDisableMembers,
   onEnableMembers,
-  onOpenConnection,
+  onOpenMemberConnectionAccess,
   onRemoveMember,
   onRetryMembers,
-  onRetryConnectionAccess,
-  onSaveMemberConnectionAccess,
   onUpdateMemberRole,
   team,
 }: {
@@ -127,11 +124,9 @@ export function TeamDetailPanel({
   onAddMember: () => void
   onDisableMembers: (userIds: string[]) => void
   onEnableMembers: (userIds: string[]) => void
-  onOpenConnection: (target: { appId: string; service: string }) => void
+  onOpenMemberConnectionAccess: (member: MemberView) => void
   onRemoveMember: (member: TeamMember) => Promise<void>
   onRetryMembers: () => void
-  onRetryConnectionAccess: () => void
-  onSaveMemberConnectionAccess: (delta: MemberConnectionAccessDelta) => Promise<void>
   onUpdateMemberRole: (member: TeamMember, role: EditableTeamMemberRole) => Promise<void>
   team: Team | null
 }) {
@@ -189,10 +184,8 @@ export function TeamDetailPanel({
                 members={members}
                 onDisableMembers={onDisableMembers}
                 onEnableMembers={onEnableMembers}
-                onOpenConnection={onOpenConnection}
+                onOpenMemberConnectionAccess={onOpenMemberConnectionAccess}
                 onRemoveMember={onRemoveMember}
-                onRetryConnectionAccess={onRetryConnectionAccess}
-                onSaveMemberConnectionAccess={onSaveMemberConnectionAccess}
                 onUpdateMemberRole={onUpdateMemberRole}
               />
             </>

--- a/src/routes/Skills/TeamMembersTable.tsx
+++ b/src/routes/Skills/TeamMembersTable.tsx
@@ -1,12 +1,11 @@
 import type { EditableTeamMemberRole, TeamMember, TeamRole } from "../../../electron/teams/common.ts"
 import type { BusyAction, MemberView } from "./team-management-model.ts"
-import type { MemberConnectionAccessDelta } from "./team-member-connection-access-model.ts"
 import type { TeamMemberConnectionAccessData } from "./TeamMemberConnectionAccessDialog.tsx"
 
 import { MoreHorizontalIcon, Trash2Icon, UserCheckIcon, UserXIcon } from "lucide-react"
 import * as React from "react"
 import { projectTeamMemberConnectionAccess } from "./team-member-connection-access-model.ts"
-import { MemberConnectionAccessButton, TeamMemberConnectionAccessDialog } from "./TeamMemberConnectionAccessDialog.tsx"
+import { MemberConnectionAccessButton } from "./TeamMemberConnectionAccessDialog.tsx"
 import { TeamUserAvatar } from "./TeamUserAvatar.tsx"
 import { hasMemberStatus, isBulkEditableMember, useMemberStatusSelection } from "./use-member-status-selection.ts"
 import { CopyIconButton } from "@/components/CopyIconButton"
@@ -37,9 +36,7 @@ export function MembersTable({
   canManage,
   members,
   connectionAccess,
-  onOpenConnection,
-  onRetryConnectionAccess,
-  onSaveMemberConnectionAccess,
+  onOpenMemberConnectionAccess,
   onDisableMembers,
   onEnableMembers,
   onRemoveMember,
@@ -51,9 +48,7 @@ export function MembersTable({
   canManage: boolean
   members: MemberView[]
   connectionAccess: TeamMemberConnectionAccessData
-  onOpenConnection: (target: { appId: string; service: string }) => void
-  onRetryConnectionAccess: () => void
-  onSaveMemberConnectionAccess: (delta: MemberConnectionAccessDelta) => Promise<void>
+  onOpenMemberConnectionAccess: (member: MemberView) => void
   onDisableMembers: (userIds: string[]) => void
   onEnableMembers: (userIds: string[]) => void
   onRemoveMember: (member: TeamMember) => Promise<void>
@@ -61,7 +56,6 @@ export function MembersTable({
 }) {
   const { t } = useAppI18n()
   const [removeTarget, setRemoveTarget] = React.useState<MemberView | null>(null)
-  const [connectionAccessTarget, setConnectionAccessTarget] = React.useState<MemberView | null>(null)
   const [roleChangeTarget, setRoleChangeTarget] = React.useState<{
     member: MemberView
     role: EditableTeamMemberRole
@@ -246,7 +240,7 @@ export function MembersTable({
                         ? (connectionProjections.byUserId.get(member.user_id) ?? null)
                         : connectionProjections
                     }
-                    onClick={() => setConnectionAccessTarget(member)}
+                    onClick={() => onOpenMemberConnectionAccess(member)}
                   />
                 ) : null}
                 {canRemove ? (
@@ -259,14 +253,6 @@ export function MembersTable({
       </div>
       {removeConfirmDialog}
       {roleChangeConfirmDialog}
-      <TeamMemberConnectionAccessDialog
-        data={connectionAccess}
-        member={connectionAccessTarget}
-        onClose={() => setConnectionAccessTarget(null)}
-        onOpenConnection={onOpenConnection}
-        onRetry={onRetryConnectionAccess}
-        onSave={onSaveMemberConnectionAccess}
-      />
     </>
   )
 }

--- a/src/routes/Skills/TeamSettingsSheet.tsx
+++ b/src/routes/Skills/TeamSettingsSheet.tsx
@@ -1,4 +1,4 @@
-import { XIcon } from "lucide-react"
+import { ArrowLeftIcon, XIcon } from "lucide-react"
 import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { useAppI18n } from "@/i18n"
@@ -24,11 +24,13 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
 
 export function TeamSettingsSheet({
   children,
+  onBack,
   onClose,
   open,
   title,
 }: {
   children: React.ReactNode
+  onBack?: () => void
   onClose: () => void
   open: boolean
   title: string
@@ -116,7 +118,14 @@ export function TeamSettingsSheet({
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div className="oo-border-divider flex min-w-0 items-center justify-between gap-2 border-b px-3 py-2">
-          <div className="oo-text-label min-w-0 truncate">{title}</div>
+          <div className="flex min-w-0 items-center gap-1">
+            {onBack ? (
+              <Button type="button" variant="ghost" size="icon" aria-label={t("browser.back")} onClick={onBack}>
+                <ArrowLeftIcon className="size-4" />
+              </Button>
+            ) : null}
+            <div className="oo-text-label min-w-0 truncate">{title}</div>
+          </div>
           <Button type="button" variant="ghost" size="icon" aria-label={t("common.close")} onClick={onClose}>
             <XIcon className="size-4" />
           </Button>


### PR DESCRIPTION
## Issue

Opening a connection's permission management screen from team member settings displayed a backdrop that was noticeably darker than other modal backdrops. The permission dialog itself appeared once, but the page behaved as though two modal layers were active.

## Root cause

The connections page mounts separate mobile and desktop `ProviderDetail` trees at the same time and hides the inactive layout with CSS. Each tree previously owned its own `ConnectionAccessDialog` state inside `ConnectionAccountItem`.

When navigation supplied a `selectedAppId`, both responsive trees opened their local dialog. Because the dialog is rendered through a portal into `document.body`, the dialog in the CSS-hidden tree remained visible. The two identical dialog surfaces overlapped exactly while their two full-screen backdrops compounded, producing the double-mask effect. This also registered duplicate focus and keyboard handlers and could duplicate permission data loading.

## Fix

The first commit streamlines member connection permissions inside the existing team settings sheet. Opening the shield control now replaces the sheet contents with a member-access panel instead of stacking a separate member-access dialog and backdrop. It also provides an explicit back path and closes the team overlay before navigating to a connection.

The second commit moves connection-access dialog ownership to `ConnectionsPanel`, outside the responsive detail branches. Account rows now emit `onOpenAccess(app)` instead of mounting dialogs themselves, and the mobile and desktop detail trees only forward that event.

The page-level owner consumes a routed `selectedAppId` once, renders one `ConnectionAccessDialog`, and clears the selected access target when the connection workspace changes. Manual access buttons and team-to-connection navigation now share the same single modal owner.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run src/routes/Connections/ConnectionAccountsList.test.tsx src/routes/Connections/connection-access-model.test.ts src/routes/Connections/connection-route-model.test.ts`
- `corepack pnpm exec oxfmt --check src/routes/Connections/ConnectionAccountsList.test.tsx src/routes/Connections/index.tsx src/routes/Connections/ConnectionAccountsList.tsx src/routes/Connections/ConnectionProviderDetailPane.tsx`
- Manual Electron verification of Team settings -> Member connection access -> Configure in connections -> Connection access
- Confirmed that one close action removes the dialog and backdrop completely

The new component regression test mounts duplicate responsive account lists and verifies that they delegate the open action without mounting their own modal. The PR contains the related local team-permission streamlining commit followed by the single-owner connection dialog fix.
