### PR TITLE
fix(build): normalize exported oo Skill line endings before hashing

### DIFF
--- a/scripts/skills.test.ts
+++ b/scripts/skills.test.ts
@@ -41,6 +41,35 @@ describe("Wanta bundled skills", () => {
     expect(content).toContain("Do not search logs, shell history, SQLite databases")
   })
 
+  it("normalizes CRLF from the oo CLI export so Skill hashes match on every platform", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wanta-skill-crlf-"))
+    const outDir = path.join(root, "skills")
+    try {
+      await exportBundledSkills(outDir, async (directory) => {
+        for (const skillId of ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"]) {
+          await mkdir(path.join(directory, skillId, "references"), { recursive: true })
+          await writeFile(path.join(directory, skillId, "SKILL.md"), "# Upstream\r\n\r\nline\r\n")
+          await writeFile(path.join(directory, skillId, "references", "guide.md"), "a\r\nb\r\n")
+        }
+        return JSON.stringify({
+          skills: ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"].map((skillId) => ({
+            skillId,
+            status: "exported",
+          })),
+          summary: { failed: 0 },
+        })
+      })
+
+      const skill = await readFile(path.join(outDir, "oo", "SKILL.md"), "utf8")
+      const reference = await readFile(path.join(outDir, "oo", "references", "guide.md"), "utf8")
+      expect(skill).toBe("# Upstream\n\nline\n")
+      expect(reference).toBe("a\nb\n")
+      expect(await readFile(path.join(outDir, "oo-publish-skill", "SKILL.md"), "utf8")).not.toContain("\r")
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("pins the exported oo Skill and reviews every required command domain", async () => {
     const lock = JSON.parse(await readFile(path.join(skillLockDir, "oo.json"), "utf8")) as {
       ooCliVersion: string

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -9,7 +9,7 @@
 
 import { spawnSync } from "node:child_process"
 import { createHash } from "node:crypto"
-import { appendFile, cp, mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { appendFile, cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -60,6 +60,7 @@ export async function exportBundledSkills(
 
   const stdout = await installOoSkills(outDir)
   assertSkillsExported(stdout, outDir)
+  await normalizeExportedSkillLineEndings(outDir)
   await applyBundledSkillOverrides(outDir)
   await Promise.all(
     wantaBundledSkillIds.map((skillId) =>
@@ -105,6 +106,29 @@ export async function installBundledOoSkillsFromBinary(ooBin: string, outDir: st
   } finally {
     await rm(storeDir, { force: true, recursive: true })
   }
+}
+
+// Text files the oo CLI emits into an exported Skill. Only these are rewritten to LF.
+const exportedSkillTextExtensions = new Set([".md", ".yaml", ".yml", ".json", ".txt"])
+
+/**
+ * Rewrite CRLF to LF in every exported text file. `oo skills install` writes CRLF on Windows, which
+ * would change the sha256 recorded in resources/skill-lock/oo.json and in bin/oo-runtime-integrity.json.
+ * Normalizing on disk keeps the lock, the packaged integrity descriptor and the runtime check byte-exact
+ * across platforms.
+ */
+export async function normalizeExportedSkillLineEndings(outDir: string): Promise<void> {
+  const files = await readdirFilesRecursive(outDir)
+  await Promise.all(
+    files
+      .filter((relativePath) => exportedSkillTextExtensions.has(path.extname(relativePath).toLowerCase()))
+      .map(async (relativePath) => {
+        const filePath = path.join(outDir, relativePath)
+        const content = await readFile(filePath, "utf8")
+        if (!content.includes("\r\n")) return
+        await writeFile(filePath, content.replaceAll("\r\n", "\n"), "utf8")
+      }),
+  )
 }
 
 export async function applyBundledSkillOverrides(

--- a/scripts/skills.ts
+++ b/scripts/skills.ts
@@ -60,13 +60,13 @@ export async function exportBundledSkills(
 
   const stdout = await installOoSkills(outDir)
   assertSkillsExported(stdout, outDir)
-  await normalizeExportedSkillLineEndings(outDir)
   await applyBundledSkillOverrides(outDir)
   await Promise.all(
     wantaBundledSkillIds.map((skillId) =>
       cp(path.join(wantaSkillsDir, skillId), path.join(outDir, skillId), { recursive: true }),
     ),
   )
+  await normalizeExportedSkillLineEndings(outDir)
   return outDir
 }
 
@@ -108,14 +108,15 @@ export async function installBundledOoSkillsFromBinary(ooBin: string, outDir: st
   }
 }
 
-// Text files the oo CLI emits into an exported Skill. Only these are rewritten to LF.
+// Text files that end up in an exported Skill. Only these are rewritten to LF.
 const exportedSkillTextExtensions = new Set([".md", ".yaml", ".yml", ".json", ".txt"])
 
 /**
- * Rewrite CRLF to LF in every exported text file. `oo skills install` writes CRLF on Windows, which
- * would change the sha256 recorded in resources/skill-lock/oo.json and in bin/oo-runtime-integrity.json.
- * Normalizing on disk keeps the lock, the packaged integrity descriptor and the runtime check byte-exact
- * across platforms.
+ * Rewrite CRLF to LF in every text file under outDir. `oo skills install` writes CRLF on Windows, and a
+ * Windows checkout with core.autocrlf can do the same to the tracked overrides and Wanta skills, so this
+ * runs last, after overrides are appended and Wanta skills are copied. That keeps resources/skill-lock/oo.json,
+ * bin/oo-runtime-integrity.json and the runtime skill hashes (electron/skills/hash.ts) byte-exact across
+ * platforms.
  */
 export async function normalizeExportedSkillLineEndings(outDir: string): Promise<void> {
   const files = await readdirFilesRecursive(outDir)


### PR DESCRIPTION
## Summary

The Windows release build (run 33171152436) failed in `prepare:binaries` with `bundled oo Skill lock changed at SKILL.md`. `oo skills install` writes CRLF on Windows, so the sha256 of `oo/SKILL.md` did not match _resources/skill-lock/oo.json_ once the lock check from #363 landed. The CRLF-converted hash of the LF export is exactly the `got` value in the CI log, and macOS was unaffected.

`exportBundledSkills()` now rewrites CRLF to LF in the exported text files (`.md`, `.yaml`, `.yml`, `.json`, `.txt`) as the last step of the export, after the tracked overrides are appended and the Wanta skills are copied, since a Windows checkout with `core.autocrlf` can also turn those tracked files into CRLF. Normalizing on disk rather than at hash time keeps the lock, the packaged `bin/oo-runtime-integrity.json`, `verifyPackagedOoRuntimeIntegrity()` and the runtime skill hashes in _electron/skills/hash.ts_ comparing the same bytes on every platform without touching runtime code, and `oo:upgrade` goes through the same export path so its candidate hashes stay consistent. A new test feeds a CRLF export through `exportBundledSkills()` and asserts the files come out LF.

## Verification

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint`
- [ ] `corepack pnpm run format`
- [x] `corepack pnpm test` (`scripts/skills.test.ts` and `electron/agent/external/oo-runtime-integrity.test.ts`, plus `pnpm run oo:verify`)
- [ ] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable (build-script only, final confirmation is a Windows Release Build run after merge)

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.

