### PR TITLE
feat(chat): add explicit artifact publication

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -170,6 +170,13 @@ External agents build on `electron/agent/external/`:
   preserves the original user text. This remains a guidance transport; Wanta's
   guarded command and host-capability layers enforce identity independently of
   whether the agent follows the prompt.
+- **Artifact publication**: every adapter receives the same artifact and process
+  roots plus the same explicit publication instructions. Final files are
+  declared with relative paths in `.wanta-artifact.json`; raw responses,
+  temporary scripts, logs, checkpoints, and machine-review data stay in the
+  process root. The chat finalizer validates the declaration and persists the
+  normalized bundle, so adapters never need an artifact-specific method or UI
+  branch.
 - **Usage reporting**: adapters emit `usageUpdated` (normalized
   `ChatTokenUsage` + optional `contextWindow`) from ACP `usage_update`. The recorder attaches it to the
   latest assistant message, which is what lights the composer context meter.

--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -170,6 +170,14 @@ artifact/scratch-process locations and uses the same finalizer. `ask_user`
 bridges a blocking tool call to Wanta's structured-question UI and is cancelled
 on task deletion or shutdown.
 
+Final deliverables use the adapter-independent `.wanta-artifact.json`
+publication declaration. The host resolves and validates only relative,
+non-symbolic-link files inside the current turn's artifact root, persists their
+primary/supporting/summary roles in a versioned artifact bundle, and routes
+undeclared or metadata files to execution details. Turns without a declaration
+retain legacy inference for compatibility; a present but invalid declaration
+fails closed instead of exposing the whole directory as final output.
+
 Wanta intentionally does not expose a second arbitrary-command process manager
 as a host capability. Local subprocess start/stop remains an agent-native tool
 subject to that adapter's permission flow; Wanta owns only the per-turn scratch

--- a/electron/agent/acp/translator.test.ts
+++ b/electron/agent/acp/translator.test.ts
@@ -294,6 +294,20 @@ describe("agent_thought_chunk", () => {
       },
     ])
   })
+
+  test("synthetic message ids use a restart-safe translator namespace", () => {
+    const firstTranslator = createAcpSessionTranslator(SESSION_ID)
+    const secondTranslator = createAcpSessionTranslator(SESSION_ID)
+    firstTranslator.noteTurnStarted()
+    secondTranslator.noteTurnStarted()
+
+    const firstId = messageIdOf(firstTranslator.translate(textChunk("first"))[0]!)
+    const secondId = messageIdOf(secondTranslator.translate(textChunk("second"))[0]!)
+
+    expect(firstId).toMatch(/^acp-msg-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-1$/u)
+    expect(secondId).toMatch(/^acp-msg-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-1$/u)
+    expect(secondId).not.toBe(firstId)
+  })
 })
 
 describe("tool_call lifecycle", () => {

--- a/electron/agent/acp/translator.test.ts
+++ b/electron/agent/acp/translator.test.ts
@@ -296,8 +296,8 @@ describe("agent_thought_chunk", () => {
   })
 
   test("synthetic message ids use a restart-safe translator namespace", () => {
-    const firstTranslator = createAcpSessionTranslator(SESSION_ID)
-    const secondTranslator = createAcpSessionTranslator(SESSION_ID)
+    const firstTranslator = createAcpSessionTranslator(SESSION_ID, undefined, "11111111-1111-4111-8111-111111111111")
+    const secondTranslator = createAcpSessionTranslator(SESSION_ID, undefined, "22222222-2222-4222-8222-222222222222")
     firstTranslator.noteTurnStarted()
     secondTranslator.noteTurnStarted()
 

--- a/electron/agent/acp/translator.ts
+++ b/electron/agent/acp/translator.ts
@@ -190,11 +190,11 @@ function toolOutputText(snapshot: ToolCallSnapshot): string {
 export function createAcpSessionTranslator(
   wantaSessionId: string,
   wantaHostServerNames: ReadonlySet<string> = new Set(),
+  syntheticIdNamespace = randomUUID(),
 ): AcpSessionTranslator {
   // Agent-provided message ids are optional. The fallback must remain unique
   // after an Electron main restart; a process-local counter would reset and
   // merge new turn parts into persisted transcript messages from an older run.
-  const instanceId = randomUUID()
   let messageSeq = 0
   /** Message the next chunk/tool call belongs to when the agent omits messageId. */
   let currentMessageId: string | undefined
@@ -209,7 +209,7 @@ export function createAcpSessionTranslator(
 
   function mintMessageId(): string {
     messageSeq += 1
-    return `acp-msg-${instanceId}-${messageSeq}`
+    return `acp-msg-${syntheticIdNamespace}-${messageSeq}`
   }
 
   function ensureStarted(messageId: string, events: AgentEvent[]): void {

--- a/electron/agent/acp/translator.ts
+++ b/electron/agent/acp/translator.ts
@@ -2,6 +2,7 @@ import type { AssistantActivityPhase, ChatMessage } from "../../chat/common.ts"
 import type { AgentEvent } from "../contract/event.ts"
 import type { ContentBlock, SessionUpdate, ToolCallContent } from "@agentclientprotocol/sdk"
 
+import { randomUUID } from "node:crypto"
 import { classifyToolFailure } from "../tool-failure.ts"
 
 // ACP session/update -> AgentEvent translation (BYOA phase 2).
@@ -37,13 +38,6 @@ interface ToolCallSnapshot {
   rawOutput?: unknown
   content: ToolCallContent[]
 }
-
-/**
- * Global sequence for synthetic message ids. Translator instances for the same
- * Wanta session can be recreated (agent respawn after a crash), so ids must
- * stay unique across instances or transcript bubbles would merge.
- */
-let translatorSeq = 0
 
 interface AcpCompactionStatus {
   phase: Extract<AssistantActivityPhase, "compacting" | "resuming" | "retrying">
@@ -197,7 +191,10 @@ export function createAcpSessionTranslator(
   wantaSessionId: string,
   wantaHostServerNames: ReadonlySet<string> = new Set(),
 ): AcpSessionTranslator {
-  const seed = ++translatorSeq
+  // Agent-provided message ids are optional. The fallback must remain unique
+  // after an Electron main restart; a process-local counter would reset and
+  // merge new turn parts into persisted transcript messages from an older run.
+  const instanceId = randomUUID()
   let messageSeq = 0
   /** Message the next chunk/tool call belongs to when the agent omits messageId. */
   let currentMessageId: string | undefined
@@ -212,7 +209,7 @@ export function createAcpSessionTranslator(
 
   function mintMessageId(): string {
     messageSeq += 1
-    return `acp-msg-${seed}-${messageSeq}`
+    return `acp-msg-${instanceId}-${messageSeq}`
   }
 
   function ensureStarted(messageId: string, events: AgentEvent[]): void {

--- a/electron/agent/artifact-system.ts
+++ b/electron/agent/artifact-system.ts
@@ -1,0 +1,41 @@
+export function buildArtifactSystem(artifactDir: string | undefined, outputProjectRoot?: string): string | undefined {
+  if (!artifactDir) {
+    return undefined
+  }
+  const projectPublication = outputProjectRoot
+    ? [
+        `- This turn belongs to a folder project. Wanta will publish final deliverables from this managed directory into the visible project directory: ${outputProjectRoot}`,
+        "- Use descriptive user-facing file and directory names. Preserve any project-relative output layout explicitly requested by the user inside this managed directory; Wanta will reproduce that layout in the project.",
+        "- Do not write a second copy directly into the project directory. Wanta performs the checked, collision-safe publication after the turn completes.",
+        "- In the final response, refer to deliverables by their user-facing names or requested project-relative locations. Do not present the managed artifact path as the final project location.",
+      ]
+    : []
+  return [
+    "Artifact output contract for this turn:",
+    `- Use this exact directory for files you create, convert, export, download, or modify as user-facing deliverables: ${artifactDir}`,
+    "- Do not create files just because this artifact directory is provided.",
+    ...projectPublication,
+    "- For edits to an existing local project, modify the requested project files in place; even when this artifact directory is inside the project, use it only for exported deliverables, generated assets, converted files, reports, or packaged outputs.",
+    "- Temporary scripts, raw API or query responses, logs, checkpoints, caches, and machine-review files belong in the managed process directory, never in the artifact directory.",
+    "- When you create one or more deliverables, write .wanta-artifact.json in the artifact directory as the explicit publication declaration. Use only relative paths to files that already exist under the artifact directory.",
+    '- The declaration format is {"version":2,"title":"...","kind":"document|spreadsheet|presentation|web_page|image_set|code_project|archive|mixed","display":"single|document|table|project|gallery|file_list","items":[{"path":"report.html","role":"primary","order":1}],"supporting":[{"path":"report.md","role":"supporting","order":1}]}. Use role "metadata" for reproducibility data that must remain hidden from normal artifact UI.',
+    "- Wanta validates the declaration and publishes only declared primary, summary, and supporting files. Do not declare temporary or machine-facing files as primary/supporting. Do not describe files that do not exist.",
+    "- Treat HTML reports, images, PDFs, charts, spreadsheets, presentations, archives, and documents as user-facing deliverables.",
+    "- Keep HTML reports usable in a resizable preview viewport. Include a standard viewport meta tag, avoid overflow:hidden on html/body unless the user explicitly requests a fixed non-scrollable canvas, and make fixed-size content responsive or leave the document scrollable.",
+    "- For image sets, save every final image in display order with stable padded names such as 001.jpg and 002.jpg.",
+    "- Image preview and artifact persistence are separate outputs, and both are required for every final generated image whenever the source can be materialized. Preserve a useful inline preview whenever an image provider or tool returns a viewable image, even when that preview is remote, data-backed, or temporary.",
+    "- Persist every final generated image into this directory. If a tool returns only a remote, data-backed, or temporary preview, keep the preview reference intact so Wanta can materialize the same image during turn finalization. Do not describe it as a saved local file until persistence succeeds.",
+    "- When a generated image has both a successfully saved local path and a matching remote or temporary preview, use the local path for the inline Markdown image. Keep the remote reference only as recovery metadata; do not make it the primary preview.",
+    "- When the final deliverable is one to four image files and inline viewing helps the user, include Markdown image references in the final response using their absolute local paths, for example ![short title](</absolute/path/image.png>).",
+    "- On Windows, use drive-letter paths such as C:/Users/name/output.png or C:\\Users\\name\\output.png without an extra leading slash. Never emit /C:/Users/... as a local Markdown image destination.",
+    "- If only a provider-backed image preview is available, keep that preview visible in the final response instead of omitting it. Wanta will materialize supported preview sources and independently report persistence failures.",
+    "- When there are many images, such as crawled or downloaded image sets, do not inline every image in the final response. Summarize the set and rely on the artifact browser.",
+    "- Do not reuse output folders from earlier turns or other chats.",
+    "- If you reuse a script from an earlier turn, copy or update it before running and replace every embedded output path with this turn's artifact directory. Never run a prior-turn script while it still targets an earlier output directory.",
+    "- Do not write deliverables to Desktop, Downloads, the OpenCode workspace, or prior output directories unless the user explicitly requested that exact destination.",
+    outputProjectRoot
+      ? "- When you finish, summarize the deliverable contents and names in prose; Wanta will surface the checked final project locations after publication."
+      : "- When you finish, summarize the deliverable contents and report generated file paths in prose or inline code, not fenced code blocks; fenced blocks are only for code or multi-line text.",
+    "- Do not open generated files with system commands unless the user explicitly asks you to open them externally; the app is responsible for surfacing artifacts in the UI.",
+  ].join("\n")
+}

--- a/electron/agent/external/prompt.test.ts
+++ b/electron/agent/external/prompt.test.ts
@@ -10,9 +10,9 @@ test("external prompt carries Wanta's exact managed turn directories", () => {
   })
 
   expect(prompt).toContain("Host policy")
-  expect(prompt).toContain("User-facing deliverables must be written to this exact artifact directory")
+  expect(prompt).toContain("Use this exact directory for files you create")
   expect(prompt).toContain("/managed/artifacts/turn-1")
   expect(prompt).toContain("/managed/process/turn-1")
-  expect(prompt).toContain("Wanta publishes files found there when the turn completes")
+  expect(prompt).toContain("write .wanta-artifact.json")
   expect(prompt).toContain("<user_request>\nCreate a report\n</user_request>")
 })

--- a/electron/agent/external/prompt.test.ts
+++ b/electron/agent/external/prompt.test.ts
@@ -14,5 +14,18 @@ test("external prompt carries Wanta's exact managed turn directories", () => {
   expect(prompt).toContain("/managed/artifacts/turn-1")
   expect(prompt).toContain("/managed/process/turn-1")
   expect(prompt).toContain("write .wanta-artifact.json")
+  expect(prompt).toContain("inspect its byte and line counts first")
+  expect(prompt).toContain("very long single-line file")
+  expect(prompt).toContain("do not retry the same line-based read")
+  expect(prompt).toContain("native write-tool content payload below 16 KB")
+  expect(prompt).toContain("controlled shell heredoc in the process directory")
   expect(prompt).toContain("<user_request>\nCreate a report\n</user_request>")
+})
+
+test("external prompt omits managed file guidance without turn directories", () => {
+  const prompt = externalAgentPromptText({ text: "Explain this code" })
+
+  expect(prompt).toBe("Explain this code")
+  expect(prompt).not.toContain("16 KB")
+  expect(prompt).not.toContain("byte and line counts")
 })

--- a/electron/agent/external/prompt.ts
+++ b/electron/agent/external/prompt.ts
@@ -1,26 +1,23 @@
 import type { PromptAgentInput } from "../contract/input.ts"
 
+import { buildArtifactSystem } from "../artifact-system.ts"
+
 /**
  * ACP has no portable per-turn system-prompt field. Carry Wanta's dynamic host context in
  * a clearly delimited first text block while keeping the recorded user turn
  * unchanged. The context is host-authored and must precede the user request.
  */
 export function externalAgentPromptText(
-  input: Pick<PromptAgentInput, "artifactDir" | "processDir" | "system" | "text">,
+  input: Pick<PromptAgentInput, "artifactDir" | "outputProjectRoot" | "processDir" | "system" | "text">,
 ): string {
   const turnPaths = [
-    input.artifactDir
-      ? `- User-facing deliverables must be written to this exact artifact directory: ${input.artifactDir}`
-      : undefined,
     input.processDir
       ? `- Temporary scripts, raw responses, logs, and scratch files must be written to this exact process directory: ${input.processDir}`
-      : undefined,
-    input.artifactDir
-      ? "- Do not put implementation files in the artifact directory. Wanta publishes files found there when the turn completes."
       : undefined,
   ].filter((line): line is string => Boolean(line))
   const system = [
     input.system?.trim(),
+    buildArtifactSystem(input.artifactDir, input.outputProjectRoot),
     turnPaths.length > 0 ? ["Managed turn directories:", ...turnPaths].join("\n") : "",
   ]
     .filter(Boolean)

--- a/electron/agent/external/prompt.ts
+++ b/electron/agent/external/prompt.ts
@@ -14,6 +14,12 @@ export function externalAgentPromptText(
     input.processDir
       ? `- Temporary scripts, raw responses, logs, and scratch files must be written to this exact process directory: ${input.processDir}`
       : undefined,
+    input.processDir
+      ? "- If a file exceeds a read tool's token limit, inspect its byte and line counts first. For a very long single-line file, use search or byte-range shell reads; do not retry the same line-based read with only a smaller line limit."
+      : undefined,
+    input.processDir
+      ? "- Keep one native write-tool content payload below 16 KB. Split larger generated files into smaller chunks/files, or use a controlled shell heredoc in the process directory."
+      : undefined,
   ].filter((line): line is string => Boolean(line))
   const system = [
     input.system?.trim(),

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -494,6 +494,15 @@ describe("AgentManager", () => {
     expect(system).not.toContain("Do not present a remote")
   })
 
+  it("separates explicit deliverables from process files", () => {
+    const system = buildArtifactSystem("/tmp/wanta-artifacts/turn")
+
+    expect(system).toContain("machine-review files belong in the managed process directory")
+    expect(system).toContain("write .wanta-artifact.json")
+    expect(system).toContain("publishes only declared primary, summary, and supporting files")
+    expect(system).not.toContain("Do not create a manifest")
+  })
+
   it("tells project turns that managed deliverables are published into the visible project", () => {
     const system = buildArtifactSystem("/tmp/project/.wanta/artifacts/session/turn", "/tmp/project")
 

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -43,6 +43,7 @@ import {
   resolveBuiltinModel,
   resolveExecutionBuiltinModelId,
 } from "../models/builtin.ts"
+import { buildArtifactSystem } from "./artifact-system.ts"
 import { planAttachmentInputs } from "./attachment-input.ts"
 import { buildOpencodeConfig, customProviderId, WANTA_MODEL_ID, WANTA_PROVIDER_ID } from "./config.ts"
 import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
@@ -1718,44 +1719,7 @@ function sleep(ms: number): Promise<void> {
   })
 }
 
-export function buildArtifactSystem(artifactDir: string | undefined, outputProjectRoot?: string): string | undefined {
-  if (!artifactDir) {
-    return undefined
-  }
-  const projectPublication = outputProjectRoot
-    ? [
-        `- This turn belongs to a folder project. Wanta will publish final deliverables from this managed directory into the visible project directory: ${outputProjectRoot}`,
-        "- Use descriptive user-facing file and directory names. Preserve any project-relative output layout explicitly requested by the user inside this managed directory; Wanta will reproduce that layout in the project.",
-        "- Do not write a second copy directly into the project directory. Wanta performs the checked, collision-safe publication after the turn completes.",
-        "- In the final response, refer to deliverables by their user-facing names or requested project-relative locations. Do not present the managed artifact path as the final project location.",
-      ]
-    : []
-  return [
-    "Artifact output contract for this turn:",
-    `- Use this exact directory for files you create, convert, export, download, or modify as user-facing deliverables: ${artifactDir}`,
-    "- Do not create files just because this artifact directory is provided.",
-    ...projectPublication,
-    "- For edits to an existing local project, modify the requested project files in place; even when this artifact directory is inside the project, use it only for exported deliverables, generated assets, converted files, reports, or packaged outputs.",
-    "- Wanta indexes the directory recursively and determines the artifact type from the actual files. Do not create a manifest or describe files that do not exist.",
-    "- Treat HTML reports, images, PDFs, charts, spreadsheets, presentations, archives, and documents as user-facing deliverables.",
-    "- Keep HTML reports usable in a resizable preview viewport. Include a standard viewport meta tag, avoid overflow:hidden on html/body unless the user explicitly requests a fixed non-scrollable canvas, and make fixed-size content responsive or leave the document scrollable.",
-    "- For image sets, save every final image in display order with stable padded names such as 001.jpg and 002.jpg.",
-    "- Image preview and artifact persistence are separate outputs, and both are required for every final generated image whenever the source can be materialized. Preserve a useful inline preview whenever an image provider or tool returns a viewable image, even when that preview is remote, data-backed, or temporary.",
-    "- Persist every final generated image into this directory. If a tool returns only a remote, data-backed, or temporary preview, keep the preview reference intact so Wanta can materialize the same image during turn finalization. Do not describe it as a saved local file until persistence succeeds.",
-    "- When a generated image has both a successfully saved local path and a matching remote or temporary preview, use the local path for the inline Markdown image. Keep the remote reference only as recovery metadata; do not make it the primary preview.",
-    "- When the final deliverable is one to four image files and inline viewing helps the user, include Markdown image references in the final response using their absolute local paths, for example ![short title](</absolute/path/image.png>).",
-    "- On Windows, use drive-letter paths such as C:/Users/name/output.png or C:\\Users\\name\\output.png without an extra leading slash. Never emit /C:/Users/... as a local Markdown image destination.",
-    "- If only a provider-backed image preview is available, keep that preview visible in the final response instead of omitting it. Wanta will materialize supported preview sources and independently report persistence failures.",
-    "- When there are many images, such as crawled or downloaded image sets, do not inline every image in the final response. Summarize the set and rely on the artifact browser.",
-    "- Do not reuse output folders from earlier turns or other chats.",
-    "- If you reuse a script from an earlier turn, copy or update it before running and replace every embedded output path with this turn's artifact directory. Never run a prior-turn script while it still targets an earlier output directory.",
-    "- Do not write deliverables to Desktop, Downloads, the OpenCode workspace, or prior output directories unless the user explicitly requested that exact destination.",
-    outputProjectRoot
-      ? "- When you finish, summarize the deliverable contents and names in prose; Wanta will surface the checked final project locations after publication."
-      : "- When you finish, summarize the deliverable contents and report generated file paths in prose or inline code, not fenced code blocks; fenced blocks are only for code or multi-line text.",
-    "- Do not open generated files with system commands unless the user explicitly asks you to open them externally; the app is responsible for surfacing artifacts in the UI.",
-  ].join("\n")
-}
+export { buildArtifactSystem } from "./artifact-system.ts"
 
 function buildProcessSystem(processDir: string | undefined): string | undefined {
   if (!processDir) {

--- a/electron/artifact-resource/lease-store.test.ts
+++ b/electron/artifact-resource/lease-store.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { test } from "vitest"
 import { ArtifactResourceLeaseStore } from "./lease-store.ts"
 
-const input = { mime: "application/pdf", modifiedAt: 10, path: "/tmp/report.pdf", size: 100 }
+const input = { dev: 1, ino: 1, mime: "application/pdf", modifiedAt: 10, path: "/tmp/report.pdf", size: 100 }
 
 test("artifact resource leases expire and refresh on access", () => {
   const store = new ArtifactResourceLeaseStore(100, 4)

--- a/electron/artifact-resource/lease-store.ts
+++ b/electron/artifact-resource/lease-store.ts
@@ -1,7 +1,9 @@
 import crypto from "node:crypto"
 
 export interface ArtifactResourceLease {
+  dev: number
   expiresAt: number
+  ino: number
   mime: string
   modifiedAt: number
   path: string

--- a/electron/artifact-resource/lease-store.ts
+++ b/electron/artifact-resource/lease-store.ts
@@ -1,8 +1,11 @@
+import type { FileHandle } from "node:fs/promises"
+
 import crypto from "node:crypto"
 
 export interface ArtifactResourceLease {
   dev: number
   expiresAt: number
+  handle?: FileHandle
   ino: number
   mime: string
   modifiedAt: number
@@ -34,7 +37,7 @@ export class ArtifactResourceLeaseStore {
       if (!oldest) {
         break
       }
-      this.leases.delete(oldest)
+      this.remove(oldest)
     }
     return lease
   }
@@ -46,7 +49,7 @@ export class ArtifactResourceLeaseStore {
       return null
     }
     if (lease.expiresAt <= now) {
-      this.leases.delete(token)
+      this.remove(token)
       return null
     }
     const refreshed = { ...lease, expiresAt: now + this.ttlMs }
@@ -57,14 +60,20 @@ export class ArtifactResourceLeaseStore {
 
   // 清空所有租约，供应用退出时统一释放资源访问能力。
   clear(): void {
-    this.leases.clear()
+    for (const token of this.leases.keys()) this.remove(token)
   }
 
   private removeExpired(now: number): void {
     for (const [token, lease] of this.leases) {
       if (lease.expiresAt <= now) {
-        this.leases.delete(token)
+        this.remove(token)
       }
     }
+  }
+
+  private remove(token: string): void {
+    const lease = this.leases.get(token)
+    this.leases.delete(token)
+    void lease?.handle?.close().catch(() => undefined)
   }
 }

--- a/electron/artifact-resource/protocol.test.ts
+++ b/electron/artifact-resource/protocol.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdir, mkdtemp, rename, rm, stat, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, open, rename, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { test } from "vitest"
@@ -78,6 +78,44 @@ test.skipIf(process.platform === "win32")(
       const response = await artifactResourceResponse(new Request(artifactResourceUrl(lease.token)), store)
       assert.equal(response.status, 404)
     } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  },
+)
+
+test.skipIf(process.platform === "win32")(
+  "artifact resource response streams from a retained verified handle after a parent-directory swap",
+  async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wanta-resource-handle-"))
+    const store = new ArtifactResourceLeaseStore()
+    try {
+      const artifactDirectory = path.join(root, "artifacts")
+      const movedArtifactDirectory = path.join(root, "artifacts-original")
+      const outsideDirectory = path.join(root, "outside")
+      await Promise.all([mkdir(artifactDirectory), mkdir(outsideDirectory)])
+      const filePath = path.join(artifactDirectory, "report.txt")
+      await writeFile(filePath, "safe")
+      await writeFile(path.join(outsideDirectory, "report.txt"), "outside")
+      const handle = await open(filePath, "r")
+      const info = await handle.stat()
+      const lease = store.grant({
+        dev: info.dev,
+        handle,
+        ino: info.ino,
+        mime: "text/plain",
+        modifiedAt: info.mtimeMs,
+        path: filePath,
+        size: info.size,
+      })
+
+      await rename(artifactDirectory, movedArtifactDirectory)
+      await symlink(outsideDirectory, artifactDirectory, "dir")
+
+      const response = await artifactResourceResponse(new Request(artifactResourceUrl(lease.token)), store)
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), "safe")
+    } finally {
+      store.clear()
       await rm(root, { force: true, recursive: true })
     }
   },

--- a/electron/artifact-resource/protocol.test.ts
+++ b/electron/artifact-resource/protocol.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rename, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { test } from "vitest"
@@ -28,6 +28,8 @@ test("artifact resource response streams full and ranged file content", async ()
     const info = await stat(filePath)
     const store = new ArtifactResourceLeaseStore()
     const lease = store.grant({
+      dev: info.dev,
+      ino: info.ino,
       mime: "text/plain",
       modifiedAt: info.mtimeMs,
       path: filePath,
@@ -46,3 +48,37 @@ test("artifact resource response streams full and ranged file content", async ()
     await rm(directory, { force: true, recursive: true })
   }
 })
+
+test.skipIf(process.platform === "win32")(
+  "artifact resource response rejects a parent-directory symlink swap",
+  async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wanta-resource-swap-"))
+    try {
+      const artifactDirectory = path.join(root, "artifacts")
+      const movedArtifactDirectory = path.join(root, "artifacts-original")
+      const outsideDirectory = path.join(root, "outside")
+      await Promise.all([mkdir(artifactDirectory), mkdir(outsideDirectory)])
+      const filePath = path.join(artifactDirectory, "report.txt")
+      await writeFile(filePath, "safe")
+      await writeFile(path.join(outsideDirectory, "report.txt"), "outside")
+      const info = await stat(filePath)
+      const store = new ArtifactResourceLeaseStore()
+      const lease = store.grant({
+        dev: info.dev,
+        ino: info.ino,
+        mime: "text/plain",
+        modifiedAt: info.mtimeMs,
+        path: filePath,
+        size: info.size,
+      })
+
+      await rename(artifactDirectory, movedArtifactDirectory)
+      await symlink(outsideDirectory, artifactDirectory, "dir")
+
+      const response = await artifactResourceResponse(new Request(artifactResourceUrl(lease.token)), store)
+      assert.equal(response.status, 404)
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  },
+)

--- a/electron/artifact-resource/protocol.ts
+++ b/electron/artifact-resource/protocol.ts
@@ -61,29 +61,33 @@ export function parseSingleByteRange(header: string | null, size: number): ByteR
   return { start, end: Math.min(requestedEnd, size - 1) }
 }
 
-async function openCurrentLease(lease: ArtifactResourceLease): Promise<FileHandle | null> {
+interface OpenedLease {
+  closeAfterUse: boolean
+  handle: FileHandle
+}
+
+async function openCurrentLease(lease: ArtifactResourceLease): Promise<OpenedLease | null> {
   const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0
   let handle: FileHandle | undefined
   try {
-    handle = await open(lease.path, constants.O_RDONLY | noFollow)
-    const [pathInfo, openedInfo] = await Promise.all([lstat(lease.path), handle.stat()])
+    handle = lease.handle ?? (await open(lease.path, constants.O_RDONLY | noFollow))
+    const openedInfo = await handle.stat()
+    const pathInfo = lease.handle ? undefined : await lstat(lease.path)
     if (
-      !pathInfo.isFile() ||
-      pathInfo.isSymbolicLink() ||
+      (pathInfo && (!pathInfo.isFile() || pathInfo.isSymbolicLink())) ||
       !openedInfo.isFile() ||
       openedInfo.dev !== lease.dev ||
       openedInfo.ino !== lease.ino ||
-      pathInfo.dev !== openedInfo.dev ||
-      pathInfo.ino !== openedInfo.ino ||
+      (pathInfo && (pathInfo.dev !== openedInfo.dev || pathInfo.ino !== openedInfo.ino)) ||
       openedInfo.size !== lease.size ||
       openedInfo.mtimeMs !== lease.modifiedAt
     ) {
-      await handle.close()
+      if (!lease.handle) await handle.close()
       return null
     }
-    return handle
+    return { closeAfterUse: !lease.handle, handle }
   } catch {
-    await handle?.close().catch(() => undefined)
+    if (!lease.handle) await handle?.close().catch(() => undefined)
     return null
   }
 }
@@ -114,11 +118,11 @@ export async function artifactResourceResponse(request: Request, store: Artifact
   if (!lease) {
     return new Response(null, { status: 404 })
   }
-  const handle = await openCurrentLease(lease)
-  if (!handle) return new Response(null, { status: 404 })
+  const opened = await openCurrentLease(lease)
+  if (!opened) return new Response(null, { status: 404 })
   const range = parseSingleByteRange(request.headers.get("range"), lease.size)
   if (range === "invalid") {
-    await handle.close()
+    if (opened.closeAfterUse) await opened.handle.close()
     return new Response(null, { status: 416, headers: { "Content-Range": `bytes */${lease.size}` } })
   }
   const start = range?.start ?? 0
@@ -135,9 +139,11 @@ export async function artifactResourceResponse(request: Request, store: Artifact
     headers.set("Content-Range", `bytes ${start}-${end}/${lease.size}`)
   }
   if (request.method === "HEAD" || lease.size === 0) {
-    await handle.close()
+    if (opened.closeAfterUse) await opened.handle.close()
     return new Response(null, { status: range ? 206 : 200, headers })
   }
-  const body = Readable.toWeb(handle.createReadStream({ start, end, autoClose: true })) as ReadableStream<Uint8Array>
+  const body = Readable.toWeb(
+    opened.handle.createReadStream({ start, end, autoClose: opened.closeAfterUse }),
+  ) as ReadableStream<Uint8Array>
   return new Response(body, { status: range ? 206 : 200, headers })
 }

--- a/electron/artifact-resource/protocol.ts
+++ b/electron/artifact-resource/protocol.ts
@@ -1,8 +1,9 @@
 import type { ArtifactResourceLease, ArtifactResourceLeaseStore } from "./lease-store.ts"
+import type { FileHandle } from "node:fs/promises"
 
 import { protocol } from "electron"
-import { createReadStream } from "node:fs"
-import { stat } from "node:fs/promises"
+import { constants } from "node:fs"
+import { lstat, open } from "node:fs/promises"
 import { Readable } from "node:stream"
 import { branding } from "../branding.ts"
 
@@ -60,12 +61,30 @@ export function parseSingleByteRange(header: string | null, size: number): ByteR
   return { start, end: Math.min(requestedEnd, size - 1) }
 }
 
-async function leaseIsCurrent(lease: ArtifactResourceLease): Promise<boolean> {
+async function openCurrentLease(lease: ArtifactResourceLease): Promise<FileHandle | null> {
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0
+  let handle: FileHandle | undefined
   try {
-    const info = await stat(lease.path)
-    return info.isFile() && info.size === lease.size && info.mtimeMs === lease.modifiedAt
+    handle = await open(lease.path, constants.O_RDONLY | noFollow)
+    const [pathInfo, openedInfo] = await Promise.all([lstat(lease.path), handle.stat()])
+    if (
+      !pathInfo.isFile() ||
+      pathInfo.isSymbolicLink() ||
+      !openedInfo.isFile() ||
+      openedInfo.dev !== lease.dev ||
+      openedInfo.ino !== lease.ino ||
+      pathInfo.dev !== openedInfo.dev ||
+      pathInfo.ino !== openedInfo.ino ||
+      openedInfo.size !== lease.size ||
+      openedInfo.mtimeMs !== lease.modifiedAt
+    ) {
+      await handle.close()
+      return null
+    }
+    return handle
   } catch {
-    return false
+    await handle?.close().catch(() => undefined)
+    return null
   }
 }
 
@@ -92,11 +111,14 @@ export async function artifactResourceResponse(request: Request, store: Artifact
   }
   const token = tokenFromUrl(request.url)
   const lease = token ? store.resolve(token) : null
-  if (!lease || !(await leaseIsCurrent(lease))) {
+  if (!lease) {
     return new Response(null, { status: 404 })
   }
+  const handle = await openCurrentLease(lease)
+  if (!handle) return new Response(null, { status: 404 })
   const range = parseSingleByteRange(request.headers.get("range"), lease.size)
   if (range === "invalid") {
+    await handle.close()
     return new Response(null, { status: 416, headers: { "Content-Range": `bytes */${lease.size}` } })
   }
   const start = range?.start ?? 0
@@ -113,8 +135,9 @@ export async function artifactResourceResponse(request: Request, store: Artifact
     headers.set("Content-Range", `bytes ${start}-${end}/${lease.size}`)
   }
   if (request.method === "HEAD" || lease.size === 0) {
+    await handle.close()
     return new Response(null, { status: range ? 206 : 200, headers })
   }
-  const body = Readable.toWeb(createReadStream(lease.path, { start, end })) as ReadableStream<Uint8Array>
+  const body = Readable.toWeb(handle.createReadStream({ start, end, autoClose: true })) as ReadableStream<Uint8Array>
   return new Response(body, { status: range ? 206 : 200, headers })
 }

--- a/electron/chat/artifact-bundles.test.ts
+++ b/electron/chat/artifact-bundles.test.ts
@@ -157,6 +157,43 @@ test("buildArtifactBundle publishes only explicitly declared deliverables", asyn
   }
 })
 
+test("buildArtifactBundle reports declared directories as rejected entries", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-declared-directory-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    await mkdir(path.join(root, "support"))
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        version: 2,
+        title: "Report",
+        kind: "web_page",
+        display: "document",
+        items: [{ path: "report.html", role: "primary", order: 1 }],
+        supporting: [{ path: "support", role: "supporting", order: 1 }],
+      }),
+    )
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.status, "partial")
+    assert.equal(bundle?.failure, "artifact_declaration_partial")
+    assert.deepEqual(
+      bundle?.items.map((item) => item.name),
+      ["report.html"],
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test("buildArtifactBundle fails closed for an invalid explicit declaration", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-invalid-declaration-"))
   try {

--- a/electron/chat/artifact-bundles.test.ts
+++ b/electron/chat/artifact-bundles.test.ts
@@ -110,6 +110,76 @@ test("buildArtifactBundle keeps legitimate and uncertain JSON deliverables", asy
   }
 })
 
+test("buildArtifactBundle publishes only explicitly declared deliverables", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-declared-"))
+  try {
+    await writeFile(path.join(root, "weekly-report.html"), "<!doctype html><title>Weekly report</title>")
+    await writeFile(path.join(root, "weekly-report.md"), "# Weekly report")
+    await writeFile(path.join(root, "q_accounts.json"), JSON.stringify({ results: [1, 2, 3] }))
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        title: "Weekly report",
+        kind: "web_page",
+        display: "document",
+        items: [{ path: "weekly-report.html", role: "primary", order: 1 }],
+        supporting: [
+          { path: "weekly-report.md", role: "supporting", order: 1 },
+          { path: "q_accounts.json", role: "metadata", order: 2 },
+        ],
+      }),
+    )
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.version, 2)
+    assert.equal(bundle?.classification, "declared")
+    assert.equal(bundle?.title, "Weekly report")
+    assert.equal(bundle?.kind, "web_page")
+    assert.equal(bundle?.display, "document")
+    assert.deepEqual(
+      bundle?.items.map((item) => [item.name, item.role]),
+      [
+        ["weekly-report.html", "primary"],
+        ["weekly-report.md", "supporting"],
+      ],
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("buildArtifactBundle fails closed for an invalid explicit declaration", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-invalid-declaration-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    await writeFile(path.join(root, ".wanta-artifact.json"), "{not-json")
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.version, 2)
+    assert.equal(bundle?.status, "failed")
+    assert.equal(bundle?.failure, "artifact_declaration_invalid")
+    assert.deepEqual(bundle?.items, [])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test("buildArtifactBundle keeps a lone operational state file as the only output", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-only-state-"))
   try {

--- a/electron/chat/artifact-bundles.test.ts
+++ b/electron/chat/artifact-bundles.test.ts
@@ -119,6 +119,7 @@ test("buildArtifactBundle publishes only explicitly declared deliverables", asyn
     await writeFile(
       path.join(root, ".wanta-artifact.json"),
       JSON.stringify({
+        version: 2,
         title: "Weekly report",
         kind: "web_page",
         display: "document",
@@ -175,6 +176,100 @@ test("buildArtifactBundle fails closed for an invalid explicit declaration", asy
     assert.equal(bundle?.status, "failed")
     assert.equal(bundle?.failure, "artifact_declaration_invalid")
     assert.deepEqual(bundle?.items, [])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("buildArtifactBundle fails closed for an unversioned declaration", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-unversioned-declaration-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        title: "Report",
+        kind: "web_page",
+        display: "single",
+        items: [{ path: "report.html", role: "primary", order: 1 }],
+      }),
+    )
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.status, "failed")
+    assert.equal(bundle?.failure, "artifact_declaration_invalid")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("buildArtifactBundle fails closed when a declaration has no publishable files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-empty-declaration-"))
+  try {
+    await writeFile(path.join(root, "query.json"), JSON.stringify({ results: [] }))
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        version: 2,
+        title: "Metadata only",
+        kind: "mixed",
+        display: "file_list",
+        supporting: [{ path: "query.json", role: "metadata", order: 1 }],
+      }),
+    )
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.status, "failed")
+    assert.equal(bundle?.failure, "artifact_declaration_invalid")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test.skipIf(process.platform === "win32")("buildArtifactBundle rejects a symlinked declaration", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-linked-declaration-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    const declarationTarget = path.join(root, "declaration.json")
+    await writeFile(
+      declarationTarget,
+      JSON.stringify({
+        version: 2,
+        title: "Report",
+        kind: "web_page",
+        display: "single",
+        items: [{ path: "report.html", role: "primary", order: 1 }],
+      }),
+    )
+    await symlink(declarationTarget, path.join(root, ".wanta-artifact.json"))
+
+    const bundle = await buildArtifactBundle({
+      artifactRoot: root,
+      completedAt: 2,
+      createdAt: 1,
+      generatedPreviewCount: 0,
+      messageId: "assistant-1",
+      sessionId: "session-1",
+    })
+
+    assert.equal(bundle?.status, "failed")
+    assert.equal(bundle?.failure, "artifact_declaration_invalid")
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/electron/chat/artifact-bundles.ts
+++ b/electron/chat/artifact-bundles.ts
@@ -5,7 +5,9 @@ import type {
   ArtifactItem,
   ArtifactItemOrigin,
   ChatMessage,
+  LocalArtifactEntry,
   LocalArtifactGroup,
+  LocalArtifactPack,
 } from "./common.ts"
 import type { MaterializeAssistantArtifactsOptions } from "./safe-image-source.ts"
 
@@ -17,7 +19,7 @@ import { atomicWriteText } from "../atomic-file.ts"
 import { logStoreReadFailure } from "../store-diagnostics.ts"
 import { isOperationalStateArtifact } from "./artifact-file-classification.ts"
 import { mimeFromPath, normalizeLocalPathCandidate } from "./artifacts.ts"
-import { localArtifactItem } from "./local-artifacts.ts"
+import { artifactManifestExists, localArtifactItem, readArtifactPack } from "./local-artifacts.ts"
 import { extractMarkdownImageSources } from "./markdown-images.ts"
 import { dataImage, remoteImage } from "./safe-image-source.ts"
 
@@ -94,6 +96,12 @@ function validBundle(value: unknown): value is ArtifactBundle {
     validText(bundle.sessionId) &&
     validText(bundle.messageId) &&
     validText(bundle.rootPath) &&
+    (bundle.version === undefined || bundle.version === 2) &&
+    (bundle.title === undefined || typeof bundle.title === "string") &&
+    (bundle.summary === undefined || typeof bundle.summary === "string") &&
+    (bundle.classification === undefined ||
+      bundle.classification === "declared" ||
+      bundle.classification === "inferred") &&
     (bundle.status === "ready" || bundle.status === "partial" || bundle.status === "failed") &&
     typeof bundle.createdAt === "number" &&
     Number.isFinite(bundle.createdAt) &&
@@ -105,6 +113,8 @@ function validBundle(value: unknown): value is ArtifactBundle {
     (bundle.totalItems ?? -1) >= 0 &&
     typeof bundle.truncated === "boolean" &&
     (bundle.failure === undefined ||
+      bundle.failure === "artifact_declaration_invalid" ||
+      bundle.failure === "artifact_declaration_partial" ||
       bundle.failure === "generated_preview_not_persisted" ||
       bundle.failure === "generated_preview_persistence_unverified" ||
       bundle.failure === "project_output_publish_failed" ||
@@ -120,10 +130,44 @@ function validBundle(value: unknown): value is ArtifactBundle {
         validText(item.mime) &&
         item.status === "ready" &&
         artifactItemOrigins.has(item.origin) &&
+        (item.role === undefined || item.role === "primary" || item.role === "supporting" || item.role === "summary") &&
+        (item.order === undefined || (typeof item.order === "number" && Number.isFinite(item.order))) &&
+        (item.title === undefined || typeof item.title === "string") &&
+        (item.description === undefined || typeof item.description === "string") &&
         (item.size === undefined || (typeof item.size === "number" && Number.isFinite(item.size) && item.size >= 0)) &&
         (item.modifiedAt === undefined || (typeof item.modifiedAt === "number" && Number.isFinite(item.modifiedAt))),
     )
   )
+}
+
+function declaredArtifactGroup(pack: LocalArtifactPack): LocalArtifactGroup {
+  const items = [...pack.items, ...pack.supporting]
+    .filter((item) => item.role !== "metadata" && item.kind === "file")
+    .sort(
+      (left, right) =>
+        Number(left.role !== "primary") - Number(right.role !== "primary") ||
+        left.order - right.order ||
+        left.name.localeCompare(right.name, undefined, { numeric: true }),
+    )
+  return {
+    root: pack.root,
+    items,
+    totalItems: items.length,
+    truncated: false,
+  }
+}
+
+function declaredArtifactEntry(item: LocalArtifactGroup["items"][number]): LocalArtifactEntry | undefined {
+  if (!("role" in item)) {
+    return undefined
+  }
+  const candidate = item as LocalArtifactEntry
+  return candidate.role === "primary" ||
+    candidate.role === "supporting" ||
+    candidate.role === "summary" ||
+    candidate.role === "metadata"
+    ? candidate
+    : undefined
 }
 
 function normalizeArtifactBundles(value: unknown): ArtifactBundles {
@@ -679,11 +723,36 @@ export async function buildArtifactBundle(input: {
   materializedOrigins?: ReadonlyMap<string, ArtifactItemOrigin>
 }): Promise<ArtifactBundle | null> {
   const { artifactRoot, excludedPaths, materializedOrigins = new Map<string, ArtifactItemOrigin>() } = input
-  const group = await managedArtifactGroup(artifactRoot, materializedOrigins, 200, excludedPaths)
+  const [pack, hasDeclaration] = await Promise.all([
+    readArtifactPack(artifactRoot),
+    artifactManifestExists(artifactRoot),
+  ])
+  if (hasDeclaration && !pack) {
+    return {
+      version: 2,
+      id: stableArtifactId(input.sessionId, input.messageId, "bundle"),
+      sessionId: input.sessionId,
+      messageId: input.messageId,
+      rootPath: artifactRoot,
+      classification: "declared",
+      status: "failed",
+      kind: "mixed",
+      display: "file_list",
+      items: [],
+      totalItems: 0,
+      truncated: false,
+      createdAt: input.createdAt,
+      completedAt: input.completedAt,
+      failure: "artifact_declaration_invalid",
+    }
+  }
+  const group = pack
+    ? declaredArtifactGroup(pack)
+    : await managedArtifactGroup(artifactRoot, materializedOrigins, 200, excludedPaths)
   if (!group) {
     return null
   }
-  return buildArtifactBundleFromGroup({ ...input, group })
+  return buildArtifactBundleFromGroup({ ...input, group, ...(pack ? { pack } : {}) })
 }
 
 export function buildArtifactBundleFromGroup(input: {
@@ -692,6 +761,7 @@ export function buildArtifactBundleFromGroup(input: {
   createdAt: number
   generatedPreviewCount: number
   group: LocalArtifactGroup
+  pack?: LocalArtifactPack
   messageId: string
   sessionId: string
   materializedOrigins?: ReadonlyMap<string, ArtifactItemOrigin>
@@ -703,6 +773,7 @@ export function buildArtifactBundleFromGroup(input: {
     createdAt,
     generatedPreviewCount,
     group,
+    pack,
     messageId,
     sessionId,
   } = input
@@ -725,25 +796,37 @@ export function buildArtifactBundleFromGroup(input: {
         }
       : null
   }
-  const kind = inferredKind(group)
-  const display = inferredDisplay(kind, group.items.length)
+  const kind = pack?.kind ?? inferredKind(group)
+  const display = pack?.display ?? inferredDisplay(kind, group.items.length)
   // 只计算能追溯到本轮 assistant source 的图片；目录中无关的旧图片不能掩盖物化失败。
   const persistedImageCount = group.items.filter(
     (item) => item.mime.startsWith("image/") && materializedOrigins.has(path.relative(artifactRoot, item.path)),
   ).length
-  const isPartial = generatedPreviewCount > persistedImageCount
-  const items: ArtifactItem[] = group.items.map((item) => ({
-    ...item,
-    id: stableArtifactId(sessionId, messageId, path.relative(artifactRoot, item.path)),
-    status: "ready",
-    origin: materializedOrigins.get(path.relative(artifactRoot, item.path)) ?? "managed_output",
-  }))
+  const generatedPreviewPartial = generatedPreviewCount > persistedImageCount
+  const declarationPartial = Boolean(pack?.rejectedItems)
+  const items: ArtifactItem[] = group.items.map((item) => {
+    const declared = declaredArtifactEntry(item)
+    return {
+      ...item,
+      id: stableArtifactId(sessionId, messageId, path.relative(artifactRoot, item.path)),
+      status: "ready",
+      origin: materializedOrigins.get(path.relative(artifactRoot, item.path)) ?? "managed_output",
+      ...(declared?.role && declared.role !== "metadata" ? { role: declared.role } : {}),
+      ...(typeof declared?.order === "number" ? { order: declared.order } : {}),
+      ...(declared?.title ? { title: declared.title } : {}),
+      ...(declared?.description ? { description: declared.description } : {}),
+    }
+  })
   return {
+    ...(pack ? { version: 2 as const } : {}),
     id: stableArtifactId(sessionId, messageId, "bundle"),
     sessionId,
     messageId,
     rootPath: artifactRoot,
-    status: isPartial ? "partial" : "ready",
+    ...(pack?.title ? { title: pack.title } : {}),
+    ...(pack?.summary ? { summary: pack.summary } : {}),
+    classification: pack ? "declared" : "inferred",
+    status: generatedPreviewPartial || declarationPartial ? "partial" : "ready",
     kind,
     display,
     items,
@@ -751,7 +834,11 @@ export function buildArtifactBundleFromGroup(input: {
     truncated: group.truncated,
     createdAt,
     completedAt,
-    ...(isPartial ? { failure: "generated_preview_persistence_unverified" as const } : {}),
+    ...(declarationPartial
+      ? { failure: "artifact_declaration_partial" as const }
+      : generatedPreviewPartial
+        ? { failure: "generated_preview_persistence_unverified" as const }
+        : {}),
   }
 }
 

--- a/electron/chat/artifact-bundles.ts
+++ b/electron/chat/artifact-bundles.ts
@@ -170,6 +170,32 @@ function declaredArtifactEntry(item: LocalArtifactGroup["items"][number]): Local
     : undefined
 }
 
+function invalidDeclaredArtifactBundle(input: {
+  artifactRoot: string
+  completedAt: number
+  createdAt: number
+  messageId: string
+  sessionId: string
+}): ArtifactBundle {
+  return {
+    version: 2,
+    id: stableArtifactId(input.sessionId, input.messageId, "bundle"),
+    sessionId: input.sessionId,
+    messageId: input.messageId,
+    rootPath: input.artifactRoot,
+    classification: "declared",
+    status: "failed",
+    kind: "mixed",
+    display: "file_list",
+    items: [],
+    totalItems: 0,
+    truncated: false,
+    createdAt: input.createdAt,
+    completedAt: input.completedAt,
+    failure: "artifact_declaration_invalid",
+  }
+}
+
 function normalizeArtifactBundles(value: unknown): ArtifactBundles {
   const persisted = value && typeof value === "object" ? (value as PersistedArtifactBundles) : undefined
   const records: ArtifactBundles = new Map()
@@ -728,29 +754,16 @@ export async function buildArtifactBundle(input: {
     artifactManifestExists(artifactRoot),
   ])
   if (hasDeclaration && !pack) {
-    return {
-      version: 2,
-      id: stableArtifactId(input.sessionId, input.messageId, "bundle"),
-      sessionId: input.sessionId,
-      messageId: input.messageId,
-      rootPath: artifactRoot,
-      classification: "declared",
-      status: "failed",
-      kind: "mixed",
-      display: "file_list",
-      items: [],
-      totalItems: 0,
-      truncated: false,
-      createdAt: input.createdAt,
-      completedAt: input.completedAt,
-      failure: "artifact_declaration_invalid",
-    }
+    return invalidDeclaredArtifactBundle(input)
   }
   const group = pack
     ? declaredArtifactGroup(pack)
     : await managedArtifactGroup(artifactRoot, materializedOrigins, 200, excludedPaths)
   if (!group) {
     return null
+  }
+  if (pack && group.items.length === 0) {
+    return invalidDeclaredArtifactBundle(input)
   }
   return buildArtifactBundleFromGroup({ ...input, group, ...(pack ? { pack } : {}) })
 }

--- a/electron/chat/common.ts
+++ b/electron/chat/common.ts
@@ -614,6 +614,8 @@ export type ArtifactBundleKind = LocalArtifactPackKind
 export type ArtifactBundleDisplay = LocalArtifactDisplayMode
 export type ArtifactBundleStatus = "ready" | "partial" | "failed"
 export type ArtifactBundleFailure =
+  | "artifact_declaration_invalid"
+  | "artifact_declaration_partial"
   | "generated_preview_not_persisted"
   | "generated_preview_persistence_unverified"
   | "project_output_publish_failed"
@@ -640,13 +642,19 @@ export interface LocalArtifactPack {
   supporting: LocalArtifactEntry[]
   totalItems: number
   truncated: boolean
+  rejectedItems?: number
 }
 
 export interface ArtifactBundle {
+  /** Version 2 bundles were built from a host-validated explicit artifact declaration. */
+  version?: 2
   id: string
   sessionId: string
   messageId: string
   rootPath: string
+  title?: string
+  summary?: string
+  classification?: "declared" | "inferred"
   status: ArtifactBundleStatus
   kind: ArtifactBundleKind
   display: ArtifactBundleDisplay
@@ -662,6 +670,10 @@ export interface ArtifactItem extends LocalArtifactItem {
   id: string
   status: ArtifactItemStatus
   origin: ArtifactItemOrigin
+  role?: Exclude<LocalArtifactEntryRole, "metadata">
+  order?: number
+  title?: string
+  description?: string
 }
 
 export interface ArtifactBundlesRequest {
@@ -696,6 +708,8 @@ export interface TurnOutputFile {
 export interface TurnOutputRecord {
   sessionId: string
   messageId: string
+  /** Managed artifact root may also contain explicitly undeclared execution files. */
+  artifactProcessRoot?: string
   processRoot?: string
   projectRoot?: string
   createdAt: number

--- a/electron/chat/local-artifacts.ts
+++ b/electron/chat/local-artifacts.ts
@@ -16,8 +16,8 @@ const artifactManifestFileName = ".wanta-artifact.json"
 
 export async function artifactManifestExists(rootDir: string): Promise<boolean> {
   try {
-    const info = await lstat(path.join(rootDir, artifactManifestFileName))
-    return info.isFile() && !info.isSymbolicLink()
+    await lstat(path.join(rootDir, artifactManifestFileName))
+    return true
   } catch {
     return false
   }
@@ -252,16 +252,21 @@ export async function readArtifactPack(rootDir: string): Promise<LocalArtifactPa
   if (!root || root.kind !== "directory") {
     return null
   }
+  const manifestPath = path.join(rootDir, artifactManifestFileName)
   let manifest: ArtifactManifest
   try {
-    manifest = JSON.parse(await readFile(path.join(rootDir, artifactManifestFileName), "utf-8")) as ArtifactManifest
+    const manifestInfo = await lstat(manifestPath)
+    if (!manifestInfo.isFile() || manifestInfo.isSymbolicLink()) {
+      return null
+    }
+    manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as ArtifactManifest
   } catch {
     return null
   }
   if (!manifest || typeof manifest !== "object") {
     return null
   }
-  if (manifest.version !== undefined && manifest.version !== 1 && manifest.version !== 2) {
+  if (manifest.version !== 1 && manifest.version !== 2) {
     return null
   }
   const seen = new Set<string>()

--- a/electron/chat/local-artifacts.ts
+++ b/electron/chat/local-artifacts.ts
@@ -126,10 +126,10 @@ async function resolveArtifactManifestPath(rootDir: string, value: unknown): Pro
     if (realResolved !== realRoot && !realResolved.startsWith(`${realRoot}${path.sep}`)) {
       return null
     }
+    return realResolved
   } catch {
     return null
   }
-  return resolved
 }
 
 export async function localArtifactItem(filePath: string): Promise<LocalArtifactItem | null> {
@@ -162,7 +162,7 @@ async function artifactManifestEntry(
   }
   seen.add(filePath)
   const item = await localArtifactItem(filePath)
-  if (!item) {
+  if (!item || item.kind !== "file") {
     seen.delete(filePath)
     return null
   }

--- a/electron/chat/local-artifacts.ts
+++ b/electron/chat/local-artifacts.ts
@@ -8,11 +8,20 @@ import type {
   LocalArtifactPackKind,
 } from "./common.ts"
 
-import { readdir, readFile, realpath, stat } from "node:fs/promises"
+import { lstat, readdir, readFile, realpath, stat } from "node:fs/promises"
 import path from "node:path"
 import { mimeFromPath } from "./artifacts.ts"
 
 const artifactManifestFileName = ".wanta-artifact.json"
+
+export async function artifactManifestExists(rootDir: string): Promise<boolean> {
+  try {
+    const info = await lstat(path.join(rootDir, artifactManifestFileName))
+    return info.isFile() && !info.isSymbolicLink()
+  } catch {
+    return false
+  }
+}
 
 const artifactPackKinds = new Set<LocalArtifactPackKind>([
   "image_set",
@@ -43,6 +52,7 @@ interface ArtifactManifestItem {
 }
 
 interface ArtifactManifest {
+  version?: unknown
   title?: unknown
   kind?: unknown
   display?: unknown
@@ -105,7 +115,14 @@ async function resolveArtifactManifestPath(rootDir: string, value: unknown): Pro
     return null
   }
   try {
-    const [realRoot, realResolved] = await Promise.all([realpath(root), realpath(resolved)])
+    const [realRoot, realResolved, resolvedInfo] = await Promise.all([
+      realpath(root),
+      realpath(resolved),
+      lstat(resolved),
+    ])
+    if (resolvedInfo.isSymbolicLink()) {
+      return null
+    }
     if (realResolved !== realRoot && !realResolved.startsWith(`${realRoot}${path.sep}`)) {
       return null
     }
@@ -244,6 +261,9 @@ export async function readArtifactPack(rootDir: string): Promise<LocalArtifactPa
   if (!manifest || typeof manifest !== "object") {
     return null
   }
+  if (manifest.version !== undefined && manifest.version !== 1 && manifest.version !== 2) {
+    return null
+  }
   const seen = new Set<string>()
   const primaryRawItems = manifestItems(manifest.items)
   const fallbackPrimaryItems = primaryRawItems.length > 0 ? [] : primaryPathItems(manifest.primary)
@@ -281,5 +301,14 @@ export async function readArtifactPack(rootDir: string): Promise<LocalArtifactPa
     supporting: normalized.supportingItems,
     totalItems: artifactPackVisibleCount(normalized.primaryItems, normalized.supportingItems),
     truncated: false,
+    ...([...primaryRawItems, ...fallbackPrimaryItems, ...supportingRawItems].length >
+    normalized.primaryItems.length + normalized.supportingItems.length
+      ? {
+          rejectedItems:
+            [...primaryRawItems, ...fallbackPrimaryItems, ...supportingRawItems].length -
+            normalized.primaryItems.length -
+            normalized.supportingItems.length,
+        }
+      : {}),
   }
 }

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -1231,6 +1231,70 @@ test("message completion records intermediate code files left in artifact root",
   }
 })
 
+test("message completion separates declared deliverables from artifact-root process files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-chat-declared-artifact-"))
+  try {
+    const artifactDir = path.join(root, "artifacts")
+    const processDir = path.join(root, "process")
+    await mkdir(artifactDir, { recursive: true })
+    await mkdir(processDir, { recursive: true })
+
+    const bridge = createBridgeAgent()
+    bridge.createArtifactDir.mockResolvedValue(artifactDir)
+    bridge.createProcessDir.mockResolvedValue(processDir)
+    const artifactBundleStore = new ArtifactBundleStore(root)
+    const turnOutputStore = new TurnOutputStore(root)
+    const service = new ChatServiceImpl(bridge.agent, { artifactBundleStore, turnOutputStore })
+    const events = captureServiceEvents(service)
+    service.startEventBridge()
+
+    await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "生成一份周报" })
+    bridge.emit({
+      type: "message.updated",
+      properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+    })
+    const queryPath = path.join(artifactDir, "q_accounts.json")
+    await writeFile(path.join(artifactDir, "weekly-report.html"), "<!doctype html><title>Weekly report</title>")
+    await writeFile(queryPath, JSON.stringify({ results: [1, 2, 3] }))
+    await writeFile(
+      path.join(artifactDir, ".wanta-artifact.json"),
+      JSON.stringify({
+        title: "Weekly report",
+        kind: "web_page",
+        display: "single",
+        items: [{ path: "weekly-report.html", role: "primary", order: 1 }],
+      }),
+    )
+
+    bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+    await waitForCondition(
+      () =>
+        events.some((event) => event.event === "artifactBundleUpdated") &&
+        events.some((event) => event.event === "turnOutputUpdated"),
+    )
+
+    const bundle = (await artifactBundleStore.read()).get("session-1")?.get("assistant-1")
+    assert.equal(bundle?.version, 2)
+    assert.deepEqual(
+      bundle?.items.map((item) => item.name),
+      ["weekly-report.html"],
+    )
+
+    const record = (await turnOutputStore.read()).get("session-1")?.get("assistant-1")
+    assert.equal(record?.artifactProcessRoot, artifactDir)
+    assert.deepEqual(
+      record?.files.map((item) => item.name),
+      ["q_accounts.json"],
+    )
+    assert.equal(
+      (await service.getTurnFileDiff({ sessionId: "session-1", messageId: "assistant-1", path: queryPath })).kind,
+      "text",
+    )
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})
+
 test("message completion treats a standalone HTML report as an artifact without requiring web keywords", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-chat-html-artifact-"))
   try {
@@ -4117,6 +4181,8 @@ test("resolveLocalArtifacts reads artifact pack manifests", async () => {
     sessionId: "session-1",
   })
   assert.ok(bundle)
+  assert.equal(bundle.status, "partial")
+  assert.equal(bundle.failure, "artifact_declaration_partial")
   const records = new Map()
   recordArtifactBundle(records, bundle)
   await artifactBundleStore.write(records)

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -1259,6 +1259,7 @@ test("message completion separates declared deliverables from artifact-root proc
     await writeFile(
       path.join(artifactDir, ".wanta-artifact.json"),
       JSON.stringify({
+        version: 2,
         title: "Weekly report",
         kind: "web_page",
         display: "single",

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -63,6 +63,7 @@ import type {
   TurnOutputsRequest,
 } from "./common.ts"
 import type { SessionGeneration } from "./generation-registry.ts"
+import type { CreateArtifactResourceUrl } from "./previews.ts"
 import type { StoppedGenerationStore } from "./stopped-generations.ts"
 import type { StoredTurnOutputRecord, TurnOutputRecords, TurnOutputStore } from "./turn-outputs.ts"
 import type { UserAttachmentStore } from "./user-attachments.ts"
@@ -276,10 +277,7 @@ interface ChatServiceDeps {
   browserAvailable?: () => boolean
   hostQuestions?: HostQuestionBroker
   managedTurnDirectories?: ManagedTurnDirectories
-  createArtifactResourceUrl?: (item: { mime: string; modifiedAt: number; path: string; size: number }) => {
-    expiresAt: number
-    url: string
-  }
+  createArtifactResourceUrl?: CreateArtifactResourceUrl
   createSpreadsheetPreview?: (path: string, mime: string, size: number) => Promise<LocalArtifactPreviewResult>
   createArtifactThumbnail?: (path: string) => Promise<LocalArtifactThumbnailResult>
   artifactBundleStore?: ArtifactBundleStore
@@ -1425,8 +1423,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     return this.trustedAccess.isPathInRoots(filePath, roots)
   }
 
-  private async assertTrustedLocalPath(filePath: string): Promise<void> {
-    await this.trustedAccess.assertPath(filePath)
+  private async assertTrustedLocalPath(filePath: string): Promise<string> {
+    return this.trustedAccess.assertPath(filePath)
   }
 
   private async assertTrustedAttachments(attachments: readonly ChatAttachment[] | undefined): Promise<void> {
@@ -2554,8 +2552,13 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   }
 
   public async getLocalArtifactPreview(req: LocalArtifactPreviewRequest): Promise<LocalArtifactPreviewResult> {
-    await this.assertTrustedLocalPath(req.path)
-    return localArtifactPreview(req, this.deps.createArtifactResourceUrl, this.deps.createSpreadsheetPreview)
+    const trustedFile = await this.trustedAccess.assertFile(req.path)
+    return localArtifactPreview(
+      { path: trustedFile.path },
+      this.deps.createArtifactResourceUrl,
+      this.deps.createSpreadsheetPreview,
+      trustedFile,
+    )
   }
 
   public async getLocalArtifactThumbnail(req: LocalArtifactThumbnailRequest): Promise<LocalArtifactThumbnailResult> {

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1396,6 +1396,9 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     }
     for (const records of turnOutputs.values()) {
       for (const record of records.values()) {
+        if (record.artifactProcessRoot) {
+          roots.add(record.artifactProcessRoot)
+        }
         if (record.processRoot) {
           roots.add(record.processRoot)
         }
@@ -2609,8 +2612,14 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (!record || !file) {
       return { kind: "missing", path: req.path, mime: "application/octet-stream", additions: 0, deletions: 0 }
     }
-    if (file.role === "process" && (!record.processRoot || !isPathInside(record.processRoot, file.path))) {
-      return { kind: "missing", path: req.path, mime: file.mime, additions: 0, deletions: 0 }
+    if (file.role === "process") {
+      const insideManagedProcess = Boolean(record.processRoot && isPathInside(record.processRoot, file.path))
+      const insideManagedArtifacts = Boolean(
+        record.artifactProcessRoot && isPathInside(record.artifactProcessRoot, file.path),
+      )
+      if (!insideManagedProcess && !insideManagedArtifacts) {
+        return { kind: "missing", path: req.path, mime: file.mime, additions: 0, deletions: 0 }
+      }
     }
     if (file.role === "project_change" && (!record.projectRoot || !isPathInside(record.projectRoot, file.path))) {
       return { kind: "missing", path: req.path, mime: file.mime, additions: 0, deletions: 0 }

--- a/electron/chat/previews.test.ts
+++ b/electron/chat/previews.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, open, rename, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { test } from "vitest"
@@ -95,3 +95,37 @@ test("localArtifactPreview streams large videos through an artifact resource lea
     await rm(directory, { force: true, recursive: true })
   }
 })
+
+test.skipIf(process.platform === "win32")(
+  "localArtifactPreview reads a verified snapshot after a parent-directory replacement without a resource grant",
+  async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wanta-preview-snapshot-"))
+    try {
+      const artifactDirectory = path.join(root, "artifacts")
+      const movedArtifactDirectory = path.join(root, "artifacts-original")
+      const outsideDirectory = path.join(root, "outside")
+      await Promise.all([mkdir(artifactDirectory), mkdir(outsideDirectory)])
+      const filePath = path.join(artifactDirectory, "report.txt")
+      await writeFile(filePath, "trusted content")
+      await writeFile(path.join(outsideDirectory, "report.txt"), "outside content")
+      const handle = await open(filePath, "r")
+      const info = await stat(filePath)
+
+      await rename(artifactDirectory, movedArtifactDirectory)
+      await symlink(outsideDirectory, artifactDirectory, "dir")
+
+      const preview = await localArtifactPreview({ path: filePath }, undefined, undefined, {
+        dev: info.dev,
+        handle,
+        ino: info.ino,
+        modifiedAt: info.mtimeMs,
+        size: info.size,
+      })
+
+      assert.equal(preview.kind, "text")
+      assert.equal(preview.text, "trusted content")
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  },
+)

--- a/electron/chat/previews.ts
+++ b/electron/chat/previews.ts
@@ -4,11 +4,15 @@ import type {
   LocalArtifactPreviewRequest,
   LocalArtifactPreviewResult,
 } from "./common.ts"
+import type { FileHandle } from "node:fs/promises"
 
-import { readFile, stat } from "node:fs/promises"
+import { mkdtemp, open, readFile, rm, stat } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import { logDiagnostic } from "../diagnostics-log.ts"
 import {
   archivePreview,
+  archiveFormatFromPath,
   binaryDataPreview,
   isBinaryDataPreviewArtifact,
   isDocxArtifact,
@@ -18,10 +22,11 @@ import {
   richPreviewMaxBytes,
   rtfToPlainText,
   spreadsheetPreview,
+  spreadsheetPreviewMaxBytes,
 } from "./artifact-preview.ts"
-import { imageMimeFromPath } from "./artifacts.ts"
+import { imageMimeFromPath, mimeFromPath } from "./artifacts.ts"
 import { localArtifactItem } from "./local-artifacts.ts"
-import { isTextArtifactMime, readTextPreview } from "./turn-output-files.ts"
+import { artifactTextPreviewMaxBytes, isTextArtifactMime, readTextPreview } from "./turn-output-files.ts"
 import { zipArchiveStats, zipArchiveWithinLimits } from "./zip-central-directory.ts"
 
 const attachmentPreviewMaxBytes = 16 * 1024 * 1024
@@ -49,11 +54,13 @@ function resourceResult(
 
 export interface ArtifactResourceGrant {
   expiresAt: number
+  retainsHandle?: boolean
   url: string
 }
 export type CreateArtifactResourceUrl = (item: {
   dev: number
   ino: number
+  handle?: FileHandle
   mime: string
   modifiedAt: number
   path: string
@@ -63,9 +70,57 @@ export type CreateSpreadsheetPreview = (path: string, mime: string, size: number
 
 export interface ArtifactPreviewFileIdentity {
   dev: number
+  handle: FileHandle
   ino: number
   modifiedAt: number
   size: number
+}
+
+async function snapshotTrustedFile(
+  identity: ArtifactPreviewFileIdentity,
+  sourcePath: string,
+  maxBytes = identity.size,
+): Promise<{ directory: string; path: string }> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-artifact-preview-"))
+  const target = path.join(directory, path.basename(sourcePath) || "artifact")
+  let targetHandle: FileHandle | undefined
+  try {
+    targetHandle = await open(target, "wx")
+    const buffer = Buffer.allocUnsafe(64 * 1024)
+    const snapshotSize = Math.min(identity.size, maxBytes)
+    let position = 0
+    while (position < snapshotSize) {
+      const { bytesRead } = await identity.handle.read(
+        buffer,
+        0,
+        Math.min(buffer.length, snapshotSize - position),
+        position,
+      )
+      if (bytesRead === 0) break
+      let written = 0
+      while (written < bytesRead) {
+        const result = await targetHandle.write(buffer, written, bytesRead - written, position + written)
+        written += result.bytesWritten
+      }
+      position += bytesRead
+    }
+    const current = await identity.handle.stat()
+    if (
+      position !== snapshotSize ||
+      current.dev !== identity.dev ||
+      current.ino !== identity.ino ||
+      current.size !== identity.size ||
+      current.mtimeMs !== identity.modifiedAt
+    ) {
+      throw new Error("Artifact changed while creating a preview snapshot")
+    }
+    return { directory, path: target }
+  } catch (error) {
+    await rm(directory, { force: true, recursive: true })
+    throw error
+  } finally {
+    await targetHandle?.close().catch(() => undefined)
+  }
 }
 
 function errorMessage(error: unknown): string {
@@ -132,85 +187,164 @@ export async function localArtifactPreview(
   createSpreadsheetPreview: CreateSpreadsheetPreview = spreadsheetPreview,
   fileIdentity?: ArtifactPreviewFileIdentity,
 ): Promise<LocalArtifactPreviewResult> {
-  const item = await localArtifactItem(req.path)
+  const item = fileIdentity
+    ? {
+        kind: "file" as const,
+        mime: mimeFromPath(req.path),
+        modifiedAt: fileIdentity.modifiedAt,
+        name: path.basename(req.path),
+        path: req.path,
+        size: fileIdentity.size,
+      }
+    : await localArtifactItem(req.path)
   if (!item || item.kind !== "file") {
     return { kind: "unsupported", mime: "application/octet-stream", reason: "missing" }
   }
 
   const size = fileIdentity?.size ?? item.size ?? 0
-  const requestResource = (): ArtifactResourceGrant | undefined =>
-    createResourceUrl?.({
+  let handleTransferred = false
+  let snapshot: { directory: string; path: string } | undefined
+  const requestResource = (): ArtifactResourceGrant | undefined => {
+    const resource = createResourceUrl?.({
       dev: fileIdentity?.dev ?? 0,
+      handle: fileIdentity?.handle,
       ino: fileIdentity?.ino ?? 0,
       mime: item.mime,
       modifiedAt: fileIdentity?.modifiedAt ?? item.modifiedAt ?? 0,
       path: item.path,
       size,
     })
-  if (item.mime.toLowerCase().startsWith("image/")) {
-    if (size > attachmentPreviewMaxBytes) {
+    if (resource?.retainsHandle && fileIdentity) handleTransferred = true
+    return resource
+  }
+  const previewPath = async (maxBytes?: number): Promise<string> => {
+    if (!fileIdentity) return item.path
+    snapshot ??= await snapshotTrustedFile(fileIdentity, item.path, maxBytes)
+    return snapshot.path
+  }
+  try {
+    if (item.mime.toLowerCase().startsWith("image/")) {
+      if (size > attachmentPreviewMaxBytes) {
+        return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
+      }
+      const resource = requestResource()
+      if (resource) {
+        return { kind: "image", mime: item.mime, size, ...resourceResult(resource) }
+      }
+      try {
+        const bytes = await readFile(await previewPath())
+        return {
+          kind: "image",
+          mime: item.mime,
+          size,
+          dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
+        }
+      } catch (error) {
+        logPreviewFailure("getLocalArtifactPreview image", item.path, error, item.mime)
+        return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+      }
+    }
+
+    if (item.mime.toLowerCase().startsWith("audio/") || item.mime.toLowerCase().startsWith("video/")) {
+      const resource = requestResource()
+      if (resource) {
+        return { kind: "media", mime: item.mime, size, ...resourceResult(resource) }
+      }
+      if (size > attachmentPreviewMaxBytes) {
+        return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
+      }
+      try {
+        const bytes = await readFile(await previewPath())
+        return {
+          kind: "media",
+          mime: item.mime,
+          size,
+          dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
+        }
+      } catch (error) {
+        logPreviewFailure("getLocalArtifactPreview media", item.path, error, item.mime)
+        return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+      }
+    }
+
+    if (isSpreadsheetPreviewArtifact(item.path, item.mime)) {
+      if (size > spreadsheetPreviewMaxBytes) {
+        return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
+      }
+      try {
+        return await createSpreadsheetPreview(await previewPath(), item.mime, size)
+      } catch (error) {
+        logPreviewFailure("getLocalArtifactPreview spreadsheet", item.path, error, item.mime)
+        return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+      }
+    }
+
+    if (archiveFormatFromPath(item.path, item.mime)) {
+      const archive = await archivePreview(await previewPath(), item.mime, size).catch((error: unknown) => {
+        logPreviewFailure("getLocalArtifactPreview archive", item.path, error, item.mime)
+        return { kind: "unsupported" as const, mime: item.mime, size, reason: "read_failed" as const }
+      })
+      return archive ?? { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+    }
+
+    if (isRtfArtifact(item.path, item.mime)) {
+      try {
+        const preview = await readTextPreview(await previewPath(artifactTextPreviewMaxBytes), size)
+        if (!preview) {
+          return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+        }
+        return {
+          kind: "text",
+          mime: item.mime,
+          size,
+          text: rtfToPlainText(preview.text),
+          truncated: preview.truncated,
+        }
+      } catch (error) {
+        logPreviewFailure("getLocalArtifactPreview rtf", item.path, error, item.mime)
+        return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+      }
+    }
+
+    if (isBinaryDataPreviewArtifact(item.path, item.mime) && size <= richPreviewMaxBytes) {
+      let verifiedDocxBytes: Buffer | undefined
+      if (isPdfArtifact(item.path, item.mime) || isDocxArtifact(item.path, item.mime)) {
+        if (isDocxArtifact(item.path, item.mime)) {
+          const validation = await safeDocxBytes(await previewPath()).catch(() => ({ reason: "read_failed" as const }))
+          if (!("bytes" in validation)) {
+            return { kind: "unsupported", mime: item.mime, size, reason: validation.reason }
+          }
+          verifiedDocxBytes = validation.bytes
+        }
+        const resource = requestResource()
+        if (resource && isPdfArtifact(item.path, item.mime)) {
+          return { kind: "pdf", mime: item.mime, size, ...resourceResult(resource) }
+        }
+        if (resource && isDocxArtifact(item.path, item.mime)) {
+          return { kind: "document", mime: item.mime, size, documentFormat: "docx", ...resourceResult(resource) }
+        }
+      }
+      try {
+        const bytes = isDocxArtifact(item.path, item.mime) ? verifiedDocxBytes : await readFile(await previewPath())
+        if (!bytes) return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+        const richPreview = binaryDataPreview(item.path, item.mime, size, bytes)
+        if (richPreview) {
+          return richPreview
+        }
+      } catch (error) {
+        logPreviewFailure("getLocalArtifactPreview rich file", item.path, error, item.mime)
+        return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+      }
+    } else if (isBinaryDataPreviewArtifact(item.path, item.mime)) {
       return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
     }
-    const resource = requestResource()
-    if (resource) {
-      return { kind: "image", mime: item.mime, size, ...resourceResult(resource) }
-    }
-    try {
-      const bytes = await readFile(item.path)
-      return {
-        kind: "image",
-        mime: item.mime,
-        size,
-        dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
-      }
-    } catch (error) {
-      logPreviewFailure("getLocalArtifactPreview image", item.path, error, item.mime)
-      return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-    }
-  }
 
-  if (item.mime.toLowerCase().startsWith("audio/") || item.mime.toLowerCase().startsWith("video/")) {
-    const resource = requestResource()
-    if (resource) {
-      return { kind: "media", mime: item.mime, size, ...resourceResult(resource) }
+    if (!isTextArtifactMime(item.mime)) {
+      return { kind: "unsupported", mime: item.mime, size, reason: "unsupported_type" }
     }
-    if (size > attachmentPreviewMaxBytes) {
-      return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
-    }
-    try {
-      const bytes = await readFile(item.path)
-      return {
-        kind: "media",
-        mime: item.mime,
-        size,
-        dataUrl: `data:${item.mime};base64,${bytes.toString("base64")}`,
-      }
-    } catch (error) {
-      logPreviewFailure("getLocalArtifactPreview media", item.path, error, item.mime)
-      return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-    }
-  }
 
-  if (isSpreadsheetPreviewArtifact(item.path, item.mime)) {
     try {
-      return await createSpreadsheetPreview(item.path, item.mime, size)
-    } catch (error) {
-      logPreviewFailure("getLocalArtifactPreview spreadsheet", item.path, error, item.mime)
-      return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-    }
-  }
-
-  const archive = await archivePreview(item.path, item.mime, size).catch((error: unknown) => {
-    logPreviewFailure("getLocalArtifactPreview archive", item.path, error, item.mime)
-    return { kind: "unsupported" as const, mime: item.mime, size, reason: "read_failed" as const }
-  })
-  if (archive) {
-    return archive
-  }
-
-  if (isRtfArtifact(item.path, item.mime)) {
-    try {
-      const preview = await readTextPreview(item.path, size)
+      const preview = await readTextPreview(await previewPath(artifactTextPreviewMaxBytes), size)
       if (!preview) {
         return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
       }
@@ -218,66 +352,15 @@ export async function localArtifactPreview(
         kind: "text",
         mime: item.mime,
         size,
-        text: rtfToPlainText(preview.text),
+        text: preview.text,
         truncated: preview.truncated,
       }
     } catch (error) {
-      logPreviewFailure("getLocalArtifactPreview rtf", item.path, error, item.mime)
+      logPreviewFailure("getLocalArtifactPreview text", item.path, error, item.mime)
       return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
     }
-  }
-
-  if (isBinaryDataPreviewArtifact(item.path, item.mime) && size <= richPreviewMaxBytes) {
-    let verifiedDocxBytes: Buffer | undefined
-    if (isPdfArtifact(item.path, item.mime) || isDocxArtifact(item.path, item.mime)) {
-      if (isDocxArtifact(item.path, item.mime)) {
-        const validation = await safeDocxBytes(item.path).catch(() => ({ reason: "read_failed" as const }))
-        if (!("bytes" in validation)) {
-          return { kind: "unsupported", mime: item.mime, size, reason: validation.reason }
-        }
-        verifiedDocxBytes = validation.bytes
-      }
-      const resource = requestResource()
-      if (resource && isPdfArtifact(item.path, item.mime)) {
-        return { kind: "pdf", mime: item.mime, size, ...resourceResult(resource) }
-      }
-      if (resource && isDocxArtifact(item.path, item.mime)) {
-        return { kind: "document", mime: item.mime, size, documentFormat: "docx", ...resourceResult(resource) }
-      }
-    }
-    try {
-      const bytes = isDocxArtifact(item.path, item.mime) ? verifiedDocxBytes : await readFile(item.path)
-      if (!bytes) return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-      const richPreview = binaryDataPreview(item.path, item.mime, size, bytes)
-      if (richPreview) {
-        return richPreview
-      }
-    } catch (error) {
-      logPreviewFailure("getLocalArtifactPreview rich file", item.path, error, item.mime)
-      return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-    }
-  } else if (isBinaryDataPreviewArtifact(item.path, item.mime)) {
-    return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }
-  }
-
-  if (!isTextArtifactMime(item.mime)) {
-    return { kind: "unsupported", mime: item.mime, size, reason: "unsupported_type" }
-  }
-
-  try {
-    const preview = await readTextPreview(item.path, size)
-    if (!preview) {
-      return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
-    }
-    return {
-      kind: "text",
-      mime: item.mime,
-      size,
-      text: preview.text,
-      truncated: preview.truncated,
-    }
-  } catch (error) {
-    logPreviewFailure("getLocalArtifactPreview text", item.path, error, item.mime)
-    return { kind: "unsupported", mime: item.mime, size, reason: "read_failed" }
+  } finally {
+    if (snapshot) await rm(snapshot.directory, { force: true, recursive: true }).catch(() => undefined)
+    if (fileIdentity && !handleTransferred) await fileIdentity.handle.close().catch(() => undefined)
   }
 }

--- a/electron/chat/previews.ts
+++ b/electron/chat/previews.ts
@@ -52,12 +52,21 @@ export interface ArtifactResourceGrant {
   url: string
 }
 export type CreateArtifactResourceUrl = (item: {
+  dev: number
+  ino: number
   mime: string
   modifiedAt: number
   path: string
   size: number
-}) => ArtifactResourceGrant
+}) => ArtifactResourceGrant | undefined
 export type CreateSpreadsheetPreview = (path: string, mime: string, size: number) => Promise<LocalArtifactPreviewResult>
+
+export interface ArtifactPreviewFileIdentity {
+  dev: number
+  ino: number
+  modifiedAt: number
+  size: number
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -97,9 +106,16 @@ export async function attachmentPreview(
       return { dataUrl: null }
     }
     if (createResourceUrl) {
-      return {
-        dataUrl: null,
-        ...resourceResult(createResourceUrl({ mime, modifiedAt: info.mtimeMs, path: req.path, size: info.size })),
+      const resource = createResourceUrl({
+        dev: info.dev,
+        ino: info.ino,
+        mime,
+        modifiedAt: info.mtimeMs,
+        path: req.path,
+        size: info.size,
+      })
+      if (resource) {
+        return { dataUrl: null, ...resourceResult(resource) }
       }
     }
     const bytes = await readFile(req.path)
@@ -114,15 +130,23 @@ export async function localArtifactPreview(
   req: LocalArtifactPreviewRequest,
   createResourceUrl?: CreateArtifactResourceUrl,
   createSpreadsheetPreview: CreateSpreadsheetPreview = spreadsheetPreview,
+  fileIdentity?: ArtifactPreviewFileIdentity,
 ): Promise<LocalArtifactPreviewResult> {
   const item = await localArtifactItem(req.path)
   if (!item || item.kind !== "file") {
     return { kind: "unsupported", mime: "application/octet-stream", reason: "missing" }
   }
 
-  const size = item.size ?? 0
+  const size = fileIdentity?.size ?? item.size ?? 0
   const requestResource = (): ArtifactResourceGrant | undefined =>
-    createResourceUrl?.({ mime: item.mime, modifiedAt: item.modifiedAt ?? 0, path: item.path, size })
+    createResourceUrl?.({
+      dev: fileIdentity?.dev ?? 0,
+      ino: fileIdentity?.ino ?? 0,
+      mime: item.mime,
+      modifiedAt: fileIdentity?.modifiedAt ?? item.modifiedAt ?? 0,
+      path: item.path,
+      size,
+    })
   if (item.mime.toLowerCase().startsWith("image/")) {
     if (size > attachmentPreviewMaxBytes) {
       return { kind: "unsupported", mime: item.mime, size, reason: "too_large" }

--- a/electron/chat/trusted-local-access.ts
+++ b/electron/chat/trusted-local-access.ts
@@ -17,6 +17,7 @@ export interface TrustedLocalAccessOptions {
 
 export interface TrustedLocalFile {
   dev: number
+  handle: FileHandle
   ino: number
   modifiedAt: number
   path: string
@@ -216,15 +217,15 @@ export class TrustedLocalAccess {
       }
       return {
         dev: openedInfo.dev,
+        handle,
         ino: openedInfo.ino,
         modifiedAt: openedInfo.mtimeMs,
         path: target,
         size: openedInfo.size,
       }
     } catch {
-      throw new Error("Local path is not available from this conversation.")
-    } finally {
       await handle?.close().catch(() => undefined)
+      throw new Error("Local path is not available from this conversation.")
     }
   }
 }

--- a/electron/chat/trusted-local-access.ts
+++ b/electron/chat/trusted-local-access.ts
@@ -1,6 +1,8 @@
 import type { ChatAttachment, ChatMessage, ChatPermissionRequest } from "./common.ts"
+import type { FileHandle } from "node:fs/promises"
 
-import { realpath } from "node:fs/promises"
+import { constants } from "node:fs"
+import { lstat, open, realpath } from "node:fs/promises"
 import os from "node:os"
 import { logDiagnostic } from "../diagnostics-log.ts"
 import { normalizeLocalPathCandidate } from "./artifacts.ts"
@@ -11,6 +13,14 @@ const rootsCacheMs = 1_000
 export interface TrustedLocalAccessOptions {
   loadAdditionalRoots: () => Promise<Iterable<string>>
   trustedAttachmentPaths?: Iterable<string> & { readonly revision?: number }
+}
+
+export interface TrustedLocalFile {
+  dev: number
+  ino: number
+  modifiedAt: number
+  path: string
+  size: number
 }
 
 /** 汇总会话明确授权的本地路径，并统一处理 realpath、缓存失效与路径包含校验。 */
@@ -171,13 +181,50 @@ export class TrustedLocalAccess {
   }
 
   public async isPathInRoots(filePath: string, roots: readonly string[]): Promise<boolean> {
-    const target = await realpath(filePath).catch(() => null)
-    return Boolean(target && roots.some((root) => isPathInside(root, target)))
+    return Boolean(await this.resolvePathInRoots(filePath, roots))
   }
 
-  public async assertPath(filePath: string): Promise<void> {
-    if (!(await this.isPathInRoots(filePath, await this.roots()))) {
+  public async resolvePathInRoots(filePath: string, roots: readonly string[]): Promise<string | null> {
+    const target = await realpath(filePath).catch(() => null)
+    return target && roots.some((root) => isPathInside(root, target)) ? target : null
+  }
+
+  public async assertPath(filePath: string): Promise<string> {
+    const target = await this.resolvePathInRoots(filePath, await this.roots())
+    if (!target) {
       throw new Error("Local path is not available from this conversation.")
+    }
+    return target
+  }
+
+  public async assertFile(filePath: string): Promise<TrustedLocalFile> {
+    const roots = await this.roots()
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0
+    let handle: FileHandle | undefined
+    try {
+      handle = await open(filePath, constants.O_RDONLY | noFollow)
+      const [target, pathInfo, openedInfo] = await Promise.all([realpath(filePath), lstat(filePath), handle.stat()])
+      if (
+        !roots.some((root) => isPathInside(root, target)) ||
+        !pathInfo.isFile() ||
+        pathInfo.isSymbolicLink() ||
+        !openedInfo.isFile() ||
+        pathInfo.dev !== openedInfo.dev ||
+        pathInfo.ino !== openedInfo.ino
+      ) {
+        throw new Error("Local path is not available from this conversation.")
+      }
+      return {
+        dev: openedInfo.dev,
+        ino: openedInfo.ino,
+        modifiedAt: openedInfo.mtimeMs,
+        path: target,
+        size: openedInfo.size,
+      }
+    } catch {
+      throw new Error("Local path is not available from this conversation.")
+    } finally {
+      await handle?.close().catch(() => undefined)
     }
   }
 }

--- a/electron/chat/turn-output-files.test.ts
+++ b/electron/chat/turn-output-files.test.ts
@@ -1,8 +1,11 @@
 import type { StoredTurnOutputFile } from "./turn-outputs.ts"
 
 import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import { test } from "vitest"
-import { boundTurnOutputPatchPayloads, isPathInside } from "./turn-output-files.ts"
+import { boundTurnOutputPatchPayloads, intermediateArtifactProcessFiles, isPathInside } from "./turn-output-files.ts"
 
 function file(path: string, patch: string): StoredTurnOutputFile {
   return {
@@ -29,4 +32,32 @@ test("boundTurnOutputPatchPayloads enforces a per-turn persisted patch budget", 
 test("isPathInside accepts a child whose name starts with two dots", () => {
   assert.equal(isPathInside("/repo", "/repo/..config/file.txt"), true)
   assert.equal(isPathInside("/repo", "/outside/file.txt"), false)
+})
+
+test("explicit artifact declarations route every undeclared file to execution details", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-turn-output-declared-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    await writeFile(path.join(root, "q_accounts.json"), JSON.stringify({ results: [] }))
+    await writeFile(path.join(root, "build-report.py"), "print('report')\n")
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        title: "Report",
+        kind: "web_page",
+        display: "single",
+        items: [{ path: "report.html", role: "primary", order: 1 }],
+      }),
+    )
+
+    const files = await intermediateArtifactProcessFiles(root, "Create a website report")
+
+    assert.deepEqual(
+      files.map((item) => item.name),
+      ["build-report.py", "q_accounts.json"],
+    )
+    assert.ok(files.every((item) => item.role === "process"))
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })

--- a/electron/chat/turn-output-files.test.ts
+++ b/electron/chat/turn-output-files.test.ts
@@ -43,6 +43,7 @@ test("explicit artifact declarations route every undeclared file to execution de
     await writeFile(
       path.join(root, ".wanta-artifact.json"),
       JSON.stringify({
+        version: 2,
         title: "Report",
         kind: "web_page",
         display: "single",
@@ -57,6 +58,31 @@ test("explicit artifact declarations route every undeclared file to execution de
       ["build-report.py", "q_accounts.json"],
     )
     assert.ok(files.every((item) => item.role === "process"))
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test("unversioned artifact declarations fail closed into execution details", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-turn-output-unversioned-"))
+  try {
+    await writeFile(path.join(root, "report.html"), "<!doctype html><title>Report</title>")
+    await writeFile(
+      path.join(root, ".wanta-artifact.json"),
+      JSON.stringify({
+        title: "Report",
+        kind: "web_page",
+        display: "single",
+        items: [{ path: "report.html", role: "primary", order: 1 }],
+      }),
+    )
+
+    const files = await intermediateArtifactProcessFiles(root, "Create a report")
+
+    assert.deepEqual(
+      files.map((item) => item.name),
+      ["report.html"],
+    )
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/electron/chat/turn-output-files.ts
+++ b/electron/chat/turn-output-files.ts
@@ -7,7 +7,12 @@ import path from "node:path"
 import { WANTA_MANAGED_PYTHON_ENV_DIRNAME } from "../agent/python-environment.ts"
 import { buildUnifiedDiff, collectGitTurnDiffs } from "../git/turn-diff.ts"
 import { mimeFromPath } from "./artifacts.ts"
-import { artifactPackVisiblePaths, localArtifactItem, readArtifactPack } from "./local-artifacts.ts"
+import {
+  artifactManifestExists,
+  artifactPackVisiblePaths,
+  localArtifactItem,
+  readArtifactPack,
+} from "./local-artifacts.ts"
 
 export const artifactTextPreviewMaxBytes = 512 * 1024
 export const turnOutputPatchBudgetChars = 2_000_000
@@ -243,14 +248,20 @@ export async function intermediateArtifactProcessFiles(
   artifactRoot: string,
   requestText: string,
 ): Promise<StoredTurnOutputFile[]> {
-  if (sourceRequestsCode(requestText)) {
+  const [pack, hasDeclaration] = await Promise.all([
+    readArtifactPack(artifactRoot),
+    artifactManifestExists(artifactRoot),
+  ])
+  if (!hasDeclaration && !pack && sourceRequestsCode(requestText)) {
     return []
   }
-  const pack = await readArtifactPack(artifactRoot)
   const visiblePaths = artifactPackVisiblePaths(pack)
   const relativePaths = (await listProcessFiles(artifactRoot)).filter((relativePath) => {
     const absolutePath = path.join(artifactRoot, relativePath)
-    return !visiblePaths.has(absolutePath) && intermediateCodeExtensions.has(fileExtension(relativePath))
+    if (path.basename(relativePath) === ".wanta-artifact.json" || visiblePaths.has(absolutePath)) {
+      return false
+    }
+    return pack || hasDeclaration ? true : intermediateCodeExtensions.has(fileExtension(relativePath))
   })
   const entries = await Promise.all(relativePaths.map((relativePath) => processFileEntry(artifactRoot, relativePath)))
   return entries.filter((entry): entry is StoredTurnOutputFile => Boolean(entry))

--- a/electron/chat/turn-output-files.ts
+++ b/electron/chat/turn-output-files.ts
@@ -2,7 +2,7 @@ import type { GitTurnBaseline } from "../git/turn-diff.ts"
 import type { TurnFileDiffResult } from "./common.ts"
 import type { StoredTurnOutputFile, StoredTurnOutputRecord } from "./turn-outputs.ts"
 
-import { open, readdir } from "node:fs/promises"
+import { open, readdir, realpath } from "node:fs/promises"
 import path from "node:path"
 import { WANTA_MANAGED_PYTHON_ENV_DIRNAME } from "../agent/python-environment.ts"
 import { buildUnifiedDiff, collectGitTurnDiffs } from "../git/turn-diff.ts"
@@ -256,9 +256,12 @@ export async function intermediateArtifactProcessFiles(
     return []
   }
   const visiblePaths = artifactPackVisiblePaths(pack)
+  const resolvedArtifactRoot = await realpath(artifactRoot).catch(() => path.resolve(artifactRoot))
+  const visibleRelativePaths = new Set(
+    [...visiblePaths].map((filePath) => path.relative(resolvedArtifactRoot, filePath)),
+  )
   const relativePaths = (await listProcessFiles(artifactRoot)).filter((relativePath) => {
-    const absolutePath = path.join(artifactRoot, relativePath)
-    if (path.basename(relativePath) === ".wanta-artifact.json" || visiblePaths.has(absolutePath)) {
+    if (path.basename(relativePath) === ".wanta-artifact.json" || visibleRelativePaths.has(relativePath)) {
       return false
     }
     return pack || hasDeclaration ? true : intermediateCodeExtensions.has(fileExtension(relativePath))

--- a/electron/chat/turn-output-finalizer.ts
+++ b/electron/chat/turn-output-finalizer.ts
@@ -101,6 +101,7 @@ export async function finalizeTurnOutput(options: {
     await options.publishTurnOutput({
       sessionId,
       messageId,
+      artifactProcessRoot: active.artifactRoot,
       processRoot: active.processRoot,
       ...(active.projectRoot ? { projectRoot: active.projectRoot } : {}),
       createdAt: active.createdAt,

--- a/electron/chat/turn-outputs.ts
+++ b/electron/chat/turn-outputs.ts
@@ -96,6 +96,7 @@ function normalizeRecord(value: unknown): StoredTurnOutputRecord | null {
   return {
     sessionId: source.sessionId,
     messageId: source.messageId,
+    ...(validString(source.artifactProcessRoot) ? { artifactProcessRoot: source.artifactProcessRoot } : {}),
     ...(validString(source.processRoot) ? { processRoot: source.processRoot } : {}),
     ...(validString(source.projectRoot) ? { projectRoot: source.projectRoot } : {}),
     createdAt: validNumber(source.createdAt) ? source.createdAt : Date.now(),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -557,7 +557,7 @@ const chatService = new ChatServiceImpl(null, {
   },
   createArtifactResourceUrl: (item) => {
     const lease = artifactResourceLeaseStore.grant(item)
-    return { expiresAt: lease.expiresAt, url: artifactResourceUrl(lease.token) }
+    return { expiresAt: lease.expiresAt, retainsHandle: Boolean(item.handle), url: artifactResourceUrl(lease.token) }
   },
   createSpreadsheetPreview: (filePath, mime, size) => spreadsheetPreviewWorker.preview(filePath, mime, size),
   artifactBundleStore,

--- a/src/i18n/app-messages.en.ts
+++ b/src/i18n/app-messages.en.ts
@@ -1073,6 +1073,12 @@ export const enMessages = {
   "artifacts.persistenceFailedTitle": "Artifact not saved",
   "artifacts.persistenceFailedDescription":
     "The generated result was shown in the response but was not saved as a local file that can be reopened.",
+  "artifacts.declarationInvalidTitle": "Artifact publication declaration is invalid",
+  "artifacts.declarationInvalidDescription":
+    "Wanta did not treat files in the directory as final outputs. Inspect them in execution details and regenerate the artifact.",
+  "artifacts.declarationPartialTitle": "Some artifacts were not published",
+  "artifacts.declarationPartialDescription":
+    "Some declared files were missing, duplicated, or outside the current artifact directory.",
   "artifacts.projectPublishFailedTitle": "Output not saved to the project",
   "artifacts.projectPublishFailedDescription":
     "The output remains available in Wanta, but it could not be copied into the project folder.",

--- a/src/i18n/app-messages.zh.ts
+++ b/src/i18n/app-messages.zh.ts
@@ -1026,6 +1026,11 @@ export const zhCNMessages = {
   "artifacts.emptyDescription": "当前对话还没有可查看的成果。Markdown、图片、视频、音频等文件会显示在这里。",
   "artifacts.persistenceFailedTitle": "制成品保存失败",
   "artifacts.persistenceFailedDescription": "生成结果已显示在回复中，但没有保存为可重新打开的本地文件。",
+  "artifacts.declarationInvalidTitle": "成果发布声明无效",
+  "artifacts.declarationInvalidDescription":
+    "Wanta 未把目录中的文件自动当作最终成果；可在执行详情中检查文件，并重新生成成果。",
+  "artifacts.declarationPartialTitle": "部分成果未发布",
+  "artifacts.declarationPartialDescription": "成果声明中的部分文件不存在、重复或不在当前成果目录内。",
   "artifacts.projectPublishFailedTitle": "制成品未保存到项目",
   "artifacts.projectPublishFailedDescription": "制成品仍可在 Wanta 中查看，但未能复制到项目文件夹。",
   "artifacts.projectPublishPartialTitle": "部分制成品未保存到项目",

--- a/src/routes/Chat/ArtifactBrowser.tsx
+++ b/src/routes/Chat/ArtifactBrowser.tsx
@@ -30,6 +30,8 @@ export function ArtifactFileStrip({
   browseLevels,
   entries,
   listHeight,
+  listMaxHeight,
+  listMinHeight,
   onContextMenu,
   onEnterFolder,
   onNavigateBreadcrumb,
@@ -45,6 +47,8 @@ export function ArtifactFileStrip({
   browseLevels: ArtifactBrowseLevel[]
   entries: ArtifactPanelEntry[]
   listHeight: number
+  listMaxHeight: number
+  listMinHeight: number
   onContextMenu: (item: LocalArtifactItem, x: number, y: number) => void
   onEnterFolder: (entry: ArtifactPanelEntry) => void
   onNavigateBreadcrumb: (index: number) => void
@@ -96,6 +100,8 @@ export function ArtifactFileStrip({
         ) : null}
       </div>
       <ArtifactPanelResizeHandle
+        maxValue={listMaxHeight}
+        minValue={listMinHeight}
         value={listHeight}
         onDoubleClick={onResizeDoubleClick}
         onKeyDown={onResizeKeyDown}
@@ -176,11 +182,15 @@ function ArtifactBrowserHeader({
 }
 
 function ArtifactPanelResizeHandle({
+  maxValue,
+  minValue,
   onDoubleClick,
   onKeyDown,
   onPointerDown,
   value,
 }: {
+  maxValue: number
+  minValue: number
   onDoubleClick: () => void
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
   onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
@@ -193,7 +203,8 @@ function ArtifactPanelResizeHandle({
       role="separator"
       aria-label={t("artifacts.resizeFileBrowser")}
       aria-orientation="horizontal"
-      aria-valuemin={0}
+      aria-valuemax={Math.round(maxValue)}
+      aria-valuemin={Math.round(minValue)}
       aria-valuenow={Math.round(value)}
       tabIndex={0}
       title={t("artifacts.resizeFileBrowser")}
@@ -255,6 +266,8 @@ export function ImageGalleryPanel({
   entries,
   group,
   listHeight,
+  listMaxHeight,
+  listMinHeight,
   mode,
   onContextMenu,
   onEnterFolder,
@@ -273,6 +286,8 @@ export function ImageGalleryPanel({
   entries: ArtifactPanelEntry[]
   group: LocalArtifactGroup | null
   listHeight: number
+  listMaxHeight: number
+  listMinHeight: number
   mode: ArtifactPreviewMode
   onContextMenu: (item: LocalArtifactItem, x: number, y: number) => void
   onEnterFolder: (entry: ArtifactPanelEntry) => void
@@ -323,6 +338,8 @@ export function ImageGalleryPanel({
           </div>
         </div>
         <ArtifactPanelResizeHandle
+          maxValue={listMaxHeight}
+          minValue={listMinHeight}
           value={listHeight}
           onDoubleClick={onResizeDoubleClick}
           onKeyDown={onResizeKeyDown}

--- a/src/routes/Chat/ArtifactBrowser.tsx
+++ b/src/routes/Chat/ArtifactBrowser.tsx
@@ -25,8 +25,6 @@ export interface ArtifactBrowseLevel {
   path: string
 }
 
-const artifactListMinHeightPx = 96
-
 export function ArtifactFileStrip({
   baseCrumb,
   browseLevels,
@@ -195,7 +193,7 @@ function ArtifactPanelResizeHandle({
       role="separator"
       aria-label={t("artifacts.resizeFileBrowser")}
       aria-orientation="horizontal"
-      aria-valuemin={artifactListMinHeightPx}
+      aria-valuemin={0}
       aria-valuenow={Math.round(value)}
       tabIndex={0}
       title={t("artifacts.resizeFileBrowser")}

--- a/src/routes/Chat/ArtifactImageGallery.tsx
+++ b/src/routes/Chat/ArtifactImageGallery.tsx
@@ -121,6 +121,7 @@ export function ImageGalleryPreview({
       }}
     >
       <div
+        key={item.path}
         className={cn(
           "min-h-0 flex-1",
           mode === "preview" && preview?.kind === "pdf" ? "overflow-hidden" : "overflow-auto",

--- a/src/routes/Chat/ArtifactPreviewPane.tsx
+++ b/src/routes/Chat/ArtifactPreviewPane.tsx
@@ -207,6 +207,7 @@ export function ArtifactPreview({
       ) : null}
 
       <div
+        key={item.path}
         className={cn(
           "min-h-0 flex-1",
           activeMode === "preview" && preview?.kind === "pdf" ? "overflow-hidden" : "overflow-auto",
@@ -634,13 +635,13 @@ function ArtifactHtmlPreview({ preview }: { preview: LocalArtifactPreviewResult 
   const source = preview.text ?? ""
 
   return (
-    <div className="flex min-h-full min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)]">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)]">
       <iframe
         title={t("artifacts.htmlPreview")}
         srcDoc={htmlPreviewSrcDoc(source)}
         sandbox={htmlPreviewSandbox()}
         referrerPolicy="no-referrer"
-        className="block h-full min-h-[480px] w-full min-w-0 flex-1 border-0 bg-transparent"
+        className="block h-full min-h-0 w-full min-w-0 flex-1 border-0 bg-transparent"
       />
       {preview.truncated ? (
         <p className="oo-text-caption oo-border-divider border-t px-3 py-2 text-muted-foreground">

--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -5,6 +5,7 @@ import type {
   ChatPermissionRequest,
   ChatQuestionRequest,
   ChatMessage,
+  LocalArtifactPack,
   TurnOutputRecord,
 } from "../../../electron/chat/common.ts"
 import type { ChatErrorKind } from "../../../electron/chat/error.ts"
@@ -477,28 +478,52 @@ export const ChatTimeline = React.memo(function ChatTimeline({
     const ageMs = Date.now() - latestAssistant.createdAt
     return ageMs >= 0 && ageMs <= ASSISTANT_TEXT_SMOOTH_WINDOW_MS ? latestAssistant.id : undefined
   }, [activeAssistantMessageId, latestAssistant])
-  const visibleArtifactGroups = React.useMemo<ResolvedArtifactGroup[]>(
-    () =>
-      artifactBundles.map((bundle) => ({
+  const visibleArtifactGroups = React.useMemo<ResolvedArtifactGroup[]>(() => {
+    return artifactBundles.map((bundle) => {
+      const root = {
+        path: bundle.rootPath,
+        name: bundle.rootPath.split(/[\\/]/u).pop() ?? bundle.rootPath,
+        kind: "directory" as const,
+        mime: "inode/directory",
+      }
+      const pack: LocalArtifactPack | undefined =
+        bundle.version === 2 && bundle.title
+          ? {
+              root,
+              title: bundle.title,
+              kind: bundle.kind,
+              display: bundle.display,
+              ...(bundle.summary ? { summary: bundle.summary } : {}),
+              items: bundle.items
+                .filter((item) => item.role === "primary")
+                .map((item, index) => ({ ...item, role: "primary" as const, order: item.order ?? index + 1 })),
+              supporting: bundle.items
+                .filter((item) => item.role !== "primary")
+                .map((item, index) => ({
+                  ...item,
+                  role: item.role ?? ("supporting" as const),
+                  order: item.order ?? index + 1,
+                })),
+              totalItems: bundle.totalItems,
+              truncated: bundle.truncated,
+            }
+          : undefined
+      return {
         display: bundle.display,
         messageId: bundle.messageId,
         kind: bundle.kind,
         group: {
-          root: {
-            path: bundle.rootPath,
-            name: bundle.rootPath.split(/[\\/]/u).pop() ?? bundle.rootPath,
-            kind: "directory" as const,
-            mime: "inode/directory",
-          },
+          root,
           items: bundle.items,
           totalItems: bundle.totalItems,
           truncated: bundle.truncated,
         },
+        ...(pack ? { pack } : {}),
         status: bundle.status,
         ...(bundle.failure ? { failure: bundle.failure } : {}),
-      })),
-    [artifactBundles],
-  )
+      }
+    })
+  }, [artifactBundles])
   const artifactGroupsByMessageId = React.useMemo(() => {
     const byMessageId = new Map<string, ResolvedArtifactGroup[]>()
     for (const group of visibleArtifactGroups) {

--- a/src/routes/Chat/GeneratedArtifacts.test.ts
+++ b/src/routes/Chat/GeneratedArtifacts.test.ts
@@ -8,7 +8,11 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { htmlPreviewSandbox, htmlPreviewSrcDoc } from "./artifact-html-preview.ts"
 import { artifactGroupDisplayItem, artifactKindLabel, isVideoArtifact } from "./artifact-metadata.ts"
-import { artifactListHeightForRatio, artifactListRatioForHeight } from "./artifact-panel-layout.ts"
+import {
+  artifactListHeightForRatio,
+  artifactListMinimumHeight,
+  artifactListRatioForHeight,
+} from "./artifact-panel-layout.ts"
 import { buildArtifactPaletteItems } from "./composer-palette-items.ts"
 import { GeneratedArtifactsShelf } from "./GeneratedArtifacts.tsx"
 import { I18nContext, translate } from "@/i18n/i18n"
@@ -215,6 +219,12 @@ describe("artifact panel split layout", () => {
     expect(artifactListHeightForRatio(0.9, 1_000)).toBe(550)
     expect(artifactListHeightForRatio(0.9, 600)).toBe(330)
     expect(artifactListHeightForRatio(0.9, 300)).toBe(80)
+  })
+
+  it("reports the same responsive minimum used by the layout clamp", () => {
+    expect(artifactListMinimumHeight(1_000)).toBe(96)
+    expect(artifactListMinimumHeight(300)).toBe(80)
+    expect(artifactListMinimumHeight(200)).toBe(0)
   })
 
   it("normalizes drag heights before persisting a ratio", () => {

--- a/src/routes/Chat/GeneratedArtifacts.test.ts
+++ b/src/routes/Chat/GeneratedArtifacts.test.ts
@@ -8,6 +8,7 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { htmlPreviewSandbox, htmlPreviewSrcDoc } from "./artifact-html-preview.ts"
 import { artifactGroupDisplayItem, artifactKindLabel, isVideoArtifact } from "./artifact-metadata.ts"
+import { artifactListHeightForRatio, artifactListRatioForHeight } from "./artifact-panel-layout.ts"
 import { buildArtifactPaletteItems } from "./composer-palette-items.ts"
 import { GeneratedArtifactsShelf } from "./GeneratedArtifacts.tsx"
 import { I18nContext, translate } from "@/i18n/i18n"
@@ -206,6 +207,19 @@ describe("artifact group display", () => {
         truncated: false,
       }),
     ).toBe(first)
+  })
+})
+
+describe("artifact panel split layout", () => {
+  it("reclamps a stored ratio against every current panel height", () => {
+    expect(artifactListHeightForRatio(0.9, 1_000)).toBe(550)
+    expect(artifactListHeightForRatio(0.9, 600)).toBe(330)
+    expect(artifactListHeightForRatio(0.9, 300)).toBe(80)
+  })
+
+  it("normalizes drag heights before persisting a ratio", () => {
+    expect(artifactListRatioForHeight(900, 1_000)).toBe(0.55)
+    expect(artifactListRatioForHeight(10, 1_000)).toBe(0.096)
   })
 })
 

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -23,7 +23,7 @@ import {
   artifactListDefaultRatio,
   artifactListHeightForRatio,
   artifactListMaximumHeight,
-  artifactListMinHeightPx,
+  artifactListMinimumHeight,
   artifactListRatioForHeight,
 } from "./artifact-panel-layout.ts"
 import { resolveArtifactResultPayloads } from "./artifact-resolution.ts"
@@ -348,6 +348,8 @@ export function ArtifactsPanel({
     return () => observer.disconnect()
   }, [])
   const artifactListHeight = artifactListHeightForRatio(artifactListRatio, panelHeight)
+  const artifactListMinHeight = artifactListMinimumHeight(panelHeight)
+  const artifactListMaxHeight = artifactListMaximumHeight(panelHeight)
   const [selectedPath, setSelectedPath] = React.useState<string | null>(fallbackPath)
   const [previewMode, setPreviewMode] = React.useState<ArtifactPreviewMode>("preview")
   const selectedEntry = entries.find((entry) => entry.item.path === selectedPath) ?? entries[0] ?? null
@@ -469,23 +471,21 @@ export function ArtifactsPanel({
     [browseLevels, groups],
   )
 
-  const updateArtifactListHeight = React.useCallback((nextHeight: number): void => {
-    const currentPanelHeight = shellRef.current?.getBoundingClientRect().height ?? 0
-    if (currentPanelHeight <= 0) {
-      return
-    }
-    const ratio = artifactListRatioForHeight(nextHeight, currentPanelHeight)
-    setArtifactListRatio(ratio)
-    saveArtifactListRatio(ratio)
-  }, [])
+  const updateArtifactListHeight = React.useCallback(
+    (nextHeight: number): void => {
+      if (panelHeight <= 0) {
+        return
+      }
+      const ratio = artifactListRatioForHeight(nextHeight, panelHeight)
+      setArtifactListRatio(ratio)
+      saveArtifactListRatio(ratio)
+    },
+    [panelHeight],
+  )
 
   const handleArtifactListResizeStart = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>): void => {
-      if (event.button !== 0) {
-        return
-      }
-      const panelHeight = shellRef.current?.getBoundingClientRect().height ?? 0
-      if (panelHeight <= 0) {
+      if (event.button !== 0 || panelHeight <= 0) {
         return
       }
       const startY = event.clientY
@@ -515,7 +515,7 @@ export function ArtifactsPanel({
       window.addEventListener("pointerup", handlePointerUp)
       window.addEventListener("pointercancel", handlePointerCancel)
     },
-    [artifactListHeight],
+    [artifactListHeight, panelHeight],
   )
 
   const handleArtifactListResizeKeyDown = React.useCallback(
@@ -532,15 +532,15 @@ export function ArtifactsPanel({
       }
       if (event.key === "Home") {
         event.preventDefault()
-        updateArtifactListHeight(artifactListMinHeightPx)
+        updateArtifactListHeight(artifactListMinHeight)
         return
       }
       if (event.key === "End") {
         event.preventDefault()
-        updateArtifactListHeight(artifactListMaximumHeight(shellRef.current?.getBoundingClientRect().height ?? 0))
+        updateArtifactListHeight(artifactListMaxHeight)
       }
     },
-    [artifactListHeight, updateArtifactListHeight],
+    [artifactListHeight, artifactListMaxHeight, artifactListMinHeight, updateArtifactListHeight],
   )
 
   return (
@@ -628,6 +628,8 @@ export function ArtifactsPanel({
               entries={entries}
               group={selectedEntry?.group ?? null}
               listHeight={artifactListHeight}
+              listMaxHeight={artifactListMaxHeight}
+              listMinHeight={artifactListMinHeight}
               previewCache={previewCache}
               mode={previewMode}
               baseCrumb={baseCrumb}
@@ -651,6 +653,8 @@ export function ArtifactsPanel({
                   browseLevels={browseLevels}
                   entries={entries}
                   listHeight={artifactListHeight}
+                  listMaxHeight={artifactListMaxHeight}
+                  listMinHeight={artifactListMinHeight}
                   selectedItem={selectedItem}
                   truncated={activeGroups.some(({ group }) => group.truncated)}
                   onContextMenu={(item, x, y) => setContextMenu({ item, x, y })}

--- a/src/routes/Chat/GeneratedArtifacts.tsx
+++ b/src/routes/Chat/GeneratedArtifacts.tsx
@@ -19,6 +19,13 @@ import {
   isImageArtifact,
   readableArtifactTitle,
 } from "./artifact-metadata.ts"
+import {
+  artifactListDefaultRatio,
+  artifactListHeightForRatio,
+  artifactListMaximumHeight,
+  artifactListMinHeightPx,
+  artifactListRatioForHeight,
+} from "./artifact-panel-layout.ts"
 import { resolveArtifactResultPayloads } from "./artifact-resolution.ts"
 import { shouldRenderGeneratedArtifactsShelf } from "./artifact-shelf-visibility.ts"
 import { ArtifactFileStrip, ImageGalleryPanel } from "./ArtifactBrowser.tsx"
@@ -33,11 +40,7 @@ import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { resolveUserFacingError, userFacingErrorDescription } from "@/lib/user-facing-error"
 import { cn } from "@/lib/utils"
 
-const artifactListHeightStorageKey = "wanta:artifacts:list-height"
-const artifactListDefaultHeightPx = 168
-const artifactListMinHeightPx = 96
-const artifactPreviewMinHeightPx = 220
-const artifactListMaxHeightRatio = 0.55
+const artifactListRatioStorageKey = "wanta:artifacts:list-ratio-v2"
 
 export interface ArtifactSelection {
   messageId: string
@@ -103,24 +106,14 @@ function artifactBrowserHasMultipleRoots(groups: ResolvedArtifactGroup[]): boole
   return false
 }
 
-function readArtifactListHeight(): number {
-  const value = Number(globalThis.localStorage?.getItem(artifactListHeightStorageKey))
-  return Number.isFinite(value) && value > 0 ? value : artifactListDefaultHeightPx
+function readArtifactListRatio(): number {
+  const value = Number(globalThis.localStorage?.getItem(artifactListRatioStorageKey))
+  return Number.isFinite(value) && value > 0 && value < 1 ? value : artifactListDefaultRatio
 }
 
-function artifactListMaxHeight(panelHeight: number): number {
-  return Math.max(artifactListMinHeightPx, panelHeight - artifactPreviewMinHeightPx)
-}
-
-function clampArtifactListHeight(height: number, panelHeight: number): number {
-  const ratioMax = Math.floor(panelHeight * artifactListMaxHeightRatio)
-  const maxHeight = Math.max(artifactListMinHeightPx, Math.min(artifactListMaxHeight(panelHeight), ratioMax))
-  return Math.min(Math.max(height, artifactListMinHeightPx), maxHeight)
-}
-
-function saveArtifactListHeight(height: number): void {
+function saveArtifactListRatio(ratio: number): void {
   try {
-    globalThis.localStorage?.setItem(artifactListHeightStorageKey, String(Math.round(height)))
+    globalThis.localStorage?.setItem(artifactListRatioStorageKey, ratio.toFixed(4))
   } catch {
     // 受限环境中 localStorage 可能不可用。
   }
@@ -138,18 +131,28 @@ function selectionWithContext(
 
 function ArtifactPersistenceWarning({ failure }: { failure?: ArtifactBundleFailure }) {
   const t = useT()
+  const declarationInvalid = failure === "artifact_declaration_invalid"
+  const declarationPartial = failure === "artifact_declaration_partial"
   const projectPublishFailure = failure === "project_output_publish_failed"
   const projectPublishPartial = failure === "project_output_publish_partial"
-  const titleKey = projectPublishFailure
-    ? "artifacts.projectPublishFailedTitle"
-    : projectPublishPartial
-      ? "artifacts.projectPublishPartialTitle"
-      : "artifacts.persistenceFailedTitle"
-  const descriptionKey = projectPublishFailure
-    ? "artifacts.projectPublishFailedDescription"
-    : projectPublishPartial
-      ? "artifacts.projectPublishPartialDescription"
-      : "artifacts.persistenceFailedDescription"
+  const titleKey = declarationInvalid
+    ? "artifacts.declarationInvalidTitle"
+    : declarationPartial
+      ? "artifacts.declarationPartialTitle"
+      : projectPublishFailure
+        ? "artifacts.projectPublishFailedTitle"
+        : projectPublishPartial
+          ? "artifacts.projectPublishPartialTitle"
+          : "artifacts.persistenceFailedTitle"
+  const descriptionKey = declarationInvalid
+    ? "artifacts.declarationInvalidDescription"
+    : declarationPartial
+      ? "artifacts.declarationPartialDescription"
+      : projectPublishFailure
+        ? "artifacts.projectPublishFailedDescription"
+        : projectPublishPartial
+          ? "artifacts.projectPublishPartialDescription"
+          : "artifacts.persistenceFailedDescription"
   return (
     <div className="rounded-lg border border-amber-500/30 bg-amber-500/8 px-3 py-2.5">
       <div className="flex min-w-0 items-start gap-2.5">
@@ -237,7 +240,8 @@ export function GeneratedArtifactsShelf({
         <ArtifactPersistenceWarning failure={newest.failure} />
       ) : primary.status === "partial" &&
         (primary.failure === "project_output_publish_failed" ||
-          primary.failure === "project_output_publish_partial") ? (
+          primary.failure === "project_output_publish_partial" ||
+          primary.failure === "artifact_declaration_partial") ? (
         <ArtifactPersistenceWarning failure={primary.failure} />
       ) : null}
       <OutputShelfCard
@@ -304,8 +308,10 @@ export function ArtifactsPanel({
   const [contextMenu, setContextMenu] = React.useState<ArtifactContextMenuState | null>(null)
   const previewCache = React.useRef<LocalArtifactPreviewCache>(new Map()).current
   const shellRef = React.useRef<HTMLElement | null>(null)
+  const contentRef = React.useRef<HTMLDivElement | null>(null)
   const navigationRequestRef = React.useRef(0)
-  const [artifactListHeight, setArtifactListHeight] = React.useState(readArtifactListHeight)
+  const [artifactListRatio, setArtifactListRatio] = React.useState(readArtifactListRatio)
+  const [panelHeight, setPanelHeight] = React.useState(0)
   const [browseLevels, setBrowseLevels] = React.useState<ArtifactBrowseLevel[]>([])
   const groups = React.useMemo(() => {
     if (selection?.groups?.length) {
@@ -331,18 +337,17 @@ export function ArtifactsPanel({
       : (selection?.selectedPath ?? entries[0]?.item.path ?? selection?.group.root?.path ?? null)
 
   React.useLayoutEffect(() => {
-    const panelHeight = shellRef.current?.getBoundingClientRect().height ?? 0
-    if (panelHeight <= 0) {
+    const content = contentRef.current
+    if (!content) {
       return
     }
-    setArtifactListHeight((current) => {
-      const clamped = clampArtifactListHeight(current, panelHeight)
-      if (clamped !== current) {
-        saveArtifactListHeight(clamped)
-      }
-      return clamped
-    })
+    const updatePanelHeight = (): void => setPanelHeight(content.getBoundingClientRect().height)
+    updatePanelHeight()
+    const observer = new ResizeObserver(updatePanelHeight)
+    observer.observe(content)
+    return () => observer.disconnect()
   }, [])
+  const artifactListHeight = artifactListHeightForRatio(artifactListRatio, panelHeight)
   const [selectedPath, setSelectedPath] = React.useState<string | null>(fallbackPath)
   const [previewMode, setPreviewMode] = React.useState<ArtifactPreviewMode>("preview")
   const selectedEntry = entries.find((entry) => entry.item.path === selectedPath) ?? entries[0] ?? null
@@ -465,10 +470,13 @@ export function ArtifactsPanel({
   )
 
   const updateArtifactListHeight = React.useCallback((nextHeight: number): void => {
-    const panelHeight = shellRef.current?.getBoundingClientRect().height ?? 0
-    const clamped = panelHeight > 0 ? clampArtifactListHeight(nextHeight, panelHeight) : nextHeight
-    setArtifactListHeight(clamped)
-    saveArtifactListHeight(clamped)
+    const currentPanelHeight = shellRef.current?.getBoundingClientRect().height ?? 0
+    if (currentPanelHeight <= 0) {
+      return
+    }
+    const ratio = artifactListRatioForHeight(nextHeight, currentPanelHeight)
+    setArtifactListRatio(ratio)
+    saveArtifactListRatio(ratio)
   }, [])
 
   const handleArtifactListResizeStart = React.useCallback(
@@ -484,21 +492,28 @@ export function ArtifactsPanel({
       const startHeight = artifactListHeight
       const pointerId = event.pointerId
       event.currentTarget.setPointerCapture(pointerId)
-      const handlePointerMove = (moveEvent: PointerEvent): void => {
-        const nextHeight = startHeight + moveEvent.clientY - startY
-        setArtifactListHeight(clampArtifactListHeight(nextHeight, panelHeight))
-      }
-      const handlePointerUp = (upEvent: PointerEvent): void => {
-        const nextHeight = clampArtifactListHeight(startHeight + upEvent.clientY - startY, panelHeight)
-        setArtifactListHeight(nextHeight)
-        saveArtifactListHeight(nextHeight)
+      const removeResizeListeners = (): void => {
         window.removeEventListener("pointermove", handlePointerMove)
         window.removeEventListener("pointerup", handlePointerUp)
-        window.removeEventListener("pointercancel", handlePointerUp)
+        window.removeEventListener("pointercancel", handlePointerCancel)
+      }
+      const handlePointerMove = (moveEvent: PointerEvent): void => {
+        const nextHeight = startHeight + moveEvent.clientY - startY
+        setArtifactListRatio(artifactListRatioForHeight(nextHeight, panelHeight))
+      }
+      const handlePointerUp = (upEvent: PointerEvent): void => {
+        const ratio = artifactListRatioForHeight(startHeight + upEvent.clientY - startY, panelHeight)
+        setArtifactListRatio(ratio)
+        saveArtifactListRatio(ratio)
+        removeResizeListeners()
+      }
+      const handlePointerCancel = (): void => {
+        setArtifactListRatio(artifactListRatioForHeight(startHeight, panelHeight))
+        removeResizeListeners()
       }
       window.addEventListener("pointermove", handlePointerMove)
       window.addEventListener("pointerup", handlePointerUp)
-      window.addEventListener("pointercancel", handlePointerUp)
+      window.addEventListener("pointercancel", handlePointerCancel)
     },
     [artifactListHeight],
   )
@@ -522,7 +537,7 @@ export function ArtifactsPanel({
       }
       if (event.key === "End") {
         event.preventDefault()
-        updateArtifactListHeight(artifactListMaxHeight(shellRef.current?.getBoundingClientRect().height ?? 0))
+        updateArtifactListHeight(artifactListMaximumHeight(shellRef.current?.getBoundingClientRect().height ?? 0))
       }
     },
     [artifactListHeight, updateArtifactListHeight],
@@ -606,7 +621,7 @@ export function ArtifactsPanel({
         </div>
       </header>
 
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div ref={contentRef} className="flex min-h-0 flex-1 flex-col">
         {hasArtifactBrowser ? (
           showImageGallery ? (
             <ImageGalleryPanel
@@ -623,7 +638,7 @@ export function ArtifactsPanel({
               onEnterFolder={(entry) => void enterFolder(entry)}
               onModeChange={setPreviewMode}
               onNavigateBreadcrumb={navigateToBreadcrumb}
-              onResizeDoubleClick={() => updateArtifactListHeight(artifactListDefaultHeightPx)}
+              onResizeDoubleClick={() => updateArtifactListHeight(panelHeight * artifactListDefaultRatio)}
               onResizeKeyDown={handleArtifactListResizeKeyDown}
               onResizeStart={handleArtifactListResizeStart}
               onSelect={selectPreviewPath}
@@ -642,7 +657,7 @@ export function ArtifactsPanel({
                   onEnterFolder={(entry) => void enterFolder(entry)}
                   onOpenPath={openArtifactPath}
                   onNavigateBreadcrumb={navigateToBreadcrumb}
-                  onResizeDoubleClick={() => updateArtifactListHeight(artifactListDefaultHeightPx)}
+                  onResizeDoubleClick={() => updateArtifactListHeight(panelHeight * artifactListDefaultRatio)}
                   onResizeKeyDown={handleArtifactListResizeKeyDown}
                   onResizeStart={handleArtifactListResizeStart}
                   onSelect={selectPreviewPath}

--- a/src/routes/Chat/artifact-panel-layout.ts
+++ b/src/routes/Chat/artifact-panel-layout.ts
@@ -1,0 +1,29 @@
+export const artifactListDefaultHeightPx = 168
+export const artifactListDefaultRatio = 0.22
+export const artifactListMinHeightPx = 96
+export const artifactPreviewMinHeightPx = 220
+
+const artifactListMaxHeightRatio = 0.55
+
+function clampArtifactListHeight(height: number, panelHeight: number): number {
+  const availableAbovePreview = Math.max(0, panelHeight - artifactPreviewMinHeightPx)
+  const effectiveMinHeight = Math.min(artifactListMinHeightPx, availableAbovePreview)
+  const ratioMax = Math.floor(panelHeight * artifactListMaxHeightRatio)
+  const maxHeight = Math.max(effectiveMinHeight, Math.min(availableAbovePreview, ratioMax))
+  return Math.min(Math.max(height, effectiveMinHeight), maxHeight)
+}
+
+export function artifactListHeightForRatio(ratio: number, panelHeight: number): number {
+  return panelHeight > 0 ? clampArtifactListHeight(panelHeight * ratio, panelHeight) : artifactListDefaultHeightPx
+}
+
+export function artifactListRatioForHeight(height: number, panelHeight: number): number {
+  if (panelHeight <= 0) {
+    return artifactListDefaultRatio
+  }
+  return clampArtifactListHeight(height, panelHeight) / panelHeight
+}
+
+export function artifactListMaximumHeight(panelHeight: number): number {
+  return clampArtifactListHeight(Number.POSITIVE_INFINITY, panelHeight)
+}

--- a/src/routes/Chat/artifact-panel-layout.ts
+++ b/src/routes/Chat/artifact-panel-layout.ts
@@ -7,10 +7,14 @@ const artifactListMaxHeightRatio = 0.55
 
 function clampArtifactListHeight(height: number, panelHeight: number): number {
   const availableAbovePreview = Math.max(0, panelHeight - artifactPreviewMinHeightPx)
-  const effectiveMinHeight = Math.min(artifactListMinHeightPx, availableAbovePreview)
+  const effectiveMinHeight = artifactListMinimumHeight(panelHeight)
   const ratioMax = Math.floor(panelHeight * artifactListMaxHeightRatio)
   const maxHeight = Math.max(effectiveMinHeight, Math.min(availableAbovePreview, ratioMax))
   return Math.min(Math.max(height, effectiveMinHeight), maxHeight)
+}
+
+export function artifactListMinimumHeight(panelHeight: number): number {
+  return Math.min(artifactListMinHeightPx, Math.max(0, panelHeight - artifactPreviewMinHeightPx))
 }
 
 export function artifactListHeightForRatio(ratio: number, panelHeight: number): number {

--- a/src/routes/Chat/artifact-preview-cache.ts
+++ b/src/routes/Chat/artifact-preview-cache.ts
@@ -170,6 +170,7 @@ export function useLocalArtifactPreview(
   const chatService = useChatService()
   const [preview, setPreview] = React.useState<LocalArtifactPreviewResult | null>(null)
   const [loading, setLoading] = React.useState(false)
+  const [loadedPreviewKey, setLoadedPreviewKey] = React.useState<string | null>(null)
   const [reloadVersion, setReloadVersion] = React.useState(0)
   const reloadAttemptRef = React.useRef<{ count: number; key: string | null }>({ count: 0, key: null })
   const previewKey = item ? artifactPreviewCacheKey(item) : null
@@ -185,23 +186,28 @@ export function useLocalArtifactPreview(
       previewCache.delete(previewKey)
     }
     setPreview(null)
+    setLoadedPreviewKey(null)
     setReloadVersion((value) => value + 1)
   }, [previewCache, previewKey])
 
   React.useEffect(() => {
     if (!item || item.kind !== "file") {
       setPreview(null)
+      setLoadedPreviewKey(null)
       setLoading(false)
       return
     }
     const cached = cachedArtifactPreviewResult(previewCache, item)
     if (cached) {
       setPreview(cached)
+      setLoadedPreviewKey(previewKey)
       setLoading(false)
       return
     }
     let cancelled = false
     const controller = new AbortController()
+    setPreview(null)
+    setLoadedPreviewKey(null)
     setLoading(true)
     void loadCachedArtifactPreview(
       previewCache,
@@ -213,6 +219,7 @@ export function useLocalArtifactPreview(
       .then((result) => {
         if (!cancelled) {
           setPreview(result)
+          setLoadedPreviewKey(previewKey)
         }
       })
       .catch(() => undefined)
@@ -227,5 +234,10 @@ export function useLocalArtifactPreview(
     }
   }, [chatService, item, previewCache, priority, reloadVersion])
 
-  return { loading, preview, reload }
+  const previewMatchesItem = loadedPreviewKey === previewKey
+  return {
+    loading: Boolean(item && item.kind === "file" && (!previewMatchesItem || loading)),
+    preview: previewMatchesItem ? preview : null,
+    reload,
+  }
 }

--- a/src/routes/Chat/artifact-preview-hook.test.tsx
+++ b/src/routes/Chat/artifact-preview-hook.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import type { LocalArtifactItem, LocalArtifactPreviewResult } from "../../../electron/chat/common.ts"
+import type { AppContextValue } from "@/components/AppContext"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useLocalArtifactPreview } from "./artifact-preview-cache.ts"
+import { AppContext } from "@/components/AppContext"
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function artifact(name: string, mime: string): LocalArtifactItem {
+  return { path: `/tmp/${name}`, name, kind: "file", mime, size: 10, modifiedAt: 1 }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+describe("useLocalArtifactPreview", () => {
+  const containers: HTMLElement[] = []
+
+  afterEach(() => {
+    for (const container of containers.splice(0)) {
+      container.remove()
+    }
+  })
+
+  it("never exposes the previous file preview under a newly selected item", async () => {
+    const htmlItem = artifact("report.html", "text/html")
+    const jsonItem = artifact("q_accounts.json", "application/json")
+    const htmlRequest = deferred<LocalArtifactPreviewResult>()
+    const jsonRequest = deferred<LocalArtifactPreviewResult>()
+    const invoke = vi.fn((_method: string, request: { path: string }) =>
+      request.path === htmlItem.path ? htmlRequest.promise : jsonRequest.promise,
+    )
+    const appContext = { chatService: { invoke } } as unknown as AppContextValue
+    const cache = new Map()
+    let latest: ReturnType<typeof useLocalArtifactPreview> | undefined
+
+    function Harness({ item }: { item: LocalArtifactItem }) {
+      latest = useLocalArtifactPreview(item, cache)
+      return null
+    }
+
+    const container = document.createElement("div")
+    containers.push(container)
+    document.body.append(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={appContext}>
+          <Harness item={htmlItem} />
+        </AppContext.Provider>,
+      )
+    })
+    expect(latest).toMatchObject({ loading: true, preview: null })
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={appContext}>
+          <Harness item={jsonItem} />
+        </AppContext.Provider>,
+      )
+    })
+    expect(latest).toMatchObject({ loading: true, preview: null })
+
+    await act(async () => {
+      htmlRequest.resolve({ kind: "text", mime: "text/html", text: "<h1>old report</h1>" })
+      await htmlRequest.promise
+    })
+    expect(latest).toMatchObject({ loading: true, preview: null })
+
+    await act(async () => {
+      jsonRequest.resolve({ kind: "text", mime: "application/json", text: '{"results":[]}' })
+      await jsonRequest.promise
+    })
+    expect(latest).toMatchObject({
+      loading: false,
+      preview: { kind: "text", mime: "application/json", text: '{"results":[]}' },
+    })
+
+    await act(async () => root.unmount())
+  })
+})


### PR DESCRIPTION
## Summary

This PR introduces an explicit, host-validated artifact publication contract and stabilizes the artifact preview layout and loading lifecycle.

Generated reports could previously surface every file under the managed artifact directory as a final output. Raw query responses, machine-review JSON, temporary scripts, and other process files therefore appeared alongside the actual report. Repeated artifact selection could also leave the preview with stale data from another file or let a persisted fixed list height squeeze the preview out of view.

## Root cause

Artifact finalization recursively inferred outputs from the filesystem and only excluded a narrow class of operational state files. The data model did not persist semantic roles such as primary, supporting, summary, or metadata. In the renderer, the file browser height was persisted as pixels and clamped only on mount, while preview hook state could temporarily combine a newly selected file with the prior file's loaded result.

## Changes

- Add a shared Artifact Contract V2 for built-in and external/BYOA agents using `.wanta-artifact.json`.
- Validate declared relative paths in the host, reject symlinked manifests and entries, reject path escapes, require a supported declaration version, and fail closed for invalid or empty declarations.
- Persist declared artifact titles, display metadata, roles, ordering, and partial-publication failures in versioned bundles.
- Route undeclared and metadata files to execution details while retaining versioned V1 and inferred legacy compatibility.
- Preserve trusted access to process files that originated in the managed artifact root.
- Reconstruct role-aware artifact packs in the renderer and surface declaration failures with localized messages.
- Persist the artifact browser split as a ratio, recalculate it with `ResizeObserver`, and use the same content height for rendering, dragging, keyboard bounds, reset behavior, and accessibility metadata.
- Remove the fixed 480 px HTML iframe minimum height.
- Isolate preview state by artifact cache key so late results from a previous selection cannot render under the current file.
- Document the adapter-independent artifact publication boundary.

## Verification

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm run format`
- [x] `corepack pnpm test` — 357 files passed, 2 skipped; 2821 tests passed, 4 skipped
- [x] `corepack pnpm run build`
- [x] Runtime/UI verification completed: the Electron development app hot-reloaded the review fixes and diagnostics contained no new error/fatal records.

The production build completed successfully. It reported only the repository's existing large-chunk warnings.

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately; artifact declaration and preview behavior are host-owned and do not depend on model credential mode.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned; built-in and external adapters receive the same artifact contract.
- [x] Migration, packaging, endpoint, and update implications were considered. Versioned V1 manifests and declaration-free legacy turns remain readable; V2 requires an explicit version and invalid declarations fail closed.
- [x] Relevant documentation and tests were updated.
