### PR TITLE
fix(byoa): harden runtime validation and routing boundaries

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -181,7 +181,8 @@ External agents build on `electron/agent/external/`:
   `ChatTokenUsage` + optional `contextWindow`) from ACP `usage_update`. The recorder attaches it to the
   latest assistant message, which is what lights the composer context meter.
 - **Probing** (`external/probe.ts`): PATH scan (reusing
-  `electron/agents/catalog.ts` + `resolveUserCommandPath`) with `--version`
+  `electron/agents/catalog.ts` + `resolveUserCommandPath`) with `--version`, plus
+  validation of any native CLI delegated to by a packaged ACP bridge
   verification, plus fail-open login detection for agent-owned ACP agents via
   config marker files. Login status gates only `agent-cli` profiles;
   a Wanta-routed harness is gated by its binary and Wanta model availability.

--- a/electron/agent/claude-model-gateway.ts
+++ b/electron/agent/claude-model-gateway.ts
@@ -1,29 +1,12 @@
-import type { WantaReasoningLevel } from "./reasoning.ts"
-import type { JSONValue, ModelMessage, ToolSet } from "ai"
-import type { LanguageModel } from "ai"
+import type { WantaModelRoute } from "./wanta-model-route.ts"
+import type { ModelMessage, ToolSet } from "ai"
 import type { IncomingMessage, Server, ServerResponse } from "node:http"
 
-import { createOpenAI } from "@ai-sdk/openai"
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { jsonSchema, streamText, tool } from "ai"
 import { randomBytes, randomUUID } from "node:crypto"
 import { createServer } from "node:http"
 import { errorMessage, logDiagnostic } from "../diagnostics-log.ts"
-
-export type ClaudeGatewayProviderKind = "openai-compatible" | "openai-responses"
-
-/** A credential-bearing route. It never leaves Electron main. */
-export interface ClaudeModelRoute {
-  apiKey: string
-  baseUrl: string
-  contextWindow?: number
-  displayName: string
-  maxOutputTokens?: number
-  modelId: string
-  providerKind: ClaudeGatewayProviderKind
-  reasoningLevel?: WantaReasoningLevel
-  reasoningStyle?: "effort" | "qwen-thinking"
-}
+import { boundedMaxOutputTokens, createLanguageModel, reasoningProviderOptions } from "./wanta-model-route.ts"
 
 export interface ClaudeModelGatewayDescriptor {
   /** Anthropic-compatible API root injected into one Claude Code session. */
@@ -35,7 +18,7 @@ export interface ClaudeModelGatewayDescriptor {
 }
 
 interface GatewayLease {
-  route: ClaudeModelRoute
+  route: WantaModelRoute
   sessionId: string
   token: string
 }
@@ -108,7 +91,7 @@ export class ClaudeModelGateway {
     })
   }
 
-  public async issue(sessionId: string, route: ClaudeModelRoute): Promise<ClaudeModelGatewayDescriptor> {
+  public async issue(sessionId: string, route: WantaModelRoute): Promise<ClaudeModelGatewayDescriptor> {
     if (this.disposed) throw new Error("Claude model gateway has been disposed.")
     const connection = await this.connection()
     const existing = this.leaseBySessionId.get(sessionId)
@@ -122,7 +105,7 @@ export class ClaudeModelGateway {
     return { baseUrl: connection.baseUrl, token: lease.token, model: CLAUDE_GATEWAY_MODEL_ALIAS }
   }
 
-  public update(sessionId: string, route: ClaudeModelRoute): void {
+  public update(sessionId: string, route: WantaModelRoute): void {
     const lease = this.leaseBySessionId.get(sessionId)
     if (!lease) throw new Error("Claude model route has not been issued for this session.")
     lease.route = route
@@ -214,7 +197,7 @@ export class ClaudeModelGateway {
 
   private async complete(
     response: ServerResponse,
-    route: ClaudeModelRoute,
+    route: WantaModelRoute,
     request: AnthropicMessageRequest,
   ): Promise<void> {
     const controller = new AbortController()
@@ -243,44 +226,6 @@ export class ClaudeModelGateway {
     }
     await streamCompletion(response, route, result.fullStream)
   }
-}
-
-export function createLanguageModel(route: ClaudeModelRoute): LanguageModel {
-  if (route.providerKind === "openai-responses") {
-    return createOpenAI({ apiKey: route.apiKey, baseURL: route.baseUrl, name: "wanta" }).responses(route.modelId)
-  }
-  return createOpenAICompatible({
-    apiKey: route.apiKey,
-    baseURL: route.baseUrl,
-    includeUsage: true,
-    name: "wanta",
-    ...(route.reasoningStyle === "qwen-thinking" && route.reasoningLevel !== undefined
-      ? {
-          transformRequestBody: (body: Record<string, unknown>) => ({
-            ...body,
-            enable_thinking: route.reasoningLevel !== "low",
-          }),
-        }
-      : {}),
-  }).languageModel(route.modelId)
-}
-
-export function reasoningProviderOptions(
-  route: ClaudeModelRoute,
-): Record<string, Record<string, JSONValue | undefined>> | undefined {
-  const level = route.reasoningLevel
-  if (!level || level === "default" || route.reasoningStyle === "qwen-thinking") return undefined
-  const effort = level === "max" && route.providerKind === "openai-responses" ? "xhigh" : level
-  return { [route.providerKind === "openai-responses" ? "openai" : "wanta"]: { reasoningEffort: effort } }
-}
-
-export function boundedMaxOutputTokens(requested: number | undefined, configured: number | undefined): number {
-  const requestValue = positiveInteger(requested) ?? 8_192
-  return configured ? Math.min(requestValue, configured) : requestValue
-}
-
-function positiveInteger(value: number | undefined): number | undefined {
-  return Number.isSafeInteger(value) && (value ?? 0) > 0 ? value : undefined
 }
 
 function createTools(definitions: readonly AnthropicTool[]): ToolSet {
@@ -388,7 +333,7 @@ async function collectCompletion(stream: AsyncIterable<unknown>): Promise<Comple
 
 async function streamCompletion(
   response: ServerResponse,
-  route: ClaudeModelRoute,
+  route: WantaModelRoute,
   stream: AsyncIterable<unknown>,
 ): Promise<void> {
   response.writeHead(200, {
@@ -579,7 +524,7 @@ interface StreamingBlocks {
   open: Map<string, { index: number; kind: "text" | "thinking" | "tool" }>
 }
 
-function completionResponse(route: ClaudeModelRoute, events: CompletionEvents): unknown {
+function completionResponse(route: WantaModelRoute, events: CompletionEvents): unknown {
   return {
     id: `msg_${randomUUID().replaceAll("-", "")}`,
     type: "message",

--- a/electron/agent/claude-model-route.ts
+++ b/electron/agent/claude-model-route.ts
@@ -1,7 +1,7 @@
 import type { ModelChoice } from "../models/common.ts"
 import type { RuntimeCustomModel } from "../models/store.ts"
-import type { ClaudeModelRoute } from "./claude-model-gateway.ts"
 import type { WantaReasoningLevel } from "./reasoning.ts"
+import type { WantaModelRoute } from "./wanta-model-route.ts"
 
 import { llmBaseUrl } from "../domain.ts"
 import { builtinProviderDefinition, isBuiltinModelId, resolveBuiltinModel } from "../models/builtin.ts"
@@ -15,7 +15,7 @@ export interface ClaudeModelRouteInput {
 }
 
 /** Resolve a public Wanta model choice into a credential-bearing main-process route. */
-export function resolveClaudeModelRoute(input: ClaudeModelRouteInput): ClaudeModelRoute {
+export function resolveClaudeModelRoute(input: ClaudeModelRouteInput): WantaModelRoute {
   if (input.choice.kind === "custom") {
     const model = input.customModels.find((candidate) => candidate.id === input.choice.id)
     if (!model) throw new Error("The selected custom model is unavailable or its API key is missing.")

--- a/electron/agent/contract/profile.ts
+++ b/electron/agent/contract/profile.ts
@@ -139,6 +139,11 @@ export const EXTERNAL_AGENT_KINDS = (Object.keys(AGENT_PROFILES) as AgentKind[])
   (kind): kind is ExternalAgentKind => kind !== "opencode",
 )
 
-export function isExternalAgentKind(kind: AgentKind): kind is ExternalAgentKind {
-  return kind !== "opencode"
+/** Runtime-safe registry check for persisted, IPC, and renderer-owned values. */
+export function isAgentKind(value: unknown): value is AgentKind {
+  return typeof value === "string" && Object.hasOwn(AGENT_PROFILES, value)
+}
+
+export function isExternalAgentKind(value: unknown): value is ExternalAgentKind {
+  return isAgentKind(value) && value !== "opencode"
 }

--- a/electron/agent/direct-cli-bin.test.ts
+++ b/electron/agent/direct-cli-bin.test.ts
@@ -39,5 +39,5 @@ describe("ensureDirectCliCommandBin", () => {
     } finally {
       await rm(base, { force: true, recursive: true })
     }
-  })
+  }, 15_000)
 })

--- a/electron/agent/external/adapter-base.ts
+++ b/electron/agent/external/adapter-base.ts
@@ -93,7 +93,7 @@ export abstract class ExternalAgentAdapter extends BaseAgentAdapter implements C
     if (typeof sessionId === "string" && this.forgottenSessions.has(sessionId)) {
       return
     }
-    this.transcript.record(safeEvent)
+    this.transcript.recordSafe(safeEvent)
     if (safeEvent.event === "permissionAsked") {
       this.pendingPermissionRequests.set(safeEvent.data.request.id, safeEvent.data.request)
     } else if (safeEvent.event === "permissionReplied") {

--- a/electron/agent/external/probe.test.ts
+++ b/electron/agent/external/probe.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest"
-import { parseClaudeAuthStatus } from "./probe.ts"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { ACP_AGENT_REGISTRY } from "../acp/registry.ts"
+import { parseClaudeAuthStatus, probeRegisteredRuntime, shouldProbeExternalAgentLogin } from "./probe.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })))
+})
 
 describe("parseClaudeAuthStatus", () => {
   it("recognizes the current Claude CLI logged-in response", () => {
@@ -15,5 +25,48 @@ describe("parseClaudeAuthStatus", () => {
   it("falls back when the command is unsupported or malformed", () => {
     expect(parseClaudeAuthStatus("unknown command: auth")).toBeUndefined()
     expect(parseClaudeAuthStatus(JSON.stringify({ authenticated: true }))).toBeUndefined()
+  })
+})
+
+describe("shouldProbeExternalAgentLogin", () => {
+  it("only probes a detected agent-owned CLI", () => {
+    const cliAuth = { kind: "agent-cli" as const, loginCommand: "agent login" }
+    expect(shouldProbeExternalAgentLogin(cliAuth, { status: "detected", path: "/bin/agent" })).toBe(true)
+    expect(shouldProbeExternalAgentLogin(cliAuth, { status: "not_found" })).toBe(false)
+    expect(shouldProbeExternalAgentLogin(cliAuth, { status: "error", message: "version failed" })).toBe(false)
+    expect(shouldProbeExternalAgentLogin({ kind: "wanta-account" }, { status: "detected", path: "/bin/harness" })).toBe(
+      false,
+    )
+  })
+})
+
+describe("probeRegisteredRuntime", () => {
+  it("rejects an invalid explicit native runtime override", async () => {
+    const missing = path.join(os.tmpdir(), "wanta-missing-codex-runtime")
+    await expect(
+      probeRegisteredRuntime(ACP_AGENT_REGISTRY.codex, "", { env: { CODEX_PATH: missing } }),
+    ).resolves.toEqual({
+      status: "not_found",
+      message: expect.stringContaining("set CODEX_PATH to a valid executable path"),
+    })
+  })
+
+  it.runIf(process.platform !== "win32")("detects the native CLI required by a packaged bridge", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "wanta-probe-runtime-"))
+    temporaryDirectories.push(directory)
+    const codexPath = path.join(directory, "codex")
+    await writeFile(codexPath, "#!/bin/sh\nexit 0\n", "utf8")
+    await chmod(codexPath, 0o755)
+
+    await expect(probeRegisteredRuntime(ACP_AGENT_REGISTRY.codex, directory, { env: {} })).resolves.toEqual({
+      status: "detected",
+      path: codexPath,
+    })
+  })
+
+  it("does nothing for agents that launch their native runtime directly", async () => {
+    await expect(probeRegisteredRuntime(ACP_AGENT_REGISTRY.grok, "", { env: {} })).resolves.toEqual({
+      status: "not_required",
+    })
   })
 })

--- a/electron/agent/external/probe.ts
+++ b/electron/agent/external/probe.ts
@@ -1,5 +1,5 @@
 import type { AcpAgentRegistration } from "../acp/registry.ts"
-import type { ExternalAgentKind } from "../contract/profile.ts"
+import type { AgentAuthMode, ExternalAgentKind } from "../contract/profile.ts"
 import type { ExternalAgentBinaryProbe, ExternalAgentLoginProbe, ExternalAgentRuntimeStatus } from "./status.ts"
 
 import { execFile } from "node:child_process"
@@ -31,6 +31,38 @@ export interface ExternalAgentProbeOptions {
   homeDirectory?: string
   /** Extra directories searched before PATH (dev node_modules/.bin, bundled Resources/bin). */
   extraBinDirectories?: readonly string[]
+}
+
+export function shouldProbeExternalAgentLogin(auth: AgentAuthMode, binary: ExternalAgentBinaryProbe): boolean {
+  return auth.kind === "agent-cli" && binary.status === "detected"
+}
+
+export type ExternalAgentRuntimeDependencyProbe =
+  | { status: "not_required" }
+  | { status: "detected"; path: string }
+  | { status: "not_found"; message: string }
+
+/** Verify the native CLI delegated to by a packaged ACP bridge. */
+export async function probeRegisteredRuntime(
+  registration: AcpAgentRegistration,
+  pathEnv: string,
+  options: ExternalAgentProbeOptions = {},
+): Promise<ExternalAgentRuntimeDependencyProbe> {
+  const runtime = registration.runtimeExecutable
+  if (!runtime) return { status: "not_required" }
+  const env = options.env ?? process.env
+  const configuredPath = env[runtime.envVar]?.trim()
+  const commands = configuredPath ? [configuredPath] : runtime.cliCommands
+  const detected = await detectCliExecutable(commands, {
+    env,
+    homeDirectory: options.homeDirectory,
+    pathEnv,
+  })
+  if (detected) return { status: "detected", path: detected.executablePath }
+  return {
+    status: "not_found",
+    message: `${registration.displayName} ACP bridge is installed, but its native CLI is missing. Install ${runtime.cliCommands[0] ?? registration.displayName} or set ${runtime.envVar} to a valid executable path.`,
+  }
 }
 
 async function probeCommandPath(options: ExternalAgentProbeOptions): Promise<string> {
@@ -180,8 +212,16 @@ export async function probeExternalAgent(
   const loginHint = agentLoginHint(kind)
   const pathEnv = await probeCommandPath(options)
   const registration = ACP_AGENT_REGISTRY[kind]
-  const binary = await probeBinary(registration.cliCommands, registration.versionArgs, options, pathEnv)
-  const login = await probeRegisteredLogin(registration, pathEnv, options)
+  let binary = await probeBinary(registration.cliCommands, registration.versionArgs, options, pathEnv)
+  if (binary.status === "detected") {
+    const runtime = await probeRegisteredRuntime(registration, pathEnv, options)
+    if (runtime.status === "not_found") {
+      binary = { status: "error", message: runtime.message }
+    }
+  }
+  const login = shouldProbeExternalAgentLogin(profile.auth, binary)
+    ? await probeRegisteredLogin(registration, pathEnv, options)
+    : { status: "unknown" as const }
   const status: ExternalAgentRuntimeStatus = { kind, displayName: profile.displayName, binary, login, loginHint }
   logDiagnosticOnChange(`byoa-probe:${kind}`, "byoa-probe", "external agent probe", {
     kind,

--- a/electron/agent/external/prompt-preparation.test.ts
+++ b/electron/agent/external/prompt-preparation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest"
+import { memoizePromptPreparation } from "./prompt-preparation.ts"
+
+describe("memoizePromptPreparation", () => {
+  it("shares one immutable preparation across hooks for the same prompt object", async () => {
+    const prepare = vi.fn(async (input: { model: string }) => ({
+      model: input.model,
+      sequence: prepare.mock.calls.length,
+    }))
+    const prepared = memoizePromptPreparation(prepare)
+    const prompt = { model: "first" }
+
+    const first = prepared(prompt)
+    prompt.model = "changed-after-submit"
+    const second = prepared(prompt)
+
+    expect(first).toBe(second)
+    await expect(first).resolves.toEqual({ model: "first", sequence: 1 })
+    expect(prepare).toHaveBeenCalledTimes(1)
+  })
+
+  it("prepares distinct prompt objects independently", async () => {
+    const prepare = vi.fn(async (input: { model: string }) => input.model)
+    const prepared = memoizePromptPreparation(prepare)
+
+    await expect(Promise.all([prepared({ model: "one" }), prepared({ model: "two" })])).resolves.toEqual(["one", "two"])
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+})

--- a/electron/agent/external/prompt-preparation.test.ts
+++ b/electron/agent/external/prompt-preparation.test.ts
@@ -1,5 +1,15 @@
+import type { PromptAgentInput } from "../contract/input.ts"
+
 import { describe, expect, it, vi } from "vitest"
-import { memoizePromptPreparation } from "./prompt-preparation.ts"
+import { memoizePromptPreparation, memoizePromptRoutePreparation } from "./prompt-preparation.ts"
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
 
 describe("memoizePromptPreparation", () => {
   it("shares one immutable preparation across hooks for the same prompt object", async () => {
@@ -25,5 +35,34 @@ describe("memoizePromptPreparation", () => {
 
     await expect(Promise.all([prepared({ model: "one" }), prepared({ model: "two" })])).resolves.toEqual(["one", "two"])
     expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
+  it("snapshots route fields before asynchronous model resolution", async () => {
+    const gate = deferred()
+    const prepare = vi.fn(async (input: { model?: unknown; reasoningLevel?: string; sessionId: string }) => {
+      await gate.promise
+      return input
+    })
+    const prepared = memoizePromptRoutePreparation(prepare)
+    const prompt: PromptAgentInput = {
+      type: "prompt",
+      sessionId: "session-original",
+      text: "hello",
+      model: { kind: "builtin", id: "gpt-5.6-sol" },
+      reasoningLevel: "high",
+    }
+
+    const result = prepared(prompt)
+    prompt.sessionId = "session-mutated"
+    prompt.model = { kind: "builtin", id: "oopilot" }
+    prompt.reasoningLevel = "low"
+    gate.resolve()
+
+    await expect(result).resolves.toEqual({
+      sessionId: "session-original",
+      model: { kind: "builtin", id: "gpt-5.6-sol" },
+      reasoningLevel: "high",
+    })
+    expect(prepare).toHaveBeenCalledTimes(1)
   })
 })

--- a/electron/agent/external/prompt-preparation.ts
+++ b/electron/agent/external/prompt-preparation.ts
@@ -1,0 +1,18 @@
+/**
+ * Memoize preparation by the identity of one prompt input. The entry is held
+ * weakly, so completed turns do not become app-lifetime state. This lets
+ * multiple setup hooks consume one immutable per-turn snapshot.
+ */
+export function memoizePromptPreparation<TInput extends object, TResult>(
+  prepare: (input: TInput) => Promise<TResult>,
+): (input: TInput) => Promise<TResult> {
+  const preparations = new WeakMap<TInput, Promise<TResult>>()
+  return (input) => {
+    let preparation = preparations.get(input)
+    if (!preparation) {
+      preparation = prepare(input)
+      preparations.set(input, preparation)
+    }
+    return preparation
+  }
+}

--- a/electron/agent/external/prompt-preparation.ts
+++ b/electron/agent/external/prompt-preparation.ts
@@ -1,3 +1,5 @@
+import type { PromptAgentInput } from "../contract/input.ts"
+
 /**
  * Memoize preparation by the identity of one prompt input. The entry is held
  * weakly, so completed turns do not become app-lifetime state. This lets
@@ -15,4 +17,24 @@ export function memoizePromptPreparation<TInput extends object, TResult>(
     }
     return preparation
   }
+}
+
+export type PromptRouteSelectionSnapshot = Pick<PromptAgentInput, "sessionId" | "model" | "reasoningLevel">
+
+/**
+ * Capture route-bearing prompt fields synchronously before preparation can
+ * yield. Callers may keep and mutate a draft object while model discovery is
+ * pending; one dispatched turn must retain its submission-time selection.
+ */
+export function memoizePromptRoutePreparation<TResult>(
+  prepare: (snapshot: PromptRouteSelectionSnapshot) => Promise<TResult>,
+): (input: PromptAgentInput) => Promise<TResult> {
+  return memoizePromptPreparation((input: PromptAgentInput) => {
+    const snapshot: PromptRouteSelectionSnapshot = {
+      sessionId: input.sessionId,
+      ...(input.model !== undefined ? { model: input.model } : {}),
+      ...(input.reasoningLevel !== undefined ? { reasoningLevel: input.reasoningLevel } : {}),
+    }
+    return prepare(snapshot)
+  })
 }

--- a/electron/agent/external/session-id.ts
+++ b/electron/agent/external/session-id.ts
@@ -1,7 +1,9 @@
-import type { AgentKind, ExternalAgentKind } from "../contract/profile.ts"
+import type { ExternalAgentKind } from "../contract/profile.ts"
 
 import { randomUUID } from "node:crypto"
-import { AGENT_PROFILES, isExternalAgentKind } from "../contract/profile.ts"
+import { isExternalAgentKind } from "../contract/profile.ts"
+
+export { isAgentKind } from "../contract/profile.ts"
 
 // External-agent sessions carry their agent kind inside the session id
 // (`wanta-ext:<kind>:<uuid>`), so routing between the built-in kernel and
@@ -44,15 +46,9 @@ export function parseExternalSessionIdentity(sessionId: string): ExternalSession
   return { kind, uuid }
 }
 
-export function isAgentKind(kind: string): kind is AgentKind {
-  // Own-property check only: `in` walks the prototype chain, so inherited
-  // Object.prototype keys must never be accepted as registered agent kinds.
-  return Object.hasOwn(AGENT_PROFILES, kind)
-}
-
 export function externalAgentKindForSessionId(sessionId: string): ExternalAgentKind | undefined {
   const identity = parseExternalSessionIdentity(sessionId)
-  if (identity && isAgentKind(identity.kind) && isExternalAgentKind(identity.kind)) {
+  if (identity && isExternalAgentKind(identity.kind)) {
     return identity.kind
   }
   return undefined

--- a/electron/agent/external/transcript-redaction.test.ts
+++ b/electron/agent/external/transcript-redaction.test.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent } from "../contract/event.ts"
 
 import { describe, expect, test } from "vitest"
+import { redactExternalAgentEvent } from "./transcript-redaction.ts"
 import { ExternalTranscriptRecorder } from "./transcript.ts"
 
 describe("external transcript credential boundary", () => {
@@ -48,5 +49,30 @@ describe("external transcript credential boundary", () => {
       rawInput: { authorization: "[redacted]" },
       formatted_output: String.raw`{\"api_token\":\"[redacted]\"}`,
     })
+  })
+
+  test("the adapter-safe recording path is behaviorally identical to recorder-owned redaction", () => {
+    const event: AgentEvent = {
+      event: "toolCallResult",
+      data: {
+        sessionId: "wanta-ext:codex:test",
+        messageId: "assistant-equivalence",
+        partId: "tool-equivalence",
+        callId: "tool-equivalence",
+        tool: "execute",
+        status: "completed",
+        input: { authorization: "Bearer input-secret", nested: { api_key: "nested-secret" } },
+        output: `{"refresh_token":"output-secret"}`,
+      },
+    }
+    const recorderOwned = new ExternalTranscriptRecorder()
+    const adapterOwned = new ExternalTranscriptRecorder()
+
+    recorderOwned.record(event)
+    adapterOwned.recordSafe(redactExternalAgentEvent(event))
+
+    const withoutCreationTime = (recorder: ExternalTranscriptRecorder) =>
+      recorder.messages(event.data.sessionId).map(({ createdAt: _createdAt, ...message }) => message)
+    expect(withoutCreationTime(adapterOwned)).toEqual(withoutCreationTime(recorderOwned))
   })
 })

--- a/electron/agent/external/transcript-redaction.ts
+++ b/electron/agent/external/transcript-redaction.ts
@@ -9,6 +9,9 @@ const sensitiveTextHint =
   /(?:access[_-]?token|api[_-]?(?:key|token)|authorization|bearer\s|client[_-]?secret|cookie|credential|password|personal[_-]?api[_-]?key|refresh[_-]?token|secret[_-]?api[_-]?token)/iu
 const bearerToken = /(\bbearer\s+)[^\s,;]+/giu
 
+declare const redactedExternalAgentEvent: unique symbol
+export type RedactedExternalAgentEvent = AgentEvent & { readonly [redactedExternalAgentEvent]: true }
+
 function redactTranscriptString(value: string): string {
   if (!sensitiveTextHint.test(value)) return value
   return redactConnectorOutput(value.replace(bearerToken, "$1[redacted]"))
@@ -38,8 +41,8 @@ export function redactExternalTranscriptValue<T>(value: T): T {
   ) as T
 }
 
-export function redactExternalAgentEvent(event: AgentEvent): AgentEvent {
-  return redactExternalTranscriptValue(event)
+export function redactExternalAgentEvent(event: AgentEvent): RedactedExternalAgentEvent {
+  return redactExternalTranscriptValue(event) as RedactedExternalAgentEvent
 }
 
 export function redactExternalMessages(messages: readonly ChatMessage[]): ChatMessage[] {

--- a/electron/agent/external/transcript.ts
+++ b/electron/agent/external/transcript.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ChatMessagePart, ChatTokenUsage } from "../../chat/common.ts"
 import type { AgentEvent } from "../contract/event.ts"
+import type { RedactedExternalAgentEvent } from "./transcript-redaction.ts"
 
 import { redactExternalAgentEvent, redactExternalMessages } from "./transcript-redaction.ts"
 
@@ -23,7 +24,11 @@ export class ExternalTranscriptRecorder {
   private readonly latestAssistantIds = new Map<string, string>()
 
   public record(event: AgentEvent): void {
-    const safeEvent = redactExternalAgentEvent(event)
+    this.recordSafe(redactExternalAgentEvent(event))
+  }
+
+  /** Record an event already normalized at the external-adapter trust boundary. */
+  public recordSafe(safeEvent: RedactedExternalAgentEvent): void {
     switch (safeEvent.event) {
       case "messageStarted": {
         const entry = this.ensureMessage(safeEvent.data.sessionId, safeEvent.data.messageId, safeEvent.data.role)

--- a/electron/agent/grok-model-gateway.ts
+++ b/electron/agent/grok-model-gateway.ts
@@ -1,4 +1,4 @@
-import type { ClaudeModelRoute } from "./claude-model-gateway.ts"
+import type { WantaModelRoute } from "./wanta-model-route.ts"
 import type { ModelMessage, TextStreamPart, ToolSet } from "ai"
 import type { IncomingMessage, Server, ServerResponse } from "node:http"
 
@@ -6,7 +6,7 @@ import { jsonSchema, streamText, tool } from "ai"
 import { randomBytes, randomUUID } from "node:crypto"
 import { createServer } from "node:http"
 import { errorMessage, logDiagnostic } from "../diagnostics-log.ts"
-import { boundedMaxOutputTokens, createLanguageModel, reasoningProviderOptions } from "./claude-model-gateway.ts"
+import { boundedMaxOutputTokens, createLanguageModel, reasoningProviderOptions } from "./wanta-model-route.ts"
 
 const GROK_GATEWAY_MODEL_ALIAS = "wanta-selected-model"
 const MAX_REQUEST_BYTES = 32 * 1024 * 1024
@@ -18,7 +18,7 @@ export interface GrokModelGatewayDescriptor {
 }
 
 interface GrokGatewayRoute {
-  route: ClaudeModelRoute
+  route: WantaModelRoute
   sessionId: string
 }
 
@@ -73,7 +73,7 @@ export class GrokModelGateway {
     })
   }
 
-  public prepare(sessionId: string, route: ClaudeModelRoute): void {
+  public prepare(sessionId: string, route: WantaModelRoute): void {
     if (this.disposed) throw new Error("Grok model gateway has been disposed.")
     this.currentRoute = { route, sessionId }
   }
@@ -166,7 +166,7 @@ export class GrokModelGateway {
 
   private async complete(
     response: ServerResponse,
-    route: ClaudeModelRoute,
+    route: WantaModelRoute,
     request: ChatCompletionRequest,
   ): Promise<void> {
     const controller = new AbortController()
@@ -289,7 +289,7 @@ function parseArguments(value: string | undefined): unknown {
 
 async function streamChatCompletion(
   response: ServerResponse,
-  route: ClaudeModelRoute,
+  route: WantaModelRoute,
   stream: AsyncIterable<TextStreamPart<ToolSet>>,
 ): Promise<void> {
   response.writeHead(200, {

--- a/electron/agent/wanta-model-route.ts
+++ b/electron/agent/wanta-model-route.ts
@@ -1,0 +1,59 @@
+import type { WantaReasoningLevel } from "./reasoning.ts"
+import type { JSONValue, LanguageModel } from "ai"
+
+import { createOpenAI } from "@ai-sdk/openai"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+
+export type WantaModelRouteProviderKind = "openai-compatible" | "openai-responses"
+
+/** A credential-bearing route that remains inside Electron main. */
+export interface WantaModelRoute {
+  apiKey: string
+  baseUrl: string
+  contextWindow?: number
+  displayName: string
+  maxOutputTokens?: number
+  modelId: string
+  providerKind: WantaModelRouteProviderKind
+  reasoningLevel?: WantaReasoningLevel
+  reasoningStyle?: "effort" | "qwen-thinking"
+}
+
+/** Build the AI SDK model shared by each authenticated loopback protocol gateway. */
+export function createLanguageModel(route: WantaModelRoute): LanguageModel {
+  if (route.providerKind === "openai-responses") {
+    return createOpenAI({ apiKey: route.apiKey, baseURL: route.baseUrl, name: "wanta" }).responses(route.modelId)
+  }
+  return createOpenAICompatible({
+    apiKey: route.apiKey,
+    baseURL: route.baseUrl,
+    includeUsage: true,
+    name: "wanta",
+    ...(route.reasoningStyle === "qwen-thinking" && route.reasoningLevel !== undefined
+      ? {
+          transformRequestBody: (body: Record<string, unknown>) => ({
+            ...body,
+            enable_thinking: route.reasoningLevel !== "low",
+          }),
+        }
+      : {}),
+  }).languageModel(route.modelId)
+}
+
+export function reasoningProviderOptions(
+  route: WantaModelRoute,
+): Record<string, Record<string, JSONValue | undefined>> | undefined {
+  const level = route.reasoningLevel
+  if (!level || level === "default" || route.reasoningStyle === "qwen-thinking") return undefined
+  const effort = level === "max" && route.providerKind === "openai-responses" ? "xhigh" : level
+  return { [route.providerKind === "openai-responses" ? "openai" : "wanta"]: { reasoningEffort: effort } }
+}
+
+export function boundedMaxOutputTokens(requested: number | undefined, configured: number | undefined): number {
+  const requestValue = positiveInteger(requested) ?? 8_192
+  return configured ? Math.min(requestValue, configured) : requestValue
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+  return Number.isSafeInteger(value) && (value ?? 0) > 0 ? value : undefined
+}

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -747,6 +747,7 @@ test("edge6: removing an external session mid-turn cleans the run and blocks zom
       await chatService.forgetSession(sessionId)
     },
   })
+  ;(sessionService as unknown as { send: () => Promise<void> }).send = async () => undefined
 
   const doomed = await sessionService.create({ agentKind: "claude-code", scope: localScope, title: "doomed" })
   const survivor = await sessionService.create({ agentKind: "claude-code", scope: localScope, title: "survivor" })

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -73,6 +73,7 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   public permissionModeBarrierEntries = 0
   /** When set, the next native permission-mode projection rejects. */
   public failNextPermissionMode: Error | undefined
+  public runtimeStatusError: Error | undefined
   private readonly modelSelections = new Map<string, string>()
   private readonly effortSelections = new Map<string, string>()
   private readonly nativePendingPermissionIds = new Set<string>()
@@ -177,6 +178,7 @@ class FakeExternalAdapter extends ExternalAgentAdapter {
   }
 
   public runtimeStatus(): Promise<ExternalAgentRuntimeStatus> {
+    if (this.runtimeStatusError) return Promise.reject(this.runtimeStatusError)
     return Promise.resolve({
       kind: this.kind,
       displayName: this.profile.displayName,
@@ -279,6 +281,23 @@ async function waitForCondition(condition: () => boolean, label = "condition"): 
 async function waitForTurnCompletion(service: ChatServiceImpl): Promise<void> {
   await waitForCondition(() => !service.hasActiveGeneration(), "generation completion")
 }
+
+test("external agent probe failures remain visible as disabled error rows", async () => {
+  const { service, adapters } = createHarness(["claude-code", "codex"])
+  const failed = adapters.get("codex")
+  if (!failed) assert.fail("codex adapter missing")
+  failed.runtimeStatusError = new Error("probe exploded")
+
+  const statuses = await service.getExternalAgents()
+
+  assert.deepEqual(
+    statuses.map((status) => ({ kind: status.kind, binary: status.binary })),
+    [
+      { kind: "claude-code", binary: { status: "detected", path: "/fake/bin/claude-code" } },
+      { kind: "codex", binary: { status: "error", message: "probe exploded" } },
+    ],
+  )
+})
 
 // ---------------------------------------------------------------------------
 // Edge 1: attachments into an external session

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -483,17 +483,22 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   }
 
   public async getExternalAgents(): Promise<ExternalAgentRuntimeStatus[]> {
-    const statuses = await Promise.all(
-      [...this.externalAgents.values()].map(async (adapter) => {
+    return Promise.all(
+      [...this.externalAgents.entries()].map(async ([kind, adapter]) => {
         try {
           return await adapter.runtimeStatus()
         } catch (error) {
-          logDiagnostic("chat-service", "external agent probe failed", { error, kind: adapter.kind }, "warn")
-          return null
+          logDiagnostic("chat-service", "external agent probe failed", { error, kind }, "warn")
+          return {
+            kind,
+            displayName: adapter.profile.displayName,
+            binary: { status: "error", message: errorMessage(error) },
+            login: { status: "unknown" },
+            loginHint: adapter.profile.auth.kind === "agent-cli" ? adapter.profile.auth.loginCommand : "",
+          } satisfies ExternalAgentRuntimeStatus
         }
       }),
     )
-    return statuses.filter((status): status is ExternalAgentRuntimeStatus => Boolean(status))
   }
 
   public async setExternalSessionModel(req: SetExternalSessionModelRequest): Promise<void> {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -59,6 +59,7 @@ import { memoizeExternalCommandEnvironment } from "./agent/external/command-envi
 import { createExternalAgents } from "./agent/external/create.ts"
 import { ExternalOoGuardServer } from "./agent/external/oo-guard-server.ts"
 import { externalSessionScratchCwd, ExternalOoScopeStore } from "./agent/external/oo-scope-store.ts"
+import { memoizePromptPreparation } from "./agent/external/prompt-preparation.ts"
 import { externalAgentKindForSessionId } from "./agent/external/session-id.ts"
 import { GrokModelGateway } from "./agent/grok-model-gateway.ts"
 import { HostCapabilityInvokeServer } from "./agent/host-capability-invoke-server.ts"
@@ -402,13 +403,19 @@ function claudeRoutingEnvironment(descriptor: {
   }
 }
 
+const prepareClaudePromptRoute = memoizePromptPreparation(async (input: PromptAgentInput) =>
+  claudeModelGateway.issue(input.sessionId, await wantaRouteFor(input)),
+)
 const claudeModelRouter = {
   onForgetSession: (sessionId: string): void => claudeModelGateway.revokeSession(sessionId),
   preparePrompt: async (input: PromptAgentInput): Promise<void> => {
-    await claudeModelGateway.issue(input.sessionId, await wantaRouteFor(input))
+    await prepareClaudePromptRoute(input)
   },
   sessionMeta: async (input: PromptAgentInput): Promise<Record<string, unknown>> => {
-    const descriptor = await claudeModelGateway.issue(input.sessionId, await wantaRouteFor(input))
+    // First-turn preparation and session metadata consume the exact same route
+    // snapshot. Existing sessions only call preparePrompt; WeakMap ownership
+    // lets each completed PromptAgentInput be collected normally.
+    const descriptor = await prepareClaudePromptRoute(input)
     const env = claudeRoutingEnvironment(descriptor)
     return {
       claudeCode: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -59,7 +59,7 @@ import { memoizeExternalCommandEnvironment } from "./agent/external/command-envi
 import { createExternalAgents } from "./agent/external/create.ts"
 import { ExternalOoGuardServer } from "./agent/external/oo-guard-server.ts"
 import { externalSessionScratchCwd, ExternalOoScopeStore } from "./agent/external/oo-scope-store.ts"
-import { memoizePromptPreparation } from "./agent/external/prompt-preparation.ts"
+import { memoizePromptRoutePreparation } from "./agent/external/prompt-preparation.ts"
 import { externalAgentKindForSessionId } from "./agent/external/session-id.ts"
 import { GrokModelGateway } from "./agent/grok-model-gateway.ts"
 import { HostCapabilityInvokeServer } from "./agent/host-capability-invoke-server.ts"
@@ -403,7 +403,7 @@ function claudeRoutingEnvironment(descriptor: {
   }
 }
 
-const prepareClaudePromptRoute = memoizePromptPreparation(async (input: PromptAgentInput) =>
+const prepareClaudePromptRoute = memoizePromptRoutePreparation(async (input) =>
   claudeModelGateway.issue(input.sessionId, await wantaRouteFor(input)),
 )
 const claudeModelRouter = {

--- a/electron/session/external-sessions.test.ts
+++ b/electron/session/external-sessions.test.ts
@@ -88,6 +88,30 @@ test("an unregistered agentKind never mints an external session id (create gate)
   assert.equal(external.current().size, 0)
 })
 
+test("an unregistered agentKind preserves the historical built-in fallback when the kernel is available", async () => {
+  const external = externalStore()
+  let createdWithTitle: string | undefined
+  const kernel = {
+    createSession: async (title?: string) => {
+      createdWithTitle = title
+      return { id: "kernel-fallback", title: title ?? "New session", createdAt: 1, updatedAt: 1 }
+    },
+    deleteSession: async () => undefined,
+    listSessions: async () => [],
+  } as unknown as OpencodeAgentAdapter
+  const service = new SessionServiceImpl(kernel, {
+    externalSessionStore: external.store,
+    metadataStore: metadataStore(),
+  })
+  ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
+
+  const created = await service.create({ agentKind: "gemini" as never, scope: localScope, title: "Legacy fallback" })
+
+  assert.equal(created.id, "kernel-fallback")
+  assert.equal(createdWithTitle, "Legacy fallback")
+  assert.equal(external.current().size, 0)
+})
+
 test("external archived sessions and projects remain available when no kernel adapter exists", async () => {
   const external = externalStore()
   const service = new SessionServiceImpl(null, {

--- a/electron/session/external-sessions.test.ts
+++ b/electron/session/external-sessions.test.ts
@@ -73,9 +73,8 @@ test("external sessions are created and listed when no kernel adapter exists", a
   )
 })
 
-test("an unregistered agentKind never mints an external session id (create gate)", async () => {
+test("an unregistered agentKind is rejected before any session is created", async () => {
   // RPC types are erased at runtime; a junk kind must not reach mintExternalSessionId.
-  // With no kernel adapter it falls to the kernel path and fails closed instead.
   const external = externalStore()
   const service = new SessionServiceImpl(null, {
     externalSessionStore: external.store,
@@ -83,18 +82,18 @@ test("an unregistered agentKind never mints an external session id (create gate)
   })
   ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
 
-  await assert.rejects(service.create({ agentKind: "gemini" as never, scope: localScope }), /Agent not configured/)
+  await assert.rejects(service.create({ agentKind: "gemini" as never, scope: localScope }), /Unsupported agent kind/)
   // No wanta-ext:gemini record was persisted.
   assert.equal(external.current().size, 0)
 })
 
-test("an unregistered agentKind preserves the historical built-in fallback when the kernel is available", async () => {
+test("an unregistered agentKind never silently falls back to an available kernel", async () => {
   const external = externalStore()
-  let createdWithTitle: string | undefined
+  let createCalls = 0
   const kernel = {
-    createSession: async (title?: string) => {
-      createdWithTitle = title
-      return { id: "kernel-fallback", title: title ?? "New session", createdAt: 1, updatedAt: 1 }
+    createSession: async () => {
+      createCalls += 1
+      return { id: "kernel-fallback", title: "Unexpected", createdAt: 1, updatedAt: 1 }
     },
     deleteSession: async () => undefined,
     listSessions: async () => [],
@@ -105,10 +104,12 @@ test("an unregistered agentKind preserves the historical built-in fallback when 
   })
   ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
 
-  const created = await service.create({ agentKind: "gemini" as never, scope: localScope, title: "Legacy fallback" })
+  await assert.rejects(
+    service.create({ agentKind: "gemini" as never, scope: localScope, title: "Must not fall back" }),
+    /Unsupported agent kind/,
+  )
 
-  assert.equal(created.id, "kernel-fallback")
-  assert.equal(createdWithTitle, "Legacy fallback")
+  assert.equal(createCalls, 0)
   assert.equal(external.current().size, 0)
 })
 

--- a/electron/session/external-sessions.test.ts
+++ b/electron/session/external-sessions.test.ts
@@ -113,6 +113,26 @@ test("an unregistered agentKind never silently falls back to an available kernel
   assert.equal(external.current().size, 0)
 })
 
+test("an empty agentKind is rejected without invoking an available kernel", async () => {
+  let createCalls = 0
+  const kernel = {
+    createSession: async () => {
+      createCalls += 1
+      return { id: "kernel-fallback", title: "Unexpected", createdAt: 1, updatedAt: 1 }
+    },
+    deleteSession: async () => undefined,
+    listSessions: async () => [],
+  } as unknown as OpencodeAgentAdapter
+  const service = new SessionServiceImpl(kernel, {
+    externalSessionStore: externalStore().store,
+    metadataStore: metadataStore(),
+  })
+  ;(service as unknown as { send: () => Promise<void> }).send = async () => undefined
+
+  await assert.rejects(service.create({ agentKind: "" as never, scope: localScope }), /Unsupported agent kind/)
+  assert.equal(createCalls, 0)
+})
+
 test("external archived sessions and projects remain available when no kernel adapter exists", async () => {
   const external = externalStore()
   const service = new SessionServiceImpl(null, {

--- a/electron/session/node.ts
+++ b/electron/session/node.ts
@@ -27,7 +27,7 @@ import type { IConnectionService } from "@oomol/connection"
 import { ConnectionService } from "@oomol/connection"
 import { randomUUID } from "node:crypto"
 import path from "node:path"
-import { EXTERNAL_AGENT_KINDS, isExternalAgentKind } from "../agent/contract/profile.ts"
+import { isExternalAgentKind } from "../agent/contract/profile.ts"
 import {
   externalAgentKindForSessionId,
   isExternalSessionId,
@@ -217,22 +217,12 @@ export class SessionServiceImpl
   }
 
   private async createMutation(req: CreateSessionRequest, revision: number): Promise<SessionInfo> {
-    // Only a REGISTERED external kind mints an external session id; isExternalAgentKind
-    // alone is `!== "opencode"`, so RPC-erased junk (unknown or prototype-chain kinds)
-    // must not reach mintExternalSessionId. Unknown kinds fall through to the kernel.
-    if (req.agentKind && isExternalAgentKind(req.agentKind) && EXTERNAL_AGENT_KINDS.includes(req.agentKind)) {
+    if (isExternalAgentKind(req.agentKind)) {
       return this.createExternalMutation(req, req.agentKind, revision)
     }
     if (req.agentKind && req.agentKind !== "opencode") {
-      // Preserve the historical kernel fallback for compatibility, but make
-      // erased/obsolete agent kinds observable before a future fail-closed
-      // migration is considered.
-      logDiagnostic(
-        "session-service",
-        "unregistered agent kind fell back to the built-in agent",
-        { agentKind: req.agentKind },
-        "warn",
-      )
+      logDiagnostic("session-service", "rejected unregistered agent kind", { agentKind: req.agentKind }, "warn")
+      throw new Error(`Unsupported agent kind: ${String(req.agentKind)}`)
     }
     const agent = this.agent
     if (!agent) {

--- a/electron/session/node.ts
+++ b/electron/session/node.ts
@@ -223,6 +223,17 @@ export class SessionServiceImpl
     if (req.agentKind && isExternalAgentKind(req.agentKind) && EXTERNAL_AGENT_KINDS.includes(req.agentKind)) {
       return this.createExternalMutation(req, req.agentKind, revision)
     }
+    if (req.agentKind && req.agentKind !== "opencode") {
+      // Preserve the historical kernel fallback for compatibility, but make
+      // erased/obsolete agent kinds observable before a future fail-closed
+      // migration is considered.
+      logDiagnostic(
+        "session-service",
+        "unregistered agent kind fell back to the built-in agent",
+        { agentKind: req.agentKind },
+        "warn",
+      )
+    }
     const agent = this.agent
     if (!agent) {
       throw new Error("Agent not configured (sign in first)")

--- a/electron/session/node.ts
+++ b/electron/session/node.ts
@@ -220,7 +220,7 @@ export class SessionServiceImpl
     if (isExternalAgentKind(req.agentKind)) {
       return this.createExternalMutation(req, req.agentKind, revision)
     }
-    if (req.agentKind && req.agentKind !== "opencode") {
+    if (req.agentKind !== undefined && req.agentKind !== "opencode") {
       logDiagnostic("session-service", "rejected unregistered agent kind", { agentKind: req.agentKind }, "warn")
       throw new Error(`Unsupported agent kind: ${String(req.agentKind)}`)
     }

--- a/src/components/app-shell/composer-agent-prefs.ts
+++ b/src/components/app-shell/composer-agent-prefs.ts
@@ -1,7 +1,7 @@
 import type { AgentKind } from "../../../electron/agent/contract/profile.ts"
 import type { AgentPermissionMode } from "../../../electron/chat/common.ts"
 
-import { AGENT_PROFILES } from "../../../electron/agent/contract/profile.ts"
+import { AGENT_PROFILES, isAgentKind } from "../../../electron/agent/contract/profile.ts"
 
 // Sticky composer defaults. The most recently selected agent drives future new
 // chats, while model/effort/permission preferences stay separate per agent.
@@ -25,10 +25,6 @@ interface StoredComposerAgentPrefs {
 
 const storageKey = "wanta.composerAgentPrefs"
 export const DEFAULT_COMPOSER_AGENT_KIND: AgentKind = "opencode"
-
-function isAgentKind(value: unknown): value is AgentKind {
-  return typeof value === "string" && Object.hasOwn(AGENT_PROFILES, value)
-}
 
 function readStore(storage: LocalStorageLike | null | undefined): StoredComposerAgentPrefs {
   try {


### PR DESCRIPTION
## Summary

This PR hardens the Bring Your Own Agent (BYOA) integration after several rounds of historical iteration, while preserving the behavior of correctly configured agents.

It extracts the shared Wanta model-route layer used by the Claude and Grok loopback gateways, reuses one immutable Claude route snapshot during first-turn setup, and removes duplicate live-event transcript redaction without weakening the disk-load or persistence credential boundaries.

It also makes runtime capability checks fail visibly instead of degrading silently. Unknown or retired agent kinds are rejected rather than being routed to the built-in OpenCode agent. External-agent probe failures remain visible as disabled picker rows. Login probing now runs only for detected agent-owned CLIs, and packaged ACP bridges such as `claude-agent-acp` and `codex-acp` are considered usable only when their delegated native `claude` or `codex` executable is also available. Explicit `CLAUDE_CODE_EXECUTABLE` and `CODEX_PATH` overrides are validated during probing.

## User impact

Correctly installed Claude Code, Codex, Grok, and built-in Agent workflows retain their existing prompt, model, permission, transcript, session, and artifact behavior.

Misconfigured states now fail earlier and more clearly: an unsupported agent kind no longer creates an OpenCode session, a transient probe failure no longer makes an agent disappear from the picker, and a bundled ACP bridge without its native CLI is shown as unavailable before the user creates a task and sends the first prompt.

## Root causes

The BYOA layer previously had several stage-specific abstractions left over from iterative development. Common model-route code lived under the Claude gateway even though Grok used it too; Claude first-turn hooks independently resolved the same route; external events were recursively redacted twice before recording; runtime kind checks depended partly on erased TypeScript types; and binary probing verified an ACP bridge without verifying a delegated native CLI.

## Verification

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm run format`
- `pnpm test`
- `git diff --check`

Full test result: 358 test files passed, 2 skipped; 2,836 tests passed, 4 skipped.

After addressing AI review findings, the updated result is 358 test files passed, 2 skipped; 2,838 tests passed, 4 skipped. Regression coverage now includes mutation of Claude route-bearing prompt fields while asynchronous model resolution is pending, and an empty-string `agentKind` reaching a configured kernel.

## Safety and Compatibility

- **Credentials:** No upstream model credential is newly exposed. Wanta account tokens and BYOK API keys remain inside Electron main; external harnesses continue to receive only authenticated loopback credentials. Transcript disk-load and persistence redaction boundaries remain in place.
- **BYOK and signed-in OOMOL modes:** Both continue through the same `WantaModelRoute` resolution. The Claude first-turn setup now snapshots the submitted model and reasoning level before asynchronous model discovery, preventing caller mutation from changing an in-flight route.
- **Agent tools and prompts:** Correctly configured Claude Code, Codex, Grok, and built-in Agent prompt, tool, permission, artifact, and transcript behavior is unchanged. Host capabilities and native Agent Skills/subagents retain their existing ownership and enforcement boundaries.
- **Failure behavior:** Unsupported or malformed defined agent kinds, including the empty string, are rejected rather than silently creating a built-in session. Probe failures remain visible as disabled rows, and packaged ACP bridges require their delegated native CLI.
- **Migration and packaging:** No persisted session or transcript format changes are introduced. Existing supported sessions remain readable. Packaged `claude-agent-acp` and `codex-acp` bridges are still resolved as before, with additional preflight validation for their native executables and explicit runtime overrides.
- **Documentation and tests:** The BYOA adapter guide documents delegated runtime validation. Contract, route preparation, transcript redaction, probe, session, and external chat edge tests cover the changed behavior.
