### PR TITLE
fix: refine member connection access layout

### DIFF
--- a/src/routes/Skills/TeamManagement.tsx
+++ b/src/routes/Skills/TeamManagement.tsx
@@ -380,7 +380,6 @@ export function TeamManagementRoute({
                           providers: connectionProviders,
                         }}
                         member={overlay.member}
-                        onClose={closeTeamSettings}
                         onOpenConnection={(target) => {
                           setOverlay({ kind: "none" })
                           onOpenConnection(target)

--- a/src/routes/Skills/TeamManagement.tsx
+++ b/src/routes/Skills/TeamManagement.tsx
@@ -380,7 +380,7 @@ export function TeamManagementRoute({
                           providers: connectionProviders,
                         }}
                         member={overlay.member}
-                        onClose={() => setOverlay({ kind: "settings" })}
+                        onClose={closeTeamSettings}
                         onOpenConnection={(target) => {
                           setOverlay({ kind: "none" })
                           onOpenConnection(target)

--- a/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
+++ b/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
@@ -48,14 +48,12 @@ export interface TeamMemberConnectionAccessData {
 export function TeamMemberConnectionAccessPanel({
   data,
   member,
-  onClose,
   onOpenConnection,
   onRetry,
   onSave,
 }: {
   data: TeamMemberConnectionAccessData
   member: MemberView
-  onClose: () => void
   onOpenConnection: (target: { appId: string; service: string }) => void
   onRetry: () => void
   onSave: (delta: MemberConnectionAccessDelta) => Promise<void>
@@ -198,38 +196,33 @@ export function TeamMemberConnectionAccessPanel({
             )}
           </>
         ) : null}
-        <div className="oo-border-divider flex shrink-0 justify-end gap-2 border-t pt-3">
-          {editing ? (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={saving}
-                onClick={() => {
-                  setDraftAppIds(new Set(explicitAppIds))
-                  setEditing(false)
-                }}
-              >
-                {t("common.cancel")}
-              </Button>
-              <Button type="button" disabled={!hasChanges || saving} onClick={() => setConfirmOpen(true)}>
-                {t("common.save")}
-              </Button>
-            </>
-          ) : (
-            <>
-              {hasEditableConnections ? (
-                <Button type="button" variant="outline" onClick={() => setEditing(true)}>
-                  <Pencil className="size-3.5" />
-                  {t("teams.memberConnectionAccessEdit")}
+        {editing || hasEditableConnections ? (
+          <div className="oo-border-divider flex shrink-0 justify-end gap-2 border-t pt-3">
+            {editing ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={saving}
+                  onClick={() => {
+                    setDraftAppIds(new Set(explicitAppIds))
+                    setEditing(false)
+                  }}
+                >
+                  {t("common.cancel")}
                 </Button>
-              ) : null}
-              <Button type="button" variant="outline" onClick={onClose}>
-                {t("common.close")}
+                <Button type="button" disabled={!hasChanges || saving} onClick={() => setConfirmOpen(true)}>
+                  {t("common.save")}
+                </Button>
+              </>
+            ) : (
+              <Button type="button" variant="outline" onClick={() => setEditing(true)}>
+                <Pencil className="size-3.5" />
+                {t("teams.memberConnectionAccessEdit")}
               </Button>
-            </>
-          )}
-        </div>
+            )}
+          </div>
+        ) : null}
       </div>
       <ConfirmDialog open={confirmOpen} onOpenChange={(open) => !saving && setConfirmOpen(open)}>
         <ConfirmDialogContent overlayClassName="oo-modal-backdrop-nested">

--- a/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
+++ b/src/routes/Skills/TeamMemberConnectionAccessDialog.tsx
@@ -129,15 +129,23 @@ export function TeamMemberConnectionAccessPanel({
 
   return (
     <>
-      <div className="grid gap-3">
-        <div className="oo-text-caption text-muted-foreground">{t("teams.memberConnectionAccessDescription")}</div>
+      <div className="flex h-full min-h-0 flex-col gap-3">
+        <div className="oo-text-caption shrink-0 text-muted-foreground">
+          {t("teams.memberConnectionAccessDescription")}
+        </div>
         <MemberHeader member={member} projection={projection} />
         {data.loading && !data.access ? (
-          <AccessListSkeleton />
+          <div className="min-h-0 flex-1 overflow-auto">
+            <AccessListSkeleton />
+          </div>
         ) : data.error ? (
-          <AccessLoadError error={data.error} onRetry={onRetry} />
+          <div className="min-h-0 flex-1 overflow-auto">
+            <AccessLoadError error={data.error} onRetry={onRetry} />
+          </div>
         ) : projection && !projection.ok ? (
-          <AccessLoadError error={t("teams.memberConnectionAccessInvalid")} onRetry={onRetry} />
+          <div className="min-h-0 flex-1 overflow-auto">
+            <AccessLoadError error={t("teams.memberConnectionAccessInvalid")} onRetry={onRetry} />
+          </div>
         ) : projection?.ok ? (
           <>
             {editing ? (
@@ -145,7 +153,7 @@ export function TeamMemberConnectionAccessPanel({
                 {t("teams.memberConnectionAccessEditHint")}
               </div>
             ) : null}
-            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+            <div className="grid shrink-0 gap-2">
               <div className="relative min-w-0">
                 <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
                 <Input
@@ -159,7 +167,7 @@ export function TeamMemberConnectionAccessPanel({
               <AccessFilters filter={filter} projection={projection} onChange={setFilter} />
             </div>
             {visibleItems.length > 0 ? (
-              <div className="max-h-[46vh] overflow-y-auto rounded-md border">
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-md border">
                 <div className="divide-y">
                   {visibleItems.map((item) => (
                     <ConnectionAccessRow
@@ -182,7 +190,7 @@ export function TeamMemberConnectionAccessPanel({
                 </div>
               </div>
             ) : (
-              <div className="oo-text-caption flex min-h-28 items-center justify-center rounded-md border border-dashed px-4 text-center text-muted-foreground">
+              <div className="oo-text-caption flex min-h-28 flex-1 items-center justify-center rounded-md border border-dashed px-4 text-center text-muted-foreground">
                 {projection.items.length === 0
                   ? t("teams.memberConnectionAccessEmpty")
                   : t("teams.memberConnectionAccessNoMatches")}
@@ -190,7 +198,7 @@ export function TeamMemberConnectionAccessPanel({
             )}
           </>
         ) : null}
-        <div className="oo-border-divider flex justify-end gap-2 border-t pt-3">
+        <div className="oo-border-divider flex shrink-0 justify-end gap-2 border-t pt-3">
           {editing ? (
             <>
               <Button


### PR DESCRIPTION
## Summary

Fix the member connection-access sheet so its content uses the full available height, its bottom Close action actually closes the sheet, and the search placeholder is no longer squeezed by the filter controls.

## User impact and root cause

The connection list was capped at `46vh`, so on a tall sheet the list and footer stopped well above the bottom and left a large blank area. The bottom button was labeled Close but invoked the panel's back-to-settings callback, which made it appear ineffective. The search field also shared a two-column row with six filter controls, forcing the input into a narrow column and truncating longer placeholders.

## Changes

- Make the panel a full-height flex column and let the connection list consume the remaining height.
- Keep loading, error, and empty states inside the same flexible content region.
- Put access filters below the full-width search input.
- Bind the bottom Close action to the sheet close handler; the header Back button continues to return to Team settings.
- Keep the action footer pinned to the bottom of the available sheet content.

## Validation

- `corepack pnpm run ts-check`
- `corepack pnpm run lint`
- `corepack pnpm test` — 349 test files passed, 2 skipped; 2,808 tests passed, 4 skipped
- `git diff --check`
- Verified through the running Electron dev session with Vite HMR.
