### PR TITLE
fix: keep OO Connect agent turns running

### DIFF
--- a/electron/agent/skill-host-capability.ts
+++ b/electron/agent/skill-host-capability.ts
@@ -9,7 +9,7 @@ export const SKILL_CAPABILITY_ID = "skills"
 export const SKILL_SNAPSHOT_BINDING = "skills.snapshot"
 
 const HOST_EXECUTION_POLICY = `<wanta_execution_policy>
-Skill files describe business workflows, schemas, and safety rules. When a Wanta MCP capability covers the operation, use that host capability instead of executing CLI or shell examples from the Skill. For connected services, prefer wanta_link discovery and action tools; they are mandatory while available, and Wanta rejects raw connector business commands in that state. A raw CLI is only a compatibility fallback when no Wanta host capability covers the operation, and that fallback must invoke $WANTA_OO_BIN rather than a bare oo executable. This transport rule does not change the Skill's write or destructive confirmation requirements.
+Skill files describe business workflows, schemas, and safety rules. When a Wanta MCP capability covers the operation, prefer that host capability over CLI or shell examples from the Skill. For connected services, prefer wanta_link discovery and action tools. The managed OOCLI remains an allowed compatibility path and should invoke $WANTA_OO_BIN rather than an unmanaged executable. This transport preference does not change the Skill's write or destructive confirmation requirements.
 </wanta_execution_policy>`
 
 export function createSkillHostCapability(): HostCapability {

--- a/electron/chat/context-system.test.ts
+++ b/electron/chat/context-system.test.ts
@@ -13,7 +13,7 @@ test("buildLinkRuntimeSystem binds raw OOMOL calls to the exact team", () => {
 
   assert.match(prompt, /Current-turn Wanta Link workspace: team "Team \\"Quoted\\""/)
   assert.match(prompt, /`wanta_link` MCP tools/)
-  assert.match(prompt, /Do not invoke the raw `oo` CLI/)
+  assert.match(prompt, /managed `oo` CLI remains available/)
   assert.match(prompt, /--team "Team \\"Quoted\\""/)
   assert.match(prompt, /never retry in a personal or default workspace/i)
   assert.match(prompt, /does not prove that the current Wanta team is disconnected/)

--- a/electron/chat/context-system.ts
+++ b/electron/chat/context-system.ts
@@ -18,7 +18,7 @@ export function buildLinkRuntimeSystem(runtime: ActiveLinkRuntime, teamName: str
       return [
         "Wanta Link runtime for this turn: OpenConnector.",
         "- Wanta owns the active connection identity; preserve it across every Link call.",
-        "- When the `wanta_link` MCP tools are present, use them for Link work and do not invoke the raw `oo` CLI; inspect_action is required before call_action.",
+        "- When the `wanta_link` MCP tools are present, prefer them for Link work; inspect_action is required before call_action. The managed `oo` CLI remains an allowed compatibility path.",
         "- Raw `oo connector apps` and `oo connector run` calls must omit `--team` and `--personal`.",
         "- An authorization error applies only to the exact runtime and selector used by that call; do not claim a different workspace is disconnected.",
       ].join("\n")
@@ -33,7 +33,7 @@ export function buildLinkRuntimeSystem(runtime: ActiveLinkRuntime, teamName: str
       }
       return [
         `Current-turn Wanta Link workspace: team ${quoted(normalizedTeamName)}.`,
-        "- The `wanta_link` MCP tools are the required transport for Link work; inspect_action is required before call_action. Do not invoke the raw `oo` CLI: Wanta rejects `oo connector apps`, `run`, and `proxy` shell calls while this capability is active.",
+        "- Prefer the `wanta_link` MCP tools for Link work; inspect_action is required before call_action. The managed `oo` CLI remains available as a compatibility path.",
         `- Every raw \`oo connector apps\` or \`oo connector run\` call must preserve the selector \`--team ${quoted(normalizedTeamName)}\`.`,
         "- Raw `oo connector schema` and `oo connector search` calls never accept workspace selectors such as `--team` or `--personal`.",
         "- Never omit, replace, or change that selector after an error, and never retry in a personal or default workspace.",

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -15,7 +15,7 @@ function permission(overrides: Partial<ChatPermissionRequest>): ChatPermissionRe
   }
 }
 
-test("local access policy allows ordinary commands and gates Link business CLI in default mode", () => {
+test("local access policy allows ordinary commands and Link business CLI in default mode", () => {
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ metadata: { command: "npm test" } }), { permissionMode: "default" }),
     { type: "allow", reason: "default_command", kind: "command", highRisk: false },
@@ -25,11 +25,11 @@ test("local access policy allows ordinary commands and gates Link business CLI i
       linkRuntime: "oomol",
       permissionMode: "default",
     }),
-    { type: "deny", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
 })
 
-test("OpenCode, Claude, and ACP agents share the Host Link transport gate", () => {
+test("OpenCode, Claude, and ACP agents auto-approve Link business CLI", () => {
   const command =
     'oo connector run "posthog" --action "list_projects" --data \'{}\' --json --team "OOMOL-Internal" 2>&1 | head -100'
   const requests = [
@@ -39,7 +39,8 @@ test("OpenCode, Claude, and ACP agents share the Host Link transport gate", () =
   ]
 
   assert.deepEqual(evaluateLocalAccessRequest(requests[0]!, { linkRuntime: "oomol", permissionMode: "default" }), {
-    type: "deny",
+    type: "allow",
+    reason: "oo_cli",
     kind: "command",
     highRisk: false,
   })
@@ -50,12 +51,12 @@ test("OpenCode, Claude, and ACP agents share the Host Link transport gate", () =
         linkRuntime: "oomol",
         permissionMode: "default",
       }),
-      { type: "deny", kind: "command", highRisk: false },
+      { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
     )
   }
 })
 
-test("OOCLI parity preserves hard denials and blocks compound Link business commands", () => {
+test("OOCLI parity preserves hard denials while allowing ordinary compound Link business commands", () => {
   for (const command of ["oo auth login", "oo connector logout", "oo connector apps --connector-token secret"]) {
     assert.equal(
       evaluateLocalAccessRequest(permission({ metadata: { command } }), {
@@ -78,7 +79,7 @@ test("OOCLI parity preserves hard denials and blocks compound Link business comm
         linkRuntime: "oomol",
         permissionMode: "default",
       }),
-      { type: "deny", kind: "command", highRisk: false },
+      { type: "allow", reason: "default_command", kind: "command", highRisk: false },
       command,
     )
   }
@@ -91,7 +92,7 @@ test("OOCLI parity preserves hard denials and blocks compound Link business comm
       }),
       { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
     ),
-    { type: "deny", kind: "command", highRisk: true },
+    { type: "prompt", kind: "command", highRisk: true },
   )
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ metadata: { command: "oo connector apps --json | head -20" } }), {
@@ -110,7 +111,7 @@ test("OOCLI parity preserves hard denials and blocks compound Link business comm
         linkRuntime: "oomol",
         permissionMode: "default",
       }),
-      { type: "deny", kind: "command", highRisk: false },
+      { type: "allow", reason: "default_command", kind: "command", highRisk: false },
     )
   }
 })
@@ -123,13 +124,13 @@ test("safe OOCLI classification is agent-independent even without an active Link
     ),
     { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
-  // An active runtime requires the Host Link transport.
+  // An active runtime keeps the managed OOCLI compatibility path available.
   assert.equal(
     evaluateLocalAccessRequest(
       permission({ metadata: { command: "oo connector run gmail --action send_email --json" } }),
       { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
     ).type,
-    "deny",
+    "allow",
   )
   assert.deepEqual(
     evaluateLocalAccessRequest(
@@ -139,7 +140,7 @@ test("safe OOCLI classification is agent-independent even without an active Link
       }),
       { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
     ),
-    { type: "deny", kind: "command", highRisk: false },
+    { type: "prompt", kind: "command", highRisk: false },
   )
 })
 
@@ -186,7 +187,7 @@ test("local access policy allows pure oo commands without a renderer prompt", ()
   )
 })
 
-test("local access policy blocks direct and standard wrapped business oo commands under OpenConnector", () => {
+test("local access policy allows direct and standard wrapped business oo commands under OpenConnector", () => {
   for (const command of [
     "oo connector apps --json",
     "bash -c 'oo connector apps --json'",
@@ -201,7 +202,7 @@ test("local access policy blocks direct and standard wrapped business oo command
         linkRuntime: "openconnector",
         permissionMode: "full_access",
       }),
-      { type: "deny", kind: "command", highRisk: false },
+      { type: "allow", reason: "full_access", kind: "command", highRisk: false },
       command,
     )
   }
@@ -210,14 +211,14 @@ test("local access policy blocks direct and standard wrapped business oo command
       linkRuntime: "openconnector",
       permissionMode: "default",
     }),
-    { type: "deny", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
   assert.deepEqual(
     evaluateLocalAccessRequest(permission({ metadata: { command: "zsh -c 'cd /tmp && oo connector apps --json'" } }), {
       linkRuntime: "openconnector",
       permissionMode: "default",
     }),
-    { type: "deny", kind: "command", highRisk: false },
+    { type: "allow", reason: "default_command", kind: "command", highRisk: false },
   )
   for (const command of ["oo connector apps --json 2>&1", "oo connector apps --json 2>&1 | head -80"]) {
     assert.deepEqual(
@@ -225,7 +226,7 @@ test("local access policy blocks direct and standard wrapped business oo command
         linkRuntime: "openconnector",
         permissionMode: "default",
       }),
-      { type: "deny", kind: "command", highRisk: false },
+      { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
       command,
     )
   }

--- a/electron/chat/local-access-policy.ts
+++ b/electron/chat/local-access-policy.ts
@@ -2,7 +2,7 @@ import type { ActiveLinkRuntime } from "../link-runtime/common.ts"
 import type { AgentPermissionMode, ChatPermissionRequest, LocalPermissionPromptReason } from "./common.ts"
 import type { PermissionRequestKind, SessionPermissionGrant } from "./permission-request.ts"
 
-import { connectorBusinessCliTransport, openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
+import { openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
 import { isLowConsequenceCleanupCommand } from "./bounded-cleanup.ts"
 import {
   createSessionPermissionGrant,
@@ -199,14 +199,6 @@ export function evaluateLocalAccessRequest(
 ): LocalAccessDecision {
   const kind = permissionRequestKind(request)
   const highRisk = isHighRiskPermissionRequest(request)
-  const connectorTransport = kind === "command" ? connectorBusinessCliTransport(permissionCommand(request) ?? "") : null
-  // Link identity, credentials, validation, redaction, and auditing are
-  // host-owned. Once a Link runtime is active, every agent must use the same
-  // Wanta capability instead of selecting a raw shell transport. This gate is
-  // deliberately adapter-neutral and applies even in Full Access mode.
-  if (connectorTransport && context.linkRuntime && context.linkRuntime !== "none") {
-    return { type: "deny", kind, highRisk }
-  }
   // This is deliberately the only adapter-specific policy branch, and it can
   // only make an external-agent decision more permissive. All other requests
   // go through the baseline that powered the built-in OpenCode experience;

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -973,6 +973,50 @@ test("an indeterminate idle check does not complete the active generation", asyn
   service.dispose()
 })
 
+test("a tool-call finish reason does not complete the user turn", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "research" })
+  const userMessageId = bridge.promptStreaming.mock.calls[0]?.[2]?.messageId as string
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-tools", sessionID: "session-1", role: "assistant" } },
+  })
+  bridge.getMessages.mockResolvedValue([
+    { id: userMessageId, role: "user", createdAt: 1, parts: [] },
+    {
+      id: "assistant-tools",
+      role: "assistant",
+      createdAt: 2,
+      completedAt: 3,
+      finishReason: "tool-calls",
+      parts: [],
+    },
+  ])
+
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await new Promise((resolve) => setTimeout(resolve, 175))
+
+  assert.equal(service.hasActiveGeneration(), true)
+  assert.equal(events.filter((event) => event.event === "messageCompleted").length, 0)
+
+  bridge.getMessages.mockResolvedValue([
+    { id: userMessageId, role: "user", createdAt: 1, parts: [] },
+    { id: "assistant-final", role: "assistant", createdAt: 4, completedAt: 5, finishReason: "stop", parts: [] },
+  ])
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-final", sessionID: "session-1", role: "assistant" } },
+  })
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await waitForCondition(() => !service.hasActiveGeneration())
+
+  assert.equal(events.filter((event) => event.event === "messageCompleted").length, 1)
+})
+
 test("an idle generation fails recoverably when completion cannot be verified before the retry deadline", async () => {
   vi.useFakeTimers()
   const bridge = createBridgeAgent()
@@ -3372,7 +3416,7 @@ test("pure oo permissions are approved in the main process", async () => {
   )
 })
 
-test("OpenConnector direct oo commands are rejected in favor of Host Link", async () => {
+test("OpenConnector direct oo commands are automatically allowed", async () => {
   const bridge = createBridgeAgent()
   const service = new ChatServiceImpl(bridge.agent)
   service.setLinkRuntime("openconnector")
@@ -3390,7 +3434,7 @@ test("OpenConnector direct oo commands are rejected in favor of Host Link", asyn
   })
 
   await waitForCondition(() => bridge.answerPermission.mock.calls.length === 1)
-  assert.deepEqual(bridge.answerPermission.mock.calls, [["session-1", "permission-1", "reject"]])
+  assert.deepEqual(bridge.answerPermission.mock.calls, [["session-1", "permission-1", "once"]])
   assert.equal(
     events.some((event) => event.event === "permissionAsked"),
     false,

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1460,7 +1460,14 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     const assistant =
       activeAssistant ??
       (userIndex >= 0 ? messages.slice(userIndex + 1).find((message) => message.role === "assistant") : undefined)
-    return Boolean(assistant?.finishReason || assistant?.completedAt !== undefined)
+    if (!assistant) return false
+    const finishReason = assistant.finishReason?.trim().toLowerCase().replaceAll("_", "-")
+    // A completed tool-call message is only one step in the agent loop. Some
+    // runtimes briefly emit session.idle after a rejected or failed tool; do
+    // not turn that transient boundary into a completed user turn before the
+    // agent produces a terminal response.
+    if (["tool-calls", "tool-use"].includes(finishReason ?? "")) return false
+    return Boolean(finishReason || assistant.completedAt !== undefined)
   }
 
   private scheduleCompletionRetry(


### PR DESCRIPTION
## Summary

Keep ordinary OO Connect CLI operations available to every agent runtime and prevent tool-call steps from being mistaken for completed user turns.

## User impact

Agents researching connected services could call `oo connector apps`, `oo connector run`, or `oo connector proxy` and receive a synthetic permission rejection even though OOCLI was otherwise configured for automatic approval. OpenCode could then settle at the tool boundary without a final answer, while Wanta treated the tool-call finish reason as terminal and displayed “Processing did not complete.” To users this looked like the chat had disconnected or stopped by itself.

## Root cause

The baseline local-access policy already auto-approved ordinary first-party OOCLI commands, but a later Link transport gate overrode that decision whenever a Link runtime was active. The gate denied connector business commands even in Full Access mode in order to force the structured Host Link transport. The rejection was surfaced through the native permission protocol as if the user had denied the command.

Separately, idle-history verification considered any assistant `finishReason` or `completedAt` value sufficient to complete the whole user turn. Tool-step reasons such as `tool-calls` and `tool_use` therefore passed the terminal check even though the agent had not produced a final response.

## Fix

- Remove the Link-runtime transport denial and let ordinary connector `apps`, `run`, and `proxy` commands use the existing OOCLI automatic-approval path for OpenCode, Claude Code, Codex/ACP, and other adapters.
- Preserve the managed OO wrapper, workspace binding, output redaction, output limits, and the existing protections around credentials, authentication/configuration mutations, sensitive paths, and high-risk command composition.
- Update host and Skill execution guidance to prefer structured `wanta_link` tools while keeping managed OOCLI as an allowed compatibility path.
- Treat `tool-calls`, `tool_calls`, `tool-use`, and `tool_use` as non-terminal assistant states during `session.idle` verification, so Wanta waits for a real final response instead of prematurely emitting `messageCompleted`.
- Add regression coverage for the exact OO Connect permission flow across built-in and external agents and for an idle tool-call step followed by a terminal assistant response.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm test` — 349 test files passed, 2 skipped; 2,809 tests passed, 4 skipped
- `corepack pnpm run build`
- `git diff --check`
