### PR TITLE
fix(images): stabilize generated image previews

### DIFF
--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -489,6 +489,7 @@ describe("AgentManager", () => {
     expect(system).toContain("Wanta can materialize the same image")
     expect(system).toContain("use the local path for the inline Markdown image")
     expect(system).toContain("do not make it the primary preview")
+    expect(system).toContain("Never emit /C:/Users/...")
     expect(system).toContain("replace every embedded output path")
     expect(system).not.toContain("Do not present a remote")
   })

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -1744,6 +1744,7 @@ export function buildArtifactSystem(artifactDir: string | undefined, outputProje
     "- Persist every final generated image into this directory. If a tool returns only a remote, data-backed, or temporary preview, keep the preview reference intact so Wanta can materialize the same image during turn finalization. Do not describe it as a saved local file until persistence succeeds.",
     "- When a generated image has both a successfully saved local path and a matching remote or temporary preview, use the local path for the inline Markdown image. Keep the remote reference only as recovery metadata; do not make it the primary preview.",
     "- When the final deliverable is one to four image files and inline viewing helps the user, include Markdown image references in the final response using their absolute local paths, for example ![short title](</absolute/path/image.png>).",
+    "- On Windows, use drive-letter paths such as C:/Users/name/output.png or C:\\Users\\name\\output.png without an extra leading slash. Never emit /C:/Users/... as a local Markdown image destination.",
     "- If only a provider-backed image preview is available, keep that preview visible in the final response instead of omitting it. Wanta will materialize supported preview sources and independently report persistence failures.",
     "- When there are many images, such as crawled or downloaded image sets, do not inline every image in the final response. Summarize the set and rely on the artifact browser.",
     "- Do not reuse output folders from earlier turns or other chats.",

--- a/electron/skills/default-registry-install.test.ts
+++ b/electron/skills/default-registry-install.test.ts
@@ -1,0 +1,76 @@
+import type { SkillInventory } from "./common.ts"
+
+import { describe, expect, it } from "vitest"
+import { defaultRegistrySkillNeedsUpdate } from "./default-registry-install.ts"
+
+function inventory(version?: string): SkillInventory {
+  return {
+    groups: [
+      {
+        externalHosts: [],
+        hosts: [],
+        id: "gpt-image-2",
+        kind: "registry",
+        name: "gpt-image-2",
+        packageName: "@zjxuyunshi/gpt-image-2",
+        runtimeHosts: [
+          {
+            agentId: "wanta",
+            agentName: "Wanta",
+            scope: "runtime",
+            status: "installed",
+            version,
+          },
+        ],
+        version,
+      },
+    ],
+    summary: {
+      localSkills: 0,
+      managedSkills: 1,
+      modifiedHosts: 0,
+      needsAttention: 0,
+      publishableSkills: 0,
+      registrySkills: 1,
+      skills: [],
+      sourceMissingHosts: 0,
+    },
+    updatedAt: new Date(0).toISOString(),
+  }
+}
+
+const spec = {
+  enabled: true,
+  minimumVersion: "1.1.2",
+  packageName: "@zjxuyunshi/gpt-image-2",
+  skillId: "gpt-image-2",
+}
+
+describe("defaultRegistrySkillNeedsUpdate", () => {
+  it("updates a runtime below the required baseline", () => {
+    expect(defaultRegistrySkillNeedsUpdate(inventory("1.1.1"), spec)).toBe(true)
+    expect(defaultRegistrySkillNeedsUpdate(inventory(undefined), spec)).toBe(true)
+  })
+
+  it("leaves the baseline and newer versions unchanged", () => {
+    expect(defaultRegistrySkillNeedsUpdate(inventory("1.1.2"), spec)).toBe(false)
+    expect(defaultRegistrySkillNeedsUpdate(inventory("1.2.0"), spec)).toBe(false)
+  })
+
+  it("does not update defaults without a version requirement", () => {
+    expect(defaultRegistrySkillNeedsUpdate(inventory("0.0.1"), { ...spec, minimumVersion: undefined })).toBe(false)
+  })
+
+  it("does not replace a local or differently packaged skill with the same id", () => {
+    const localInventory = inventory("1.1.1")
+    localInventory.groups[0] = { ...localInventory.groups[0]!, kind: "local" }
+    expect(defaultRegistrySkillNeedsUpdate(localInventory, spec)).toBe(false)
+
+    const otherPackageInventory = inventory("1.1.1")
+    otherPackageInventory.groups[0] = {
+      ...otherPackageInventory.groups[0]!,
+      packageName: "@someone-else/gpt-image-2",
+    }
+    expect(defaultRegistrySkillNeedsUpdate(otherPackageInventory, spec)).toBe(false)
+  })
+})

--- a/electron/skills/default-registry-install.ts
+++ b/electron/skills/default-registry-install.ts
@@ -2,6 +2,7 @@ import type { SkillInventory } from "./common.ts"
 import type { DefaultRegistrySkillSpec } from "./default-registry-skills.ts"
 
 import { normalizeSkillId } from "./file-operations.ts"
+import { semanticVersionIsBefore } from "./semantic-version.ts"
 
 export function normalizeDefaultRegistrySkillRequest(spec: DefaultRegistrySkillSpec): {
   packageName: string
@@ -22,6 +23,23 @@ export function isRuntimeSkillInstalled(inventory: SkillInventory, skillId: stri
   const normalizedSkillId = normalizeSkillId(skillId)
   const group = inventory.groups.find((item) => item.id === normalizedSkillId)
   return group?.runtimeHosts.some((host) => host.status === "installed") ?? false
+}
+
+export function defaultRegistrySkillNeedsUpdate(inventory: SkillInventory, spec: DefaultRegistrySkillSpec): boolean {
+  const minimumVersion = spec.minimumVersion?.trim()
+  if (!minimumVersion) {
+    return false
+  }
+  const skillId = normalizeSkillId(spec.skillId)
+  const group = inventory.groups.find((item) => item.id === skillId)
+  if (group?.kind !== "registry" || group.packageName?.trim() !== spec.packageName.trim()) {
+    return false
+  }
+  const runtimeHost = group?.runtimeHosts.find((host) => host.status === "installed")
+  if (!runtimeHost) {
+    return false
+  }
+  return semanticVersionIsBefore(runtimeHost.version ?? group?.version, minimumVersion)
 }
 
 export function runtimeErrorMessage(error: unknown): string {

--- a/electron/skills/default-registry-skills.test.ts
+++ b/electron/skills/default-registry-skills.test.ts
@@ -3,7 +3,14 @@ import { defaultRegistrySkillSetVersion, defaultRegistrySkills } from "./default
 
 describe("default Registry Skills", () => {
   it("installs the public social research adapter through the Registry runtime", () => {
-    expect(defaultRegistrySkillSetVersion).toBe(3)
+    expect(defaultRegistrySkillSetVersion).toBe(4)
+    expect(defaultRegistrySkills).toContainEqual({
+      category: "image-generation",
+      enabled: true,
+      minimumVersion: "1.1.2",
+      packageName: "@zjxuyunshi/gpt-image-2",
+      skillId: "gpt-image-2",
+    })
     expect(defaultRegistrySkills).toContainEqual({
       category: "other",
       enabled: true,

--- a/electron/skills/default-registry-skills.ts
+++ b/electron/skills/default-registry-skills.ts
@@ -1,17 +1,19 @@
 export interface DefaultRegistrySkillSpec {
   category?: "ecommerce" | "image-generation" | "document" | "productivity" | "other"
   enabled: boolean
+  minimumVersion?: string
   packageName: string
   skillId: string
 }
 
-export const defaultRegistrySkillSetVersion = 3
+export const defaultRegistrySkillSetVersion = 4
 
 // 默认安装清单：登录后后台补装，必须使用 registry 中稳定的 packageName + skillId。
 export const defaultRegistrySkills: readonly DefaultRegistrySkillSpec[] = [
   {
     category: "image-generation",
     enabled: true,
+    minimumVersion: "1.1.2",
     packageName: "@zjxuyunshi/gpt-image-2",
     skillId: "gpt-image-2",
   },

--- a/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
@@ -14,122 +14,102 @@ afterEach(async () => {
   await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
 })
 
-describe("GPT Image 2 Windows runtime compatibility", () => {
-  it("adds idempotent guidance for supported raw oo team selection", () => {
-    const source = "# GPT Image 2\n"
+function legacyRunnerSource(): string {
+  return [
+    "const proc = spawn(command, cmdArgs, { env });",
+    "const match = output.match(/Saved to:\\s*(.+)/);",
+    "if (",
+    '    typeof first === "string" &&',
+    '    first.endsWith(".js") &&',
+    '    path.basename(first) === "run_image.js"',
+    "  ) {",
+  ].join("\n")
+}
+
+async function createSkill(version: string, runnerSource = legacyRunnerSource()) {
+  const root = await mkdtemp(path.join(tmpdir(), "wanta-gpt-image-2-"))
+  temporaryRoots.push(root)
+  const skillPath = path.join(root, "gpt-image-2")
+  const runner = path.join(skillPath, "scripts", "run_image.js")
+  await mkdir(path.dirname(runner), { recursive: true })
+  await writeFile(runner, runnerSource, "utf8")
+  await writeFile(
+    path.join(skillPath, "SKILL.md"),
+    [
+      "---",
+      "name: gpt-image-2",
+      `metadata: { version: ${version} }`,
+      `version: ${version}`,
+      "---",
+      "# GPT Image 2",
+      "",
+      "<!-- wanta-gpt-image-2-local-image-display:start -->",
+      "Duplicate local image delivery guidance.",
+      "<!-- wanta-gpt-image-2-local-image-display:end -->",
+    ].join("\n"),
+    "utf8",
+  )
+  return { runner, skillPath }
+}
+
+describe("GPT Image 2 runtime compatibility", () => {
+  it("keeps Wanta team guidance but removes the obsolete local-image injection", () => {
+    const source = [
+      "# GPT Image 2",
+      "",
+      "<!-- wanta-gpt-image-2-local-image-display:start -->",
+      "Duplicate local image delivery guidance.",
+      "<!-- wanta-gpt-image-2-local-image-display:end -->",
+    ].join("\n")
     const patched = patchGptImage2RuntimeInstructions(source)
 
     expect(patched).toContain("do not pass `--team`")
     expect(patched).toContain("`OO_TEAM_ID` or `OO_TEAM_NAME`")
-    expect(patched).toContain("`oo team use` does not persist")
-    expect(patched).toContain("Wanta local image delivery")
-    expect(patched).toContain("use those saved local files for inline previews instead of matching `remote_urls`")
-    expect(patched).toContain("one Markdown image per final image selected for inline display")
-    expect(patched).toContain("Do not arbitrarily limit a multi-image result to its first path")
-    expect(patched).toContain("Never add a leading slash such as `/C:/...`")
+    expect(patched).not.toContain("Wanta local image delivery")
+    expect(patched).not.toContain("Duplicate local image delivery guidance")
     expect(patchGptImage2RuntimeInstructions(patched)).toBe(patched)
   })
 
-  it("hides runner children, accepts localized download output, and permits renamed runner files", () => {
-    const patched = patchWindowsGptImage2Runner(
-      [
-        "const proc = spawn(command, cmdArgs, { env });",
-        "const match = output.match(/Saved to:\\s*(.+)/);",
-        "if (",
-        '    typeof first === "string" &&',
-        '    first.endsWith(".js") &&',
-        '    path.basename(first) === "run_image.js"',
-        "  ) {",
-      ].join("\n"),
-    )
-
-    expect(patched).toContain("spawn(command, cmdArgs, { env, windowsHide: true });")
-    expect(patched).toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
-    expect(patched).toContain('if (typeof first === "string" && first.endsWith(".js")) {')
-    expect(patched).not.toContain('path.basename(first) === "run_image.js"')
-  })
-
-  it("upgrades the previous localized download parser", () => {
-    const patched = patchWindowsGptImage2Runner(
-      "const match = output.match(/(?:Saved to:|已保存到[:：]|保存至[:：])\\s*(.+)/u);",
-    )
-
-    expect(patched).toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
-    expect(patchWindowsGptImage2Runner(patched)).toBe(patched)
-  })
-
-  it("patches only the private Windows runtime copy and is idempotent", async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "wanta-gpt-image-2-"))
-    temporaryRoots.push(root)
-    const skillPath = path.join(root, "gpt-image-2")
-    const runner = path.join(skillPath, "scripts", "run_image.js")
-    await mkdir(path.dirname(runner), { recursive: true })
-    await writeFile(
-      runner,
-      [
-        "const proc = spawn(command, cmdArgs, { env });",
-        "const match = output.match(/Saved to:\\s*(.+)/);",
-        "if (",
-        '    typeof first === "string" &&',
-        '    first.endsWith(".js") &&',
-        '    path.basename(first) === "run_image.js"',
-        "  ) {",
-      ].join("\n"),
-      "utf8",
-    )
-
-    await writeFile(path.join(skillPath, "SKILL.md"), "# GPT Image 2\n", "utf8")
+  it("retains the legacy Windows runner repair for versions below 1.1.2", async () => {
+    const { runner, skillPath } = await createSkill("1.1.1")
 
     await expect(ensureGptImage2RuntimeCompatibility(skillPath, "win32")).resolves.toBe(true)
     await expect(ensureGptImage2RuntimeCompatibility(skillPath, "win32")).resolves.toBe(false)
     await expect(readFile(runner, "utf8")).resolves.toContain("windowsHide: true")
-    await expect(readFile(runner, "utf8")).resolves.not.toContain('path.basename(first) === "run_image.js"')
-    await expect(readFile(path.join(skillPath, "SKILL.md"), "utf8")).resolves.toContain(
-      "`OO_TEAM_ID` or `OO_TEAM_NAME`",
-    )
-    await expect(readFile(path.join(skillPath, "SKILL.md"), "utf8")).resolves.toContain(
-      "one Markdown image per final image selected for inline display",
-    )
+    await expect(readFile(runner, "utf8")).resolves.toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
   })
 
-  it("replaces the obsolete first-image-only runtime override with ordered local delivery", () => {
-    const patched = patchGptImage2RuntimeInstructions(
-      [
-        "# GPT Image 2",
-        "",
-        "<!-- wanta-gpt-image-2-local-image-display:start -->",
-        "Use the first path only.",
-        "<!-- wanta-gpt-image-2-local-image-display:end -->",
-      ].join("\n"),
-    )
+  it("does not rewrite the native runner in version 1.1.2 or newer", async () => {
+    const source = legacyRunnerSource()
+    const { runner, skillPath } = await createSkill("1.1.2", source)
 
-    expect(patched).not.toContain("Use the first path only")
-    expect(patched).toContain("Do not arbitrarily limit a multi-image result to its first path")
-    expect(patched.match(/wanta-gpt-image-2-local-image-display:start/g)).toHaveLength(1)
-    expect(patched.match(/wanta-gpt-image-2-local-image-display:end/g)).toHaveLength(1)
-  })
-
-  it("applies team guidance on every platform but leaves non-Windows runners unchanged", async () => {
-    const root = await mkdtemp(path.join(tmpdir(), "wanta-gpt-image-2-"))
-    temporaryRoots.push(root)
-    const otherSkillPath = path.join(root, "other-skill")
-    const runner = path.join(otherSkillPath, "scripts", "run_image.js")
-    const source = "const proc = spawn(command, cmdArgs, { env });\n"
-    await mkdir(path.dirname(runner), { recursive: true })
-    await writeFile(runner, source, "utf8")
-
-    await expect(ensureGptImage2RuntimeCompatibility(otherSkillPath, "win32")).resolves.toBe(false)
-    await expect(ensureGptImage2RuntimeCompatibility(otherSkillPath, "darwin")).resolves.toBe(false)
+    await expect(ensureGptImage2RuntimeCompatibility(skillPath, "win32")).resolves.toBe(true)
     await expect(readFile(runner, "utf8")).resolves.toBe(source)
+    await expect(readFile(path.join(skillPath, "SKILL.md"), "utf8")).resolves.not.toContain(
+      "Duplicate local image delivery guidance",
+    )
+  })
 
-    const skillPath = path.join(root, "gpt-image-2")
-    const skillRunner = path.join(skillPath, "scripts", "run_image.js")
-    await mkdir(path.dirname(skillRunner), { recursive: true })
-    await writeFile(skillRunner, source, "utf8")
-    await writeFile(path.join(skillPath, "SKILL.md"), "# GPT Image 2\n", "utf8")
+  it("leaves runners unchanged outside Windows", async () => {
+    const source = legacyRunnerSource()
+    const { runner, skillPath } = await createSkill("1.1.1", source)
 
     await expect(ensureGptImage2RuntimeCompatibility(skillPath, "darwin")).resolves.toBe(true)
-    await expect(readFile(skillRunner, "utf8")).resolves.toBe(source)
-    await expect(readFile(path.join(skillPath, "SKILL.md"), "utf8")).resolves.toContain("do not pass `--team`")
+    await expect(readFile(runner, "utf8")).resolves.toBe(source)
+  })
+
+  it("ignores unrelated skill directories", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wanta-other-skill-"))
+    temporaryRoots.push(root)
+    await expect(ensureGptImage2RuntimeCompatibility(path.join(root, "other-skill"), "win32")).resolves.toBe(false)
+  })
+
+  it("upgrades old runner source idempotently", () => {
+    const patched = patchWindowsGptImage2Runner(legacyRunnerSource())
+
+    expect(patched).toContain("spawn(command, cmdArgs, { env, windowsHide: true });")
+    expect(patched).toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
+    expect(patched).toContain('if (typeof first === "string" && first.endsWith(".js")) {')
+    expect(patchWindowsGptImage2Runner(patched)).toBe(patched)
   })
 })

--- a/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
@@ -26,6 +26,7 @@ describe("GPT Image 2 Windows runtime compatibility", () => {
     expect(patched).toContain("use those saved local files for inline previews instead of matching `remote_urls`")
     expect(patched).toContain("one Markdown image per final image selected for inline display")
     expect(patched).toContain("Do not arbitrarily limit a multi-image result to its first path")
+    expect(patched).toContain("Never add a leading slash such as `/C:/...`")
     expect(patchGptImage2RuntimeInstructions(patched)).toBe(patched)
   })
 
@@ -43,9 +44,18 @@ describe("GPT Image 2 Windows runtime compatibility", () => {
     )
 
     expect(patched).toContain("spawn(command, cmdArgs, { env, windowsHide: true });")
-    expect(patched).toContain("/(?:Saved to:|已保存到[:：]|保存至[:：])\\s*(.+)/u")
+    expect(patched).toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
     expect(patched).toContain('if (typeof first === "string" && first.endsWith(".js")) {')
     expect(patched).not.toContain('path.basename(first) === "run_image.js"')
+  })
+
+  it("upgrades the previous localized download parser", () => {
+    const patched = patchWindowsGptImage2Runner(
+      "const match = output.match(/(?:Saved to:|已保存到[:：]|保存至[:：])\\s*(.+)/u);",
+    )
+
+    expect(patched).toContain("/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u")
+    expect(patchWindowsGptImage2Runner(patched)).toBe(patched)
   })
 
   it("patches only the private Windows runtime copy and is idempotent", async () => {

--- a/electron/skills/gpt-image-2-windows-runtime-fix.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.ts
@@ -25,10 +25,13 @@ const localImageDisplayInstructions = [
   "",
   "When the runner returns non-empty `local_paths`, use those saved local files for inline previews instead of matching `remote_urls`.",
   "Include one Markdown image per final image selected for inline display, preserving `local_paths` order: `![Generated image](<absolute-local-path>)`.",
+  "On Windows, keep drive-letter paths in `C:/...` or `C:\\...` form. Never add a leading slash such as `/C:/...` in the Markdown destination.",
   "Do not arbitrarily limit a multi-image result to its first path. Follow Wanta's artifact output contract when deciding whether a large image set should be inlined or left to the artifact browser.",
   "Use a remote URL for the inline preview only when no corresponding local path was saved successfully.",
   localImageDisplayInstructionsEnd,
 ].join("\n")
+
+const localizedSavedPathMatch = "output.match(/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u);"
 
 /**
  * The default GPT Image 2 runner starts short-lived `oo` commands while a
@@ -38,7 +41,8 @@ const localImageDisplayInstructions = [
 export function patchWindowsGptImage2Runner(source: string): string {
   return source
     .replace("spawn(command, cmdArgs, { env });", "spawn(command, cmdArgs, { env, windowsHide: true });")
-    .replace("output.match(/Saved to:\\s*(.+)/);", "output.match(/(?:Saved to:|已保存到[:：]|保存至[:：])\\s*(.+)/u);")
+    .replace("output.match(/Saved to:\\s*(.+)/);", localizedSavedPathMatch)
+    .replace("output.match(/(?:Saved to:|已保存到[:：]|保存至[:：])\\s*(.+)/u);", localizedSavedPathMatch)
     .replace(
       [
         "if (",

--- a/electron/skills/gpt-image-2-windows-runtime-fix.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { semanticVersionIsBefore } from "./semantic-version.ts"
 
 const gptImage2SkillId = "gpt-image-2"
 const runnerPath = path.join("scripts", "run_image.js")
@@ -8,6 +9,7 @@ const teamScopeInstructionsStart = "<!-- wanta-gpt-image-2-team-scope:start -->"
 const teamScopeInstructionsEnd = "<!-- wanta-gpt-image-2-team-scope:end -->"
 const localImageDisplayInstructionsStart = "<!-- wanta-gpt-image-2-local-image-display:start -->"
 const localImageDisplayInstructionsEnd = "<!-- wanta-gpt-image-2-local-image-display:end -->"
+const nativeWindowsRunnerVersion = "1.1.2"
 
 const teamScopeInstructions = [
   teamScopeInstructionsStart,
@@ -17,18 +19,6 @@ const teamScopeInstructions = [
   "When authentication uses `OO_API_KEY`, `oo team use` does not persist a default team. Set `OO_TEAM_ID` or `OO_TEAM_NAME` in the environment for that command instead.",
   "This guidance applies to direct `oo` calls only and does not change Wanta-managed connector workspace selection.",
   teamScopeInstructionsEnd,
-].join("\n")
-
-const localImageDisplayInstructions = [
-  localImageDisplayInstructionsStart,
-  "## Wanta local image delivery",
-  "",
-  "When the runner returns non-empty `local_paths`, use those saved local files for inline previews instead of matching `remote_urls`.",
-  "Include one Markdown image per final image selected for inline display, preserving `local_paths` order: `![Generated image](<absolute-local-path>)`.",
-  "On Windows, keep drive-letter paths in `C:/...` or `C:\\...` form. Never add a leading slash such as `/C:/...` in the Markdown destination.",
-  "Do not arbitrarily limit a multi-image result to its first path. Follow Wanta's artifact output contract when deciding whether a large image set should be inlined or left to the artifact browser.",
-  "Use a remote URL for the inline preview only when no corresponding local path was saved successfully.",
-  localImageDisplayInstructionsEnd,
 ].join("\n")
 
 const localizedSavedPathMatch = "output.match(/(?:Saved to|已保存到|保存至)\\s*[:：]\\s*(.+)/u);"
@@ -55,22 +45,25 @@ export function patchWindowsGptImage2Runner(source: string): string {
     )
 }
 
-/** Adds Wanta-specific, supported team-selection guidance to the private skill copy. */
+/** Keeps only Wanta-specific team guidance; image delivery is native in gpt-image-2 1.1.2+. */
 export function patchGptImage2RuntimeInstructions(source: string): string {
   const lineEnding = source.includes("\r\n") ? "\r\n" : "\n"
-  return appendRuntimeInstructions(
-    appendRuntimeInstructions(
-      source,
-      teamScopeInstructionsStart,
-      teamScopeInstructionsEnd,
-      teamScopeInstructions,
-      lineEnding,
-    ),
+  const withoutLegacyImageInstructions = removeRuntimeInstructions(
+    source,
     localImageDisplayInstructionsStart,
     localImageDisplayInstructionsEnd,
-    localImageDisplayInstructions,
+  )
+  return appendRuntimeInstructions(
+    withoutLegacyImageInstructions,
+    teamScopeInstructionsStart,
+    teamScopeInstructionsEnd,
+    teamScopeInstructions,
     lineEnding,
   )
+}
+
+function removeRuntimeInstructions(source: string, start: string, end: string): string {
+  return source.replace(new RegExp(`${start}[\\s\\S]*?${end}(?:\\r?\\n)?`, "u"), "")
 }
 
 function appendRuntimeInstructions(
@@ -88,23 +81,27 @@ function appendRuntimeInstructions(
   return `${withoutExistingInstructions}${lineEnding}${lineEnding}${instructions.replaceAll("\n", lineEnding)}${lineEnding}`
 }
 
-async function patchInstructions(skillPath: string): Promise<boolean> {
+function skillVersionFromInstructions(source: string): string | undefined {
+  return /^\s*version:\s*['"]?([^\s'"]+)/mu.exec(source)?.[1]
+}
+
+async function patchInstructions(skillPath: string): Promise<{ instructionsPatched: boolean; skillVersion?: string }> {
   const filePath = path.join(skillPath, skillInstructionsPath)
   let source: string
   try {
     source = await readFile(filePath, "utf8")
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false
+      return { instructionsPatched: false }
     }
     throw error
   }
   const patched = patchGptImage2RuntimeInstructions(source)
   if (patched === source) {
-    return false
+    return { instructionsPatched: false, skillVersion: skillVersionFromInstructions(source) }
   }
   await writeFile(filePath, patched, "utf8")
-  return true
+  return { instructionsPatched: true, skillVersion: skillVersionFromInstructions(source) }
 }
 
 /** Applies the compatibility fix only to Wanta's private runtime copy. */
@@ -116,8 +113,8 @@ export async function ensureGptImage2RuntimeCompatibility(
     return false
   }
 
-  const instructionsPatched = await patchInstructions(skillPath)
-  if (platform !== "win32") {
+  const { instructionsPatched, skillVersion } = await patchInstructions(skillPath)
+  if (platform !== "win32" || !semanticVersionIsBefore(skillVersion, nativeWindowsRunnerVersion)) {
     return instructionsPatched
   }
 

--- a/electron/skills/node.ts
+++ b/electron/skills/node.ts
@@ -53,6 +53,7 @@ import {
   upsertDefaultSkillInstallRecord,
 } from "./default-install-store.ts"
 import {
+  defaultRegistrySkillNeedsUpdate,
   isRuntimeSkillInstalled,
   normalizeDefaultRegistrySkillRequest,
   runtimeErrorMessage,
@@ -302,15 +303,29 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
 
   public async updateRegistrySkill(request: UpdateRegistrySkillRequest): Promise<SkillInventory> {
     return this.enqueueSkillMutation(async () => {
-      const result = await this.runOoCommand(createUpdateRegistrySkillArgs(request), {
-        rejectOnFailure: false,
-      })
-      assertOoSkillOperationResult(result, "skills.update")
-      await this.enqueueRuntimeSync(() => this.registryRuntimeSynchronizer.syncUpdated(request))
+      await this.updateRegistrySkillTarget(request)
       this.notifyRuntimeSkillsChanged("update-registry-skill")
 
       return this.readAndPublishSkillInventory()
     })
+  }
+
+  private async updateRegistrySkillTarget(request: UpdateRegistrySkillRequest): Promise<void> {
+    const result = await this.runOoCommand(createUpdateRegistrySkillArgs(request), {
+      rejectOnFailure: false,
+    })
+    assertOoSkillOperationResult(result, "skills.update")
+    await this.enqueueRuntimeSync(() => this.registryRuntimeSynchronizer.syncUpdated(request))
+  }
+
+  private async refreshDefaultRegistrySkillTarget(request: { packageName: string; skillId: string }): Promise<void> {
+    await this.repairCachedRegistrySkillSource(request)
+    await this.enqueueRuntimeSync(() =>
+      this.registryRuntimeSynchronizer.syncSkill(request.skillId, {
+        force: true,
+        packageName: request.packageName,
+      }),
+    )
   }
 
   public async executeCliUpdate(): Promise<SkillVersionReport> {
@@ -563,10 +578,38 @@ export class SkillServiceImpl extends ConnectionService<SkillService> implements
       const now = new Date().toISOString()
 
       if (isRuntimeSkillInstalled(inventory, request.skillId)) {
+        const needsUpdate = defaultRegistrySkillNeedsUpdate(inventory, spec)
+        if (needsUpdate) {
+          try {
+            await this.refreshDefaultRegistrySkillTarget(request)
+            this.notifyRuntimeSkillsChanged("update-default-registry-skill")
+            inventory = await this.readAndPublishSkillInventory()
+          } catch (error) {
+            const message = runtimeErrorMessage(error)
+            console.warn("[wanta] failed to update default registry skill:", {
+              error: message,
+              minimumVersion: spec.minimumVersion,
+              packageName: request.packageName,
+              skillId: request.skillId,
+            })
+            installStore = upsertDefaultSkillInstallRecord(installStore, {
+              ...request,
+              installedAt: existingRecord?.installedAt ?? now,
+              lastAttemptAt: now,
+              lastError: message,
+              status: "failed",
+              updatedAt: now,
+            })
+            await store.write(installStore)
+            await ensureGptImage2RuntimeCompatibility(path.join(this.getSharedAgentSkillRoot(), request.skillId))
+            continue
+          }
+        }
         await ensureGptImage2RuntimeCompatibility(path.join(this.getSharedAgentSkillRoot(), request.skillId))
         installStore = upsertDefaultSkillInstallRecord(installStore, {
           ...request,
           installedAt: existingRecord?.installedAt ?? now,
+          ...(needsUpdate ? { lastAttemptAt: now } : {}),
           status: "installed",
           updatedAt: now,
         })

--- a/electron/skills/semantic-version.test.ts
+++ b/electron/skills/semantic-version.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { semanticVersionIsBefore } from "./semantic-version.ts"
+
+describe("semanticVersionIsBefore", () => {
+  it.each([
+    [undefined, "1.1.2", true],
+    ["1.1.1", "1.1.2", true],
+    ["1.1.2-beta.1", "1.1.2", true],
+    ["1.1.2", "1.1.2", false],
+    ["1.1.3", "1.1.2", false],
+    ["1.2.0", "1.1.2", false],
+    ["v2.0.0", "1.1.2", false],
+  ])("compares %s against minimum %s", (current, minimum, expected) => {
+    expect(semanticVersionIsBefore(current, minimum)).toBe(expected)
+  })
+})

--- a/electron/skills/semantic-version.test.ts
+++ b/electron/skills/semantic-version.test.ts
@@ -20,6 +20,8 @@ describe("semanticVersionIsBefore", () => {
     ["1.0.0-alpha", "1.0.0-alpha.1", true],
     ["1.0.0-alpha.1", "1.0.0-alpha", false],
     ["1.1.2+build.99", "1.1.2+build.1", false],
+    ["1.1.2-alpha..1", "1.1.2-alpha.1", true],
+    ["1.1.2+build..1", "1.1.2", true],
   ])("compares %s against minimum %s", (current, minimum, expected) => {
     expect(semanticVersionIsBefore(current, minimum)).toBe(expected)
   })

--- a/electron/skills/semantic-version.test.ts
+++ b/electron/skills/semantic-version.test.ts
@@ -10,6 +10,16 @@ describe("semanticVersionIsBefore", () => {
     ["1.1.3", "1.1.2", false],
     ["1.2.0", "1.1.2", false],
     ["v2.0.0", "1.1.2", false],
+    ["9007199254740992.0.0", "9007199254740993.0.0", true],
+    ["9007199254740993.0.0", "9007199254740992.0.0", false],
+    ["1.0.0-alpha.2", "1.0.0-alpha.10", true],
+    ["1.0.0-alpha.9007199254740992", "1.0.0-alpha.9007199254740993", true],
+    ["1.0.0-1", "1.0.0-alpha", true],
+    ["1.0.0-alpha", "1.0.0-1", false],
+    ["1.0.0-Alpha", "1.0.0-alpha", true],
+    ["1.0.0-alpha", "1.0.0-alpha.1", true],
+    ["1.0.0-alpha.1", "1.0.0-alpha", false],
+    ["1.1.2+build.99", "1.1.2+build.1", false],
   ])("compares %s against minimum %s", (current, minimum, expected) => {
     expect(semanticVersionIsBefore(current, minimum)).toBe(expected)
   })

--- a/electron/skills/semantic-version.ts
+++ b/electron/skills/semantic-version.ts
@@ -4,7 +4,10 @@ interface ParsedSemanticVersion {
 }
 
 function parseSemanticVersion(value: string): ParsedSemanticVersion | null {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(value.trim())
+  const match =
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      value.trim(),
+    )
   if (!match) {
     return null
   }

--- a/electron/skills/semantic-version.ts
+++ b/electron/skills/semantic-version.ts
@@ -1,0 +1,46 @@
+interface ParsedSemanticVersion {
+  core: [number, number, number]
+  prerelease: string[]
+}
+
+function parseSemanticVersion(value: string): ParsedSemanticVersion | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value.trim())
+  if (!match) {
+    return null
+  }
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4]?.split(".") ?? [],
+  }
+}
+
+export function semanticVersionIsBefore(current: string | undefined, minimum: string): boolean {
+  if (!current?.trim()) {
+    return true
+  }
+  const parsedCurrent = parseSemanticVersion(current)
+  const parsedMinimum = parseSemanticVersion(minimum)
+  if (!parsedCurrent || !parsedMinimum) {
+    return current.trim() !== minimum.trim()
+  }
+
+  for (let index = 0; index < parsedCurrent.core.length; index += 1) {
+    const currentPart = parsedCurrent.core[index] ?? 0
+    const minimumPart = parsedMinimum.core[index] ?? 0
+    if (currentPart !== minimumPart) {
+      return currentPart < minimumPart
+    }
+  }
+
+  if (parsedCurrent.prerelease.length === 0) {
+    return false
+  }
+  if (parsedMinimum.prerelease.length === 0) {
+    return true
+  }
+  return (
+    parsedCurrent.prerelease.join(".").localeCompare(parsedMinimum.prerelease.join("."), undefined, {
+      numeric: true,
+    }) < 0
+  )
+}

--- a/electron/skills/semantic-version.ts
+++ b/electron/skills/semantic-version.ts
@@ -1,17 +1,74 @@
 interface ParsedSemanticVersion {
-  core: [number, number, number]
+  core: [string, string, string]
   prerelease: string[]
 }
 
 function parseSemanticVersion(value: string): ParsedSemanticVersion | null {
-  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value.trim())
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(value.trim())
   if (!match) {
     return null
   }
   return {
-    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    core: [match[1]!, match[2]!, match[3]!],
     prerelease: match[4]?.split(".") ?? [],
   }
+}
+
+function normalizeNumericIdentifier(value: string): string {
+  return value.replace(/^0+(?=\d)/, "")
+}
+
+function compareNumericIdentifiers(left: string, right: string): number {
+  const normalizedLeft = normalizeNumericIdentifier(left)
+  const normalizedRight = normalizeNumericIdentifier(right)
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return normalizedLeft.length < normalizedRight.length ? -1 : 1
+  }
+  if (normalizedLeft === normalizedRight) {
+    return 0
+  }
+  return normalizedLeft < normalizedRight ? -1 : 1
+}
+
+function comparePrereleaseIdentifiers(left: string[], right: string[]): number {
+  const length = Math.max(left.length, right.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left[index]
+    const rightIdentifier = right[index]
+    if (leftIdentifier === undefined) return -1
+    if (rightIdentifier === undefined) return 1
+    if (leftIdentifier === rightIdentifier) continue
+
+    const leftIsNumeric = /^\d+$/.test(leftIdentifier)
+    const rightIsNumeric = /^\d+$/.test(rightIdentifier)
+    if (leftIsNumeric && rightIsNumeric) {
+      const comparison = compareNumericIdentifiers(leftIdentifier, rightIdentifier)
+      if (comparison !== 0) return comparison
+      continue
+    }
+    if (leftIsNumeric !== rightIsNumeric) {
+      return leftIsNumeric ? -1 : 1
+    }
+    return leftIdentifier < rightIdentifier ? -1 : 1
+  }
+  return 0
+}
+
+function compareSemanticVersions(left: ParsedSemanticVersion, right: ParsedSemanticVersion): number {
+  for (let index = 0; index < left.core.length; index += 1) {
+    const comparison = compareNumericIdentifiers(left.core[index]!, right.core[index]!)
+    if (comparison !== 0) {
+      return comparison
+    }
+  }
+
+  if (left.prerelease.length === 0) {
+    return right.prerelease.length === 0 ? 0 : 1
+  }
+  if (right.prerelease.length === 0) {
+    return -1
+  }
+  return comparePrereleaseIdentifiers(left.prerelease, right.prerelease)
 }
 
 export function semanticVersionIsBefore(current: string | undefined, minimum: string): boolean {
@@ -24,23 +81,5 @@ export function semanticVersionIsBefore(current: string | undefined, minimum: st
     return current.trim() !== minimum.trim()
   }
 
-  for (let index = 0; index < parsedCurrent.core.length; index += 1) {
-    const currentPart = parsedCurrent.core[index] ?? 0
-    const minimumPart = parsedMinimum.core[index] ?? 0
-    if (currentPart !== minimumPart) {
-      return currentPart < minimumPart
-    }
-  }
-
-  if (parsedCurrent.prerelease.length === 0) {
-    return false
-  }
-  if (parsedMinimum.prerelease.length === 0) {
-    return true
-  }
-  return (
-    parsedCurrent.prerelease.join(".").localeCompare(parsedMinimum.prerelease.join("."), undefined, {
-      numeric: true,
-    }) < 0
-  )
+  return compareSemanticVersions(parsedCurrent, parsedMinimum) < 0
 }

--- a/src/components/ai-elements/message-image.retry.test.tsx
+++ b/src/components/ai-elements/message-image.retry.test.tsx
@@ -282,3 +282,20 @@ test("keeps a Windows Markdown image at its authored position", async () => {
   expect(invoke).toHaveBeenCalledTimes(1)
   act(() => root.unmount())
 })
+
+test("repairs a leading slash before a Windows drive in Markdown images", async () => {
+  const invoke = vi
+    .fn()
+    .mockResolvedValue({ resourceExpiresAt: Date.now() + 120_000, resourceUrl: "wanta-resource://inline" })
+  const { host, root } = await renderResponse(
+    "before ![artifact](</C:/Users/Cheerego/output%20files/artifact.png>) after",
+    invoke,
+  )
+
+  expect(invoke).toHaveBeenCalledWith("getAttachmentPreview", {
+    path: "C:/Users/Cheerego/output files/artifact.png",
+    mime: "application/octet-stream",
+  })
+  expect(host.querySelector('img[src="wanta-resource://inline"]')).not.toBeNull()
+  act(() => root.unmount())
+})

--- a/src/components/ai-elements/message-image.tsx
+++ b/src/components/ai-elements/message-image.tsx
@@ -121,6 +121,10 @@ function decodeLocalImagePath(value: string): string {
     .join("")
 }
 
+function normalizeWindowsDrivePath(value: string): string {
+  return /^\/[A-Za-z]:[\\/]/.test(value) ? value.slice(1) : value
+}
+
 export function localImagePathFromSrc(src: string | undefined): string | null {
   const value = src?.trim()
   if (value?.startsWith(localImagePreviewMarkerPrefix)) {
@@ -137,13 +141,13 @@ export function localImagePathFromSrc(src: string | undefined): string | null {
     try {
       const url = new URL(value)
       const decoded = decodeURIComponent(url.pathname)
-      return /^\/[A-Za-z]:[\\/]/.test(decoded) ? decoded.slice(1) : decoded
+      return normalizeWindowsDrivePath(decoded)
     } catch {
       return null
     }
   }
   if (/^(?:[\\/]|[A-Za-z]:[\\/])/.test(value)) {
-    return decodeLocalImagePath(value)
+    return normalizeWindowsDrivePath(decodeLocalImagePath(value))
   }
   return null
 }

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -320,6 +320,13 @@ describe("MarkdownImage", () => {
     ).toBe("C:/Users/me/output files/image.png")
   })
 
+  it("removes a mistaken leading slash from Windows drive paths", () => {
+    expect(localImagePathFromSrc("/C:/Users/me/output%20files/image.png")).toBe("C:/Users/me/output files/image.png")
+    expect(
+      localImagePathFromSrc("https://wanta.local/__local-image__/%2FC%3A%2FUsers%2Fme%2Foutput%2520files%2Fimage.png"),
+    ).toBe("C:/Users/me/output files/image.png")
+  })
+
   it("does not treat home-relative image paths as absolute local paths", () => {
     expect(localImagePathFromSrc("~/output/image.png")).toBeNull()
   })

--- a/src/components/ai-elements/message.test.ts
+++ b/src/components/ai-elements/message.test.ts
@@ -18,6 +18,7 @@ import {
 import { MessageStreamdown } from "./message-streamdown.tsx"
 import {
   compactLocalPath,
+  extractLocalImagePreviews,
   markdownCodeLanguage,
   markdownCodeRendererLanguages,
   markdownCodeText,
@@ -220,6 +221,32 @@ describe("normalizeLocalImageMarkdown", () => {
     expect(normalizeLocalImageMarkdown("![image](https://example.com/output image.png)")).toBe(
       "![image](https://example.com/output image.png)",
     )
+  })
+})
+
+describe("extractLocalImagePreviews", () => {
+  it("does not append a duplicate preview when an encoded Markdown image is repeated as a decoded path", () => {
+    const encodedPath = "/Users/me/Library/Application%20Support/wanta/agent/artifacts/turn/cute-cat.png"
+    const decodedPath = "/Users/me/Library/Application Support/wanta/agent/artifacts/turn/cute-cat.png"
+    const markdown = [`![generated cat](${encodedPath})`, "", "Saved to:", `\`${decodedPath}\``].join("\n")
+
+    expect(extractLocalImagePreviews(markdown)).toEqual([])
+  })
+
+  it("deduplicates equivalent Windows path separators", () => {
+    const markdown = [
+      String.raw`![generated](C:\Users\me\output%20files\image.png)`,
+      "",
+      String.raw`C:/Users/me/output files/image.png`,
+    ].join("\n")
+
+    expect(extractLocalImagePreviews(markdown)).toEqual([])
+  })
+
+  it("still appends a preview for a standalone local image path", () => {
+    expect(extractLocalImagePreviews("Saved to `/Users/me/output/image.png`")).toEqual([
+      { path: "/Users/me/output/image.png", alt: "image.png" },
+    ])
   })
 })
 

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -20,7 +20,7 @@ import {
   CodeBlockTitle,
 } from "./code-block.tsx"
 import { incompleteMermaidLanguage, normalizeMermaidMarkdown } from "./mermaid-policy.ts"
-import { MarkdownImage } from "./message-image.tsx"
+import { localImagePathFromSrc, MarkdownImage } from "./message-image.tsx"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useT } from "@/i18n/i18n"
@@ -400,11 +400,25 @@ function localImageAltText(value: string): string {
   return normalized.split(/[\\/]/).pop() || "image"
 }
 
-function extractLocalImagePreviews(markdown: string): LocalImagePreview[] {
+function localImageIdentity(value: string): string {
+  const localPath = localImagePathFromSrc(value)
+  if (!localPath) {
+    return value
+  }
+  const normalizedSeparators = localPath.replaceAll("\\", "/")
+  return normalizedSeparators.replace(/^([A-Z]):\//, (_match, drive: string) => `${drive.toLowerCase()}:/`)
+}
+
+export function extractLocalImagePreviews(markdown: string): LocalImagePreview[] {
   const previews: LocalImagePreview[] = []
-  const embeddedSources = new Set(extractMarkdownImageSources(markdown))
+  const embeddedSources = new Set(extractMarkdownImageSources(markdown).map(localImageIdentity))
   for (const candidate of extractLocalImagePaths(markdown)) {
-    if (candidate && !embeddedSources.has(candidate) && !previews.some((preview) => preview.path === candidate)) {
+    const identity = localImageIdentity(candidate)
+    if (
+      candidate &&
+      !embeddedSources.has(identity) &&
+      !previews.some((preview) => localImageIdentity(preview.path) === identity)
+    ) {
       previews.push({ path: candidate, alt: localImageAltText(candidate) })
     }
   }
@@ -581,10 +595,10 @@ export const MessageResponse = memo(
     )
     return (
       // fallback 直接铺原始 markdown 文本：streamdown chunk 首次加载时内容即可见，加载完再升级为富渲染。
-      <Suspense fallback={<div className={cn("size-full whitespace-pre-wrap", className)}>{responseChildren}</div>}>
+      <Suspense fallback={<div className={cn("w-full whitespace-pre-wrap", className)}>{responseChildren}</div>}>
         <>
           <Streamdown
-            className={cn("oo-message-response size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+            className={cn("oo-message-response w-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
             components={{
               ...messageResponseComponents,
               inlineCode: MarkdownInlineCode,


### PR DESCRIPTION
## Summary

Stabilize generated-image replies across macOS and Windows, then move the GPT Image 2 compatibility fixes into the published `@zjxuyunshi/gpt-image-2@1.1.2` baseline instead of continuing to patch current runners inside Wanta.

The change keeps Wanta's renderer and artifact contract defensive while making the private Wanta Skill runtime upgrade its isolated registry cache and runtime copy to the validated upstream version. Older Windows runtimes retain a narrowly version-gated fallback when an offline or failed upgrade leaves them below the baseline.

## User impact

- Generated-image replies no longer reserve a large blank area below the inline preview.
- A saved image mentioned once as percent-encoded Markdown and again as a decoded local path no longer creates a hidden duplicate preview.
- Windows Markdown destinations such as `</C:/Users/...>` are repaired before requesting the local attachment preview.
- GPT Image 2 downloads accept localized `Saved to`, `已保存到`, and `保存至` output with half-width or full-width colons.
- Wanta's isolated GPT Image 2 cache and runtime automatically move from `1.1.1` to the validated public `1.1.2` baseline.
- Current `1.1.2+` runners are left untouched; Wanta removes its obsolete duplicate local-image instruction block and retains only Wanta-specific team-scope guidance.

## Root causes

The blank preview area came from two interacting renderer issues. The same local file appeared as an encoded Markdown source and a decoded inline-code path, but deduplication compared the raw strings. Wanta appended a second fallback image. The Markdown renderer also used `height: 100%`, so its box absorbed the fallback image's height while the fallback itself overflowed into an `overflow-hidden` ancestor.

On Windows, an agent could add a leading slash before a drive letter. The existing local-path parser treated `/C:/...` as a POSIX-style absolute path and sent that invalid Windows path to the attachment preview service.

Wanta had also accumulated exact-source runner rewrites and an appended local-image Skill block. Those were originally needed for GPT Image 2 `1.1.1`, but the fixes now live in the public `1.1.2` package. A normal `oo skills update` did not refresh Wanta's isolated cache because it could observe the already-current Universal installation, so the default migration must force-refresh the isolated package source before synchronizing the Wanta runtime.

## Fix

- Canonicalize local image identities before fallback-preview deduplication, including percent encoding, Windows drive letters, and slash variants.
- Let Markdown responses use intrinsic height instead of forcing `height: 100%`.
- Normalize an erroneous leading slash before Windows drive-letter image paths and retain explicit unavailable states for failed previews.
- Keep the general artifact prompt's Windows path and local-preview contract for all image producers.
- Declare `gpt-image-2` minimum version `1.1.2` in the default registry set.
- Compare semantic versions rather than raw strings and avoid replacing local or differently packaged Skills that share an id.
- Force-refresh Wanta's isolated registry source and atomically resynchronize the private runtime when it is below the baseline.
- Remove the old Wanta local-image instruction injection for every runtime and skip runner rewrites for `1.1.2+`.
- Preserve the legacy Windows runner repair only for versions below `1.1.2`, including when an upgrade fails offline.

## Verification

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec oxfmt --check` for all changed Skill runtime files
- `corepack pnpm exec vitest run ...` — 10 files and 164 tests passed after review follow-ups
- `corepack pnpm run build`
- `git diff --check`
- Real Chromium/Electron layout probe against the original generated-cat conversation: one image node, no fallback preview, and the response box shrank from 796 px to its 440 px intrinsic height.
- Real logged-in Wanta development profile upgrade: isolated registry cache and runtime both moved from `gpt-image-2@1.1.1` to `1.1.2`; the native runner remained unmodified, the obsolete local-image injection was absent, Wanta team-scope guidance remained singular, and the runtime stopped refreshing after the one successful migration.
- CodeRabbit follow-up: semantic-version precedence now avoids JavaScript number precision and locale collation, compares prerelease identifiers according to SemVer, ignores build metadata, and rejects empty prerelease/build segments such as `alpha..1` and `build..1`.

## Safety and compatibility

- The public GPT Image 2 package remains public and the current Hub version is `1.1.2`.
- User-managed local Skills and differently packaged Skills with the same id are not replaced by the default migration.
- Upgrade failure keeps the existing runtime and applies the old Windows compatibility only when the installed version remains below `1.1.2`.
- Wanta credential and store isolation remains unchanged; no terminal process reads or copies Electron session credentials.
- The renderer continues to accept historical malformed Windows paths from old conversations and non-GPT image producers.
