### PR TITLE
fix(chat): auto-approve bounded Python success markers

### DIFF
--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -424,19 +424,22 @@ test("default access auto-approves direct Python requirements in bounded task or
     ),
     { type: "allow", reason: "trusted_dependency", kind: "command", highRisk: false },
   )
-  assert.deepEqual(
-    evaluateLocalAccessRequest(
-      permission({
-        metadata: {
-          command:
-            `python3 -m venv "${processRoot}/.wanta-python" && ` +
-            `"${processRoot}/.wanta-python/bin/python" -m pip install openpyxl -q && echo OK`,
-        },
-      }),
-      { permissionMode: "default", taskProcessRoot: processRoot },
-    ),
-    { type: "allow", reason: "trusted_dependency", kind: "command", highRisk: false },
-  )
+  for (const marker of ["OK", "done", "success"]) {
+    assert.deepEqual(
+      evaluateLocalAccessRequest(
+        permission({
+          metadata: {
+            command:
+              `python3 -m venv "${processRoot}/.wanta-python" && ` +
+              `"${processRoot}/.wanta-python/bin/python" -m pip install openpyxl -q && echo ${marker}`,
+          },
+        }),
+        { permissionMode: "default", taskProcessRoot: processRoot },
+      ),
+      { type: "allow", reason: "trusted_dependency", kind: "command", highRisk: false },
+      marker,
+    )
+  }
   assert.deepEqual(
     evaluateLocalAccessRequest(
       permission({
@@ -514,6 +517,8 @@ test("bounded Python bootstrap approval preserves the nearest protected boundari
     `python3 -m venv "${environment}" && python3 -m pip install python-docx`,
     `"${environment}/bin/python" -m pip install python-docx > /tmp/install.log`,
     `python3 -m venv "${environment}" && "${environment}/bin/python" -m pip install python-docx && echo "$HOME"`,
+    `python3 -m venv "${environment}" && "${environment}/bin/python" -m pip install python-docx && echo OK &&`,
+    `python3 -m venv "${environment}" && "${environment}/bin/python" -m pip install python-docx && ./echo OK`,
   ]
   for (const command of promptCommands) {
     assert.deepEqual(

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -427,6 +427,19 @@ test("default access auto-approves direct Python requirements in bounded task or
   assert.deepEqual(
     evaluateLocalAccessRequest(
       permission({
+        metadata: {
+          command:
+            `python3 -m venv "${processRoot}/.wanta-python" && ` +
+            `"${processRoot}/.wanta-python/bin/python" -m pip install openpyxl -q && echo OK`,
+        },
+      }),
+      { permissionMode: "default", taskProcessRoot: processRoot },
+    ),
+    { type: "allow", reason: "trusted_dependency", kind: "command", highRisk: false },
+  )
+  assert.deepEqual(
+    evaluateLocalAccessRequest(
+      permission({
         metadata: { command: `${processRoot}/.wanta-python/bin/python -m pip install fitz` },
       }),
       { permissionMode: "default", taskProcessRoot: processRoot },
@@ -500,6 +513,7 @@ test("bounded Python bootstrap approval preserves the nearest protected boundari
     `python3 -m venv "${processRoot}/other" && "${environment}/bin/python" -m pip install python-docx`,
     `python3 -m venv "${environment}" && python3 -m pip install python-docx`,
     `"${environment}/bin/python" -m pip install python-docx > /tmp/install.log`,
+    `python3 -m venv "${environment}" && "${environment}/bin/python" -m pip install python-docx && echo "$HOME"`,
   ]
   for (const command of promptCommands) {
     assert.deepEqual(

--- a/electron/chat/permission-request.ts
+++ b/electron/chat/permission-request.ts
@@ -412,7 +412,35 @@ function boundedPythonInstallCommand(
     }
     body = possibleBootstrap.right
   }
-  return { body, ...(directory ? { directory } : {}) }
+  return { body: commandWithoutSafeSuccessMarker(body), ...(directory ? { directory } : {}) }
+}
+
+/**
+ * A success marker is commonly appended to a generated environment bootstrap
+ * so a calling agent can distinguish a completed install from command output.
+ * It has no side effect beyond stdout, so it should not make an otherwise
+ * bounded task-local installation require approval. Keep this deliberately
+ * narrow: variable expansion, additional shell syntax, and every other
+ * trailing command remain visible to the normal risk policy.
+ */
+function commandWithoutSafeSuccessMarker(command: string): string {
+  const segments = topLevelShellSegments(command)
+  if (
+    segments.length !== 2 ||
+    segments[0]?.operatorAfter !== "and" ||
+    !isLiteralSuccessMarker(segments[1]?.text ?? "")
+  ) {
+    return command
+  }
+  return segments[0]?.text ?? command
+}
+
+function isLiteralSuccessMarker(command: string): boolean {
+  const words = shellWords(command)
+  if (!words || shellCommandName(words[0]) !== "echo" || words.length !== 2) {
+    return false
+  }
+  return ["ok", "done", "success"].includes((words[1] ?? "").toLowerCase())
 }
 
 function scopedPythonDependencyInstall(

--- a/electron/chat/permission-request.ts
+++ b/electron/chat/permission-request.ts
@@ -427,7 +427,9 @@ function commandWithoutSafeSuccessMarker(command: string): string {
   const segments = topLevelShellSegments(command)
   if (
     segments.length !== 2 ||
+    !segments[0]?.text ||
     segments[0]?.operatorAfter !== "and" ||
+    segments[1]?.operatorAfter !== undefined ||
     !isLiteralSuccessMarker(segments[1]?.text ?? "")
   ) {
     return command
@@ -437,7 +439,7 @@ function commandWithoutSafeSuccessMarker(command: string): string {
 
 function isLiteralSuccessMarker(command: string): boolean {
   const words = shellWords(command)
-  if (!words || shellCommandName(words[0]) !== "echo" || words.length !== 2) {
+  if (!words || words[0] !== "echo" || words.length !== 2) {
     return false
   }
   return ["ok", "done", "success"].includes((words[1] ?? "").toLowerCase())


### PR DESCRIPTION
## Summary

A bounded task-local Python bootstrap can legitimately end with a literal success marker such as `&& echo OK`. The permission classifier previously treated that harmless marker as an unrecognized shell composition and surfaced a dependency-mutation approval.

This change recognizes only the narrow, literal success markers `echo OK`, `echo done`, and `echo success` after an otherwise valid managed `.wanta-python` environment installation. The marker is removed before the existing bounded-install classifier runs.

## Safety

The approved install still must create and use the exact private `.wanta-python` interpreter in the active turn process directory. Variable expansion, additional shell syntax, arbitrary trailing commands, external package sources, and redirections remain subject to the existing permission policy. A regression test confirms that `echo "$HOME"` is not accepted as a success marker.

## Validation

- `pnpm exec vitest run electron/chat/local-access-policy.test.ts`
- `pnpm run ts-check`
- `pnpm run lint`
- `pnpm exec oxfmt --check electron/chat/permission-request.ts electron/chat/local-access-policy.test.ts`
- `git diff --check`
