### PR TITLE
fix(byoa): stabilize managed OO tool workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,9 @@ jobs:
           # Compatibility tests verify the pinned binary's real exported Skill
           # tree, which is intentionally gitignored and skipped during install.
           OO_SKIP_BINARY_DOWNLOAD: "0"
+          # Postinstall keeps Skill export best-effort for contributor setup;
+          # CI must fail at this preparation step on export/hash drift.
+          WANTA_STRICT_SKILL_EXPORT: "1"
 
       - name: Run lint
         run: corepack pnpm run lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,6 +37,13 @@ jobs:
           # 本 job 只做 lint/test/build:app，不打包，故无需下载 oo 二进制。
           OO_SKIP_BINARY_DOWNLOAD: "1"
 
+      - name: Export bundled OO skills
+        run: node --experimental-strip-types ./scripts/download-skills.ts
+        env:
+          # Compatibility tests verify the pinned binary's real exported Skill
+          # tree, which is intentionally gitignored and skipped during install.
+          OO_SKIP_BINARY_DOWNLOAD: "0"
+
       - name: Run lint
         run: corepack pnpm run lint
 

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -23,7 +23,7 @@ import path from "node:path"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import { AGENT_PROFILES } from "../contract/profile.ts"
 import { AcpAgentAdapter } from "./adapter.ts"
-import { ACP_AGENT_REGISTRY } from "./registry.ts"
+import { ACP_AGENT_KINDS, ACP_AGENT_REGISTRY } from "./registry.ts"
 
 // Adapter tests against an IN-PROCESS fake ACP agent built with the SDK's
 // agent-side builder, wired to the adapter through an in-memory stream pair
@@ -665,6 +665,58 @@ describe("AcpAgentAdapter", () => {
         url: "http://127.0.0.1:4321/mcp",
         headers: [{ name: "Authorization", value: "Bearer opaque-token" }],
       },
+    ])
+  })
+
+  test.each(ACP_AGENT_KINDS)("%s receives the shared Skill and managed-command contract", async (kind) => {
+    const harness = await createHarness(
+      {
+        prompt: async (turn) => {
+          await turn.sendUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: `${kind}-load-skill`,
+            title: "mcp__wanta_skills__load_skill",
+            kind: "other",
+            status: "completed",
+            rawInput: { skillId: "oo" },
+          })
+          await turn.sendUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: `${kind}-read-reference`,
+            title: "mcp__wanta_skills__read_skill_file",
+            kind: "other",
+            status: "completed",
+            rawInput: { skillId: "oo", path: "references/search-and-selection.md" },
+          })
+          await turn.sendUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: `${kind}-execute-search`,
+            title: "Run command",
+            name: "bash",
+            kind: "execute",
+            status: "completed",
+            rawInput: { command: 'oo search "generate an image" --json' },
+          })
+          return { stopReason: "end_turn" }
+        },
+      },
+      kind,
+      async () => [{ name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: {} }],
+    )
+    await harness.adapter.send({ type: "prompt", sessionId: WANTA_SESSION_ID, text: "generate an image" })
+    await harness.waitFor((event) => event.event === "messageCompleted")
+
+    expect(harness.fake.newSessionRequests[0]?.mcpServers).toEqual([
+      { type: "http", name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: [] },
+    ])
+    expect(
+      harness.events
+        .filter((event) => event.event === "toolCallStarted")
+        .map((event) => ({ title: event.data.title, tool: event.data.tool })),
+    ).toEqual([
+      { title: "Loaded skill: oo", tool: "load_skill" },
+      { title: "Read skill reference: references/search-and-selection.md", tool: "read_skill_file" },
+      { title: "Run command", tool: "bash" },
     ])
   })
 

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -18,7 +18,7 @@ import type {
 
 import { agent, PROTOCOL_VERSION, RequestError } from "@agentclientprotocol/sdk"
 import { execFile } from "node:child_process"
-import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdtemp, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
@@ -764,11 +764,11 @@ describe("AcpAgentAdapter", () => {
       async () => [{ name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: {} }],
     )
     guardCwd = harness.scratchRootDir
-    const fakeOo = path.join(harness.scratchRootDir, "fake-oo")
-    await writeFile(fakeOo, '#!/bin/sh\nprintf "%s\\n" "$@"\n', "utf8")
-    await chmod(fakeOo, 0o755)
+    const fakeOo = path.join(harness.scratchRootDir, "fake-oo.mjs")
+    await writeFile(fakeOo, "for (const arg of process.argv.slice(2)) process.stdout.write(`${arg}\\n`)\n", "utf8")
     const server = new ExternalOoGuardServer({
-      command: fakeOo,
+      command: process.execPath,
+      commandArgsPrefix: [fakeOo],
       scope: () => ({
         external: true,
         runtime: "oomol",

--- a/electron/agent/acp/adapter.test.ts
+++ b/electron/agent/acp/adapter.test.ts
@@ -17,11 +17,14 @@ import type {
 } from "@agentclientprotocol/sdk"
 
 import { agent, PROTOCOL_VERSION, RequestError } from "@agentclientprotocol/sdk"
-import { mkdtemp, writeFile } from "node:fs/promises"
+import { execFile } from "node:child_process"
+import { chmod, mkdtemp, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import { promisify } from "node:util"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import { AGENT_PROFILES } from "../contract/profile.ts"
+import { ExternalOoGuardServer } from "../external/oo-guard-server.ts"
 import { AcpAgentAdapter } from "./adapter.ts"
 import { ACP_AGENT_KINDS, ACP_AGENT_REGISTRY } from "./registry.ts"
 
@@ -33,6 +36,7 @@ import { ACP_AGENT_KINDS, ACP_AGENT_REGISTRY } from "./registry.ts"
 
 const REGISTRATION = ACP_AGENT_REGISTRY["codex"]
 const WANTA_SESSION_ID = "wanta-session-1"
+const execFileAsync = promisify(execFile)
 
 interface FakePromptTurn {
   params: PromptRequest
@@ -718,6 +722,89 @@ describe("AcpAgentAdapter", () => {
       { title: "Read skill reference: references/search-and-selection.md", tool: "read_skill_file" },
       { title: "Run command", tool: "bash" },
     ])
+  })
+
+  test.each(ACP_AGENT_KINDS)("%s completes ACP to managed OO guard execution", async (kind) => {
+    let guardEnvironment: NodeJS.ProcessEnv | undefined
+    let guardCwd = ""
+    const harness = await createHarness(
+      {
+        prompt: async (turn) => {
+          if (!guardEnvironment) throw new Error("guard environment is not ready")
+          await turn.sendUpdate({
+            sessionUpdate: "tool_call",
+            toolCallId: `${kind}-guard-search`,
+            title: "Run command",
+            name: "bash",
+            kind: "execute",
+            status: "in_progress",
+            rawInput: { command: 'oo search "generate an image" --json' },
+          })
+          const result = await execFileAsync(
+            process.execPath,
+            [
+              "--experimental-strip-types",
+              path.resolve("electron/agent/oo-guard.ts"),
+              "search",
+              "generate an image",
+              "--json",
+            ],
+            { cwd: guardCwd, encoding: "utf8", env: guardEnvironment },
+          )
+          await turn.sendUpdate({
+            sessionUpdate: "tool_call_update",
+            toolCallId: `${kind}-guard-search`,
+            status: "completed",
+            rawOutput: result.stdout,
+          })
+          return { stopReason: "end_turn" }
+        },
+      },
+      kind,
+      async () => [{ name: "wanta_skills", url: "http://127.0.0.1:4321/mcp", headers: {} }],
+    )
+    guardCwd = harness.scratchRootDir
+    const fakeOo = path.join(harness.scratchRootDir, "fake-oo")
+    await writeFile(fakeOo, '#!/bin/sh\nprintf "%s\\n" "$@"\n', "utf8")
+    await chmod(fakeOo, 0o755)
+    const server = new ExternalOoGuardServer({
+      command: fakeOo,
+      scope: () => ({
+        external: true,
+        runtime: "oomol",
+        sessionCwdRoots: { [WANTA_SESSION_ID]: [harness.scratchRootDir] },
+        sessionRuntimes: { [WANTA_SESSION_ID]: "oomol" },
+        sessionTeams: { [WANTA_SESSION_ID]: "Team A" },
+      }),
+    })
+    try {
+      const descriptor = await server.descriptor()
+      guardEnvironment = {
+        ...process.env,
+        WANTA_OO_GUARD_TOKEN: descriptor.token,
+        WANTA_OO_GUARD_URL: descriptor.url,
+      }
+      await harness.adapter.send({
+        type: "prompt",
+        sessionId: WANTA_SESSION_ID,
+        text: "generate an image",
+        workingDirectory: harness.scratchRootDir,
+      })
+      await harness.waitFor((event) => event.event === "messageCompleted")
+      expect(harness.events).toContainEqual(
+        expect.objectContaining({
+          event: "toolCallResult",
+          data: expect.objectContaining({
+            callId: `${kind}-guard-search`,
+            output: expect.stringContaining("generate an image"),
+            status: "completed",
+            tool: "bash",
+          }),
+        }),
+      )
+    } finally {
+      await server.dispose()
+    }
   })
 
   test("Wanta host context precedes the user request without changing transcript text", async () => {

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -40,6 +40,7 @@ import { errorMessage, logDiagnostic } from "../../diagnostics-log.ts"
 import { AGENT_PERMISSION_MODE_ORDER, AGENT_PROFILES } from "../contract/profile.ts"
 import { ExternalAgentAdapter } from "../external/adapter-base.ts"
 import { externalExecutableNeedsShell } from "../external/executable.ts"
+import { nativeSkillSourceObservation } from "../external/native-skill-source.ts"
 import { externalAgentPromptText } from "../external/prompt.ts"
 import { externalSessionUuid } from "../external/session-id.ts"
 import { appendStderrTail, subprocessFailureSummary } from "../external/subprocess-diagnostics.ts"
@@ -423,6 +424,7 @@ function selectPermissionOptionId(
 }
 
 export class AcpAgentAdapter extends ExternalAgentAdapter {
+  private readonly observedNativeSkillSources = new Set<string>()
   private readonly options: AcpAdapterOptions
   private connectionHandle: AcpConnectionHandle | undefined
   private connectionPromise: Promise<AcpConnectionHandle> | undefined
@@ -625,6 +627,9 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
   protected override handleForgetSession(sessionId: string): void {
     this.desiredSelections.delete(sessionId)
     this.desiredPermissionModes.delete(sessionId)
+    for (const key of this.observedNativeSkillSources) {
+      if (key.startsWith(`${sessionId}\0`)) this.observedNativeSkillSources.delete(key)
+    }
     const session = this.sessionsByWantaId.get(sessionId)
     if (session) {
       this.wantaIdByAcpId.delete(session.acpSessionId)
@@ -1595,6 +1600,19 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     }
     this.observeTurnEvents(session.activeTurn, events)
     for (const event of events) {
+      if (event.event === "toolCallStarted") {
+        const observation = nativeSkillSourceObservation(event.data.input)
+        const key = observation ? `${event.data.sessionId}\0${observation.skillId}` : undefined
+        if (observation && key && !this.observedNativeSkillSources.has(key)) {
+          this.observedNativeSkillSources.add(key)
+          logDiagnostic(
+            "acp-adapter",
+            "native Skill source observed",
+            { adapter: this.kind, skillId: observation.skillId, source: observation.source },
+            "warn",
+          )
+        }
+      }
       this.emit(event)
     }
   }

--- a/electron/agent/acp/translator.test.ts
+++ b/electron/agent/acp/translator.test.ts
@@ -416,6 +416,39 @@ describe("tool_call lifecycle", () => {
     })
   })
 
+  test("replaces native Wanta Skill MCP infrastructure names with readable labels", () => {
+    const translator = createAcpSessionTranslator(SESSION_ID, new Set(["wanta_skills"]))
+    translator.noteTurnStarted()
+    const readEvents = translator.translate({
+      sessionUpdate: "tool_call",
+      toolCallId: "read-skill-reference",
+      title: "mcp__wanta_skills__read_skill_file",
+      kind: "other",
+      status: "in_progress",
+      rawInput: { skillId: "oo", path: "references/search-and-selection.md" },
+    })
+    expect(readEvents.at(-1)).toMatchObject({
+      event: "toolCallStarted",
+      data: {
+        tool: "read_skill_file",
+        title: "Read skill reference: references/search-and-selection.md",
+      },
+    })
+
+    const listEvents = translator.translate({
+      sessionUpdate: "tool_call",
+      toolCallId: "list-skills",
+      title: "mcp__wanta_skills__list_skills",
+      kind: "other",
+      status: "in_progress",
+      rawInput: {},
+    })
+    expect(listEvents.at(-1)).toMatchObject({
+      event: "toolCallStarted",
+      data: { tool: "list_skills", title: "List available skills" },
+    })
+  })
+
   test("drops Wanta MCP startup probes instead of creating unfinished tool steps", () => {
     const translator = createAcpSessionTranslator(SESSION_ID, new Set(["wanta_browser"]))
     translator.noteTurnStarted()

--- a/electron/agent/acp/translator.ts
+++ b/electron/agent/acp/translator.ts
@@ -159,6 +159,12 @@ function normalizedAcpToolTitle(
   if (tool === "load_skill" && typeof input["skillId"] === "string") {
     return `Loaded skill: ${input["skillId"]}`
   }
+  if (tool === "read_skill_file" && typeof input["path"] === "string") {
+    return `Read skill reference: ${input["path"]}`
+  }
+  if (tool === "list_skills") {
+    return "List available skills"
+  }
   return fallback
 }
 

--- a/electron/agent/external/native-skill-source.test.ts
+++ b/electron/agent/external/native-skill-source.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "vitest"
+import { nativeSkillSourceObservation } from "./native-skill-source.ts"
+
+test("detects native global Skill roots without returning the private path", () => {
+  expect(
+    nativeSkillSourceObservation({ variant: "ListDir", target_directory: "/Users/alice/.agents/skills/oo-posthog" }),
+  ).toEqual({ skillId: "oo-posthog", source: "native_global" })
+  expect(nativeSkillSourceObservation({ path: "C:\\Users\\alice\\.claude\\skills\\oo" })).toEqual({
+    skillId: "oo",
+    source: "native_global",
+  })
+})
+
+test("ignores managed and malformed Skill paths", () => {
+  expect(nativeSkillSourceObservation({ path: "/managed/.opencode/skills/oo" })).toBeUndefined()
+  expect(nativeSkillSourceObservation({ path: "/Users/alice/.agents/skills/../../secret" })).toBeUndefined()
+  expect(nativeSkillSourceObservation({ command: "echo no skill path" })).toBeUndefined()
+})

--- a/electron/agent/external/native-skill-source.ts
+++ b/electron/agent/external/native-skill-source.ts
@@ -1,0 +1,23 @@
+export interface NativeSkillSourceObservation {
+  skillId: string
+  source: "native_global"
+}
+
+/** Detect native home-directory Skill reads without retaining paths or tool payloads. */
+export function nativeSkillSourceObservation(input: unknown): NativeSkillSourceObservation | undefined {
+  for (const value of stringValues(input)) {
+    const match = value.match(/(?:^|[\\/])\.(?:agents|claude|codex)[\\/]skills[\\/]([^\\/\s"']+)/iu)
+    const skillId = match?.[1]?.trim()
+    if (skillId && /^[a-z0-9][a-z0-9._-]*$/iu.test(skillId)) {
+      return { skillId, source: "native_global" }
+    }
+  }
+  return undefined
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === "string") return [value]
+  if (Array.isArray(value)) return value.flatMap(stringValues)
+  if (!value || typeof value !== "object") return []
+  return Object.values(value as Record<string, unknown>).flatMap(stringValues)
+}

--- a/electron/agent/external/oo-capability-contract.test.ts
+++ b/electron/agent/external/oo-capability-contract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { ACP_AGENT_KINDS } from "../acp/registry.ts"
+import {
+  EXTERNAL_OO_OPERATIONS,
+  externalOoExecutionPolicy,
+  resolveExternalOoOperation,
+} from "./oo-capability-contract.ts"
+
+describe("external OO capability contract", () => {
+  it("resolves enabled and unavailable domains from one ordered table", () => {
+    expect(resolveExternalOoOperation(["search", "generate an image", "--json"])).toMatchObject({
+      availability: "enabled",
+      id: "capability.search",
+    })
+    expect(resolveExternalOoOperation(["--lang=en", "connector", "run", "posthog"])).toMatchObject({
+      availability: "enabled",
+      id: "connector.run",
+      workspace: "required",
+    })
+    expect(resolveExternalOoOperation(["file", "download", "https://example.com/a"])).toMatchObject({
+      availability: "planned",
+      id: "file.download",
+    })
+    expect(resolveExternalOoOperation(["logout"])).toMatchObject({ availability: "denied", id: "logout" })
+    expect(resolveExternalOoOperation(["unknown"])).toBeUndefined()
+  })
+
+  it("generates Skill guidance from the same operation table", () => {
+    const policy = externalOoExecutionPolicy()
+    for (const operation of EXTERNAL_OO_OPERATIONS) {
+      if (operation.availability === "enabled") {
+        expect(policy).toContain(`oo ${operation.command.join(" ")}`)
+      } else {
+        expect(policy).toContain(operation.id)
+      }
+    }
+    expect(policy).toContain("Skip the Skill recommendation wrap-up")
+  })
+
+  it("applies the same enabled operation set to every generic ACP registration", () => {
+    const enabled = EXTERNAL_OO_OPERATIONS.filter((operation) => operation.availability === "enabled").map(
+      (operation) => operation.id,
+    )
+    const byAgent = Object.fromEntries(ACP_AGENT_KINDS.map((kind) => [kind, enabled]))
+    expect(byAgent["claude-code"]).toEqual(enabled)
+    expect(byAgent.codex).toEqual(enabled)
+    expect(byAgent.grok).toEqual(enabled)
+  })
+})

--- a/electron/agent/external/oo-capability-contract.ts
+++ b/electron/agent/external/oo-capability-contract.ts
@@ -52,6 +52,13 @@ export const EXTERNAL_OO_OPERATIONS = [
     workspace: "required",
   },
   {
+    id: "connector.proxy",
+    command: ["connector", "proxy"],
+    availability: "planned",
+    effect: "external_action",
+    workspace: "required",
+  },
+  {
     id: "file.upload",
     command: ["file", "upload"],
     availability: "planned",
@@ -73,6 +80,13 @@ export const EXTERNAL_OO_OPERATIONS = [
     workspace: "optional",
   },
   {
+    id: "skills.manage",
+    command: ["skills"],
+    availability: "denied",
+    effect: "local_state",
+    workspace: "optional",
+  },
+  {
     id: "flow",
     command: ["flow"],
     availability: "planned",
@@ -85,6 +99,27 @@ export const EXTERNAL_OO_OPERATIONS = [
     availability: "denied",
     effect: "local_state",
     workspace: "none",
+  },
+  {
+    id: "llm",
+    command: ["llm"],
+    availability: "planned",
+    effect: "local_state",
+    workspace: "optional",
+  },
+  {
+    id: "team.current",
+    command: ["team", "current"],
+    availability: "planned",
+    effect: "read_only",
+    workspace: "optional",
+  },
+  {
+    id: "variables",
+    command: ["variables"],
+    availability: "planned",
+    effect: "local_state",
+    workspace: "optional",
   },
   {
     id: "config",

--- a/electron/agent/external/oo-capability-contract.ts
+++ b/electron/agent/external/oo-capability-contract.ts
@@ -1,0 +1,145 @@
+export type ExternalOoAvailability = "denied" | "enabled" | "planned"
+export type ExternalOoEffect = "external_action" | "local_read" | "local_state" | "local_write" | "read_only"
+export type ExternalOoWorkspace = "none" | "optional" | "required"
+
+export interface ExternalOoOperation {
+  id: string
+  command: readonly string[]
+  availability: ExternalOoAvailability
+  effect: ExternalOoEffect
+  workspace: ExternalOoWorkspace
+}
+
+/**
+ * Single source of truth for OO command domains exposed through the privileged
+ * external-agent boundary. Guard dispatch, Skill guidance, and compatibility
+ * tests must derive from this table rather than maintaining parallel lists.
+ */
+export const EXTERNAL_OO_OPERATIONS = [
+  {
+    id: "capability.search",
+    command: ["search"],
+    availability: "enabled",
+    effect: "read_only",
+    workspace: "none",
+  },
+  {
+    id: "connector.search",
+    command: ["connector", "search"],
+    availability: "enabled",
+    effect: "read_only",
+    workspace: "none",
+  },
+  {
+    id: "connector.schema",
+    command: ["connector", "schema"],
+    availability: "enabled",
+    effect: "read_only",
+    workspace: "none",
+  },
+  {
+    id: "connector.apps",
+    command: ["connector", "apps"],
+    availability: "enabled",
+    effect: "read_only",
+    workspace: "required",
+  },
+  {
+    id: "connector.run",
+    command: ["connector", "run"],
+    availability: "enabled",
+    effect: "external_action",
+    workspace: "required",
+  },
+  {
+    id: "file.upload",
+    command: ["file", "upload"],
+    availability: "planned",
+    effect: "local_read",
+    workspace: "optional",
+  },
+  {
+    id: "file.download",
+    command: ["file", "download"],
+    availability: "planned",
+    effect: "local_write",
+    workspace: "optional",
+  },
+  {
+    id: "skills.recommend",
+    command: ["skills", "recommend"],
+    availability: "denied",
+    effect: "local_state",
+    workspace: "optional",
+  },
+  {
+    id: "flow",
+    command: ["flow"],
+    availability: "planned",
+    effect: "external_action",
+    workspace: "required",
+  },
+  {
+    id: "auth",
+    command: ["auth"],
+    availability: "denied",
+    effect: "local_state",
+    workspace: "none",
+  },
+  {
+    id: "config",
+    command: ["config"],
+    availability: "denied",
+    effect: "local_state",
+    workspace: "none",
+  },
+  {
+    id: "logout",
+    command: ["logout"],
+    availability: "denied",
+    effect: "local_state",
+    workspace: "none",
+  },
+] as const satisfies readonly ExternalOoOperation[]
+
+export function externalOoRootCommandIndex(args: readonly string[]): number {
+  let index = 0
+  while (index < args.length) {
+    const arg = args[index] ?? ""
+    if (arg === "--lang") {
+      index += 2
+      continue
+    }
+    if (arg.startsWith("--lang=") || ["--debug", "-h", "--help", "-V", "--version"].includes(arg)) {
+      index += 1
+      continue
+    }
+    break
+  }
+  return index
+}
+
+export function resolveExternalOoOperation(args: readonly string[]): ExternalOoOperation | undefined {
+  const commandArgs = args.slice(externalOoRootCommandIndex(args))
+  return EXTERNAL_OO_OPERATIONS.find(
+    (operation) =>
+      commandArgs.length >= operation.command.length &&
+      operation.command.every((token, index) => commandArgs[index] === token),
+  )
+}
+
+export function externalOoExecutionPolicy(): string {
+  const enabled = EXTERNAL_OO_OPERATIONS.filter((operation) => operation.availability === "enabled")
+    .map((operation) => `oo ${operation.command.join(" ")}`)
+    .join(", ")
+  const unavailable = EXTERNAL_OO_OPERATIONS.filter((operation) => operation.availability !== "enabled")
+    .map((operation) => operation.id)
+    .join(", ")
+  return [
+    "This host execution profile overrides conflicting command examples or mandatory transport steps in the loaded Skill.",
+    `The managed OO boundary supports these command domains: ${enabled}.`,
+    `These domains are unavailable unless separately advertised: ${unavailable}.`,
+    "Skip the Skill recommendation wrap-up; Wanta owns recommendation state and presentation.",
+    "Do not replace an unavailable managed domain with an unmanaged OO executable.",
+  ].join(" ")
+}

--- a/electron/agent/external/oo-capability-contract.ts
+++ b/electron/agent/external/oo-capability-contract.ts
@@ -10,6 +10,8 @@ export interface ExternalOoOperation {
   workspace: ExternalOoWorkspace
 }
 
+export const EXTERNAL_OO_CONTRACT_VERSION = 1
+
 /**
  * Single source of truth for OO command domains exposed through the privileged
  * external-agent boundary. Guard dispatch, Skill guidance, and compatibility

--- a/electron/agent/external/oo-guard-server.ts
+++ b/electron/agent/external/oo-guard-server.ts
@@ -27,6 +27,7 @@ export interface ExternalOoGuardDescriptor {
 export interface ExternalOoGuardServerOptions {
   available?: () => boolean | Promise<boolean>
   command: string
+  commandArgsPrefix?: readonly string[]
   env?: NodeJS.ProcessEnv
   scope: () => WorkspaceTeamScope
 }
@@ -130,10 +131,16 @@ export class ExternalOoGuardServer {
     request.once("aborted", abortOnDisconnect)
     response.once("close", abortOnDisconnect)
     try {
-      const result = await runOo(this.options.command, args, this.options.env ?? process.env, binding.cwd, {
-        activeChildren: this.activeChildren,
-        signal: controller.signal,
-      })
+      const result = await runOo(
+        this.options.command,
+        [...(this.options.commandArgsPrefix ?? []), ...args],
+        this.options.env ?? process.env,
+        binding.cwd,
+        {
+          activeChildren: this.activeChildren,
+          signal: controller.signal,
+        },
+      )
       respondJson(response, 200, result)
     } finally {
       request.off("aborted", abortOnDisconnect)

--- a/electron/agent/external/oo-guard-server.ts
+++ b/electron/agent/external/oo-guard-server.ts
@@ -25,6 +25,7 @@ export interface ExternalOoGuardDescriptor {
 }
 
 export interface ExternalOoGuardServerOptions {
+  available?: () => boolean | Promise<boolean>
   command: string
   env?: NodeJS.ProcessEnv
   scope: () => WorkspaceTeamScope
@@ -88,6 +89,10 @@ export class ExternalOoGuardServer {
     }
     if (request.method !== "POST" || request.url !== "/run") {
       respondJson(response, 404, { error: "Not found." })
+      return
+    }
+    if (this.options.available && !(await this.options.available())) {
+      respondJson(response, 503, { error: "Managed OO runtime compatibility is unavailable." })
       return
     }
     const body = await readRequest(request)

--- a/electron/agent/external/oo-guard-server.ts
+++ b/electron/agent/external/oo-guard-server.ts
@@ -105,7 +105,9 @@ export class ExternalOoGuardServer {
     const sessionScope = externalGuardSessionScope(scope, binding.sessionId)
     const originalArgs = stripIdentityIndependentWorkspaceSelectors(rawArgs as string[])
     if (!isManagedExternalOoCommand(originalArgs)) {
-      respondJson(response, 403, { error: "Only managed connector discovery and action commands are allowed." })
+      respondJson(response, 403, {
+        error: "Only managed capability discovery and connector action commands are allowed.",
+      })
       return
     }
     const args = isConnectorBusinessCommand(originalArgs)

--- a/electron/agent/external/oo-guard-server.ts
+++ b/electron/agent/external/oo-guard-server.ts
@@ -14,6 +14,7 @@ import {
   resolveExternalGuardCwdBinding,
   stripIdentityIndependentWorkspaceSelectors,
 } from "../oo-guard-core.ts"
+import { resolveExternalOoOperation } from "./oo-capability-contract.ts"
 
 const maxCapturedOutputBytes = 32 * 1024 * 1024
 const maxRequestBytes = 256 * 1024
@@ -105,8 +106,12 @@ export class ExternalOoGuardServer {
     const sessionScope = externalGuardSessionScope(scope, binding.sessionId)
     const originalArgs = stripIdentityIndependentWorkspaceSelectors(rawArgs as string[])
     if (!isManagedExternalOoCommand(originalArgs)) {
+      const operation = resolveExternalOoOperation(originalArgs)
       respondJson(response, 403, {
+        availability: operation?.availability ?? "unrecognized",
         error: "Only managed capability discovery and connector action commands are allowed.",
+        errorCode: operation ? "UNSUPPORTED_OO_OPERATION" : "UNRECOGNIZED_OO_OPERATION",
+        ...(operation ? { operation: operation.id } : {}),
       })
       return
     }

--- a/electron/agent/external/oo-runtime-compatibility.test.ts
+++ b/electron/agent/external/oo-runtime-compatibility.test.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { expect, test } from "vitest"
+import { EXTERNAL_OO_CONTRACT_VERSION } from "./oo-capability-contract.ts"
+import { verifyPackagedOoRuntime } from "./oo-runtime-compatibility.ts"
+
+test("verifies the packaged OO descriptor and fails closed on drift", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-packaged-oo-"))
+  try {
+    await mkdir(path.join(root, "bin"), { recursive: true })
+    await mkdir(path.join(root, "skills", "oo"), { recursive: true })
+    const content = "skill"
+    await writeFile(path.join(root, "skills", "oo", "SKILL.md"), content)
+    await writeFile(
+      path.join(root, "bin", "oo-runtime-compatibility.json"),
+      JSON.stringify({
+        contractVersion: EXTERNAL_OO_CONTRACT_VERSION,
+        files: { "SKILL.md": createHash("sha256").update(content).digest("hex") },
+        ooCliVersion: "1.7.7",
+      }),
+    )
+    await expect(verifyPackagedOoRuntime(root)).resolves.toEqual({ compatible: true })
+    await writeFile(path.join(root, "skills", "oo", "SKILL.md"), "tampered")
+    await expect(verifyPackagedOoRuntime(root)).resolves.toEqual({
+      compatible: false,
+      reason: "skill_hash_mismatch",
+    })
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/electron/agent/external/oo-runtime-compatibility.test.ts
+++ b/electron/agent/external/oo-runtime-compatibility.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { expect, test } from "vitest"
+import { OO_CLI_VERSION } from "../oo-version.ts"
 import { EXTERNAL_OO_CONTRACT_VERSION } from "./oo-capability-contract.ts"
 import { verifyPackagedOoRuntime } from "./oo-runtime-compatibility.ts"
 
@@ -18,10 +19,30 @@ test("verifies the packaged OO descriptor and fails closed on drift", async () =
       JSON.stringify({
         contractVersion: EXTERNAL_OO_CONTRACT_VERSION,
         files: { "SKILL.md": createHash("sha256").update(content).digest("hex") },
-        ooCliVersion: "1.7.7",
+        ooCliVersion: OO_CLI_VERSION,
       }),
     )
     await expect(verifyPackagedOoRuntime(root)).resolves.toEqual({ compatible: true })
+    await writeFile(
+      path.join(root, "bin", "oo-runtime-compatibility.json"),
+      JSON.stringify({
+        contractVersion: EXTERNAL_OO_CONTRACT_VERSION,
+        files: { "SKILL.md": createHash("sha256").update(content).digest("hex") },
+        ooCliVersion: "0.0.0",
+      }),
+    )
+    await expect(verifyPackagedOoRuntime(root)).resolves.toEqual({
+      compatible: false,
+      reason: "oo_cli_version_mismatch",
+    })
+    await writeFile(
+      path.join(root, "bin", "oo-runtime-compatibility.json"),
+      JSON.stringify({
+        contractVersion: EXTERNAL_OO_CONTRACT_VERSION,
+        files: { "SKILL.md": createHash("sha256").update(content).digest("hex") },
+        ooCliVersion: OO_CLI_VERSION,
+      }),
+    )
     await writeFile(path.join(root, "skills", "oo", "SKILL.md"), "tampered")
     await expect(verifyPackagedOoRuntime(root)).resolves.toEqual({
       compatible: false,

--- a/electron/agent/external/oo-runtime-compatibility.ts
+++ b/electron/agent/external/oo-runtime-compatibility.ts
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { EXTERNAL_OO_CONTRACT_VERSION } from "./oo-capability-contract.ts"
+
+export interface OoRuntimeCompatibilityDescriptor {
+  contractVersion: number
+  files: Record<string, string>
+  ooCliVersion: string
+}
+
+export interface OoRuntimeCompatibilityResult {
+  compatible: boolean
+  reason?: string
+}
+
+export async function verifyPackagedOoRuntime(resourcesPath: string): Promise<OoRuntimeCompatibilityResult> {
+  try {
+    const descriptor = JSON.parse(
+      await readFile(path.join(resourcesPath, "bin", "oo-runtime-compatibility.json"), "utf8"),
+    ) as OoRuntimeCompatibilityDescriptor
+    if (descriptor.contractVersion !== EXTERNAL_OO_CONTRACT_VERSION) {
+      return { compatible: false, reason: "contract_version_mismatch" }
+    }
+    for (const [relativePath, expected] of Object.entries(descriptor.files)) {
+      const content = await readFile(path.join(resourcesPath, "skills", "oo", relativePath))
+      const actual = createHash("sha256").update(content).digest("hex")
+      if (actual !== expected) return { compatible: false, reason: "skill_hash_mismatch" }
+    }
+    return { compatible: true }
+  } catch {
+    return { compatible: false, reason: "descriptor_or_skill_missing" }
+  }
+}

--- a/electron/agent/external/oo-runtime-compatibility.ts
+++ b/electron/agent/external/oo-runtime-compatibility.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
+import { OO_CLI_VERSION } from "../oo-version.ts"
 import { EXTERNAL_OO_CONTRACT_VERSION } from "./oo-capability-contract.ts"
 
 export interface OoRuntimeCompatibilityDescriptor {
@@ -21,6 +22,9 @@ export async function verifyPackagedOoRuntime(resourcesPath: string): Promise<Oo
     ) as OoRuntimeCompatibilityDescriptor
     if (descriptor.contractVersion !== EXTERNAL_OO_CONTRACT_VERSION) {
       return { compatible: false, reason: "contract_version_mismatch" }
+    }
+    if (descriptor.ooCliVersion !== OO_CLI_VERSION) {
+      return { compatible: false, reason: "oo_cli_version_mismatch" }
     }
     for (const [relativePath, expected] of Object.entries(descriptor.files)) {
       const content = await readFile(path.join(resourcesPath, "skills", "oo", relativePath))

--- a/electron/agent/oo-guard-core.test.ts
+++ b/electron/agent/oo-guard-core.test.ts
@@ -49,8 +49,12 @@ describe("OOMOL connector workspace guard", () => {
     ])
     assert.equal(hasWorkspaceSelector(["connector", "apps", "--personal"]), true)
     assert.equal(isConnectorBusinessCommand(["connector", "search", "posthog"]), false)
+    assert.equal(isManagedExternalOoCommand(["search", "analyze PostHog usage", "--json"]), true)
+    assert.equal(isManagedExternalOoCommand(["--lang=en", "search", "generate an image", "--json"]), true)
     assert.equal(isManagedExternalOoCommand(["connector", "search", "posthog"]), true)
     assert.equal(isManagedExternalOoCommand(["connector", "run", "posthog"]), true)
+    assert.equal(isManagedExternalOoCommand(["file", "download", "https://example.com/file"]), false)
+    assert.equal(isManagedExternalOoCommand(["skills", "recommend", "plan", "posthog"]), false)
     assert.equal(isManagedExternalOoCommand(["logout"]), false)
   })
 

--- a/electron/agent/oo-guard-core.ts
+++ b/electron/agent/oo-guard-core.ts
@@ -72,7 +72,7 @@ export function redactConnectorOutput(output: string): string {
   }
 }
 
-function connectorCommandIndex(args: readonly string[]): number {
+function rootCommandIndex(args: readonly string[]): number {
   let index = 0
   while (index < args.length) {
     const arg = args[index] ?? ""
@@ -86,6 +86,11 @@ function connectorCommandIndex(args: readonly string[]): number {
     }
     break
   }
+  return index
+}
+
+function connectorCommandIndex(args: readonly string[]): number {
+  const index = rootCommandIndex(args)
   return args[index] === "connector" ? index : -1
 }
 
@@ -96,6 +101,8 @@ export function isConnectorBusinessCommand(args: readonly string[]): boolean {
 
 /** Commands exposed by the privileged external-agent OO execution boundary. */
 export function isManagedExternalOoCommand(args: readonly string[]): boolean {
+  const rootIndex = rootCommandIndex(args)
+  if (args[rootIndex] === "search") return true
   const connectorIndex = connectorCommandIndex(args)
   if (connectorIndex < 0) return false
   const command = args[connectorIndex + 1] ?? ""

--- a/electron/agent/oo-guard-core.ts
+++ b/electron/agent/oo-guard-core.ts
@@ -1,8 +1,7 @@
 import { realpathSync } from "node:fs"
 import path from "node:path"
+import { externalOoRootCommandIndex, resolveExternalOoOperation } from "./external/oo-capability-contract.ts"
 
-const connectorCommandsRequiringWorkspace = new Set(["apps", "run"])
-const connectorCommandsIgnoringWorkspace = new Set(["schema", "search"])
 const sensitiveConnectorKeys = new Set([
   "access_token",
   "api_key",
@@ -72,41 +71,19 @@ export function redactConnectorOutput(output: string): string {
   }
 }
 
-function rootCommandIndex(args: readonly string[]): number {
-  let index = 0
-  while (index < args.length) {
-    const arg = args[index] ?? ""
-    if (arg === "--lang") {
-      index += 2
-      continue
-    }
-    if (arg.startsWith("--lang=") || ["--debug", "-h", "--help", "-V", "--version"].includes(arg)) {
-      index += 1
-      continue
-    }
-    break
-  }
-  return index
-}
-
 function connectorCommandIndex(args: readonly string[]): number {
-  const index = rootCommandIndex(args)
+  const index = externalOoRootCommandIndex(args)
   return args[index] === "connector" ? index : -1
 }
 
 export function isConnectorBusinessCommand(args: readonly string[]): boolean {
-  const connectorIndex = connectorCommandIndex(args)
-  return connectorIndex >= 0 && connectorCommandsRequiringWorkspace.has(args[connectorIndex + 1] ?? "")
+  const operation = resolveExternalOoOperation(args)
+  return operation?.id.startsWith("connector.") === true && operation.workspace === "required"
 }
 
 /** Commands exposed by the privileged external-agent OO execution boundary. */
 export function isManagedExternalOoCommand(args: readonly string[]): boolean {
-  const rootIndex = rootCommandIndex(args)
-  if (args[rootIndex] === "search") return true
-  const connectorIndex = connectorCommandIndex(args)
-  if (connectorIndex < 0) return false
-  const command = args[connectorIndex + 1] ?? ""
-  return connectorCommandsRequiringWorkspace.has(command) || connectorCommandsIgnoringWorkspace.has(command)
+  return resolveExternalOoOperation(args)?.availability === "enabled"
 }
 
 export function hasWorkspaceSelector(args: readonly string[]): boolean {
@@ -189,8 +166,9 @@ export function bindExternalConnectorWorkspace(args: readonly string[], scope: W
  * model recover from an avoidable parse error.
  */
 export function stripIdentityIndependentWorkspaceSelectors(args: readonly string[]): string[] {
+  const operation = resolveExternalOoOperation(args)
   const connectorIndex = connectorCommandIndex(args)
-  if (connectorIndex < 0 || !connectorCommandsIgnoringWorkspace.has(args[connectorIndex + 1] ?? "")) {
+  if (connectorIndex < 0 || operation?.workspace !== "none") {
     return [...args]
   }
   const commandArgsStart = connectorIndex + 2

--- a/electron/agent/oo-guard-runtime.test.ts
+++ b/electron/agent/oo-guard-runtime.test.ts
@@ -134,6 +134,18 @@ describe("external OO guard runtime", () => {
     expect(output.trim().split("\n")).toEqual(["connector", "apps", "posthog", "--json"])
   })
 
+  test("allows top-level read-only capability discovery required by the bundled oo skill", async () => {
+    const { env } = await fixture({
+      external: true,
+      runtime: "oomol",
+      sessionRuntimes: { "session-a": "oomol" },
+      sessionTeams: { "session-a": "Team A" },
+    })
+
+    const output = await runGuard(["search", "generate an image with GPT Image 2", "--json"], env)
+    expect(output.trim().split("\n")).toEqual(["search", "generate an image with GPT Image 2", "--json"])
+  })
+
   test("rejects runtime-administration commands at the privileged boundary", async () => {
     const { env } = await fixture({
       external: true,
@@ -143,7 +155,7 @@ describe("external OO guard runtime", () => {
     })
 
     await expect(runGuard(["logout"], env)).rejects.toMatchObject({
-      stderr: expect.stringContaining("Only managed connector discovery and action commands are allowed"),
+      stderr: expect.stringContaining("Only managed capability discovery and connector action commands are allowed"),
     })
   })
 

--- a/electron/agent/oo-guard-runtime.test.ts
+++ b/electron/agent/oo-guard-runtime.test.ts
@@ -21,6 +21,7 @@ afterEach(async () => {
 async function fixture(
   scope: unknown,
   commandBody = '#!/bin/sh\nprintf "%s\\n" "$@"\n',
+  available?: () => boolean | Promise<boolean>,
 ): Promise<{ env: NodeJS.ProcessEnv; root: string; server: ExternalOoGuardServer }> {
   const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "wanta-oo-guard-runtime-"))
   roots.push(temporaryRoot)
@@ -40,7 +41,7 @@ async function fixture(
         ),
       ),
   }
-  const server = new ExternalOoGuardServer({ command: realOo, scope: () => normalizedScope })
+  const server = new ExternalOoGuardServer({ available, command: realOo, scope: () => normalizedScope })
   servers.push(server)
   const descriptor = await server.descriptor()
   return {
@@ -156,6 +157,22 @@ describe("external OO guard runtime", () => {
 
     await expect(runGuard(["logout"], env)).rejects.toMatchObject({
       stderr: expect.stringContaining("Only managed capability discovery and connector action commands are allowed"),
+    })
+  })
+
+  test("fails closed before dispatch when packaged OO compatibility is unavailable", async () => {
+    const { env } = await fixture(
+      {
+        external: true,
+        runtime: "oomol",
+        sessionRuntimes: { "session-a": "oomol" },
+        sessionTeams: { "session-a": "Team A" },
+      },
+      undefined,
+      () => false,
+    )
+    await expect(runGuard(["search", "posthog"], env)).rejects.toMatchObject({
+      stderr: expect.stringContaining("Managed OO runtime compatibility is unavailable"),
     })
   })
 

--- a/electron/agent/oo-version.ts
+++ b/electron/agent/oo-version.ts
@@ -1,0 +1,2 @@
+/** Pinned OOCLI version shared by build scripts and packaged runtime verification. */
+export const OO_CLI_VERSION = "1.7.7"

--- a/electron/agent/skill-host-capability.ts
+++ b/electron/agent/skill-host-capability.ts
@@ -2,6 +2,7 @@ import type { HostCapability, HostCapabilityContext } from "./host-capability.ts
 import type { SkillRegistrySnapshot } from "./skill-registry.ts"
 
 import { z } from "zod"
+import { externalOoExecutionPolicy } from "./external/oo-capability-contract.ts"
 import { hostCapabilityBinding } from "./host-capability.ts"
 import { listSkillSnapshot, readSkillSnapshotFile } from "./skill-registry.ts"
 
@@ -10,7 +11,7 @@ export const SKILL_SNAPSHOT_BINDING = "skills.snapshot"
 
 function hostExecutionPolicy(): string {
   return `<wanta_execution_policy>
-Skill files describe business workflows, schemas, and safety rules. For connected services, follow the Skill's oo connector schema/run workflow. The oo command resolves to Wanta's managed guard, which preserves the current workspace and safety policy. Wanta MCP tools are reserved for host-native capabilities that have no equivalent managed CLI. This transport policy does not change the Skill's write or destructive confirmation requirements.
+Skill files describe business workflows, schemas, and safety rules. For connected services, follow the Skill's OO workflow only through Wanta's managed guard, which preserves the current workspace and safety policy. ${externalOoExecutionPolicy()} Wanta MCP tools are reserved for host-native capabilities that have no equivalent managed CLI. This transport policy does not change the Skill's write or destructive confirmation requirements.
 </wanta_execution_policy>`
 }
 
@@ -19,7 +20,7 @@ export function createSkillHostCapability(): HostCapability {
     id: SKILL_CAPABILITY_ID,
     version: "1.0.0",
     instructions:
-      "Wanta supplies a stable skill snapshot for the current turn. Use list_skills for discovery, call load_skill before following a relevant skill, and use read_skill_file for files referenced by SKILL.md.",
+      "Wanta supplies the authoritative stable Skill snapshot for the current turn. Use list_skills for discovery, call load_skill before following a relevant skill, and use read_skill_file for files referenced by SKILL.md. Do not substitute a same-id native, global, or home-directory Skill; native Skills are fallback only when the id is absent from this snapshot.",
     tools: [
       {
         name: "list_skills",
@@ -35,12 +36,16 @@ export function createSkillHostCapability(): HostCapability {
         description:
           "Load the complete SKILL.md for one relevant skill from the current-turn snapshot. Call this before acting on that skill's instructions.",
         inputSchema: z.object({ skillId: z.string().min(1) }),
-        execute: async (context, input) => ({
-          text: `${hostExecutionPolicy()}\n\n${await readSkillSnapshotFile(
-            skillSnapshot(context),
-            requiredString(input.skillId),
-          )}`,
-        }),
+        execute: async (context, input) => {
+          const snapshot = skillSnapshot(context)
+          const skillId = requiredString(input.skillId)
+          const entry = snapshot.entries.get(skillId)
+          if (!entry) throw new Error(`Skill is not present in this turn's snapshot: ${skillId}`)
+          const source = JSON.stringify({ authoritative: true, skillId, source: entry.source })
+          return {
+            text: `${hostExecutionPolicy()}\n<wanta_skill_source>${source}</wanta_skill_source>\n\n${await readSkillSnapshotFile(snapshot, skillId)}`,
+          }
+        },
       },
       {
         name: "read_skill_file",

--- a/electron/agent/skill-registry.test.ts
+++ b/electron/agent/skill-registry.test.ts
@@ -62,8 +62,13 @@ test("skill host tools load complete instructions and keep referenced files insi
 
   const loadedSkill = (await kernel.execute("skills", "load_skill", context, { skillId: "alpha" })).text
   expect(loadedSkill).toContain("<wanta_execution_policy>")
-  expect(loadedSkill).toContain("follow the Skill's oo connector schema/run workflow")
+  expect(loadedSkill).toContain("The managed OO boundary supports these command domains")
+  expect(loadedSkill).toContain("oo search")
+  expect(loadedSkill).toContain("Skip the Skill recommendation wrap-up")
   expect(loadedSkill).toContain("Wanta's managed guard")
+  expect(loadedSkill).toContain(
+    '<wanta_skill_source>{"authoritative":true,"skillId":"alpha","source":{"id":"legacy-0","kind":"managed"}}</wanta_skill_source>',
+  )
   expect(loadedSkill).toContain("# Alpha")
   expect(
     (await kernel.execute("skills", "read_skill_file", context, { skillId: "alpha", path: "references/guide.md" }))

--- a/electron/chat/context-system.test.ts
+++ b/electron/chat/context-system.test.ts
@@ -6,6 +6,7 @@ import {
   buildLinkRuntimeSystem,
   buildPermissionModeSystem,
   buildResponseLanguageSystem,
+  buildTeamSkillsSystem,
 } from "./context-system.ts"
 
 test("buildLinkRuntimeSystem binds raw OOMOL calls to the exact team", () => {
@@ -67,6 +68,17 @@ test("buildContextMentionsSystem describes the global knowledge library", () => 
   assert.doesNotMatch(prompt, /wikg:\/\/lib\/arc\/wikg:\/\/lib/)
   assert.match(prompt, /Treat `wikg:\/\/lib` as the whole local WikiGraph library/)
   assert.match(prompt, /Use `wikg:\/\/lib` directly for a selected knowledge library/)
+})
+
+test("selected and team Skills make the Wanta snapshot authoritative over same-id native Skills", () => {
+  const selected = buildContextMentionsSystem([{ id: "oo", kind: "skill", name: "OO" }]) ?? ""
+  const team = buildTeamSkillsSystem([{ id: "oo", name: "OO" }]) ?? ""
+
+  for (const prompt of [selected, team]) {
+    assert.match(prompt, /Wanta current-turn Skill snapshot is authoritative/)
+    assert.match(prompt, /Do not substitute a same-id native, global, or home-directory Skill/)
+    assert.match(prompt, /native Skills are fallback only when the id is absent/)
+  }
 })
 
 test("buildContextMentionsSystem routes the Hua Rong Trail fixture through WikiGraph context", () => {

--- a/electron/chat/context-system.ts
+++ b/electron/chat/context-system.ts
@@ -74,6 +74,7 @@ export function buildContextMentionsSystem(mentions: ChatContextMention[] | unde
     }
     lines.push(
       "The user explicitly selected these skills for this turn. If a selected skill matches the task, load and follow it before acting. If it is clearly unrelated, ignore it and proceed normally. Mention that you used it only when useful to the user.",
+      "The Wanta current-turn Skill snapshot is authoritative for every listed skill id. Do not substitute a same-id native, global, or home-directory Skill; native Skills are fallback only when the id is absent from Wanta's snapshot.",
     )
   }
   if (connections.length > 0) {
@@ -116,6 +117,7 @@ export function buildTeamSkillsSystem(skills: ChatTeamSkillContext[] | undefined
     "- Treat these skills as workspace guidance, not mandatory tool calls.",
     "- Use them only when they are relevant to the user's actual task.",
     "- If the user selected a different explicit context for this turn, prefer the explicit user selection.",
+    "- The Wanta current-turn Skill snapshot is authoritative for every listed skill id. Do not substitute a same-id native, global, or home-directory Skill; native Skills are fallback only when the id is absent from Wanta's snapshot.",
   ]
   for (const skill of enabledSkills) {
     const details = [

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -53,6 +53,7 @@ import { createDirectCliHostCapability, DIRECT_CLI_CAPABILITY_ID } from "./agent
 import { memoizeExternalCommandEnvironment } from "./agent/external/command-environment.ts"
 import { createExternalAgents } from "./agent/external/create.ts"
 import { ExternalOoGuardServer } from "./agent/external/oo-guard-server.ts"
+import { verifyPackagedOoRuntime } from "./agent/external/oo-runtime-compatibility.ts"
 import { externalSessionScratchCwd, ExternalOoScopeStore } from "./agent/external/oo-scope-store.ts"
 import { externalAgentKindForSessionId } from "./agent/external/session-id.ts"
 import { HostCapabilityInvokeServer } from "./agent/host-capability-invoke-server.ts"
@@ -214,6 +215,14 @@ process.env.OO_CLI_PATH = ooBinPath
 const bundledSkillsDir = app.isPackaged
   ? resolveBundledSkillsDir(process.resourcesPath)
   : resolveDevBundledSkillsDir(appRoot)
+const externalOoRuntimeCompatibility = app.isPackaged
+  ? verifyPackagedOoRuntime(process.resourcesPath).then((result) => {
+      if (!result.compatible) {
+        logDiagnostic("external-oo-runtime", "packaged compatibility failed", { reason: result.reason }, "error")
+      }
+      return result
+    })
+  : Promise.resolve({ compatible: true } as const)
 const bundledLarkSkillsDir = app.isPackaged
   ? resolveBundledLarkSkillsDir(process.resourcesPath)
   : resolveDevBundledLarkSkillsDir(appRoot)
@@ -359,6 +368,7 @@ const directCliCapabilityServer = new HostCapabilityServer({
 const externalAgentRootDir = path.join(app.getPath("userData"), "agent-external")
 const externalOoScopeStore = new ExternalOoScopeStore()
 const externalOoGuardServer = new ExternalOoGuardServer({
+  available: async () => (await externalOoRuntimeCompatibility).compatible,
   command: ooBinPath,
   scope: () => externalOoScopeStore.snapshot(),
 })
@@ -414,14 +424,17 @@ const externalHostMcpServers: HostMcpServerProvider = async (input) => {
   }
   // External coding agents use Wanta's guarded OOCLI for Connector work.
   // MCP stays limited to stateful Wanta-native capabilities.
-  const servers = [
-    await skillCapabilityServer.issue({
-      ...context,
-      bindings: { ...context.bindings, [SKILL_SNAPSHOT_BINDING]: skillSnapshot },
-    }),
-    await knowledgeCapabilityServer.issue(context),
-    await questionCapabilityServer.issue(context),
-  ]
+  const servers = [await knowledgeCapabilityServer.issue(context), await questionCapabilityServer.issue(context)]
+  if ((await externalOoRuntimeCompatibility).compatible) {
+    servers.unshift(
+      await skillCapabilityServer.issue({
+        ...context,
+        bindings: { ...context.bindings, [SKILL_SNAPSHOT_BINDING]: skillSnapshot },
+      }),
+    )
+  } else {
+    skillCapabilityServer.disableSession(input.sessionId)
+  }
   if (directSkillSources.length > 0) {
     servers.push(
       await directCliCapabilityServer.issue({

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "auth:restore": "node --experimental-strip-types ./scripts/dev-auth-state.ts restore",
     "auth:clean": "node --experimental-strip-types ./scripts/dev-auth-state.ts clean",
     "auth:status": "node --experimental-strip-types ./scripts/dev-auth-state.ts status",
+    "oo:compatibility": "node --experimental-strip-types ./scripts/oo-skill-compatibility.ts",
+    "oo:compatibility:accept": "node --experimental-strip-types ./scripts/oo-skill-compatibility.ts --accept",
     "postinstall": "node --experimental-strip-types ./scripts/download-electron.ts && node --experimental-strip-types ./scripts/download-oo.ts && node --experimental-strip-types ./scripts/download-skills.ts && node --experimental-strip-types ./scripts/download-ripgrep.ts && node --experimental-strip-types ./scripts/download-lark-cli.ts && node --experimental-strip-types ./scripts/download-wecom-cli.ts && node --experimental-strip-types ./scripts/download-dingtalk-cli.ts && node --experimental-strip-types ./scripts/build-agent-tool-runtime.ts",
     "predev": "node --experimental-strip-types ./scripts/check-oo.ts",
     "dev": "node --experimental-strip-types ./scripts/dev.ts",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "auth:status": "node --experimental-strip-types ./scripts/dev-auth-state.ts status",
     "oo:compatibility": "node --experimental-strip-types ./scripts/oo-skill-compatibility.ts",
     "oo:compatibility:accept": "node --experimental-strip-types ./scripts/oo-skill-compatibility.ts --accept",
+    "oo:upgrade": "node --experimental-strip-types ./scripts/oo-upgrade.ts",
     "postinstall": "node --experimental-strip-types ./scripts/download-electron.ts && node --experimental-strip-types ./scripts/download-oo.ts && node --experimental-strip-types ./scripts/download-skills.ts && node --experimental-strip-types ./scripts/download-ripgrep.ts && node --experimental-strip-types ./scripts/download-lark-cli.ts && node --experimental-strip-types ./scripts/download-wecom-cli.ts && node --experimental-strip-types ./scripts/download-dingtalk-cli.ts && node --experimental-strip-types ./scripts/build-agent-tool-runtime.ts",
     "predev": "node --experimental-strip-types ./scripts/check-oo.ts",
     "dev": "node --experimental-strip-types ./scripts/dev.ts",

--- a/resources/skill-compatibility/oo.json
+++ b/resources/skill-compatibility/oo.json
@@ -1,0 +1,25 @@
+{
+  "ooCliVersion": "1.7.7",
+  "agentFormat": "universal",
+  "files": {
+    "SKILL.md": "96d837855764c1b7623692c47ebf9705540ce049a3b586aeb905253ddad1f647",
+    "agents/openai.yaml": "50fa43d22512453554fecb66c37bd051bb1bb37d3daf6c25d4c362f9444c2202",
+    "references/auth-and-billing.md": "47141988bd8e94cfb6f335c37b25a47885b4a54b5f70f68faa2d23d38ce55878",
+    "references/connector-execution.md": "306485ad53eb86c9d3caac72767375cc41ecb5493909aa4430b15b4d83f1aacc",
+    "references/file-transfer.md": "1547f3c3811f0bc6038ea9e9987d2cb2c18688ad1b8382e723c0d41ea34c9e46",
+    "references/flow-authoring.md": "7480673ceebc54b50dcbe9f5e8baecf1f6b18c445f6506b72edacd4b89c14bf3",
+    "references/flow-n8n-conversion.md": "0cd42a2b69f640637ecb60c7d67bc6ffcb2fcf32da11979a362242cab96ef578",
+    "references/llm-client.md": "1e89085c9e936b4d3963894e52fe47d6afdf69b8b12c5fb702f9dc148bc97abf",
+    "references/search-and-selection.md": "605ee59ecdebc929c74589bbca4daf3683b708601ae881f6bdd8202d59eff50e"
+  },
+  "requiredOperations": [
+    "capability.search",
+    "connector.search",
+    "connector.schema",
+    "connector.run",
+    "file.upload",
+    "file.download",
+    "skills.recommend",
+    "flow"
+  ]
+}

--- a/resources/skill-compatibility/oo.json
+++ b/resources/skill-compatibility/oo.json
@@ -17,9 +17,14 @@
     "connector.search",
     "connector.schema",
     "connector.run",
+    "connector.proxy",
     "file.upload",
     "file.download",
     "skills.recommend",
-    "flow"
+    "skills.manage",
+    "flow",
+    "llm",
+    "team.current",
+    "variables"
   ]
 }

--- a/scripts/check-oo.ts
+++ b/scripts/check-oo.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { localOoBinPath, OO_CLI_VERSION, resolvePlatformTarget } from "./oo-cli.ts"
 import { localRipgrepBinPath } from "./ripgrep.ts"
-import { bundledSkillIds, bundledSkillsDir, exportBundledSkills } from "./skills.ts"
+import { bundledSkillIds, bundledSkillsDir, exportBundledSkills, verifyBundledOoSkillCompatibility } from "./skills.ts"
 
 if (!process.env.WANTA_OO_BIN) {
   const ooBin = localOoBinPath()
@@ -52,5 +52,13 @@ if (!bundledSkillsReady) {
     console.log(`[wanta] bundled skills ready at ${bundledSkillsDir}`)
   } catch (error) {
     console.warn("[wanta] failed to export bundled skills (non-fatal):", error)
+  }
+}
+if (bundledSkillIds.every((id) => existsSync(path.join(bundledSkillsDir, id, "SKILL.md")))) {
+  try {
+    await verifyBundledOoSkillCompatibility()
+  } catch (error) {
+    console.error("[wanta] bundled oo Skill compatibility check failed:", error)
+    process.exit(1)
   }
 }

--- a/scripts/download-skills.ts
+++ b/scripts/download-skills.ts
@@ -4,7 +4,7 @@
 // 设 OO_SKIP_BINARY_DOWNLOAD=1 可跳过（与 oo 二进制下载共用同一开关；预演/打包会自行 ensure）。
 // 导出/校验逻辑见 scripts/skills.ts。
 
-import { exportBundledSkills } from "./skills.ts"
+import { exportBundledSkills, verifyBundledOoSkillCompatibility } from "./skills.ts"
 
 await main()
 
@@ -15,6 +15,7 @@ async function main(): Promise<void> {
       return
     }
     const dest = await exportBundledSkills()
+    await verifyBundledOoSkillCompatibility(dest)
     console.log(`[wanta] bundled skills ready at ${dest}`)
   } catch (error) {
     console.warn("[wanta] download-skills postinstall failed (non-fatal):", error)

--- a/scripts/download-skills.ts
+++ b/scripts/download-skills.ts
@@ -18,6 +18,7 @@ async function main(): Promise<void> {
     await verifyBundledOoSkillCompatibility(dest)
     console.log(`[wanta] bundled skills ready at ${dest}`)
   } catch (error) {
+    if (process.env.WANTA_STRICT_SKILL_EXPORT === "1") throw error
     console.warn("[wanta] download-skills postinstall failed (non-fatal):", error)
   }
 }

--- a/scripts/oo-cli.test.ts
+++ b/scripts/oo-cli.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
-import { test } from "vitest"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { expect, test } from "vitest"
 import {
   detectLinuxLibc,
+  downloadOoBinaryVersion,
   extractFileFromTar,
   ooExecutableName,
   resolvePlatformTarget,
@@ -103,6 +107,20 @@ test("ooExecutableName 仅 Windows 带 .exe", () => {
   assert.equal(ooExecutableName("darwin"), "oo")
   assert.equal(ooExecutableName("linux"), "oo")
   assert.equal(ooExecutableName("win32"), "oo.exe")
+})
+
+test("downloadOoBinaryVersion reuses an isolated matching candidate without touching the pinned binary", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-oo-candidate-"))
+  try {
+    const target = resolvePlatformTarget()
+    const executable = path.join(root, target.executableFileName)
+    await writeFile(executable, "candidate")
+    await writeFile(path.join(root, ".version"), `${target.packageName}@9.9.9\n`)
+    await expect(downloadOoBinaryVersion("9.9.9", root)).resolves.toBe(executable)
+    await expect(downloadOoBinaryVersion("not-a-version", root)).rejects.toThrow(/invalid oo version/u)
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
 })
 
 // ── libc 判别 ─────────────────────────────────────────────────────────────────────

--- a/scripts/oo-cli.ts
+++ b/scripts/oo-cli.ts
@@ -13,13 +13,13 @@ import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/pro
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { gunzipSync } from "node:zlib"
+import { OO_CLI_VERSION } from "../electron/agent/oo-version.ts"
 import { fetchWithRetry } from "./network-download.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
 
-// oo-cli 版本：原先经 package-lock 间接锁定，移除依赖后由此处单一锁定。升级 oo 改这里。
-export const OO_CLI_VERSION = "1.7.7"
+export { OO_CLI_VERSION }
 
 // 下载落地目录（gitignore）。dev 侧的同名路径解析见 electron/agent/binaries.ts resolveDevOoBin。
 const localOoBinDir = path.join(repoRoot, ".oo-bin")

--- a/scripts/oo-cli.ts
+++ b/scripts/oo-cli.ts
@@ -135,15 +135,20 @@ export function extractFileFromTar(tar: Buffer, wantedPath: string): Buffer | nu
 }
 
 /** 版本标记内容：平台包名 + 版本，二者任一变化即触发重新下载。 */
-function versionTag(packageName: string): string {
-  return `${packageName}@${OO_CLI_VERSION}`
+function versionTag(packageName: string, version: string): string {
+  return `${packageName}@${version}`
 }
 
-async function isUpToDate(destPath: string, versionMarker: string, packageName: string): Promise<boolean> {
+async function isUpToDate(
+  destPath: string,
+  versionMarker: string,
+  packageName: string,
+  version: string,
+): Promise<boolean> {
   try {
     await stat(destPath)
     const marker = (await readFile(versionMarker, "utf-8")).trim()
-    return marker === versionTag(packageName)
+    return marker === versionTag(packageName, version)
   } catch {
     return false
   }
@@ -155,7 +160,7 @@ interface TarballMeta {
 }
 
 /** 查 registry packument，取指定版本的 tarball URL 与 integrity（SRI），用于下载与完整性校验。 */
-async function resolveTarballMeta(packageName: string): Promise<TarballMeta> {
+async function resolveTarballMeta(packageName: string, version: string): Promise<TarballMeta> {
   const response = await fetchWithRetry(`https://registry.npmjs.org/${packageName}`)
   if (!response.ok) {
     throw new Error(`fetch packument failed: HTTP ${response.status} ${packageName}`)
@@ -163,9 +168,9 @@ async function resolveTarballMeta(packageName: string): Promise<TarballMeta> {
   const packument = (await response.json()) as {
     versions?: Record<string, { dist?: { tarball?: string; integrity?: string } }>
   }
-  const dist = packument.versions?.[OO_CLI_VERSION]?.dist
+  const dist = packument.versions?.[version]?.dist
   if (!dist?.tarball || !dist?.integrity) {
-    throw new Error(`no dist info for ${packageName}@${OO_CLI_VERSION}`)
+    throw new Error(`no dist info for ${packageName}@${version}`)
   }
   return { tarball: dist.tarball, integrity: dist.integrity }
 }
@@ -193,16 +198,24 @@ export function verifyTarballIntegrity(tgz: Buffer, integrity: string, source: s
  * chmod 0o755 →原子 rename 落位。全程不依赖任何外部命令或 npm 包，macOS/Linux/Windows 一致可用。
  */
 export async function downloadOoBinary(): Promise<string> {
+  return downloadOoBinaryVersion(OO_CLI_VERSION, localOoBinDir)
+}
+
+/** Download one explicit candidate version into an isolated directory. */
+export async function downloadOoBinaryVersion(version: string, destinationDirectory: string): Promise<string> {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(version)) {
+    throw new Error(`invalid oo version: ${version}`)
+  }
   const target = resolvePlatformTarget()
   const exe = target.executableFileName
-  const destPath = localOoBinPath()
-  const versionMarker = path.join(localOoBinDir, ".version")
+  const destPath = path.join(destinationDirectory, exe)
+  const versionMarker = path.join(destinationDirectory, ".version")
 
-  if (await isUpToDate(destPath, versionMarker, target.packageName)) {
+  if (await isUpToDate(destPath, versionMarker, target.packageName, version)) {
     return destPath
   }
 
-  const meta = await resolveTarballMeta(target.packageName)
+  const meta = await resolveTarballMeta(target.packageName, version)
   const response = await fetchWithRetry(meta.tarball)
   if (!response.ok) {
     throw new Error(`download oo failed: HTTP ${response.status} ${meta.tarball}`)
@@ -216,7 +229,7 @@ export async function downloadOoBinary(): Promise<string> {
     throw new Error(`oo binary not found inside tarball: ${meta.tarball}`)
   }
 
-  await mkdir(localOoBinDir, { recursive: true })
+  await mkdir(destinationDirectory, { recursive: true })
   // 先写临时文件、补可执行位（上游 tarball 内是 0644），再原子 rename，避免中断留下半截可执行文件。
   const tmpPath = `${destPath}.download`
   try {
@@ -228,6 +241,6 @@ export async function downloadOoBinary(): Promise<string> {
     await rm(tmpPath, { force: true })
   }
 
-  await writeFile(versionMarker, `${versionTag(target.packageName)}\n`, "utf-8")
+  await writeFile(versionMarker, `${versionTag(target.packageName, version)}\n`, "utf-8")
   return destPath
 }

--- a/scripts/oo-skill-compatibility.ts
+++ b/scripts/oo-skill-compatibility.ts
@@ -1,0 +1,76 @@
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { EXTERNAL_OO_OPERATIONS } from "../electron/agent/external/oo-capability-contract.ts"
+import { OO_CLI_VERSION } from "./oo-cli.ts"
+import { bundledOoSkillHashes, bundledSkillsDir, skillCompatibilityDir } from "./skills.ts"
+
+interface Manifest {
+  agentFormat: string
+  files: Record<string, string>
+  ooCliVersion: string
+  requiredOperations: string[]
+}
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(dirname, "..")
+const manifestPath = path.join(skillCompatibilityDir, "oo.json")
+const accept = process.argv.includes("--accept")
+const json = process.argv.includes("--json")
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Manifest
+const actualFiles = await bundledOoSkillHashes(bundledSkillsDir)
+const expectedNames = Object.keys(manifest.files).sort()
+const actualNames = Object.keys(actualFiles).sort()
+const added = actualNames.filter((name) => !manifest.files[name])
+const removed = expectedNames.filter((name) => !actualFiles[name])
+const changed = actualNames.filter(
+  (name) => manifest.files[name] !== undefined && manifest.files[name] !== actualFiles[name],
+)
+const knownOperations = new Map<string, (typeof EXTERNAL_OO_OPERATIONS)[number]>(
+  EXTERNAL_OO_OPERATIONS.map((operation) => [operation.id, operation]),
+)
+const operations = manifest.requiredOperations.map((id) => ({
+  id,
+  availability: knownOperations.get(id)?.availability ?? "missing",
+}))
+const versionChanged = manifest.ooCliVersion !== OO_CLI_VERSION || manifest.agentFormat !== "universal"
+const compatible = !versionChanged && added.length === 0 && removed.length === 0 && changed.length === 0
+const report = {
+  compatible,
+  expected: { agentFormat: manifest.agentFormat, ooCliVersion: manifest.ooCliVersion },
+  actual: { agentFormat: "universal", ooCliVersion: OO_CLI_VERSION },
+  files: { added, changed, removed },
+  operations,
+}
+
+if (accept) {
+  const missingOperations = operations.filter((operation) => operation.availability === "missing")
+  if (missingOperations.length > 0) {
+    throw new Error(`cannot accept unknown required operations: ${missingOperations.map((item) => item.id).join(", ")}`)
+  }
+  const next: Manifest = {
+    ooCliVersion: OO_CLI_VERSION,
+    agentFormat: "universal",
+    files: actualFiles,
+    requiredOperations: manifest.requiredOperations,
+  }
+  await writeFile(manifestPath, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+  process.stdout.write(
+    `Accepted OO Skill compatibility for ${OO_CLI_VERSION} at ${path.relative(repoRoot, manifestPath)}\n`,
+  )
+  process.exit(0)
+}
+
+if (json) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+} else {
+  process.stdout.write(`OO Skill compatibility: ${compatible ? "compatible" : "review required"}\n`)
+  process.stdout.write(`Version: ${manifest.ooCliVersion} -> ${OO_CLI_VERSION}\n`)
+  if (added.length > 0) process.stdout.write(`Added files: ${added.join(", ")}\n`)
+  if (removed.length > 0) process.stdout.write(`Removed files: ${removed.join(", ")}\n`)
+  if (changed.length > 0) process.stdout.write(`Changed files: ${changed.join(", ")}\n`)
+  process.stdout.write("Required operations:\n")
+  for (const operation of operations) process.stdout.write(`- ${operation.id}: ${operation.availability}\n`)
+}
+if (!compatible) process.exitCode = 1

--- a/scripts/oo-skill-compatibility.ts
+++ b/scripts/oo-skill-compatibility.ts
@@ -34,8 +34,14 @@ const operations = manifest.requiredOperations.map((id) => ({
   id,
   availability: knownOperations.get(id)?.availability ?? "missing",
 }))
+const missingOperations = operations.filter((operation) => operation.availability === "missing")
 const versionChanged = manifest.ooCliVersion !== OO_CLI_VERSION || manifest.agentFormat !== "universal"
-const compatible = !versionChanged && added.length === 0 && removed.length === 0 && changed.length === 0
+const compatible =
+  !versionChanged &&
+  added.length === 0 &&
+  removed.length === 0 &&
+  changed.length === 0 &&
+  missingOperations.length === 0
 const report = {
   compatible,
   expected: { agentFormat: manifest.agentFormat, ooCliVersion: manifest.ooCliVersion },
@@ -45,7 +51,6 @@ const report = {
 }
 
 if (accept) {
-  const missingOperations = operations.filter((operation) => operation.availability === "missing")
   if (missingOperations.length > 0) {
     throw new Error(`cannot accept unknown required operations: ${missingOperations.map((item) => item.id).join(", ")}`)
   }

--- a/scripts/oo-upgrade-review-core.test.ts
+++ b/scripts/oo-upgrade-review-core.test.ts
@@ -1,0 +1,36 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { expect, test } from "vitest"
+import { detectOoSkillCommands, renderOoUpgradeMarkdown } from "./oo-upgrade-review-core.ts"
+
+test("detects reviewed and missing OO command domains from exported Skill text", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-oo-upgrade-review-"))
+  try {
+    await mkdir(path.join(root, "oo", "references"), { recursive: true })
+    await writeFile(
+      path.join(root, "oo", "SKILL.md"),
+      "Run `oo search goal --json`, `oo connector run service`, and `oo future command`.",
+    )
+    const findings = await detectOoSkillCommands(root, ["SKILL.md"])
+    expect(findings).toEqual([
+      { availability: "enabled", command: "oo connector run", operation: "connector.run" },
+      { availability: "missing", command: "oo future command", operation: "unrecognized" },
+      { availability: "enabled", command: "oo search goal", operation: "capability.search" },
+    ])
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})
+
+test("renders a reviewable Markdown report", () => {
+  const markdown = renderOoUpgradeMarkdown({
+    actualVersion: "1.7.7",
+    candidateVersion: "1.7.8",
+    files: { added: ["references/new.md"], changed: ["SKILL.md"], removed: [] },
+    commands: [{ availability: "planned", command: "oo file download", operation: "file.download" }],
+  })
+  expect(markdown).toContain("OOCLI 1.7.7 → 1.7.8")
+  expect(markdown).toContain("references/new.md")
+  expect(markdown).toContain("`file.download`")
+})

--- a/scripts/oo-upgrade-review-core.test.ts
+++ b/scripts/oo-upgrade-review-core.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { expect, test } from "vitest"
-import { detectOoSkillCommands, renderOoUpgradeMarkdown } from "./oo-upgrade-review-core.ts"
+import { detectOoSkillCommands, renderOoUpgradeMarkdown, unknownRequiredOperations } from "./oo-upgrade-review-core.ts"
 
 test("detects reviewed and missing OO command domains from exported Skill text", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "wanta-oo-upgrade-review-"))
@@ -33,4 +33,10 @@ test("renders a reviewable Markdown report", () => {
   expect(markdown).toContain("OOCLI 1.7.7 → 1.7.8")
   expect(markdown).toContain("references/new.md")
   expect(markdown).toContain("`file.download`")
+})
+
+test("rejects retained required operations that no longer exist in the contract", () => {
+  expect(unknownRequiredOperations(["connector.run", "removed.operation"], new Set(["connector.run"]))).toEqual([
+    "removed.operation",
+  ])
 })

--- a/scripts/oo-upgrade-review-core.ts
+++ b/scripts/oo-upgrade-review-core.ts
@@ -15,6 +15,13 @@ export interface OoUpgradeReport {
   files: { added: string[]; changed: string[]; removed: string[] }
 }
 
+export function unknownRequiredOperations(
+  requiredOperations: string[],
+  knownOperationIds: ReadonlySet<string>,
+): string[] {
+  return requiredOperations.filter((operation) => !knownOperationIds.has(operation))
+}
+
 export async function detectOoSkillCommands(
   skillsRoot: string,
   relativePaths: string[],

--- a/scripts/oo-upgrade-review-core.ts
+++ b/scripts/oo-upgrade-review-core.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { resolveExternalOoOperation } from "../electron/agent/external/oo-capability-contract.ts"
+
+export interface OoUpgradeCommandFinding {
+  availability: string
+  command: string
+  operation: string
+}
+
+export interface OoUpgradeReport {
+  actualVersion: string
+  candidateVersion: string
+  commands: OoUpgradeCommandFinding[]
+  files: { added: string[]; changed: string[]; removed: string[] }
+}
+
+export async function detectOoSkillCommands(
+  skillsRoot: string,
+  relativePaths: string[],
+): Promise<OoUpgradeCommandFinding[]> {
+  const findings = new Map<string, OoUpgradeCommandFinding>()
+  for (const relativePath of relativePaths.filter((name) => /(?:\.md|\.ya?ml)$/u.test(name))) {
+    const content = await readFile(path.join(skillsRoot, "oo", relativePath), "utf8")
+    const snippets = [
+      ...[...content.matchAll(/```(?:bash|sh|shell|zsh)?\s*\n([\s\S]*?)```/giu)].flatMap((match) =>
+        (match[1] ?? "").split(/\r?\n/u).filter((line) => /^\s*oo\s+/u.test(line)),
+      ),
+      ...[...content.matchAll(/`(oo\s+[^`\r\n]+)`/giu)].map((match) => match[1] ?? ""),
+    ]
+    for (const snippet of snippets) {
+      const match = snippet.trim().match(/^oo\s+([a-z][\w-]*)(?:\s+([a-z][\w-]*))?/iu)
+      if (!match) continue
+      const command = [match[1], match[2]].filter(Boolean) as string[]
+      const operation = resolveExternalOoOperation(command)
+      const display = `oo ${command.join(" ")}`
+      findings.set(display, {
+        command: display,
+        operation: operation?.id ?? "unrecognized",
+        availability: operation?.availability ?? "missing",
+      })
+    }
+  }
+  return [...findings.values()].sort((left, right) => left.command.localeCompare(right.command))
+}
+
+export function renderOoUpgradeMarkdown(report: OoUpgradeReport): string {
+  const lines = [
+    `# OOCLI ${report.actualVersion} → ${report.candidateVersion} compatibility report`,
+    "",
+    "## Skill file changes",
+    "",
+    `- Added: ${report.files.added.join(", ") || "none"}`,
+    `- Removed: ${report.files.removed.join(", ") || "none"}`,
+    `- Changed: ${report.files.changed.join(", ") || "none"}`,
+    "",
+    "## Detected OO command domains",
+    "",
+    "| Command | Operation | Availability |",
+    "| --- | --- | --- |",
+    ...report.commands.map(
+      (finding) => `| \`${finding.command}\` | \`${finding.operation}\` | ${finding.availability} |`,
+    ),
+    "",
+  ]
+  return `${lines.join("\n")}\n`
+}

--- a/scripts/oo-upgrade.ts
+++ b/scripts/oo-upgrade.ts
@@ -1,0 +1,93 @@
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { downloadOoBinary, downloadOoBinaryVersion, OO_CLI_VERSION } from "./oo-cli.ts"
+import { detectOoSkillCommands, renderOoUpgradeMarkdown } from "./oo-upgrade-review-core.ts"
+import {
+  bundledOoSkillHashes,
+  bundledSkillsDir,
+  exportBundledSkills,
+  installBundledOoSkillsFromBinary,
+  skillCompatibilityDir,
+} from "./skills.ts"
+
+interface Manifest {
+  agentFormat: string
+  files: Record<string, string>
+  ooCliVersion: string
+  requiredOperations: string[]
+}
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(dirname, "..")
+const candidateVersion = process.argv.slice(2).find((argument) => !argument.startsWith("-"))
+if (!candidateVersion) throw new Error("usage: pnpm oo:upgrade <version> [--json] [--accept] [--output=<path>]")
+const accept = process.argv.includes("--accept")
+const json = process.argv.includes("--json")
+const outputArgument = process.argv.find((argument) => argument.startsWith("--output="))
+const outputPath = outputArgument ? path.resolve(repoRoot, outputArgument.slice("--output=".length)) : undefined
+const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), `wanta-oo-${candidateVersion}-`))
+
+try {
+  const binary =
+    candidateVersion === OO_CLI_VERSION
+      ? await downloadOoBinary()
+      : await downloadOoBinaryVersion(candidateVersion, path.join(temporaryRoot, "bin"))
+  const candidateSkills = path.join(temporaryRoot, "skills")
+  await exportBundledSkills(candidateSkills, (directory) => installBundledOoSkillsFromBinary(binary, directory))
+  const manifestPath = path.join(skillCompatibilityDir, "oo.json")
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Manifest
+  const candidateHashes = await bundledOoSkillHashes(candidateSkills)
+  const currentNames = Object.keys(manifest.files).sort()
+  const candidateNames = Object.keys(candidateHashes).sort()
+  const files = {
+    added: candidateNames.filter((name) => manifest.files[name] === undefined),
+    removed: currentNames.filter((name) => candidateHashes[name] === undefined),
+    changed: candidateNames.filter(
+      (name) => manifest.files[name] !== undefined && manifest.files[name] !== candidateHashes[name],
+    ),
+  }
+  const commands = await detectOoSkillCommands(candidateSkills, candidateNames)
+  const report = { actualVersion: OO_CLI_VERSION, candidateVersion, files, commands }
+  const markdown = renderOoUpgradeMarkdown(report)
+  const missing = commands.filter((finding) => finding.availability === "missing")
+
+  if (json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+  else process.stdout.write(markdown)
+  if (outputPath) await writeFile(outputPath, json ? `${JSON.stringify(report, null, 2)}\n` : markdown, "utf8")
+
+  if (accept) {
+    if (missing.length > 0) {
+      throw new Error(`cannot accept unrecognized OO commands: ${missing.map((item) => item.command).join(", ")}`)
+    }
+    const ooCliSourcePath = path.join(repoRoot, "scripts", "oo-cli.ts")
+    const ooCliSource = await readFile(ooCliSourcePath, "utf8")
+    const nextSource = ooCliSource.replace(
+      /export const OO_CLI_VERSION = "[^"]+"/u,
+      `export const OO_CLI_VERSION = "${candidateVersion}"`,
+    )
+    if (nextSource === ooCliSource) throw new Error("unable to update OO_CLI_VERSION")
+    const requiredOperations = [
+      ...new Set([
+        ...manifest.requiredOperations,
+        ...commands.filter((finding) => finding.operation !== "unrecognized").map((finding) => finding.operation),
+      ]),
+    ].sort()
+    const nextManifest: Manifest = {
+      ooCliVersion: candidateVersion,
+      agentFormat: "universal",
+      files: candidateHashes,
+      requiredOperations,
+    }
+    await writeFile(ooCliSourcePath, nextSource, "utf8")
+    await writeFile(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`, "utf8")
+    await rm(bundledSkillsDir, { force: true, recursive: true })
+    await cp(candidateSkills, bundledSkillsDir, { recursive: true })
+    process.stdout.write(`Accepted OOCLI ${candidateVersion}; review and commit the version and manifest changes.\n`)
+  } else if (missing.length > 0) {
+    process.exitCode = 2
+  }
+} finally {
+  await rm(temporaryRoot, { force: true, recursive: true })
+}

--- a/scripts/oo-upgrade.ts
+++ b/scripts/oo-upgrade.ts
@@ -2,8 +2,9 @@ import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { EXTERNAL_OO_OPERATIONS } from "../electron/agent/external/oo-capability-contract.ts"
 import { downloadOoBinary, downloadOoBinaryVersion, OO_CLI_VERSION } from "./oo-cli.ts"
-import { detectOoSkillCommands, renderOoUpgradeMarkdown } from "./oo-upgrade-review-core.ts"
+import { detectOoSkillCommands, renderOoUpgradeMarkdown, unknownRequiredOperations } from "./oo-upgrade-review-core.ts"
 import {
   bundledOoSkillHashes,
   bundledSkillsDir,
@@ -61,7 +62,7 @@ try {
     if (missing.length > 0) {
       throw new Error(`cannot accept unrecognized OO commands: ${missing.map((item) => item.command).join(", ")}`)
     }
-    const ooCliSourcePath = path.join(repoRoot, "scripts", "oo-cli.ts")
+    const ooCliSourcePath = path.join(repoRoot, "electron", "agent", "oo-version.ts")
     const ooCliSource = await readFile(ooCliSourcePath, "utf8")
     const nextSource = ooCliSource.replace(
       /export const OO_CLI_VERSION = "[^"]+"/u,
@@ -74,6 +75,11 @@ try {
         ...commands.filter((finding) => finding.operation !== "unrecognized").map((finding) => finding.operation),
       ]),
     ].sort()
+    const knownOperationIds = new Set<string>(EXTERNAL_OO_OPERATIONS.map((operation) => operation.id))
+    const unknownOperations = unknownRequiredOperations(requiredOperations, knownOperationIds)
+    if (unknownOperations.length > 0) {
+      throw new Error(`cannot accept unknown required operations: ${unknownOperations.join(", ")}`)
+    }
     const nextManifest: Manifest = {
       ooCliVersion: candidateVersion,
       agentFormat: "universal",

--- a/scripts/prepare-binaries.ts
+++ b/scripts/prepare-binaries.ts
@@ -7,16 +7,23 @@
 //   - rg：.oo-bin/（download-ripgrep.ts 下载；OpenCode 内置 grep 工具运行时从 PATH 查找）。
 //   - Direct CLI：各自的项目本地 bin 目录；同时导出与固定版本匹配的官方 Skills。
 import { chmodSync, copyFileSync, mkdirSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { EXTERNAL_OO_CONTRACT_VERSION } from "../electron/agent/external/oo-capability-contract.ts"
 import { buildAgentToolRuntime } from "./build-agent-tool-runtime.ts"
 import { bundleClaudeAgentAcp } from "./claude-agent-acp.ts"
 import { bundleCodexAcp } from "./codex-acp.ts"
 import { dingTalkCliBinaryName, downloadDingTalkCliBinary, exportDingTalkCliSkills } from "./dingtalk-cli.ts"
 import { downloadLarkCliBinary, exportLarkCliSkills, larkCliBinaryName } from "./lark-cli.ts"
-import { downloadOoBinary, ooExecutableName } from "./oo-cli.ts"
+import { downloadOoBinary, ooExecutableName, OO_CLI_VERSION } from "./oo-cli.ts"
 import { downloadRipgrepBinary, ripgrepExecutableName } from "./ripgrep.ts"
-import { bundledSkillsDir, exportBundledSkills, verifyBundledOoSkillCompatibility } from "./skills.ts"
+import {
+  bundledOoSkillHashes,
+  bundledSkillsDir,
+  exportBundledSkills,
+  verifyBundledOoSkillCompatibility,
+} from "./skills.ts"
 import { downloadWecomCliBinary, exportWecomCliSkills, wecomCliBinaryName } from "./wecom-cli.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -78,6 +85,19 @@ console.log("[wanta] bundled DingTalk CLI skills")
 // 运行时拷进 OpenCode workspace 的 .opencode/skill/（见 electron/agent/workspace.ts）。
 await exportBundledSkills()
 await verifyBundledOoSkillCompatibility()
+await writeFile(
+  path.join(binDir, "oo-runtime-compatibility.json"),
+  `${JSON.stringify(
+    {
+      contractVersion: EXTERNAL_OO_CONTRACT_VERSION,
+      files: await bundledOoSkillHashes(),
+      ooCliVersion: OO_CLI_VERSION,
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+)
 console.log(`[wanta] bundled skills: ${path.basename(bundledSkillsDir)}`)
 
 // 自定义工具的 tool helper + Zod 合并为单文件，随包发布，工具加载不依赖首次启动隐式联网安装 npm 包。

--- a/scripts/prepare-binaries.ts
+++ b/scripts/prepare-binaries.ts
@@ -16,7 +16,7 @@ import { dingTalkCliBinaryName, downloadDingTalkCliBinary, exportDingTalkCliSkil
 import { downloadLarkCliBinary, exportLarkCliSkills, larkCliBinaryName } from "./lark-cli.ts"
 import { downloadOoBinary, ooExecutableName } from "./oo-cli.ts"
 import { downloadRipgrepBinary, ripgrepExecutableName } from "./ripgrep.ts"
-import { bundledSkillsDir, exportBundledSkills } from "./skills.ts"
+import { bundledSkillsDir, exportBundledSkills, verifyBundledOoSkillCompatibility } from "./skills.ts"
 import { downloadWecomCliBinary, exportWecomCliSkills, wecomCliBinaryName } from "./wecom-cli.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -77,6 +77,7 @@ console.log("[wanta] bundled DingTalk CLI skills")
 // 内置 4 个 oo skill：导出到 resources/skills/，由 electron-builder extraResources 打入 Resources/skills，
 // 运行时拷进 OpenCode workspace 的 .opencode/skill/（见 electron/agent/workspace.ts）。
 await exportBundledSkills()
+await verifyBundledOoSkillCompatibility()
 console.log(`[wanta] bundled skills: ${path.basename(bundledSkillsDir)}`)
 
 // 自定义工具的 tool helper + Zod 合并为单文件，随包发布，工具加载不依赖首次启动隐式联网安装 npm 包。

--- a/scripts/skills.test.ts
+++ b/scripts/skills.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
@@ -50,5 +50,26 @@ describe("Wanta bundled skills", () => {
     const knownOperations = new Set<string>(EXTERNAL_OO_OPERATIONS.map((operation) => operation.id))
     expect(manifest.requiredOperations.every((operation) => knownOperations.has(operation))).toBe(true)
     await expect(verifyBundledOoSkillCompatibility(bundledSkillsDir)).resolves.toBeUndefined()
+  })
+
+  it("rejects an unknown required operation before reading generated Skill files", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wanta-skill-compatibility-"))
+    const manifestPath = path.join(root, "oo.json")
+    try {
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          agentFormat: "universal",
+          files: {},
+          ooCliVersion: OO_CLI_VERSION,
+          requiredOperations: ["unknown.operation"],
+        }),
+      )
+      await expect(verifyBundledOoSkillCompatibility(path.join(root, "missing-skills"), manifestPath)).rejects.toThrow(
+        /unknown operations: unknown\.operation/u,
+      )
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 })

--- a/scripts/skills.test.ts
+++ b/scripts/skills.test.ts
@@ -2,7 +2,16 @@ import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
-import { exportBundledSkills, wantaBundledSkillIds, wantaSkillsDir } from "./skills.ts"
+import { EXTERNAL_OO_OPERATIONS } from "../electron/agent/external/oo-capability-contract.ts"
+import { OO_CLI_VERSION } from "./oo-cli.ts"
+import {
+  bundledSkillsDir,
+  exportBundledSkills,
+  skillCompatibilityDir,
+  verifyBundledOoSkillCompatibility,
+  wantaBundledSkillIds,
+  wantaSkillsDir,
+} from "./skills.ts"
 
 describe("Wanta bundled skills", () => {
   it("keeps a tracked SKILL.md source for every bundled Wanta skill", async () => {
@@ -30,5 +39,16 @@ describe("Wanta bundled skills", () => {
     const content = await readFile(path.join(outDir, "oo-publish-skill", "SKILL.md"), "utf8")
     expect(content).toContain("## Wanta fast path for publishing a new version")
     expect(content).toContain("Do not search logs, shell history, SQLite databases")
+  })
+
+  it("pins the exported oo Skill and reviews every required command domain", async () => {
+    const manifest = JSON.parse(await readFile(path.join(skillCompatibilityDir, "oo.json"), "utf8")) as {
+      ooCliVersion: string
+      requiredOperations: string[]
+    }
+    expect(manifest.ooCliVersion).toBe(OO_CLI_VERSION)
+    const knownOperations = new Set<string>(EXTERNAL_OO_OPERATIONS.map((operation) => operation.id))
+    expect(manifest.requiredOperations.every((operation) => knownOperations.has(operation))).toBe(true)
+    await expect(verifyBundledOoSkillCompatibility(bundledSkillsDir)).resolves.toBeUndefined()
   })
 })

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -8,11 +8,12 @@
 // `--out-dir` 只写指定目录；仍隔离 OO_CONFIG/DATA/LOG 到临时目录并禁用 sync，避免污染开发机家目录。
 
 import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
 import { appendFile, cp, mkdir, readFile, readdir, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { downloadOoBinary } from "./oo-cli.ts"
+import { downloadOoBinary, OO_CLI_VERSION } from "./oo-cli.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.join(dirname, "..")
@@ -21,6 +22,7 @@ const repoRoot = path.join(dirname, "..")
 export const bundledSkillsDir = path.join(repoRoot, "resources", "skills")
 export const wantaSkillsDir = path.join(repoRoot, "resources", "wanta-skills")
 export const skillOverridesDir = path.join(repoRoot, "resources", "skill-overrides")
+export const skillCompatibilityDir = path.join(repoRoot, "resources", "skill-compatibility")
 
 const ooBundledSkillIds = ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"] as const
 export const wantaBundledSkillIds = ["browser", "wikigraph-knowledge"] as const
@@ -32,6 +34,13 @@ interface SkillsInstallExport {
   status?: string
   summary?: { requestedSkills?: number; exported?: number; failed?: number }
   skills?: Array<{ skillId?: string; status?: string }>
+}
+
+interface SkillCompatibilityManifest {
+  agentFormat: string
+  files: Record<string, string>
+  ooCliVersion: string
+  requiredOperations: string[]
 }
 
 export type BundledSkillsInstaller = (outDir: string) => Promise<string>
@@ -97,6 +106,56 @@ export async function applyBundledSkillOverrides(
       await appendFile(path.join(outDir, skillId, "SKILL.md"), `\n\n${supplement}\n`, "utf8")
     }),
   )
+}
+
+export async function verifyBundledOoSkillCompatibility(
+  skillsDir: string = bundledSkillsDir,
+  manifestPath: string = path.join(skillCompatibilityDir, "oo.json"),
+): Promise<void> {
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as SkillCompatibilityManifest
+  if (manifest.ooCliVersion !== OO_CLI_VERSION || manifest.agentFormat !== "universal") {
+    throw new Error(
+      `bundled oo Skill compatibility targets ${manifest.ooCliVersion}/${manifest.agentFormat}, expected ${OO_CLI_VERSION}/universal`,
+    )
+  }
+  const actualFiles = (await readdirFilesRecursive(path.join(skillsDir, "oo"))).sort()
+  const expectedFiles = Object.keys(manifest.files).sort()
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new Error(
+      `bundled oo Skill file set changed: expected [${expectedFiles.join(", ")}], got [${actualFiles.join(", ")}]`,
+    )
+  }
+  for (const [relativePath, expected] of Object.entries(manifest.files)) {
+    const content = await readFile(path.join(skillsDir, "oo", relativePath))
+    const actual = createHash("sha256").update(content).digest("hex")
+    if (actual !== expected) {
+      throw new Error(`bundled oo Skill compatibility changed at ${relativePath}: expected ${expected}, got ${actual}`)
+    }
+  }
+}
+
+export async function bundledOoSkillHashes(skillsDir: string = bundledSkillsDir): Promise<Record<string, string>> {
+  const root = path.join(skillsDir, "oo")
+  const files = (await readdirFilesRecursive(root)).sort()
+  return Object.fromEntries(
+    await Promise.all(
+      files.map(async (relativePath) => {
+        const content = await readFile(path.join(root, relativePath))
+        return [relativePath, createHash("sha256").update(content).digest("hex")] as const
+      }),
+    ),
+  )
+}
+
+async function readdirFilesRecursive(root: string, relativeDirectory = ""): Promise<string[]> {
+  const entries = await readdir(path.join(root, relativeDirectory), { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const relativePath = path.join(relativeDirectory, entry.name)
+    if (entry.isDirectory()) files.push(...(await readdirFilesRecursive(root, relativePath)))
+    else if (entry.isFile()) files.push(relativePath.split(path.sep).join("/"))
+  }
+  return files
 }
 
 async function readdirMarkdownFiles(directory: string): Promise<string[]> {

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -13,6 +13,7 @@ import { appendFile, cp, mkdir, readFile, readdir, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { EXTERNAL_OO_OPERATIONS } from "../electron/agent/external/oo-capability-contract.ts"
 import { downloadOoBinary, OO_CLI_VERSION } from "./oo-cli.ts"
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -117,6 +118,11 @@ export async function verifyBundledOoSkillCompatibility(
     throw new Error(
       `bundled oo Skill compatibility targets ${manifest.ooCliVersion}/${manifest.agentFormat}, expected ${OO_CLI_VERSION}/universal`,
     )
+  }
+  const knownOperations = new Set<string>(EXTERNAL_OO_OPERATIONS.map((operation) => operation.id))
+  const unknownOperations = manifest.requiredOperations.filter((operation) => !knownOperations.has(operation))
+  if (unknownOperations.length > 0) {
+    throw new Error(`bundled oo Skill compatibility contains unknown operations: ${unknownOperations.join(", ")}`)
   }
   const actualFiles = (await readdirFilesRecursive(path.join(skillsDir, "oo"))).sort()
   const expectedFiles = Object.keys(manifest.files).sort()

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -9,7 +9,7 @@
 
 import { spawnSync } from "node:child_process"
 import { createHash } from "node:crypto"
-import { appendFile, cp, mkdir, readFile, readdir, rm } from "node:fs/promises"
+import { appendFile, cp, mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -74,29 +74,36 @@ async function installBundledOoSkills(outDir: string): Promise<string> {
 }
 
 export async function installBundledOoSkillsFromBinary(ooBin: string, outDir: string): Promise<string> {
-  const storeDir = path.join(os.tmpdir(), "wanta-oo-skill-export-store")
+  const storeDir = await mkdtemp(path.join(os.tmpdir(), "wanta-oo-skill-export-store-"))
+  try {
+    const result = spawnSync(
+      ooBin,
+      ["skills", "install", `--out-dir=${outDir}`, "--agent-format=universal", "--json"],
+      {
+        encoding: "utf-8",
+        maxBuffer: 8 * 1024 * 1024,
+        env: {
+          ...process.env,
+          OO_CONFIG_DIR: path.join(storeDir, "config"),
+          OO_DATA_DIR: path.join(storeDir, "data"),
+          OO_LOG_DIR: path.join(storeDir, "log"),
+          OO_SKILLS_SYNC_DISABLED: "1",
+          OO_NO_SELF_UPDATE: "1",
+          OO_TELEMETRY_DISABLED: "1",
+        },
+      },
+    )
 
-  const result = spawnSync(ooBin, ["skills", "install", `--out-dir=${outDir}`, "--agent-format=universal", "--json"], {
-    encoding: "utf-8",
-    maxBuffer: 8 * 1024 * 1024,
-    env: {
-      ...process.env,
-      OO_CONFIG_DIR: path.join(storeDir, "config"),
-      OO_DATA_DIR: path.join(storeDir, "data"),
-      OO_LOG_DIR: path.join(storeDir, "log"),
-      OO_SKILLS_SYNC_DISABLED: "1",
-      OO_NO_SELF_UPDATE: "1",
-      OO_TELEMETRY_DISABLED: "1",
-    },
-  })
-
-  if (result.error) {
-    throw new Error(`failed to spawn oo skills install: ${result.error.message}`)
+    if (result.error) {
+      throw new Error(`failed to spawn oo skills install: ${result.error.message}`)
+    }
+    if (result.status !== 0) {
+      throw new Error(`oo skills install --out-dir failed (code ${result.status}): ${result.stderr || result.stdout}`)
+    }
+    return result.stdout
+  } finally {
+    await rm(storeDir, { force: true, recursive: true })
   }
-  if (result.status !== 0) {
-    throw new Error(`oo skills install --out-dir failed (code ${result.status}): ${result.stderr || result.stdout}`)
-  }
-  return result.stdout
 }
 
 export async function applyBundledSkillOverrides(

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -70,6 +70,10 @@ export async function exportBundledSkills(
 
 async function installBundledOoSkills(outDir: string): Promise<string> {
   const ooBin = await downloadOoBinary()
+  return installBundledOoSkillsFromBinary(ooBin, outDir)
+}
+
+export async function installBundledOoSkillsFromBinary(ooBin: string, outDir: string): Promise<string> {
   const storeDir = path.join(os.tmpdir(), "wanta-oo-skill-export-store")
 
   const result = spawnSync(ooBin, ["skills", "install", `--out-dir=${outDir}`, "--agent-format=universal", "--json"], {

--- a/src/routes/Chat/AssistantTurnRenderer.tsx
+++ b/src/routes/Chat/AssistantTurnRenderer.tsx
@@ -93,6 +93,7 @@ export function TurnProcessActivity({
   blocks,
   process,
   live = false,
+  pendingResponse = false,
   billingCacheScope,
   providerByService,
   onAuthorize,
@@ -104,6 +105,7 @@ export function TurnProcessActivity({
   blocks: AssistantTimelineBlock[]
   process: ReturnType<typeof summarizeTurnProcess>
   live?: boolean
+  pendingResponse?: boolean
   billingCacheScope: string
   providerByService: Map<string, ConnectionProvider>
   onAuthorize: (auth: AuthorizationInfo, source?: ChatTurnRetrySource) => void
@@ -203,7 +205,15 @@ export function TurnProcessActivity({
               onViewBilling={onViewBilling}
             />
           ))}
-          {showLiveStatus ? <LiveStatusBar process={process} live={live} /> : null}
+          {pendingResponse ? (
+            <div className="rounded-md text-muted-foreground">
+              <div className="flex min-h-6 min-w-0 items-center">
+                <LoadingShimmerText className="min-w-0 truncate">{t("chat.activityFinalizing")}</LoadingShimmerText>
+              </div>
+            </div>
+          ) : showLiveStatus ? (
+            <LiveStatusBar process={process} live={live} />
+          ) : null}
         </ProcessActivityViewport>
       </TaskContent>
     </Task>

--- a/src/routes/Chat/ChatTimeline.tsx
+++ b/src/routes/Chat/ChatTimeline.tsx
@@ -177,6 +177,7 @@ const ChatTurnView = React.memo(function ChatTurnView({
     timelineHasVisibleOutcome(timelineSegments) || hasRenderableArtifacts || hasRenderableTurnOutputs
   const process = summarizeTurnProcess(turn, activity, activeAssistantMessageId, { hasVisibleOutcome })
   const hasProcessSegment = timelineSegments.some((segment) => segment.kind === "process")
+  const hasPendingResponse = timelineSegments.some((segment) => segment.kind === "pending")
   const shouldShowProcess = shouldShowTurnProcess(process, hasProcessSegment)
   const shouldShowPlainActivity = shouldShowPlainTurnActivity(process)
   const turnIsActive = Boolean(activeAssistantMessageId)
@@ -243,6 +244,9 @@ const ChatTurnView = React.memo(function ChatTurnView({
       <>
         {shouldShowPlainActivity ? <PlainAssistantActivity activity={activity} /> : null}
         {renderSegments.map((segment, segmentIndex) => {
+          if (segment.kind === "pending") {
+            return null
+          }
           if (segment.kind === "response") {
             const ownsTurnActions = segmentIndex === lastResponseSegmentIndex && segmentIndex === lastSegmentIndex
             return (
@@ -290,6 +294,7 @@ const ChatTurnView = React.memo(function ChatTurnView({
                   blocks={segment.blocks}
                   process={segmentProcess}
                   live={processLive}
+                  pendingResponse={isLastProcess && hasPendingResponse}
                   billingCacheScope={billingCacheScope}
                   providerByService={providerByService}
                   onAuthorize={handleAuthorize}

--- a/src/routes/Chat/assistant-timeline.test.ts
+++ b/src/routes/Chat/assistant-timeline.test.ts
@@ -276,6 +276,31 @@ describe("assistantTimelineBlocks", () => {
     expect(committed[0]?.blocks.map(({ block }) => block.kind)).toEqual(["tools", "text", "tools"])
   })
 
+  it("keeps prior buffered text visible when a later empty assistant message becomes active", () => {
+    const messages = [
+      message("a1", [toolPart("tool-1")], "tool-calls"),
+      message("a2", [textPart("prior", "The tool result is ready.")]),
+      message("a3", []),
+    ]
+
+    const segments = segmentAssistantTimeline(messages, { activeAssistantMessageId: "a3" })
+    expect(segments.map(({ kind }) => kind)).toEqual(["process", "response"])
+    expect(textFromTimelineBlocks(segments[1]?.blocks ?? [])).toBe("The tool result is ready.")
+  })
+
+  it("keeps only the current assistant message pending after a process step", () => {
+    const messages = [
+      message("a1", [toolPart("tool-1")], "tool-calls"),
+      message("a2", [textPart("prior", "Previous assistant text.")]),
+      message("a3", [textPart("current", "Current assistant text.")]),
+    ]
+
+    const segments = segmentAssistantTimeline(messages, { activeAssistantMessageId: "a3" })
+    expect(segments.map(({ kind }) => kind)).toEqual(["process", "response", "pending"])
+    expect(textFromTimelineBlocks(segments[1]?.blocks ?? [])).toBe("Previous assistant text.")
+    expect(textFromTimelineBlocks(segments[2]?.blocks ?? [])).toBe("Current assistant text.")
+  })
+
   it("reconstructs process messages without unrelated response parts", () => {
     const source = message("a1", [textPart("progress", "Checking data."), toolPart("tool-1")], "tool-calls")
     const processBlocks = segmentAssistantTimeline([source])[1]?.blocks ?? []

--- a/src/routes/Chat/assistant-timeline.test.ts
+++ b/src/routes/Chat/assistant-timeline.test.ts
@@ -244,6 +244,38 @@ describe("assistantTimelineBlocks", () => {
     expect(segments[0]?.blocks.map(({ block }) => block.kind)).toEqual(["tools", "tools", "text", "tools"])
   })
 
+  it("holds an active post-tool tail out of both visible lanes until the turn settles", () => {
+    const toolMessage = message("a1", [toolPart("tool-1")], "tool-calls")
+    const finalMessage = message("a2", [textPart("final", "The image is ready.")])
+
+    const active = segmentAssistantTimeline([toolMessage, finalMessage], { activeAssistantMessageId: "a2" })
+    expect(active.map(({ kind }) => kind)).toEqual(["process", "pending"])
+    expect(timelineHasVisibleOutcome(active)).toBe(false)
+
+    const settled = segmentAssistantTimeline([toolMessage, finalMessage])
+    expect(settled.map(({ kind }) => kind)).toEqual(["process", "response"])
+    expect(settled[1]?.key).toBe(active[1]?.key)
+    expect(textFromTimelineBlocks(settled[1]?.blocks ?? [])).toBe("The image is ready.")
+  })
+
+  it("commits an active post-tool tail to processing when another tool arrives", () => {
+    const beforeNextTool = [
+      message("a1", [toolPart("tool-1")], "tool-calls"),
+      message("a2", [textPart("progress", "I will poll the result now.")]),
+    ]
+    const afterNextTool = [
+      beforeNextTool[0]!,
+      message("a2", [textPart("progress", "I will poll the result now."), toolPart("tool-2")], "tool-calls"),
+    ]
+
+    expect(
+      segmentAssistantTimeline(beforeNextTool, { activeAssistantMessageId: "a2" }).map(({ kind }) => kind),
+    ).toEqual(["process", "pending"])
+    const committed = segmentAssistantTimeline(afterNextTool, { activeAssistantMessageId: "a2" })
+    expect(committed.map(({ kind }) => kind)).toEqual(["process"])
+    expect(committed[0]?.blocks.map(({ block }) => block.kind)).toEqual(["tools", "text", "tools"])
+  })
+
   it("reconstructs process messages without unrelated response parts", () => {
     const source = message("a1", [textPart("progress", "Checking data."), toolPart("tool-1")], "tool-calls")
     const processBlocks = segmentAssistantTimeline([source])[1]?.blocks ?? []

--- a/src/routes/Chat/assistant-timeline.ts
+++ b/src/routes/Chat/assistant-timeline.ts
@@ -110,7 +110,19 @@ export function segmentAssistantTimeline(
     append(kind, [item])
   }
   if (pendingText.length > 0) {
-    append(options.activeAssistantMessageId === undefined ? "response" : "pending", pendingText)
+    const activeMessageId = options.activeAssistantMessageId
+    if (activeMessageId === undefined) {
+      append("response", pendingText)
+    } else {
+      append(
+        "response",
+        pendingText.filter((item) => item.message.id !== activeMessageId),
+      )
+      append(
+        "pending",
+        pendingText.filter((item) => item.message.id === activeMessageId),
+      )
+    }
   }
   return segments
 }

--- a/src/routes/Chat/assistant-timeline.ts
+++ b/src/routes/Chat/assistant-timeline.ts
@@ -8,7 +8,9 @@ export interface AssistantTimelineBlock {
   block: RenderBlock
 }
 
-export type AssistantTimelineSegmentKind = "process" | "response"
+export type AssistantTimelineSegmentKind = "pending" | "process" | "response"
+
+type AssistantTimelinePhase = Exclude<AssistantTimelineSegmentKind, "pending">
 
 export interface AssistantTimelineSegment {
   kind: AssistantTimelineSegmentKind
@@ -34,10 +36,7 @@ function isToolCallFinishReason(reason: string | undefined): boolean {
   return reason === "tool-calls" || reason === "tool_calls" || reason === "tool-use" || reason === "tool_use"
 }
 
-function blockSegmentKind(
-  item: AssistantTimelineBlock,
-  phase: AssistantTimelineSegmentKind,
-): AssistantTimelineSegmentKind {
+function blockSegmentKind(item: AssistantTimelineBlock, phase: AssistantTimelinePhase): AssistantTimelinePhase {
   switch (item.block.kind) {
     case "tools":
       return "process"
@@ -66,35 +65,52 @@ export function segmentAssistantTimeline(
 ): AssistantTimelineSegment[] {
   const blocks = assistantTimelineBlocks(messages)
   const segments: AssistantTimelineSegment[] = []
-  let phase: AssistantTimelineSegmentKind = "response"
+  let phase: AssistantTimelinePhase = "response"
+  let pendingText: AssistantTimelineBlock[] = []
+  const append = (kind: AssistantTimelineSegmentKind, items: AssistantTimelineBlock[]): void => {
+    if (items.length === 0) return
+    const current = segments.at(-1)
+    if (current?.kind === kind) {
+      current.blocks.push(...items)
+      return
+    }
+    const first = items[0]
+    segments.push({ kind, key: first ? blockKey(first) : kind, blocks: items })
+  }
+  const flushPending = (kind: AssistantTimelinePhase): void => {
+    append(kind, pendingText)
+    pendingText = []
+  }
+
   for (const item of blocks) {
     const kind = blockSegmentKind(item, phase)
     if (item.block.kind === "tools" || (item.block.kind === "status" && kind === "process")) {
+      flushPending("process")
       phase = "process"
-    } else if (item.block.kind === "text" && kind === "response" && item.message.finishReason) {
+      append("process", [item])
+      continue
+    }
+    if (item.block.kind === "text" && kind === "process") {
+      pendingText.push(item)
+      continue
+    }
+    if (item.block.kind === "text" && kind === "response" && item.message.finishReason) {
+      flushPending("process")
       phase = "response"
+      append("response", [item])
+      continue
     }
-    const current = segments.at(-1)
-    if (current?.kind === kind) {
-      current.blocks.push(item)
-    } else {
-      segments.push({ kind, key: blockKey(item), blocks: [item] })
+    if (item.block.kind === "attachment") {
+      flushPending("response")
+      phase = "response"
+      append("response", [item])
+      continue
     }
+    flushPending("process")
+    append(kind, [item])
   }
-  const lastSegment = segments.at(-1)
-  if (options.activeAssistantMessageId === undefined && lastSegment?.kind === "process") {
-    const trailingText: AssistantTimelineBlock[] = []
-    while (lastSegment.blocks.at(-1)?.block.kind === "text") {
-      const item = lastSegment.blocks.pop()
-      if (item) trailingText.unshift(item)
-    }
-    if (trailingText.length > 0) {
-      const first = trailingText[0]
-      segments.push({ kind: "response", key: first ? blockKey(first) : "response", blocks: trailingText })
-    }
-    if (lastSegment.blocks.length === 0) {
-      segments.splice(-2, 1)
-    }
+  if (pendingText.length > 0) {
+    append(options.activeAssistantMessageId === undefined ? "response" : "pending", pendingText)
   }
   return segments
 }


### PR DESCRIPTION
## Summary

Stabilize managed tool workflows for Claude Code, Codex, and Grok, and add a versioned compatibility boundary between bundled OO Skills and Wanta's privileged external-agent OO guard.

## User impact

External agents could expose raw `mcp__wanta_skills__...` infrastructure names, execute the bundled Skill's required top-level `oo search` command only to have Wanta reject it, and then retry through a different Connector command. During tool-driven turns, final response text could also appear inside the expanded process disclosure before moving outside it when the turn completed.

With this change, all generic ACP agents share readable Skill tool labels, a managed `oo search` path, stable response/process presentation, and one explicit execution profile that tells the agent which OO command domains are enabled, planned, or denied before it acts.

## Root cause

The bundled `oo` Skill, external OO guard allowlist, host execution guidance, and upgrade validation were maintained independently. OOCLI 1.7.7 instructed agents to run top-level `oo search`, while the guard accepted only `oo connector ...` commands. The Skill export is generated into a gitignored directory, so a version bump could change instructions without exposing the semantic delta in the repository diff. Separately, post-tool text is ambiguous until either another tool arrives or the ACP turn returns its terminal stop reason.

## Changes

### Managed tool behavior

- Allow top-level, read-only `oo search` through the external OO guard without widening file, Flow, auth, config, logout, or Skill-state permissions.
- Normalize Wanta Skill MCP calls into readable list/load/read labels for current and restored ACP transcripts.
- Introduce a pending tail for active post-tool text. A following tool commits it to processing; turn completion commits it to the final response. While unresolved, the process view shows the existing “Preparing the result…” status rather than moving visible text between containers.
- Preserve tool-prelude text, intermediate process narration, terminal responses, and stable React keys in chronological order.

### Single OO capability contract

- Add one versioned External OO operation table describing command prefixes, availability, effects, and workspace requirements.
- Derive guard admission, workspace binding, and Skill execution guidance from that table.
- Return structured `UNSUPPORTED_OO_OPERATION` and `UNRECOGNIZED_OO_OPERATION` metadata at the privileged guard boundary.
- Keep `file.upload`, `file.download`, and Flow planned; keep auth, config, logout, and Skill recommendation state denied.

### Upgrade compatibility

- Track OOCLI 1.7.7, the universal agent format, every exported `oo` Skill file, SHA-256 hashes, and reviewed command domains in a committed compatibility manifest.
- Fail on changed content or any added/removed Skill file during predev, packaging, and CI; postinstall reports the same incompatibility.
- Add `pnpm run oo:compatibility` for review and `pnpm run oo:compatibility:accept` for explicit acceptance after unknown operations have been resolved.
- Add `pnpm run oo:upgrade <version>` to download a candidate binary into an isolated temporary directory, export its Skills without replacing the pinned installation, scan documented OO command domains, and emit Markdown or JSON review reports.
- Keep acceptance explicit: unknown command domains block `--accept`; accepted versions update the pinned version and compatibility manifest only after review.

### Agent parity and Skill precedence

- Exercise Claude Code, Codex, and Grok through parameterized in-memory ACP sessions that register `wanta_skills`, load the `oo` Skill, read a reference, and emit the managed search command.
- Mark the Wanta current-turn Skill snapshot authoritative for selected, team, and host-discovered Skill ids.
- Include machine-readable Skill source metadata and instruct agents not to substitute same-id native/global/home-directory Skills.
- Exercise the full ACP → managed OO shim → authenticated loopback guard → fake OO binary → ACP tool result path for Claude Code, Codex, and Grok without model tokens or real credentials.
- Detect native home-directory Skill reads and emit metadata-only source diagnostics without retaining private paths, tool payloads, or Skill contents.

### Packaged runtime fail-closed

- Generate a packaged OO runtime descriptor containing the contract version, pinned OOCLI version, and complete Skill hashes.
- Verify the descriptor and packaged Skill tree asynchronously at startup.
- On mismatch, omit `wanta_skills` and reject managed OO dispatch while leaving local coding, browser, knowledge, questions, and other non-OO external-agent capabilities available.

## Safety

- The guard does not allow arbitrary `oo *` execution.
- Local file transfer and Flow remain disabled pending path, URL, workspace, side-effect, and confirmation policies.
- Authentication, configuration, logout, and Skill recommendation state remain denied.
- Existing workspace binding, managed cwd validation, output redaction, and credential boundaries are preserved.
- Compatibility diagnostics store versions, file hashes, operation ids, and availability only; they do not store connector payloads, outputs, or credentials.

## Validation

- `pnpm run lint`
- `pnpm test` — 364 test files passed, 2 skipped; 2,907 tests passed, 4 skipped
- `pnpm run ts-check`
- `pnpm run oo:compatibility`
- `pnpm run predev`
- `pnpm exec oxfmt --check .` — 1,097 files matched
- `git diff --check`
