### PR TITLE
fix(byoa): keep default permission mode when Grok advertises no modes

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -85,7 +85,11 @@ External agents build on `electron/agent/external/`:
   `permissionModeMap` (Claude includes its classifier-backed `auto` mode).
   Enforcement is always agent-side. Applying a declared
   mode is fail-closed: a missing or rejected native mode blocks the turn rather
-  than silently continuing under a stale, potentially broader mode.
+  than silently continuing under a stale, potentially broader mode. The one
+  exact exception is `default` on a session that advertises no ACP modes at
+  all (Grok 1.0.5 omits `modes` from `session/new`): the agent already runs
+  its own default policy and `default` is the only live mode exposed, so the
+  projection is a no-op instead of an error.
 - **Native enforcement is agent-side; user-visible approval semantics are
   host-owned**: an external CLI keeps its sandbox and decides when it needs an
   interactive native permission response. Every such request is normalized and

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -224,13 +224,15 @@ async function createHarness(
   const fake = createFakeAgent(behavior)
   const registration = ACP_AGENT_REGISTRY[kind]
   const scratchRootDir = await mkdtemp(path.join(os.tmpdir(), "acp-adapter-test-"))
-  const probe = vi.fn(async (): Promise<ExternalAgentRuntimeStatus> => ({
-    kind,
-    displayName: registration.displayName,
-    binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
-    login: { status: "unknown" },
-    loginHint: registration.loginHint,
-  }))
+  const probe = vi.fn(
+    async (): Promise<ExternalAgentRuntimeStatus> => ({
+      kind,
+      displayName: registration.displayName,
+      binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
+      login: { status: "unknown" },
+      loginHint: registration.loginHint,
+    }),
+  )
   const adapter = new AcpAgentAdapter({
     kind,
     registration,
@@ -951,6 +953,44 @@ describe("AcpAgentAdapter", () => {
       /permission mode "full_access" is not available/u,
     )
     expect(harness.fake.setModeRequests).toEqual([])
+  })
+
+  test("applyPermissionMode keeps the agent default when the session advertises no modes", async () => {
+    const harness = await createHarness()
+    // The chat layer projects `default` before the first prompt of every
+    // session; an agent that never advertises ACP modes must not block the turn.
+    await harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "default")
+    await harness.adapter.send(promptInput())
+    await harness.waitFor((event) => event.event === "messageCompleted")
+    await expect(harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "default")).resolves.toBeUndefined()
+    expect(harness.fake.setModeRequests).toEqual([])
+    expect((await harness.adapter.runtimeStatus()).permissionModes).toEqual(["default"])
+  })
+
+  test("applyPermissionMode falls back to the initial mode for default when the mapped id is not advertised", async () => {
+    const harness = await createHarness({
+      newSession: () => ({
+        sessionId: "acp-session-1",
+        modes: {
+          currentModeId: "custom-default",
+          availableModes: [
+            { id: "custom-default", name: "Custom default" },
+            { id: "agent-full-access", name: "Full access" },
+          ],
+        },
+      }),
+    })
+    await harness.adapter.send(promptInput())
+    await harness.waitFor((event) => event.event === "messageCompleted")
+    await harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "full_access")
+    await harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "default")
+    expect(harness.fake.setModeRequests.map((request) => request.modeId)).toEqual([
+      "agent-full-access",
+      "custom-default",
+    ])
+    await expect(harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "read_only")).rejects.toThrow(
+      /permission mode "read_only" is not available/u,
+    )
   })
 
   test("forgetSession drops the ACP mapping so a new ACP session is opened", async () => {

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -224,15 +224,13 @@ async function createHarness(
   const fake = createFakeAgent(behavior)
   const registration = ACP_AGENT_REGISTRY[kind]
   const scratchRootDir = await mkdtemp(path.join(os.tmpdir(), "acp-adapter-test-"))
-  const probe = vi.fn(
-    async (): Promise<ExternalAgentRuntimeStatus> => ({
-      kind,
-      displayName: registration.displayName,
-      binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
-      login: { status: "unknown" },
-      loginHint: registration.loginHint,
-    }),
-  )
+  const probe = vi.fn(async (): Promise<ExternalAgentRuntimeStatus> => ({
+    kind,
+    displayName: registration.displayName,
+    binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
+    login: { status: "unknown" },
+    loginHint: registration.loginHint,
+  }))
   const adapter = new AcpAgentAdapter({
     kind,
     registration,

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -547,9 +547,14 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
   }
 
   private updateLivePermissionModes(modes: unknown): void {
-    if (!modes || typeof modes !== "object") return
-    const availableModes = (modes as { availableModes?: unknown }).availableModes
-    if (!Array.isArray(availableModes)) return
+    const availableModes =
+      modes && typeof modes === "object" ? (modes as { availableModes?: unknown }).availableModes : undefined
+    if (!Array.isArray(availableModes)) {
+      // No advertised modes (Grok 1.0.5 omits `modes` from session/new): the
+      // agent runs a single policy, so `default` is the only honest stance.
+      this.livePermissionModes = ["default"]
+      return
+    }
     const availableIds = new Set(
       availableModes.flatMap((mode) =>
         mode && typeof mode === "object" && typeof (mode as { id?: unknown }).id === "string"
@@ -949,8 +954,21 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     if (!session) {
       return
     }
+    if (mode === "default" && session.availableModeIds.length === 0) {
+      // The agent advertises no ACP session modes (Grok 1.0.5 omits `modes`
+      // from session/new entirely). There is nothing to switch and the session
+      // already runs under the agent's own default policy, which is the only
+      // mode the live profile exposes, so leaving it untouched is exact rather
+      // than a silent widening. Every other mode still fails closed below.
+      return
+    }
     const mapped = modeMap[mode]
-    const targetModeId = mapped ?? (mode === "default" ? session.initialModeId : undefined)
+    const targetModeId =
+      mapped !== undefined && session.availableModeIds.includes(mapped)
+        ? mapped
+        : mode === "default"
+          ? session.initialModeId
+          : undefined
     if (!targetModeId || !session.availableModeIds.includes(targetModeId)) {
       this.restoreDesiredPermissionMode(sessionId, previous, mode)
       throw new Error(`${this.kind}: permission mode "${mode}" is not available in this session`)

--- a/electron/agent/acp/registry.ts
+++ b/electron/agent/acp/registry.ts
@@ -119,6 +119,9 @@ export const ACP_AGENT_REGISTRY = {
     catalogProbe: "grok-models",
     // Candidate ids are intersected with the modes returned by the live Grok
     // session, so an unavailable or renamed mode is never shown or applied.
+    // Verified against grok 1.0.5: an authenticated session/new response
+    // carries no `modes` at all, so only `default` is exposed and applying it
+    // is a no-op that keeps Grok's own default policy (see applyPermissionMode).
     permissionModeMap: {
       default: "default",
       accept_edits: "acceptEdits",
@@ -126,8 +129,6 @@ export const ACP_AGENT_REGISTRY = {
       auto: "auto",
       full_access: "bypassPermissions",
     },
-    // Permission modes are exposed only after an authenticated session; the
-    // live availableModes intersection above keeps the pre-login UI conservative.
     // Grok 1.0.5 exposes its account-scoped model and thought-level config
     // options over ACP. Both selections stay native to the local Grok runtime.
     selection: { model: true, effort: true },

--- a/electron/agent/acp/selection-edge.test.ts
+++ b/electron/agent/acp/selection-edge.test.ts
@@ -202,13 +202,15 @@ async function createHarness(
   const fake = createFakeAgent(behavior)
   const registration = ACP_AGENT_REGISTRY[kind]
   const scratchRootDir = await mkdtemp(path.join(os.tmpdir(), "acp-selection-edge-"))
-  const probe = vi.fn(async (): Promise<ExternalAgentRuntimeStatus> => ({
-    kind,
-    displayName: registration.displayName,
-    binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
-    login: { status: "unknown" },
-    loginHint: registration.loginHint,
-  }))
+  const probe = vi.fn(
+    async (): Promise<ExternalAgentRuntimeStatus> => ({
+      kind,
+      displayName: registration.displayName,
+      binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
+      login: { status: "unknown" },
+      loginHint: registration.loginHint,
+    }),
+  )
   const adapter = new AcpAgentAdapter({ kind, registration, probe, scratchRootDir, connect: fake.connect })
   await adapter.start()
   startedAdapters.push(adapter)
@@ -770,6 +772,22 @@ describe("acp selection: permission-mode projection", () => {
       event: "permissionModeUpdated",
       data: { sessionId: WANTA_SESSION_ID, permissionMode: "auto" },
     })
+  })
+
+  test("Grok opens a session under its own default policy when session/new carries no modes", async () => {
+    // Real shape from grok 1.0.5: session/new returns sessionId + models only.
+    const harness = await createHarness(
+      { newSession: () => ({ ...modelsShape("grok-4.6", ["grok-4.6", "grok-4.5"]), sessionId: "acp-session-1" }) },
+      "grok",
+    )
+    await harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "default")
+    await harness.adapter.send(promptInput())
+    await harness.waitFor((event) => event.event === "messageCompleted")
+    expect(harness.fake.setModeRequests).toEqual([])
+    expect((await harness.adapter.runtimeStatus()).permissionModes).toEqual(["default"])
+    await expect(harness.adapter.applyPermissionMode(WANTA_SESSION_ID, "full_access")).rejects.toThrow(
+      /permission mode "full_access" is not available/u,
+    )
   })
 
   test("Grok exposes only permission modes confirmed by its live session", async () => {

--- a/electron/agent/acp/selection-edge.test.ts
+++ b/electron/agent/acp/selection-edge.test.ts
@@ -202,15 +202,13 @@ async function createHarness(
   const fake = createFakeAgent(behavior)
   const registration = ACP_AGENT_REGISTRY[kind]
   const scratchRootDir = await mkdtemp(path.join(os.tmpdir(), "acp-selection-edge-"))
-  const probe = vi.fn(
-    async (): Promise<ExternalAgentRuntimeStatus> => ({
-      kind,
-      displayName: registration.displayName,
-      binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
-      login: { status: "unknown" },
-      loginHint: registration.loginHint,
-    }),
-  )
+  const probe = vi.fn(async (): Promise<ExternalAgentRuntimeStatus> => ({
+    kind,
+    displayName: registration.displayName,
+    binary: { status: "detected", path: "/fake/bin/agent", version: "1.0.0" },
+    login: { status: "unknown" },
+    loginHint: registration.loginHint,
+  }))
   const adapter = new AcpAgentAdapter({ kind, registration, probe, scratchRootDir, connect: fake.connect })
   await adapter.start()
   startedAdapters.push(adapter)


### PR DESCRIPTION
## Summary

Switching the composer to Grok and sending any message failed with `Grok could not open a session: grok: permission mode "default" is not available in this session`. Grok 1.0.5 omits `modes` from its `session/new` response entirely (verified against the local CLI with an authenticated session, the result carries only `sessionId`, `models`, and `_meta`), so `applyPermissionMode` in _electron/agent/acp/adapter.ts_ found the mapped `default` id missing from an empty `availableModeIds` and failed closed before the first prompt.

A session that advertises no ACP modes already runs the agent's own default policy, and `default` is the only mode the live profile exposes, so projecting `default` onto such a session is now a no-op rather than an error. When a mapped id is not advertised but the session reports an initial mode, `default` falls back to that initial mode. Every other mode still fails closed, and `updateLivePermissionModes` now reports `["default"]` for a modeless session so the runtime status matches the composer fallback. The Grok registry comment and _docs/ai/agent-adapter.md_ are updated to describe this one exception, and three regression tests cover the modeless session, the initial-mode fallback, and the real Grok 1.0.5 response shape.

## Verification

- [ ] `corepack pnpm run ts-check` (fails on `main` too: `electron/knowledge/runner.ts` has no `readSearchIndexCapabilityStatus` export from `wiki-graph-core`, unrelated to this change)
- [ ] `corepack pnpm run lint` (oxlint config error `Rule 'static-components' not found in plugin 'react'`, unrelated to this change)
- [x] `corepack pnpm run format` (touched files pass with the pinned oxfmt 0.64.0)
- [x] `corepack pnpm test` (_electron/agent/acp/_ and _electron/chat/_ pass, 529 tests. Two unrelated files fail in this checkout from dependency drift: `scripts/claude-agent-acp.test.ts` cannot find `@agentclientprotocol/claude-agent-acp` and `src/lib/connections-client-persistent.test.ts` reads `clear` of undefined)
- [ ] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable (ACP handshake against local `grok 1.0.5` confirmed the modeless `session/new` shape that the fix targets)

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.

