### PR TITLE
fix(chat): stabilize BYOA process timeline

### DIFF
--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -240,115 +240,94 @@ const ChatTurnView = React.memo(function ChatTurnView({
           onRetryFresh={retrySource ? handleRetryFresh : undefined}
         />
       ) : null}
-      {showTurnProcess ? (
-        <>
-          {renderSegments.map((segment, segmentIndex) => {
-            if (segment.kind === "response") {
-              const ownsTurnActions = segmentIndex === lastResponseSegmentIndex && segmentIndex === lastSegmentIndex
-              return (
-                <AssistantTimelineMessage
-                  key={segment.key}
+      <>
+        {shouldShowPlainActivity ? <PlainAssistantActivity activity={activity} /> : null}
+        {renderSegments.map((segment, segmentIndex) => {
+          if (segment.kind === "response") {
+            const ownsTurnActions = segmentIndex === lastResponseSegmentIndex && segmentIndex === lastSegmentIndex
+            return (
+              <AssistantTimelineMessage
+                key={segment.key}
+                blocks={segment.blocks}
+                billingCacheScope={billingCacheScope}
+                smoothAssistantMessageId={smoothAssistantMessageId}
+                assistantActionsText={ownsTurnActions ? responseActionsText : null}
+                assistantCancelled={ownsTurnActions && assistantCancelled}
+                activeAssistantMessageId={activeAssistantMessageId}
+                providerByService={providerByService}
+                onAuthorize={handleAuthorize}
+                onRecover={retrySource ? handleRecover : undefined}
+                onRetryFresh={retrySource ? handleRetryFresh : undefined}
+                onViewBilling={onViewBilling}
+              />
+            )
+          }
+
+          const isLastProcess = segmentIndex === lastProcessSegmentIndex
+          const segmentTurn = {
+            ...turn,
+            assistants: assistantMessagesFromTimelineBlocks(segment.blocks),
+          }
+          const scopedSegmentProcess =
+            segment.blocks.length === 0
+              ? process
+              : summarizeTurnProcess(
+                  segmentTurn,
+                  isLastProcess ? activity : null,
+                  isLastProcess ? activeAssistantMessageId : undefined,
+                  { hasVisibleOutcome },
+                )
+          const segmentProcess =
+            isLastProcess && segment.blocks.length > 0
+              ? inheritTurnProcessTiming(scopedSegmentProcess, process)
+              : scopedSegmentProcess
+          const ownsTurnActions = isLastProcess && segmentIndex === lastSegmentIndex
+          const processLive = isLastProcess && turnIsActive
+          return (
+            <Message key={`${turn.id}:process:${segment.key}`} from="assistant">
+              <MessageContent className="w-full">
+                <TurnProcessActivity
                   blocks={segment.blocks}
+                  process={segmentProcess}
+                  live={processLive}
                   billingCacheScope={billingCacheScope}
-                  smoothAssistantMessageId={smoothAssistantMessageId}
-                  assistantActionsText={ownsTurnActions ? responseActionsText : null}
-                  assistantCancelled={ownsTurnActions && assistantCancelled}
-                  activeAssistantMessageId={activeAssistantMessageId}
                   providerByService={providerByService}
                   onAuthorize={handleAuthorize}
                   onRecover={retrySource ? handleRecover : undefined}
                   onRetryFresh={retrySource ? handleRetryFresh : undefined}
                   onViewBilling={onViewBilling}
+                  onBeforeDisclosure={onBeforeDisclosure}
                 />
-              )
-            }
-
-            const isLastProcess = segmentIndex === lastProcessSegmentIndex
-            const segmentTurn = {
-              ...turn,
-              assistants: assistantMessagesFromTimelineBlocks(segment.blocks),
-            }
-            const scopedSegmentProcess =
-              segment.blocks.length === 0
-                ? process
-                : summarizeTurnProcess(
-                    segmentTurn,
-                    isLastProcess ? activity : null,
-                    isLastProcess ? activeAssistantMessageId : undefined,
-                    { hasVisibleOutcome },
-                  )
-            const segmentProcess =
-              isLastProcess && segment.blocks.length > 0
-                ? inheritTurnProcessTiming(scopedSegmentProcess, process)
-                : scopedSegmentProcess
-            const ownsTurnActions = isLastProcess && segmentIndex === lastSegmentIndex
-            const processLive = isLastProcess && turnIsActive
-            return (
-              <Message key={`${turn.id}:process`} from="assistant">
-                <MessageContent className="w-full">
-                  <TurnProcessActivity
-                    blocks={segment.blocks}
-                    process={segmentProcess}
-                    live={processLive}
-                    billingCacheScope={billingCacheScope}
-                    providerByService={providerByService}
-                    onAuthorize={handleAuthorize}
-                    onRecover={retrySource ? handleRecover : undefined}
-                    onRetryFresh={retrySource ? handleRetryFresh : undefined}
-                    onViewBilling={onViewBilling}
-                    onBeforeDisclosure={onBeforeDisclosure}
-                  />
-                </MessageContent>
-                {ownsTurnActions && (processActionsText || assistantCancelled) ? (
-                  <AssistantMessageActions text={processActionsText ?? ""} cancelled={assistantCancelled} />
-                ) : null}
-              </Message>
-            )
-          })}
-          {terminalOutcomeStatus ? <TurnOutcomeReceipt status={terminalOutcomeStatus} /> : null}
-          {!turnIsActive && (process.authorizationIssues.length > 0 || suggestedAuthorization) ? (
-            <Message from="assistant">
-              <MessageContent className="w-full">
-                {process.authorizationIssues.map((issue) => (
-                  <ConnectionAuthorizationIssueAction
-                    key={issue.key}
-                    issue={issue}
-                    provider={providerByService.get(issue.service)}
-                    onAuthorize={handleAuthorize}
-                  />
-                ))}
-                {suggestedAuthorization ? (
-                  <ConnectionSuggestionAction
-                    authorization={suggestedAuthorization}
-                    provider={providerByService.get(normalizeServiceSlug(suggestedAuthorization.service))}
-                    onAuthorize={handleAuthorize}
-                  />
-                ) : null}
               </MessageContent>
+              {ownsTurnActions && (processActionsText || assistantCancelled) ? (
+                <AssistantMessageActions text={processActionsText ?? ""} cancelled={assistantCancelled} />
+              ) : null}
             </Message>
-          ) : null}
-        </>
-      ) : (
-        <>
-          {shouldShowPlainActivity ? <PlainAssistantActivity activity={activity} /> : null}
-          {turn.assistants.map((message) => (
-            <MessageBubble
-              key={message.clientId ?? message.id}
-              message={message}
-              billingCacheScope={billingCacheScope}
-              smoothText={message.id === smoothAssistantMessageId}
-              onViewBilling={onViewBilling}
-              assistantActionsText={assistantActionTextByMessageId.get(message.id) ?? null}
-              providerByService={providerByService}
-              liveTools={message.id === activeAssistantMessageId}
-              onAuthorize={handleAuthorize}
-              onRecover={retrySource ? handleRecover : undefined}
-              onRetryFresh={retrySource ? handleRetryFresh : undefined}
-              suggestedAuthorization={message.id === lastAssistant?.id ? process.suggestedAuthorization : undefined}
-            />
-          ))}
-        </>
-      )}
+          )
+        })}
+        {showTurnProcess && terminalOutcomeStatus ? <TurnOutcomeReceipt status={terminalOutcomeStatus} /> : null}
+        {showTurnProcess && !turnIsActive && (process.authorizationIssues.length > 0 || suggestedAuthorization) ? (
+          <Message from="assistant">
+            <MessageContent className="w-full">
+              {process.authorizationIssues.map((issue) => (
+                <ConnectionAuthorizationIssueAction
+                  key={issue.key}
+                  issue={issue}
+                  provider={providerByService.get(issue.service)}
+                  onAuthorize={handleAuthorize}
+                />
+              ))}
+              {suggestedAuthorization ? (
+                <ConnectionSuggestionAction
+                  authorization={suggestedAuthorization}
+                  provider={providerByService.get(normalizeServiceSlug(suggestedAuthorization.service))}
+                  onAuthorize={handleAuthorize}
+                />
+              ) : null}
+            </MessageContent>
+          </Message>
+        ) : null}
+      </>
       {hasRenderableArtifacts || hasRenderableTurnOutputs ? (
         <div className="mt-2 grid gap-2">
           {hasRenderableArtifacts ? (

--- a/src/routes/Chat/assistant-timeline.test.ts
+++ b/src/routes/Chat/assistant-timeline.test.ts
@@ -67,7 +67,7 @@ describe("assistantTimelineBlocks", () => {
     ])
   })
 
-  it("splits processing feedback before the last tool from final response after it", () => {
+  it("preserves narration, tool, and final response chronology", () => {
     const segments = segmentAssistantTimeline([
       message("a1", [textPart("process-1", "I will inspect the page."), toolPart("tool-1")]),
       message("a2", [textPart("process-2", "The mobile page is blocked."), toolPart("tool-2")]),
@@ -84,17 +84,18 @@ describe("assistantTimelineBlocks", () => {
         partIds: block.kind === "tools" ? block.parts.map((part) => part.partId) : [block.part.partId],
       })),
     ).toEqual([
-      { kind: "text", partIds: ["process-1"] },
       { kind: "tools", partIds: ["tool-1"] },
       { kind: "text", partIds: ["process-2"] },
       { kind: "tools", partIds: ["tool-2"] },
     ])
     expect(responseBlocks.map(({ block }) => (block.kind === "text" ? block.part.partId : block.kind))).toEqual([
+      "process-1",
       "response-1",
     ])
     expect(textFromTimelineBlocks(responseBlocks)).toBe(
-      "The site blocks automated requests. Use a browser script instead.",
+      "I will inspect the page.\n\nThe site blocks automated requests. Use a browser script instead.",
     )
+    expect(segments.map(({ kind }) => kind)).toEqual(["response", "process", "response"])
   })
 
   it("joins multiple response text blocks with blank lines", () => {
@@ -128,16 +129,26 @@ describe("assistantTimelineBlocks", () => {
     ).toEqual(["response-1"])
   })
 
-  it("keeps short active ACP narration in processing before its tool call arrives", () => {
-    const active = message("a1", [textPart("progress-1", "I will inspect the PostHog project first.")])
+  it("renders a short active ACP answer as a response without execution evidence", () => {
+    const active = message("a1", [textPart("answer", "Hello!")])
 
-    expect(
-      segmentAssistantTimeline([active], { activeAssistantMessageId: active.id }).map((segment) => segment.kind),
-    ).toEqual(["process"])
     expect(segmentAssistantTimeline([active]).map((segment) => segment.kind)).toEqual(["response"])
   })
 
-  it("keeps a long structured plan in the single process disclosure while tools continue", () => {
+  it("keeps visible narration in place when its tool call arrives", () => {
+    const narration = textPart("progress", "I will inspect the PostHog project first.")
+    const beforeTool = message("a1", [narration])
+    const afterTool = message("a1", [narration, toolPart("tool-1")])
+
+    const beforeSegments = segmentAssistantTimeline([beforeTool])
+    expect(beforeSegments.map(({ kind }) => kind)).toEqual(["response"])
+    const afterSegments = segmentAssistantTimeline([afterTool])
+    expect(afterSegments.map(({ kind }) => kind)).toEqual(["response", "process"])
+    expect(afterSegments[0]?.key).toBe(beforeSegments[0]?.key)
+    expect(textFromTimelineBlocks(afterSegments[0]?.blocks ?? [])).toBe(narration.text)
+  })
+
+  it("keeps structured prelude outside and intermediate narration inside processing", () => {
     const plan = [
       "## Selection plan",
       "",
@@ -151,13 +162,10 @@ describe("assistantTimelineBlocks", () => {
       message("a3", [textPart("final", "The report is ready.")], "stop"),
     ])
 
-    expect(segments.map((segment) => segment.kind)).toEqual(["process", "response"])
-    expect(segments[0]?.blocks.map(({ block }) => (block.kind === "text" ? block.part.partId : block.kind))).toEqual([
-      "plan",
-      "tools",
-      "progress",
-      "tools",
-    ])
+    expect(segments.map((segment) => segment.kind)).toEqual(["response", "process", "response"])
+    expect(segments[0]?.blocks.map(({ block }) => block.kind)).toEqual(["text"])
+    expect(segments[1]?.blocks.map(({ block }) => block.kind)).toEqual(["tools", "text", "tools"])
+    expect(segments[2]?.blocks.map(({ block }) => block.kind)).toEqual(["text"])
     expect(timelineHasVisibleOutcome(segments)).toBe(true)
   })
 
@@ -170,8 +178,8 @@ describe("assistantTimelineBlocks", () => {
       ),
     ])
 
-    expect(segments.map((segment) => segment.kind)).toEqual(["process", "response"])
-    expect(textFromTimelineBlocks(segments[1]?.blocks ?? [])).toBe("I need you to confirm the target Notion page.")
+    expect(segments.map((segment) => segment.kind)).toEqual(["response", "process"])
+    expect(textFromTimelineBlocks(segments[0]?.blocks ?? [])).toBe("I need you to confirm the target Notion page.")
   })
 
   it("does not hide a substantive answer followed by a trailing save tool", () => {
@@ -180,18 +188,18 @@ describe("assistantTimelineBlocks", () => {
       message("a1", [textPart("answer", answer), toolPart("save")], "tool-calls"),
     ])
 
-    expect(segments.map((segment) => segment.kind)).toEqual(["process", "response"])
-    expect(textFromTimelineBlocks(segments[1]?.blocks ?? [])).toBe(answer)
+    expect(segments.map((segment) => segment.kind)).toEqual(["response", "process"])
+    expect(textFromTimelineBlocks(segments[0]?.blocks ?? [])).toBe(answer)
   })
 
-  it("does not promote process narration after a failed tool into a successful-looking outcome", () => {
+  it("keeps narration visible before a failed tool", () => {
     const failedTool = { ...toolPart("proxy"), status: "error" as const, error: "The user rejected permission." }
     const segments = segmentAssistantTimeline([
       message("a1", [textPart("progress", "I will try the provider proxy."), failedTool], "tool-calls"),
     ])
 
-    expect(segments.map((segment) => segment.kind)).toEqual(["process"])
-    expect(timelineHasVisibleOutcome(segments)).toBe(false)
+    expect(segments.map((segment) => segment.kind)).toEqual(["response", "process"])
+    expect(timelineHasVisibleOutcome(segments)).toBe(true)
   })
 
   it("keeps a short stop response visible even when its message contains a tool", () => {
@@ -202,35 +210,44 @@ describe("assistantTimelineBlocks", () => {
     expect(segments.map((segment) => segment.kind)).toEqual(["process", "response"])
   })
 
-  it("uses one process disclosure for the whole turn and preserves lane chronology", () => {
+  it("uses contiguous process disclosures to preserve lane chronology", () => {
     const segments = segmentAssistantTimeline([
       message("a1", [textPart("progress-1", "Checking data."), toolPart("tool-1")], "tool-calls"),
       message("a2", [textPart("answer", "## Interim result\n\nUseful result")], "stop"),
       message("a3", [textPart("progress-2", "Saving the result."), toolPart("tool-2")], "tool-calls"),
     ])
 
-    expect(segments.map((segment) => segment.kind)).toEqual(["process", "response"])
-    expect(
-      segments[0]?.blocks.map(({ block }) =>
-        block.kind === "tools" ? block.parts.map((part) => part.partId).join(",") : block.part.partId,
-      ),
-    ).toEqual(["progress-1", "tool-1", "progress-2", "tool-2"])
+    expect(segments.map((segment) => segment.kind)).toEqual(["response", "process", "response", "process"])
+    expect(segments.filter(({ kind }) => kind === "process").map(({ blocks }) => blocks[0]?.block.kind)).toEqual([
+      "tools",
+      "tools",
+    ])
   })
 
-  it("does not promote active structured narration to a response before the turn settles", () => {
+  it("renders active structured text as a response without execution evidence", () => {
     const active = message("a1", [
       textPart("report", "## Data quality\n\n- YouTube complete\n- Reddit needs a narrower query"),
     ])
 
-    expect(segmentAssistantTimeline([active], { activeAssistantMessageId: active.id }).map(({ kind }) => kind)).toEqual(
-      ["process"],
-    )
+    expect(segmentAssistantTimeline([active]).map(({ kind }) => kind)).toEqual(["response"])
+  })
+
+  it("keeps intermediate narration and adjacent tools in one process disclosure", () => {
+    const segments = segmentAssistantTimeline([
+      message("a1", [toolPart("tool-1")]),
+      message("a2", [toolPart("tool-2")]),
+      message("a3", [textPart("note", "Now I will continue.")]),
+      message("a4", [toolPart("tool-3")]),
+    ])
+
+    expect(segments.map(({ kind }) => kind)).toEqual(["process"])
+    expect(segments[0]?.blocks.map(({ block }) => block.kind)).toEqual(["tools", "tools", "text", "tools"])
   })
 
   it("reconstructs process messages without unrelated response parts", () => {
     const source = message("a1", [textPart("progress", "Checking data."), toolPart("tool-1")], "tool-calls")
-    const processBlocks = segmentAssistantTimeline([source], { activeAssistantMessageId: source.id })[0]?.blocks ?? []
+    const processBlocks = segmentAssistantTimeline([source])[1]?.blocks ?? []
 
-    expect(assistantMessagesFromTimelineBlocks(processBlocks)).toEqual([source])
+    expect(assistantMessagesFromTimelineBlocks(processBlocks)).toEqual([{ ...source, parts: [source.parts[1]!] }])
   })
 })

--- a/src/routes/Chat/assistant-timeline.ts
+++ b/src/routes/Chat/assistant-timeline.ts
@@ -34,52 +34,18 @@ function isToolCallFinishReason(reason: string | undefined): boolean {
   return reason === "tool-calls" || reason === "tool_calls" || reason === "tool-use" || reason === "tool_use"
 }
 
-function messageToolParts(message: ChatMessage): ChatMessagePart[] {
-  return message.parts.filter((part) => part.kind === "tool")
-}
-
-function textBelongsToProcess(
-  message: ChatMessage,
-  part: ChatMessagePart,
-  activeAssistantMessageId: string | undefined,
-): boolean {
-  const text = part.text?.trim() ?? ""
-  if (!text) {
-    return false
-  }
-
-  if (message.finishReason && !isToolCallFinishReason(message.finishReason)) {
-    // stop 等终止原因表示这条消息已经直接回应用户，即使同一消息里也有工具记录。
-    return false
-  }
-
-  const tools = messageToolParts(message)
-  if (tools.some((tool) => tool.tool === "question")) {
-    // 问题前的说明是用户做决定所需的上下文，不能随工具详情一起隐藏。
-    return false
-  }
-  if (tools.length > 0) {
-    return true
-  }
-  // Keep all still-active narration in the process disclosure until the
-  // adapter supplies a terminal finish reason. This is deliberately based on
-  // turn lifecycle rather than prose length or Markdown shape: a detailed
-  // progress report is still progress while the agent continues using tools.
-  if (message.id === activeAssistantMessageId) {
-    return true
-  }
-  return isToolCallFinishReason(message.finishReason)
-}
-
 function blockSegmentKind(
   item: AssistantTimelineBlock,
-  activeAssistantMessageId: string | undefined,
+  phase: AssistantTimelineSegmentKind,
 ): AssistantTimelineSegmentKind {
   switch (item.block.kind) {
     case "tools":
       return "process"
     case "text":
-      return textBelongsToProcess(item.message, item.block.part, activeAssistantMessageId) ? "process" : "response"
+      // A non-tool finish reason is explicit final-response evidence. Without
+      // it, narration follows the current turn phase: text seen before the
+      // first tool stays put, while text between tools remains in processing.
+      return item.message.finishReason && !isToolCallFinishReason(item.message.finishReason) ? "response" : phase
     case "status":
       return item.block.part.statusType === "connectionFailed" || item.block.part.statusType === "runtimeFailed"
         ? "response"
@@ -99,46 +65,36 @@ export function segmentAssistantTimeline(
   options: { activeAssistantMessageId?: string } = {},
 ): AssistantTimelineSegment[] {
   const blocks = assistantTimelineBlocks(messages)
-  const classified = blocks.map((item) => ({ item, kind: blockSegmentKind(item, options.activeAssistantMessageId) }))
-  const hasIncompleteTool = classified.some(
-    ({ item, kind }) =>
-      kind === "process" && item.block.kind === "tools" && item.block.parts.some((part) => part.status !== "completed"),
-  )
-
-  // Some adapters can finish a turn immediately after a tool-use step without
-  // emitting a separate stop message. Once the turn is settled, preserve the
-  // last narrated result as the visible outcome instead of leaving the user
-  // with process activity only.
-  if (
-    options.activeAssistantMessageId === undefined &&
-    !hasIncompleteTool &&
-    !classified.some(
-      ({ item, kind }) => kind === "response" && (item.block.kind === "text" || item.block.kind === "attachment"),
-    )
-  ) {
-    const fallbackIndex = classified.findLastIndex(
-      ({ item, kind }) => kind === "process" && item.block.kind === "text" && Boolean(item.block.part.text?.trim()),
-    )
-    if (fallbackIndex >= 0 && classified[fallbackIndex]) {
-      classified[fallbackIndex].kind = "response"
+  const segments: AssistantTimelineSegment[] = []
+  let phase: AssistantTimelineSegmentKind = "response"
+  for (const item of blocks) {
+    const kind = blockSegmentKind(item, phase)
+    if (item.block.kind === "tools" || (item.block.kind === "status" && kind === "process")) {
+      phase = "process"
+    } else if (item.block.kind === "text" && kind === "response" && item.message.finishReason) {
+      phase = "response"
+    }
+    const current = segments.at(-1)
+    if (current?.kind === kind) {
+      current.blocks.push(item)
+    } else {
+      segments.push({ kind, key: blockKey(item), blocks: [item] })
     }
   }
-
-  // Render one stable process disclosure per user turn. Agent loops commonly
-  // alternate narration and tools several times; mirroring those alternations
-  // as separate disclosures makes settled content appear to be regenerated.
-  // Bucketing retains the order inside each lane without constraining the
-  // agent's native loop or rewriting its transcript.
-  const processBlocks = classified.filter(({ kind }) => kind === "process").map(({ item }) => item)
-  const responseBlocks = classified.filter(({ kind }) => kind === "response").map(({ item }) => item)
-  const segments: AssistantTimelineSegment[] = []
-  if (processBlocks.length > 0) {
-    const first = processBlocks[0]
-    segments.push({ kind: "process", key: first ? blockKey(first) : "process", blocks: processBlocks })
-  }
-  if (responseBlocks.length > 0) {
-    const first = responseBlocks[0]
-    segments.push({ kind: "response", key: first ? blockKey(first) : "response", blocks: responseBlocks })
+  const lastSegment = segments.at(-1)
+  if (options.activeAssistantMessageId === undefined && lastSegment?.kind === "process") {
+    const trailingText: AssistantTimelineBlock[] = []
+    while (lastSegment.blocks.at(-1)?.block.kind === "text") {
+      const item = lastSegment.blocks.pop()
+      if (item) trailingText.unshift(item)
+    }
+    if (trailingText.length > 0) {
+      const first = trailingText[0]
+      segments.push({ kind: "response", key: first ? blockKey(first) : "response", blocks: trailingText })
+    }
+    if (lastSegment.blocks.length === 0) {
+      segments.splice(-2, 1)
+    }
   }
   return segments
 }


### PR DESCRIPTION
## Summary

Stabilize the assistant timeline for BYOA and ACP-backed agents so ordinary text-only replies do not briefly appear inside the process disclosure, while genuine multi-step work still reads as one coherent execution phase.

## User impact

Short replies such as greetings previously flashed as “Processing” until the external agent returned its turn-level completion signal. A first piece of narration could also appear as a normal response and then move into the process disclosure when a later tool call arrived. Conversely, treating every text part as a response fragmented tool-driven turns into alternating text and process cards.

With this change, text emitted before the first tool remains in its original response position, intermediate narration after execution begins stays grouped with subsequent tools, and an explicit terminal response appears after the process disclosure. Text-only turns remain normal streamed responses without process chrome.

## Root cause

The renderer inferred presentation from the final contents of an assistant message. ACP can stream ordinary `agent_message_chunk` text before announcing a tool, so adding the tool later caused the whole message to be reclassified and reordered. A temporary content-type-only split avoided that reclassification but lost the turn-phase semantics needed to keep progress narration and tools together.

## Fix

- Classify timeline blocks with a chronological response/process phase state machine.
- Keep pre-tool text stable instead of retroactively moving it when a tool arrives.
- Enter the process phase at the first tool or process status and keep intermediate narration with later tools.
- Return to the response lane for explicit non-tool completion, with a settled-turn fallback for adapters that omit a finish reason.
- Render all assistant timeline segments through one stable path and give every process segment a distinct stable React key.
- Keep only contiguous execution blocks together, preserving the original event order without global process/response rebucketing.
- Add regression coverage for text-only ACP replies, stable pre-tool narration, intermediate process narration, adjacent tools, failed tools, question context, and terminal responses.

## Validation

- `pnpm run lint`
- `pnpm run ts-check`
- `pnpm test` — 360 test files passed, 2 skipped; 2882 tests passed, 4 skipped
- `pnpm exec oxfmt --check src/routes/Chat/assistant-timeline.ts src/routes/Chat/assistant-timeline.test.ts src/routes/Chat/ChatTimeline.tsx`
- `git diff --check`

