### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,17 +57,18 @@ jobs:
       refresh_beta: ${{ steps.version.outputs.REFRESH_BETA }}
       cdn_files: ${{ steps.version.outputs.CDN_FILES }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           # 本 job 只跑 node scripts/release-version.ts，从不安装依赖。
           # setup-node@v5 默认 package-manager-cache: true 会自动探测
           # pnpm-lock.yaml 并调用 pnpm 算缓存 key，但此处未装 pnpm，直接
-          # 报 "Unable to locate executable file: pnpm"。关掉即可（注意
+          # 报 "Unable to locate executable file: pnpm"。setup-node@v6 起自动
+          # 缓存只认 npm、不再探测 pnpm，这里保留显式关闭作为防御（注意
           # cache: "" 关不掉这个自动探测，必须用 package-manager-cache）。
           package-manager-cache: false
       - name: Compute version
@@ -128,10 +129,10 @@ jobs:
       CHANNEL: ${{ needs.compute-version.outputs.channel }}
       REFRESH_BETA: ${{ needs.compute-version.outputs.refresh_beta }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+        uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: pnpm
@@ -260,7 +261,7 @@ jobs:
           audience: https://github.com/oomol-lab
 
       - name: Cache rclone
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/bin/rclone
           key: rclone-${{ runner.os }}-${{ runner.arch }}-${{ env.PINNED_RCLONE_VERSION }}
@@ -326,8 +327,8 @@ jobs:
       CHANNEL: ${{ needs.compute-version.outputs.channel }}
       REFRESH_BETA: ${{ needs.compute-version.outputs.refresh_beta }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           # This self-hosted runner cannot authenticate to the GitHub Actions
@@ -337,7 +338,9 @@ jobs:
           # setup-node took 20 min while the actual `pnpm install` took 34 s (run
           # 29923188224). The runner's disk already persists pnpm's store
           # across runs, so the GitHub-side cache is pure overhead here.
-          # Disable it. Hosted runners (release-mac, pr.yml) keep it enabled.
+          # setup-node@v6+ only auto-caches for npm, but keep this explicit
+          # off as a guard. Hosted runners (release-mac, pr.yml) keep their
+          # explicit `cache: pnpm`.
           package-manager-cache: false
       - name: Set env + version
         shell: bash
@@ -512,16 +515,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           # 同 compute-version：本 job 只跑 node scripts/release-size.ts 与 git/gh，
-          # 从不安装 pnpm 依赖。关掉自动 package-manager 缓存，否则 setup-node@v5
-          # 会因探测到 pnpm-lock.yaml 却找不到 pnpm 而报错。
+          # 从不安装 pnpm 依赖。关掉自动 package-manager 缓存（v5 会因探测到
+          # pnpm-lock.yaml 却找不到 pnpm 而报错；v6+ 自动缓存只认 npm，保留防御）。
           package-manager-cache: false
 
       # 拉取各平台 build job 上传的全部 release-size-* 元数据（都是小 JSON，绝不在此
@@ -643,7 +646,7 @@ jobs:
       CDN_FILES: ${{ needs.compute-version.outputs.cdn_files }}
     steps:
       - name: Cache Aliyun CLI
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/bin/aliyun
           key: aliyun-cli-${{ runner.os }}-${{ runner.arch }}-${{ env.PINNED_ALIYUN_CLI_VERSION }}


### PR DESCRIPTION
## Summary

Every workflow run is currently annotated with "Node.js 20 is deprecated", because four of the action refs we pin still resolve to a node20 build. This moves each of them to its node24 release: `pnpm/action-setup` v4 to v6, `actions/checkout` v6 to v7, `actions/setup-node` v5 to v7, `actions/cache` v5 to v6. `pnpm/action-setup` is the non-obvious one, its floating v4 tag is still published as `runs.using: node20` even though v4 reads as current next to the other refs, so it is the offender that survives the ones you would guess.

Nothing but the refs changes. None of these majors removed an input we use: `always-auth`, dropped in setup-node v7, appears nowhere, and `package-manager-cache` still exists in v7, so the three jobs that install no dependencies keep disabling it. The two jobs that do install dependencies already pass an explicit `cache: pnpm`, which is what keeps pnpm caching working now that setup-node v6 and later auto-cache for npm only. pnpm's major stays pinned by the `packageManager` field in _package.json_ (`pnpm@11.21.0`), and pnpm/action-setup v6 is the first release that supports pnpm 11, so the installed pnpm cannot drift. Comments sitting next to the changed refs are rewritten where they described v5 behaviour that no longer holds.

`actions/upload-artifact@v7`, `actions/download-artifact@v8`, `nick-fields/retry@v4` and `aliyun/configure-aliyun-credentials-action@v1.1.0` already run on node24 and are left alone. The self-hosted Windows runner used by `release-win` already executes node24 actions today, so it needs no upgrade. Note that _release.yml_ is `workflow_dispatch` only and is therefore not exercised by this PR, its refs were verified against each action's published `action.yml` instead.

## Verification

`actionlint` is clean on both workflows and both parse as YAML. The five commands below are exactly what the `Check Pull Request` job runs, on this PR, through the upgraded action refs, and it passed on this head, which is the verification for all of them.

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run format`
- [x] `corepack pnpm test`
- [x] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.
