### PR TITLE
fix(agent): unify managed OO execution across agents

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -117,8 +117,9 @@ External agents build on `electron/agent/external/`:
   canonicalized inside the active turn's managed roots; downloads reject local
   or private-network targets. Flow is OOMOL-only, requires an explicit Project
   on Project-scoped commands, and keeps project switching, deletion, rollback,
-  cancellation, and browser-opening commands unavailable. File upload plus
-  Flow run/publish cross the shared consequential-action confirmation policy. The agent
+  cancellation, and browser-opening commands unavailable. Enabled managed OO
+  operations, including file upload/download and Flow run/publish, are
+  first-party capability calls and do not add a user confirmation. The agent
   never receives the real CLI path or a writable scope file. A single `oo` command
   receives a fast-path allow when it includes only the shared bounded output
   suffixes (`head`/`tail` or stderr descriptor duplication). Other ordinary

--- a/docs/ai/byoa-follow-up-handoff.md
+++ b/docs/ai/byoa-follow-up-handoff.md
@@ -198,7 +198,7 @@ PR #362 最后一轮已完成：
 
 1. `file.upload` / `file.download`
    - 只允许读取或写入当前活动 turn 的 managed roots。
-   - 上传只接受普通文件，限制为 500 MiB，并进入 consequential-action 确认。
+   - 上传只接受普通文件，限制为 500 MiB；作为已启用的托管 OO 操作自动放行，不重复请求批准。
    - 下载只接受无内嵌凭据的 HTTP(S) URL，拒绝 localhost、私网、链路本地和特殊用途 IP。
    - 未提供下载目录时固定写入 managed cwd；文件名和扩展名不能形成路径逃逸。
    - 签名 `downloadUrl` 仅对当前 agent 的实时命令结果保留，进入 transcript/UI 前仍按敏感字段脱敏。
@@ -206,7 +206,7 @@ PR #362 最后一轮已完成：
    - 只在 OOMOL runtime 下开放。
    - Project-scoped 命令必须显式传 `--project`；先用 `oo flow project current --json` 解析当前 Project。
    - 已开放 Project 读取、Flow 读取、Draft 创建/编辑/检查、Run、Publish 和结果读取等已建模子命令。
-   - Flow `run` 和 `publish` 进入 consequential-action 确认。
+   - Flow `run` 和 `publish` 作为已启用的托管 OO 操作自动放行，不重复请求批准。
    - `apply`、`@file` 等本地引用只能读取 managed roots；stdin 被拒绝。
    - Project 切换、Flow 删除、rollback、run cancel、open/workbench 仍保持关闭，等待独立的状态恢复或浏览器凭据语义。
 

--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -159,9 +159,9 @@ subcommands. Uploads can read only regular files under the active turn's
 managed roots. Downloads accept only public HTTP(S) artifact URLs and write
 only inside those roots. Flow requires an OOMOL runtime and explicit Project
 binding for Project-scoped work; read and Draft operations are enabled, while
-run and publish cross the consequential-action prompt. Project switching, Flow
-deletion or rollback, run cancellation, and browser-opening commands remain
-closed until they receive separate host semantics.
+run and publish execute without a separate user confirmation. Project
+switching, Flow deletion or rollback, run cancellation, and browser-opening
+commands remain closed until they receive separate host semantics.
 
 ### Phase 4: Skill registry and task snapshots
 

--- a/docs/ai/oo-first-class-optimization-report.md
+++ b/docs/ai/oo-first-class-optimization-report.md
@@ -155,18 +155,18 @@ OO 作为一等公民能力，必须同时满足：
 
 把当前 `EXTERNAL_OO_OPERATIONS` 升级为 Agent-independent `OO_OPERATIONS`。每项至少声明：
 
-| 字段 | 含义 |
-|---|---|
-| `id` | 稳定 operation id，例如 `file.upload` |
-| `command` | OOCLI 命令前缀 |
-| `availability` | enabled / planned / denied |
-| `effect` | read / local-read / local-write / external-action / local-state |
-| `workspace` | none / optional / required |
-| `inputPolicy` | 路径、URL、stdin、`@file` 和大小限制 |
-| `timeoutPolicy` | discovery、action、异步查询、Flow 的不同 deadline |
-| `outputPolicy` | 哪些字段可实时返回、可展示、可持久化 |
-| `permissionPolicy` | 已启用托管 OO 自动放行；非法或未开放操作直接拒绝 |
-| `uiMetadata` | 工具名称、详情、安全展示信息 |
+| 字段               | 含义                                                            |
+| ------------------ | --------------------------------------------------------------- |
+| `id`               | 稳定 operation id，例如 `file.upload`                           |
+| `command`          | OOCLI 命令前缀                                                  |
+| `availability`     | enabled / planned / denied                                      |
+| `effect`           | read / local-read / local-write / external-action / local-state |
+| `workspace`        | none / optional / required                                      |
+| `inputPolicy`      | 路径、URL、stdin、`@file` 和大小限制                            |
+| `timeoutPolicy`    | discovery、action、异步查询、Flow 的不同 deadline               |
+| `outputPolicy`     | 哪些字段可实时返回、可展示、可持久化                            |
+| `permissionPolicy` | 已启用托管 OO 自动放行；非法或未开放操作直接拒绝                |
+| `uiMetadata`       | 工具名称、详情、安全展示信息                                    |
 
 OpenCode、BYOA guard、Skill guidance、权限分类器、工具展示、bundle lock 和测试全部从该契约派生，禁止维护平行清单。
 
@@ -228,16 +228,16 @@ interface OoExecutionResult {
 
 统一错误类型：
 
-| 类别 | 示例 | 恢复策略 |
-|---|---|---|
-| `transport_unavailable` | loopback/lease 不可达 | adapter 或 Host 原通道重试一次；禁止模型换通道 |
-| `runtime_integrity_failed` | OOCLI/Skill lock 不匹配 | fail closed，提示升级或重新安装 |
-| `workspace_unavailable` | turn 未绑定 team | 阻止执行；不猜 team、不切账号 |
-| `authorization_required` | Connector 未连接或 scope 失效 | 显示 Wanta 授权入口，停止当前外部步骤 |
-| `policy_denied` | operation 或 action 被禁止 | 不重试、不找非托管替代路径 |
-| `input_shape_unsupported` | schema 不接受 URI/file | 报告真实能力缺口 |
-| `remote_action_failed` | provider/action 运行失败 | 按 operation 的幂等性与错误码决定是否重试 |
-| `cancelled` | 用户取消或任务结束 | 终止真实 OOCLI 子进程并清理 lease |
+| 类别                       | 示例                          | 恢复策略                                       |
+| -------------------------- | ----------------------------- | ---------------------------------------------- |
+| `transport_unavailable`    | loopback/lease 不可达         | adapter 或 Host 原通道重试一次；禁止模型换通道 |
+| `runtime_integrity_failed` | OOCLI/Skill lock 不匹配       | fail closed，提示升级或重新安装                |
+| `workspace_unavailable`    | turn 未绑定 team              | 阻止执行；不猜 team、不切账号                  |
+| `authorization_required`   | Connector 未连接或 scope 失效 | 显示 Wanta 授权入口，停止当前外部步骤          |
+| `policy_denied`            | operation 或 action 被禁止    | 不重试、不找非托管替代路径                     |
+| `input_shape_unsupported`  | schema 不接受 URI/file        | 报告真实能力缺口                               |
+| `remote_action_failed`     | provider/action 运行失败      | 按 operation 的幂等性与错误码决定是否重试      |
+| `cancelled`                | 用户取消或任务结束            | 终止真实 OOCLI 子进程并清理 lease              |
 
 Skill 和系统提示应明确：托管 OO 基础设施错误不是“请尝试 curl/base64”的信号。
 
@@ -305,20 +305,20 @@ Skill 和系统提示应明确：托管 OO 基础设施错误不是“请尝试 
 
 每个 Agent 都必须通过同一份参数化测试矩阵：
 
-| 场景 | OpenCode | Claude | Codex | Grok | 预期 |
-|---|---:|---:|---:|---:|---|
-| capability search | 必测 | 必测 | 必测 | 必测 | 同一结果语义 |
-| connector schema | 必测 | 必测 | 必测 | 必测 | 不绑定错误 team |
-| connector read action | 必测 | 必测 | 必测 | 必测 | 同一 workspace、同一输出 |
-| authorization required | 必测 | 必测 | 必测 | 必测 | 同一 CTA、无重复请求 |
-| explicit connectionName | 必测 | 必测 | 必测 | 必测 | 严格校验，不静默换账号 |
-| file upload | 必测 | 必测 | 必测 | 必测 | Agent 可用 URL，UI/历史脱敏 |
-| file download | 必测 | 必测 | 必测 | 必测 | 只写 managed roots |
-| Flow read/run/publish | 必测 | 必测 | 必测 | 必测 | 同一项目且均自动放行 |
-| 多 team 并发 | 必测 | 必测 | 必测 | 必测 | 不串 workspace，也不互相阻塞 |
-| transport 中断 | 必测 | 必测 | 必测 | 必测 | 原通道一次重试，不绕路 |
-| task cancel/delete | 必测 | 必测 | 必测 | 必测 | OOCLI 子进程终止、lease 撤销 |
-| history restore | 必测 | 必测 | 必测 | 必测 | 无签名 URL/凭证泄漏 |
+| 场景                    | OpenCode | Claude | Codex | Grok | 预期                         |
+| ----------------------- | -------: | -----: | ----: | ---: | ---------------------------- |
+| capability search       |     必测 |   必测 |  必测 | 必测 | 同一结果语义                 |
+| connector schema        |     必测 |   必测 |  必测 | 必测 | 不绑定错误 team              |
+| connector read action   |     必测 |   必测 |  必测 | 必测 | 同一 workspace、同一输出     |
+| authorization required  |     必测 |   必测 |  必测 | 必测 | 同一 CTA、无重复请求         |
+| explicit connectionName |     必测 |   必测 |  必测 | 必测 | 严格校验，不静默换账号       |
+| file upload             |     必测 |   必测 |  必测 | 必测 | Agent 可用 URL，UI/历史脱敏  |
+| file download           |     必测 |   必测 |  必测 | 必测 | 只写 managed roots           |
+| Flow read/run/publish   |     必测 |   必测 |  必测 | 必测 | 同一项目且均自动放行         |
+| 多 team 并发            |     必测 |   必测 |  必测 | 必测 | 不串 workspace，也不互相阻塞 |
+| transport 中断          |     必测 |   必测 |  必测 | 必测 | 原通道一次重试，不绕路       |
+| task cancel/delete      |     必测 |   必测 |  必测 | 必测 | OOCLI 子进程终止、lease 撤销 |
+| history restore         |     必测 |   必测 |  必测 | 必测 | 无签名 URL/凭证泄漏          |
 
 测试层级：
 

--- a/docs/ai/oo-first-class-optimization-report.md
+++ b/docs/ai/oo-first-class-optimization-report.md
@@ -1,0 +1,358 @@
+# Wanta OO 一等公民能力优化报告
+
+更新时间：2026-08-31（Asia/Shanghai）
+
+> 2026-08-31 补充决策：已启用的 Wanta 托管 OO 上传、下载、查询和执行操作全部自动放行，不再触发用户批准。本文中把上传、Flow run/publish 描述为需要确认的旧策略已被 [OO 行为一致性与自动放行解决方案](oo-parity-auto-allow-solution.md) 取代；路径、workspace、凭证、命令准入和输出脱敏校验仍然保留。
+
+## 1. 执行原则
+
+本报告以两个不可妥协的产品原则为前提：
+
+1. **OO 是 Wanta 的一等公民能力。** 无论调用来自内置 OpenCode、Claude Code、Codex、Grok、未来新增的 BYOA，还是 Skill、Connector、文件传输、Open Flow，用户都应获得一致、可靠、可解释的 OO 能力，不应感知某个 Agent 的适配差异。
+2. **OpenCode 内置实现是兼容性基线。** 新增或调整 BYOA 路径时，优先复用 OpenCode 已验证的能力语义、权限体验、工作区绑定、错误结构、授权提示和工具展示。只有 Agent 协议确实不支持时才允许改变传输方式；传输差异不得改变业务结果。
+
+这意味着优化目标不是“分别把 OpenCode 和 BYOA 修到能用”，而是把 OO 建设为一套 Wanta Host 拥有的统一产品能力，再为不同 Agent 提供薄传输适配。
+
+## 2. 结论摘要
+
+当前实现已经具备不少正确基础：
+
+- OpenCode 的 Link 工具优先走 Electron 主进程内的 `HostCapabilityKernel`；
+- Wanta 已经拥有 Link workspace、凭证、授权信号、审计、脱敏和工具 UI；
+- 外部 Agent 已有受控 OOCLI、操作白名单、文件根目录检查和 Flow 约束；
+- `oo` Skill、OOCLI 版本和能力契约已有 bundle lock 与完整性校验；
+- 同一条 Link action 已能在不同传输上归一为一致的工具记录。
+
+但当前架构仍把 OO 分成了两套执行体系：
+
+- OpenCode：Host Invoke 为主要路径，进程内 OOCLI guard 为兼容路径；
+- BYOA：共享 loopback guard + 外部 CLI shim 为主要路径。
+
+两套体系分别维护入口、环境变量、scope 解析、进程执行和输出处理，已经导致过一次实际回归：外部 Agent 的 loopback 客户端替换了 OpenCode 的进程内 guard，而 OpenCode 没有外部 guard descriptor，最终报出 `managed OO execution boundary is unavailable`。这类问题不能靠增加更多分支长期解决。
+
+**目标架构应收敛为：一个 Host-owned OO Runtime、一个能力契约、一个精确的每轮 lease、统一的输出双视图和多种薄传输。** OpenCode 与 BYOA 只在“如何到达 Host”上不同，不再拥有不同的 OO 业务实现。
+
+## 3. OpenCode 内置路径提供的基准
+
+OpenCode 当前最值得作为基线复用的不是某个具体函数，而是以下完整行为：
+
+### 3.1 Host 优先，CLI 只做兼容
+
+OpenCode 的 `search_actions`、`list_apps`、`inspect_action`、`call_action` 会先调用 Host Capability；只有 Host transport 不可达时，才回退到受控 OOCLI。Host 路径负责绑定当前 session、team 和 Link runtime，并把结果转换成稳定的工具输出。
+
+目标状态下，所有 Agent 都应遵循同一原则：
+
+- 业务执行始终进入 Wanta Host 的 OO Runtime；
+- CLI 只是 Agent 熟悉的调用外形，不是另一套业务后端；
+- 不允许因为一种 transport 失败就绕到 curl、直连 API、本机另一个 `oo` 或错误的 workspace。
+
+### 3.2 精确 session 身份，而不是推测身份
+
+OpenCode Host Invoke 请求携带明确的 `sessionId`，Host 直接读取该 session 的能力上下文。身份解析不依赖当前目录，也不要求“所有活跃任务碰巧属于同一个团队”。
+
+BYOA 应达到同样水平。当前通过 cwd 与所有活跃 external turn 推导 scope 的方式可以作为过渡保护，但不应成为最终身份模型。
+
+### 3.3 Wanta 拥有凭证和授权体验
+
+OpenCode Host 路径不会让模型决定账号、endpoint 或 provider credential。Host 绑定当前 Link runtime，校验显式 `connectionName`，把授权问题转换成结构化 `authorization_required`，再由 Wanta 显示连接入口。
+
+BYOA 不应获得更弱的体验，也不应因为使用 CLI 就暴露、复制或重新登录 Wanta 的 OO 凭证。
+
+### 3.4 稳定的错误与重试语义
+
+OpenCode 已有以下值得统一的行为：
+
+- inspect-before-call；
+- 同一 connection/action 的短期阻断缓存；
+- 授权失败后不重复轰炸 Connector；
+- 并发 action 限制；
+- 明确区分授权、策略拒绝、workspace 缺失、普通运行错误；
+- 失败时不静默切换账号或 workspace。
+
+这些应成为 OO Runtime 的公共能力，而不是继续留在 OpenCode 生成工具的内嵌 JavaScript 中。
+
+### 3.5 OpenCode 是权限体验下限
+
+同一个已启用的托管 OO 操作，无论是只读、上传、下载、执行还是发布，OpenCode 与 BYOA 都应自动放行，不增加重复确认。Agent 自身的 sandbox 可以额外拒绝，但不应制造第二套相互矛盾的 Wanta 权限体验；未开放或非法调用由托管边界直接拒绝。
+
+## 4. 当前主要问题
+
+### P0：两套 guard 具有结构性漂移风险
+
+现状中，OpenCode guard 与 external guard 的启动协议不同：
+
+- OpenCode guard 依赖 `WANTA_REAL_OO_BIN` 和 team scope 文件；
+- external guard 依赖 `WANTA_OO_GUARD_URL` 和 `WANTA_OO_GUARD_TOKEN`；
+- 两者都以 `oo` shim 的形式出现在 Agent PATH 中；
+- 两者的文件命名和调用位置曾发生混用。
+
+已完成的拆分修复可以立即消除当前故障，但它属于止血措施，不是最终架构。继续长期维护两套业务 guard，会在命令准入、文件规则、脱敏、取消、超时和 OOCLI 升级时再次产生差异。
+
+### P0：BYOA 的 workspace 身份仍可能依赖全局一致性
+
+外部 Agent 的 CLI 调用没有天然携带 Wanta session id。当前 Host 会根据 cwd 匹配任务根目录；无法唯一匹配时，要求所有活跃 external turn 的 runtime/team 一致。这能避免错账号，但会把合法的并发多团队任务变成不可用状态。
+
+OO 作为一等公民能力，必须同时满足：
+
+- 绝不串 workspace；
+- 多 workspace 并发仍可用；
+- 不依赖模型手写 `--team`；
+- 不用 cwd 猜测身份作为主路径。
+
+### P0：输出没有完整建模“实时值”和“可持久化值”
+
+`oo file upload` 返回的临时签名 `downloadUrl` 是下一步远端 action 必须使用的实时能力值，但不应该显示到 UI、日志或长期 transcript。当前部分外部 guard 已特殊保留实时 URL，同时对其他敏感字段脱敏；但该语义还没有成为统一的 Host 输出契约。
+
+如果只做统一脱敏，Agent 拿不到下一步所需 URL；如果完全不脱敏，敏感签名 URL 会进入历史。正确做法不是在不同路径上打例外，而是明确输出双视图。
+
+### P0：基础设施错误会诱发模型绕路
+
+当托管 OO 边界不可用时，模型可能尝试：
+
+- 改走另一个 Link transport；
+- 用 curl 直传；
+- 猜测预签名 URL；
+- 把文件转换成 base64；
+- 调用未验证的替代 action。
+
+这会把一个应在秒级暴露的基础设施故障扩大成十几分钟的试错。OO transport 错误应被标记为终止型基础设施错误，由 Host 或 adapter 做一次受控重试；模型不应把它理解为“换一种上传技巧即可解决”。
+
+### P1：公共行为仍散落在 OpenCode 内嵌工具和 external guard
+
+以下能力目前存在重复或分散：
+
+- action schema 查询与执行；
+- workspace 绑定；
+- connectionName 校验；
+- 授权错误解析；
+- 并发限制与短期阻断；
+- OO command operation 识别；
+- 输出脱敏；
+- timeout、取消和进程回收；
+- UI 工具名称归一化。
+
+只要这些逻辑没有下沉到统一 Host Runtime，就无法证明所有 Agent 的 OO 行为持续一致。
+
+## 5. 目标架构
+
+### 5.1 单一 Host-owned OO Runtime
+
+在 Electron 主进程建立 `OoCapabilityRuntime`，作为所有 OO 命令的唯一业务执行者。它负责：
+
+- OOCLI 版本与 Skill bundle 完整性检查；
+- operation contract 解析；
+- runtime、team、project、artifact/process roots 绑定；
+- Connector account 与 `connectionName` 校验；
+- 托管 OO 自动放行与非法操作直接拒绝的权限判定；
+- 真实 OOCLI 进程启动、取消和输出限制；
+- 实时输出、展示输出和持久化输出的生成；
+- 结构化错误、授权信号和审计事件；
+- UI 所需的标准 operation metadata。
+
+真实 OO 二进制路径、OOMOL session token、OpenConnector token、endpoint 和 store 目录只存在于 Host Runtime，不再由任何 Agent 直接持有。
+
+### 5.2 单一 OO 能力契约
+
+把当前 `EXTERNAL_OO_OPERATIONS` 升级为 Agent-independent `OO_OPERATIONS`。每项至少声明：
+
+| 字段 | 含义 |
+|---|---|
+| `id` | 稳定 operation id，例如 `file.upload` |
+| `command` | OOCLI 命令前缀 |
+| `availability` | enabled / planned / denied |
+| `effect` | read / local-read / local-write / external-action / local-state |
+| `workspace` | none / optional / required |
+| `inputPolicy` | 路径、URL、stdin、`@file` 和大小限制 |
+| `timeoutPolicy` | discovery、action、异步查询、Flow 的不同 deadline |
+| `outputPolicy` | 哪些字段可实时返回、可展示、可持久化 |
+| `permissionPolicy` | 已启用托管 OO 自动放行；非法或未开放操作直接拒绝 |
+| `uiMetadata` | 工具名称、详情、安全展示信息 |
+
+OpenCode、BYOA guard、Skill guidance、权限分类器、工具展示、bundle lock 和测试全部从该契约派生，禁止维护平行清单。
+
+### 5.3 每轮 opaque OO lease
+
+每个 Wanta turn 由 Host 发行一个短生命周期、不可推导业务凭证的 `OoCapabilityLease`：
+
+- 绑定 session id、turn id、Link runtime、team、project 和 managed roots；
+- 任务结束、取消、账号切换、team 切换或应用退出时立即撤销；
+- lease 不能修改自己的 workspace；
+- lease token 只允许连接本机 loopback Host，不是 OOMOL credential；
+- 每个 Agent 的 `oo` shim 自动携带该 lease；模型无需、也不能指定它。
+
+这样可以同时支持多个 Agent、多个团队、多个项目并发，不再依赖 cwd 或“所有 external turn 一致”。cwd 只用于解析相对文件，不再用于决定身份。
+
+### 5.4 多传输、同执行
+
+目标数据流如下：
+
+```text
+OpenCode native tool ── host invoke ──┐
+OpenCode Skill/raw oo ─ local shim ───┤
+Claude/Codex/Grok ─ managed oo shim ──┼─> OoCapabilityRuntime ─> bundled OOCLI
+未来 Agent/MCP transport ─────────────┘
+```
+
+所有 transport 只完成：
+
+- 认证本地调用方；
+- 关联当前 lease；
+- 传递 argv、cwd、取消信号；
+- 返回 Runtime 已产生的标准结果。
+
+transport 不再自行绑定 team、解析业务错误、决定脱敏字段或维护 operation 白名单。
+
+### 5.5 输出双视图
+
+统一结果模型至少包含：
+
+```ts
+interface OoExecutionResult {
+  exitCode: number
+  liveOutput: string
+  displayOutput: string
+  persistedOutput: string
+  operation: OoOperationMetadata
+  authorization?: AuthorizationSignal
+  error?: OoStructuredError
+}
+```
+
+- `liveOutput`：只返回给当前运行中的 Agent，用于后续步骤；可包含短期签名 URL。
+- `displayOutput`：进入 Wanta 工具卡片；敏感字段脱敏，只显示文件名、大小、过期时间等安全信息。
+- `persistedOutput`：进入 transcript、diagnostics 和恢复历史；默认与 display 一样或更严格。
+
+任何 transport 都不得自行决定是否保留 `downloadUrl`。
+
+### 5.6 结构化错误与固定恢复策略
+
+统一错误类型：
+
+| 类别 | 示例 | 恢复策略 |
+|---|---|---|
+| `transport_unavailable` | loopback/lease 不可达 | adapter 或 Host 原通道重试一次；禁止模型换通道 |
+| `runtime_integrity_failed` | OOCLI/Skill lock 不匹配 | fail closed，提示升级或重新安装 |
+| `workspace_unavailable` | turn 未绑定 team | 阻止执行；不猜 team、不切账号 |
+| `authorization_required` | Connector 未连接或 scope 失效 | 显示 Wanta 授权入口，停止当前外部步骤 |
+| `policy_denied` | operation 或 action 被禁止 | 不重试、不找非托管替代路径 |
+| `input_shape_unsupported` | schema 不接受 URI/file | 报告真实能力缺口 |
+| `remote_action_failed` | provider/action 运行失败 | 按 operation 的幂等性与错误码决定是否重试 |
+| `cancelled` | 用户取消或任务结束 | 终止真实 OOCLI 子进程并清理 lease |
+
+Skill 和系统提示应明确：托管 OO 基础设施错误不是“请尝试 curl/base64”的信号。
+
+## 6. 图片编辑专项优化
+
+图片编辑应有一条稳定、可测量的标准路径：
+
+1. 加载图片 Skill；
+2. 一次 inspect 同时获取 async submit/result 两个 action contract；
+3. `oo file upload` 上传本地图片；
+4. Agent 从 `liveOutput` 获得临时 `downloadUrl`；UI 和 transcript 只看到安全摘要；
+5. 调用 async submit；
+6. 根据 action 建议的间隔轮询 result，避免固定盲等；
+7. 将明确的结果 artifact URL 交给受控 `oo file download`；
+8. 在 Wanta artifact root 发布最终图片。
+
+以下行为应禁止作为基础设施故障的自动替代方案：
+
+- curl/wget/自写 HTTP 上传；
+- 从脱敏文本猜测签名 URL；
+- 将私有上传端点当成公开下载地址；
+- 为绕过 guard 临时转 JPEG 或 base64；
+- 未 inspect 就改调另一个 action；
+- 在一个 transport 失败后静默切换本机原生 `oo`。
+
+只有 action schema 明确接受 base64，并且这是能力本身的正常输入方式时，才允许使用 base64；它不应成为 Wanta transport 失败的恢复策略。
+
+## 7. 实施计划
+
+### P0：立即可靠性，1 个小版本
+
+1. 保留当前 OpenCode/external guard 拆分止血修复，确保已发布版本不再触发边界缺失。
+2. 增加启动自检：
+   - OpenCode shim 必须能完成一个无外部副作用的 OO capability probe；
+   - external shim 必须能用临时 lease 完成同一 probe；
+   - probe 失败时不允许开始需要 OO 的 turn，并输出结构化错误。
+3. 在模型可见错误中加入稳定 error code，阻止自由文本被理解为可绕过的安全限制。
+4. 为图片编辑增加端到端回归：本地图片 → upload → submit → result → download，全程使用 fake OOCLI，断言没有 curl/base64 fallback。
+5. 记录分阶段耗时：skill、schema、upload、submit、poll、download、publish。
+
+### P1：统一 Runtime，1–2 个版本
+
+1. 将 external guard server 的执行逻辑抽取为 `OoCapabilityRuntime`。
+2. 将 `EXTERNAL_OO_OPERATIONS` 重命名并升级为共享契约。
+3. OpenCode Host Invoke 和两个 CLI shim 全部调用同一个 Runtime。
+4. 将 connection/action 并发协调、授权阻断缓存和错误归一从 OpenCode 内嵌工具下沉到 Runtime。
+5. 引入 `live/display/persisted` 输出三态，移除 transport 层的特殊脱敏分支。
+6. 真实 OO credential 只保留在 Electron main；OpenCode sidecar 也改用 opaque Host lease。
+
+### P2：精确 turn lease 与并发，1 个版本
+
+1. 每轮发行独立 OO lease，替换 external “所有活跃 turn 必须同 team”的主路径。
+2. 支持同一 Wanta 实例中多个 Agent、多个 team 和多个 project 并发。
+3. cwd 只处理相对路径；身份完全由 lease 决定。
+4. 对账号切换、team 切换、取消、删除任务和应用退出做 lease 撤销测试。
+
+### P3：一等公民体验与可观测性
+
+1. 所有 OO operation 使用统一工具 UI，不暴露 ACP、MCP、shim、loopback 等基础设施名称。
+2. 授权、上传、下载、Flow run/publish 使用同一权限词汇和 CTA。
+3. 增加 OO 健康面板或诊断摘要：版本、contract 版本、Skill lock、runtime 状态，不显示凭证和私人路径。
+4. 建立发布前真实 smoke：OpenCode、Claude Code、Codex、Grok 执行同一套 OO 用例。
+
+## 8. 验证矩阵
+
+每个 Agent 都必须通过同一份参数化测试矩阵：
+
+| 场景 | OpenCode | Claude | Codex | Grok | 预期 |
+|---|---:|---:|---:|---:|---|
+| capability search | 必测 | 必测 | 必测 | 必测 | 同一结果语义 |
+| connector schema | 必测 | 必测 | 必测 | 必测 | 不绑定错误 team |
+| connector read action | 必测 | 必测 | 必测 | 必测 | 同一 workspace、同一输出 |
+| authorization required | 必测 | 必测 | 必测 | 必测 | 同一 CTA、无重复请求 |
+| explicit connectionName | 必测 | 必测 | 必测 | 必测 | 严格校验，不静默换账号 |
+| file upload | 必测 | 必测 | 必测 | 必测 | Agent 可用 URL，UI/历史脱敏 |
+| file download | 必测 | 必测 | 必测 | 必测 | 只写 managed roots |
+| Flow read/run/publish | 必测 | 必测 | 必测 | 必测 | 同一项目且均自动放行 |
+| 多 team 并发 | 必测 | 必测 | 必测 | 必测 | 不串 workspace，也不互相阻塞 |
+| transport 中断 | 必测 | 必测 | 必测 | 必测 | 原通道一次重试，不绕路 |
+| task cancel/delete | 必测 | 必测 | 必测 | 必测 | OOCLI 子进程终止、lease 撤销 |
+| history restore | 必测 | 必测 | 必测 | 必测 | 无签名 URL/凭证泄漏 |
+
+测试层级：
+
+1. 契约单元测试：所有 operation、effect、workspace、输出策略；
+2. Runtime 测试：fake OOCLI，覆盖 argv、env、cwd、取消、超时、脱敏；
+3. transport parity：同一 fixture 经 OpenCode host invoke 与各 BYOA shim 执行，比较标准结果；
+4. Wanta UI 测试：工具名称、授权提示、过程/最终结果归组；
+5. 真实环境 smoke：使用已登录 Wanta workspace 执行非破坏性 action、文件传输和图片编辑。
+
+## 9. 成功指标
+
+上线后至少持续监控：
+
+- `managed_oo_boundary_unavailable`：目标为 0；
+- OO transport 故障后 curl/base64/本机 `oo` fallback：目标为 0；
+- workspace 错绑或静默切换：目标为 0；
+- 已启用 OO 操作在任一 Agent 上出现批准卡：目标为 0；
+- `file.upload` 的 live URL 可用率：目标接近 100%；
+- 签名 URL 或凭证进入 UI、diagnostics、transcript：目标为 0；
+- 128–1024 px 单图编辑端到端 P50：目标小于 90 秒；
+- 同类单图编辑端到端 P95：目标小于 180 秒；
+- 图片模型实际生成以外的前置工具耗时 P95：目标小于 20 秒；
+- OO 基础设施错误被首次识别的时间：目标小于 2 秒。
+
+## 10. 决策建议
+
+建议立即确认以下架构决策：
+
+1. `OoCapabilityRuntime` 是 Wanta 中所有 OO 执行的唯一业务边界；
+2. OpenCode 当前 Host Invoke 行为是其他 Agent 的兼容性基线；
+3. CLI 是 transport，不是第二套 OO backend；
+4. 所有 Agent 使用精确 turn lease，不用 cwd 或全局 team 一致性推导身份；
+5. OO 输出原生支持 live/display/persisted 多视图；
+6. OO transport 错误禁止触发非托管绕路；
+7. 每次 OOCLI 或 Skill bundle 升级必须跑跨 Agent parity suite 和真实图片编辑 smoke。
+
+当前拆分 OpenCode 与 external guard 的修复应尽快发布用于止血；随后按 P1 收敛到统一 Runtime。这样既不会为了长期重构延迟当前故障修复，也不会把两套 guard 固化成未来架构。

--- a/docs/ai/oo-optimization-completion-report.md
+++ b/docs/ai/oo-optimization-completion-report.md
@@ -1,0 +1,228 @@
+# Wanta OO 优化完成审计报告
+
+更新时间：2026-08-31（Asia/Shanghai）
+
+## 1. 审计结论
+
+前序分析中属于当前问题、能产生直接产品收益且不构成过度设计的改动，已经全部完成：
+
+- 修复内置 OpenCode 错用 BYOA guard 的故障；
+- 内置 OpenCode 与 BYOA 对合法托管 OO 操作统一自动放行；
+- `oo file upload/download`、Connector execution、Flow run/publish 不再弹批准；
+- 覆盖事故中真实出现的 `BUN_BE_BUN=1 oo ...` 命令形态；
+- 保留身份、workspace、operation、路径、URL、凭证和混合 shell 的直接拒绝；
+- 明确禁止 OO 基础设施失败后绕到 curl、wget、本机原生 `oo`、直连 API 或非 schema 要求的 base64；
+- 增加内置图片编辑 `upload → submit → result → download` 回归；
+- 保证签名上传 URL 在当前 turn 内可供 Agent 使用，完成后从 OpenCode 持久化历史中脱敏；
+- 增加 OpenCode、Claude 风格和 ACP/BYOA 风格的权限一致性测试；
+- 同步 Skill policy、架构文档和交接文档；
+- 完成全量测试、类型、lint、OO bundle 和生产构建验证。
+
+没有实施完整 `OoCapabilityRuntime`、新 turn lease 或强制所有 Agent 使用同一种协议。这些属于没有当前故障证据支持的长期抽象，暂缓可以避免过度设计。
+
+## 2. 完成项明细
+
+### 2.1 内置 OpenCode guard 修复：完成
+
+事故路径原为：
+
+```text
+内置 OpenCode
+→ Skill 中调用 oo
+→ 错误进入 BYOA loopback guard 客户端
+→ 缺少 WANTA_OO_GUARD_URL/TOKEN
+→ managed OO execution boundary is unavailable
+```
+
+现在分为两个明确入口：
+
+```text
+wanta-opencode-oo-guard.js → 内置 OpenCode
+wanta-oo-guard.js          → BYOA
+```
+
+内置 guard 使用 `WANTA_REAL_OO_BIN` 和当前 OpenCode team scope；BYOA guard 继续使用 Electron main 的 authenticated loopback boundary。两个入口不再共享不兼容的环境协议。
+
+### 2.2 OO 自动放行：完成
+
+共享 Wanta local-access policy 已移除 `managedOoCommandRequiresConfirmation`。以下已启用托管 OO 操作在默认权限模式中统一返回：
+
+```ts
+{
+  type: "allow",
+  reason: "oo_cli",
+  kind: "command",
+  highRisk: false,
+}
+```
+
+自动放行包括：
+
+- capability search；
+- Connector search/schema/apps/run；
+- file upload/download；
+- 已启用的 Flow read/edit/apply；
+- Flow run/publish；
+- 通过 Connector action 运行的异步 AI submit/result/poll。
+
+同一策略用于内置 OpenCode、Claude 风格 native permission 和 ACP/BYOA raw permission，不为外部 Agent增加第二次批准。
+
+### 2.3 真实 Bun 启动前缀：完成
+
+事故截图中的实际调用包含：
+
+```bash
+BUN_BE_BUN=1 oo file upload ...
+```
+
+严格分类器现在只额外接受固定的 `BUN_BE_BUN=1` marker。以下仍不被托管 OO 自动放行：
+
+```bash
+PATH=/tmp oo ...
+BUN_BE_BUN=0 oo ...
+OO_ENDPOINT=... oo ...
+OO_API_KEY=... oo ...
+```
+
+并已验证安全 marker 不能绕过 `oo auth`、`oo config`、`oo connector logout` 等 hard deny。
+
+### 2.4 自动放行与安全校验分层：完成
+
+产品语义现在是：
+
+> 合法托管 OO 直接执行；非法或未开放 OO 直接拒绝；都不弹用户批准。
+
+仍然拒绝：
+
+- auth/login/logout/config；
+- endpoint、connector token、connector URL、config/data directory override；
+- capability contract 为 denied/planned 的 operation；
+- BYOA 上传 managed roots 之外的文件；
+- 非普通文件或超限文件；
+- localhost、私网、链路本地、特殊用途或含 credential 的下载 URL；
+- managed roots 之外的下载目录；
+- 缺失明确 project 的 Project-scoped Flow；
+- 未开放的 project switch、delete、rollback、cancel、open/workbench；
+- 借 OO 拼接任意 shell、命令替换、环境篡改或高风险资源读取；
+- 无法唯一解析的 runtime/workspace。
+
+这些失败不能通过用户点击“批准”改变，因此由 guard 直接返回错误。
+
+### 2.5 图片编辑完整回归：完成
+
+新增内置 OpenCode fake OOCLI 集成回归，完整执行：
+
+```text
+oo file upload
+→ 获得实时签名 downloadUrl
+→ oo connector run ... submit
+→ oo connector run ... result
+→ oo file download
+```
+
+回归断言：
+
+- upload 返回的签名 URL 对当前 Agent 可用；
+- submit/result 均绑定当前 team；
+- 结果进入 managed OO download；
+- 整条 trace 不包含 curl、wget 或 base64 fallback。
+
+### 2.6 签名 URL 实时可用与持久化脱敏：完成
+
+外部 BYOA guard 已有以下行为：
+
+- `file.upload` 实时结果向当前 Agent 保留 `downloadUrl`；
+- UI/transcript 翻译层仍脱敏；
+- Connector credential-shaped 字段继续脱敏。
+
+本次补齐内置 OpenCode：
+
+- 当前 turn 中的 raw upload output 先供模型完成后续 submit；
+- `session.idle` 后扫描本 session 的 Connector 和 `oo file upload` tool parts；
+- 使用 OpenCode `part.update` 将签名 URL 和 credential-shaped 字段替换为脱敏值；
+- 启动时增加 v2 历史 sweep，处理旧 session 中遗留的 signed upload URL；
+- UI 和历史读取本身继续通过 translator 脱敏。
+
+这避免了“提前脱敏导致任务无法继续”和“长期保存签名 URL”两个相反问题。
+
+### 2.7 Skill 与失败恢复策略：完成
+
+Wanta 当前轮 Skill execution policy 现在明确：
+
+- enabled managed OO operation 不需要额外用户确认；
+- 用户请求本身提供业务授权范围；
+- managed OO policy 或 infrastructure failure 是当前路径的终止错误；
+- 不允许绕到 curl、wget、本机原生 OO、直连 provider API；
+- 不允许把 base64 当成 transport 故障恢复，除非 inspected action schema 本身要求 base64。
+
+### 2.8 文档一致性：完成
+
+已更新：
+
+- `docs/ai/oo-parity-auto-allow-solution.md`；
+- `docs/ai/oo-first-class-optimization-report.md`；
+- `docs/ai/agent-adapter.md`；
+- `docs/ai/host-capabilities.md`；
+- `docs/ai/byoa-follow-up-handoff.md`。
+
+旧的“file upload、Flow run/publish 进入 consequential confirmation”已改为自动放行。
+
+## 3. 验证结果
+
+最终验证结果：
+
+- 定向 OpenCode/BYOA/OO/图片链路测试：通过；
+- TypeScript：通过；
+- oxlint：通过；
+- 全量 test files：368 passed，2 skipped；
+- 全量 tests：2948 passed，4 skipped；
+- OO bundle lock：通过；
+- OOCLI：`1.7.12/universal`；
+- 生产构建：通过；
+- `dist-electron/wanta-opencode-oo-guard.js`：已生成；
+- `dist-electron/wanta-oo-guard.js`：已生成；
+- `git diff --check`：通过。
+
+OO bundle 确认以下为 enabled：
+
+- `connector.run`；
+- `file.upload`；
+- `file.download`；
+- `flow.apply`；
+- `flow.run`；
+- `flow.publish`。
+
+以下继续保持 denied/planned，不会变成审批：
+
+- `auth`: denied；
+- `skills.manage`: denied；
+- `skills.recommend`: denied；
+- `connector.proxy`: planned；
+- `llm`: planned；
+- `team.current`: planned；
+- `variables`: planned。
+
+## 4. 未实施但不属于当前有效缺口
+
+以下内容来自长期架构讨论，但当前没有必要实施：
+
+- 完整统一的 `OoCapabilityRuntime`；
+- 新的 per-turn lease 系统；
+- 强制 OpenCode 与 BYOA 使用相同 wire protocol；
+- 为所有 OO operation 新建 orchestration framework；
+- 重写已经稳定的 OpenCode Host Invoke Link 工具。
+
+只有再次出现 operation contract 漂移、第三种 OO transport、多 team 并发身份冲突或新的输出语义不一致时，才应逐步抽取这些能力。
+
+## 5. 仍需发布前执行的操作性验收
+
+代码与自动化改动已经完成。发布前仍建议执行两次真实 smoke，它们是运行环境验收，不是缺失实现：
+
+1. 内置 Agent 使用真实图片执行一次编辑，确认无批准卡、无 boundary unavailable、无 curl/base64 绕路；
+2. 选择一个 BYOA 执行同样流程，确认权限与结果一致。
+
+真实图片模型调用会产生外部请求、时间和可能的费用，因此未在本次自动化验证中擅自执行。
+
+## 6. 最终状态
+
+前序分析中当前应实施的有效改动已经完成，没有需要继续补的代码项。当前工作树尚未提交；开发版仍可用于真实 smoke 验收。

--- a/docs/ai/oo-parity-auto-allow-solution.md
+++ b/docs/ai/oo-parity-auto-allow-solution.md
@@ -55,18 +55,18 @@
 
 自动放行包括但不限于：
 
-| 域 | 操作示例 | 权限结果 |
-|---|---|---|
-| Capability | `oo search` | 自动放行 |
-| Connector discovery | `oo connector search/schema/apps` | 自动放行 |
-| Connector execution | `oo connector run` | 自动放行 |
-| File | `oo file upload` | 自动放行 |
-| File | `oo file download` | 自动放行 |
-| Flow read | list/show/inspect/check | 自动放行 |
-| Flow edit | create/apply/rename/node/code/connector/trigger 等已启用命令 | 自动放行 |
-| Flow execute | `oo flow run` | 自动放行 |
-| Flow publish | `oo flow publish` | 自动放行 |
-| Async AI | submit/result/poll action | 自动放行 |
+| 域                  | 操作示例                                                     | 权限结果 |
+| ------------------- | ------------------------------------------------------------ | -------- |
+| Capability          | `oo search`                                                  | 自动放行 |
+| Connector discovery | `oo connector search/schema/apps`                            | 自动放行 |
+| Connector execution | `oo connector run`                                           | 自动放行 |
+| File                | `oo file upload`                                             | 自动放行 |
+| File                | `oo file download`                                           | 自动放行 |
+| Flow read           | list/show/inspect/check                                      | 自动放行 |
+| Flow edit           | create/apply/rename/node/code/connector/trigger 等已启用命令 | 自动放行 |
+| Flow execute        | `oo flow run`                                                | 自动放行 |
+| Flow publish        | `oo flow publish`                                            | 自动放行 |
+| Async AI            | submit/result/poll action                                    | 自动放行 |
 
 用户表达任务本身就是授权，例如“编辑这张图片”“发布这个 Flow”“把结果上传并执行”。Wanta 不应再就底层 OO 上传或执行重复询问。
 
@@ -303,21 +303,21 @@ managed file upload and consequential Flow boundaries prompt in default mode
 
 ## 8. 验收矩阵
 
-| 场景 | 内置 OpenCode | BYOA | 预期 |
-|---|---:|---:|---|
-| `oo search` | 必测 | 必测 | 自动放行 |
-| connector schema/apps/run | 必测 | 必测 | 自动放行、同一 workspace |
-| file upload | 必测 | 必测 | 自动放行，无批准卡 |
-| file download | 必测 | 必测 | 自动放行，只写 managed roots |
-| Flow edit/run/publish | 必测 | 必测 | 自动放行，无批准卡 |
-| auth/config/runtime override | 必测 | 必测 | 直接拒绝，不弹批准 |
-| unmanaged upload path | 必测 | 必测 | 直接拒绝 |
-| private-network download | 必测 | 必测 | 直接拒绝 |
-| mixed dangerous shell | 必测 | 必测 | 不按 OO 白名单放行 |
-| authorization required | 必测 | 必测 | 同一授权 CTA，不是 shell 批准 |
-| 图片编辑完整链路 | 必测 | 必测 | 无绕路，1–2 分钟目标 |
-| task cancel | 必测 | 必测 | OO 子进程终止 |
-| history restore | 必测 | 必测 | 不含签名 URL/credential |
+| 场景                         | 内置 OpenCode | BYOA | 预期                          |
+| ---------------------------- | ------------: | ---: | ----------------------------- |
+| `oo search`                  |          必测 | 必测 | 自动放行                      |
+| connector schema/apps/run    |          必测 | 必测 | 自动放行、同一 workspace      |
+| file upload                  |          必测 | 必测 | 自动放行，无批准卡            |
+| file download                |          必测 | 必测 | 自动放行，只写 managed roots  |
+| Flow edit/run/publish        |          必测 | 必测 | 自动放行，无批准卡            |
+| auth/config/runtime override |          必测 | 必测 | 直接拒绝，不弹批准            |
+| unmanaged upload path        |          必测 | 必测 | 直接拒绝                      |
+| private-network download     |          必测 | 必测 | 直接拒绝                      |
+| mixed dangerous shell        |          必测 | 必测 | 不按 OO 白名单放行            |
+| authorization required       |          必测 | 必测 | 同一授权 CTA，不是 shell 批准 |
+| 图片编辑完整链路             |          必测 | 必测 | 无绕路，1–2 分钟目标          |
+| task cancel                  |          必测 | 必测 | OO 子进程终止                 |
+| history restore              |          必测 | 必测 | 不含签名 URL/credential       |
 
 ## 9. 完成标准
 

--- a/docs/ai/oo-parity-auto-allow-solution.md
+++ b/docs/ai/oo-parity-auto-allow-solution.md
@@ -1,0 +1,343 @@
+# Wanta OO 行为一致性与自动放行解决方案
+
+更新时间：2026-08-31（Asia/Shanghai）
+
+## 1. 已确认的产品决策
+
+本方案以以下产品决策为最终依据：
+
+1. **内置 OpenCode 与 BYOA 的 OO 行为尽量一致。** Agent 协议可以不同，但同一个 OO 操作的可用性、workspace、账号、输入输出、错误、工具展示和权限结果必须一致。
+2. **OO 是 Wanta 的一等公民和可信工作通道。** 凡是进入 Wanta 托管 OO 边界、且在当前能力契约中已启用的上传、下载、查询、Connector action、异步任务和 Flow 操作，全部自动放行，不再要求用户批准。
+3. **自动放行不等于取消边界校验。** Wanta 仍然负责防止串 workspace、伪造 credential、路径逃逸、写入非托管目录、访问本地/私网下载目标、运行未开放的管理命令以及把敏感输出写入 UI 或历史。这些情况直接返回结构化错误，不弹“是否批准”。
+4. **OpenCode 内置行为是兼容性基线。** BYOA 不得因为 ACP/native shell 的额外 permission request 给用户增加第二次批准，也不能因 transport 差异降低 OO 的可用性。
+
+一句话定义：
+
+> **合法的托管 OO 操作直接执行；不合法或未开放的 OO 操作直接拒绝；两种情况都不让用户处理基础设施审批。**
+
+## 2. 本次问题的准确归因
+
+15 分钟图片编辑发生在内置 Agent，而不是 BYOA：
+
+```text
+内置 Agent / OpenCode
+→ 加载图片编辑 Skill
+→ bash 调用 oo
+→ 错误命中 BYOA loopback guard 客户端
+→ 内置 Agent 没有 WANTA_OO_GUARD_URL/TOKEN
+→ managed OO execution boundary is unavailable
+→ 模型尝试 Link、curl、预签名上传、base64 等绕路
+→ 图片生成本身约 1 分钟，总流程约 15 分钟
+```
+
+根因是 BYOA 改造复用了内置 OpenCode 原有的 guard 入口，但两种入口需要完全不同的启动上下文。当前工作区已经用独立的 `wanta-opencode-oo-guard` 恢复内置路径，BYOA 保留 `wanta-oo-guard`。这是应立即发布的修复。
+
+同时，当前权限代码确实把以下操作标成 high-risk 并弹批准：
+
+- `oo file upload`；
+- `oo flow run`；
+- `oo flow publish`；
+- 部分其他 Flow consequential operation。
+
+这与最新产品决策冲突，必须修改。
+
+## 3. “OO 一律放行”的精确定义
+
+### 3.1 自动放行范围
+
+以下条件同时满足时，Wanta 必须直接执行，不显示批准卡：
+
+1. 命令使用 Wanta 注入的 `oo` 或 `WANTA_OO_BIN`；
+2. 命令能被严格识别为一个纯 OO 调用，或只带已认可的安全输出后缀；
+3. operation 在共享 OO capability contract 中为 `enabled`；
+4. 调用通过当前 Wanta session/turn 的托管 runtime；
+5. 参数通过 operation 对应的 workspace、路径、URL、文件和 project 校验。
+
+自动放行包括但不限于：
+
+| 域 | 操作示例 | 权限结果 |
+|---|---|---|
+| Capability | `oo search` | 自动放行 |
+| Connector discovery | `oo connector search/schema/apps` | 自动放行 |
+| Connector execution | `oo connector run` | 自动放行 |
+| File | `oo file upload` | 自动放行 |
+| File | `oo file download` | 自动放行 |
+| Flow read | list/show/inspect/check | 自动放行 |
+| Flow edit | create/apply/rename/node/code/connector/trigger 等已启用命令 | 自动放行 |
+| Flow execute | `oo flow run` | 自动放行 |
+| Flow publish | `oo flow publish` | 自动放行 |
+| Async AI | submit/result/poll action | 自动放行 |
+
+用户表达任务本身就是授权，例如“编辑这张图片”“发布这个 Flow”“把结果上传并执行”。Wanta 不应再就底层 OO 上传或执行重复询问。
+
+### 3.2 仍然直接拒绝的情况
+
+以下不是“需要用户批准”，而是托管 OO 边界不接受：
+
+- `oo auth/login/logout/config` 等可能改变 Wanta 托管身份或 runtime 的命令；
+- 覆盖 `--endpoint`、`--connector-token`、`--connector-url`、`--config-dir`、`--data-dir`；
+- 当前 capability contract 为 `denied` 或尚未实现的 operation；
+- 上传文件不在当前 turn 的 managed roots；
+- 上传对象不是普通文件或超过限制；
+- 下载目标是 localhost、私网、链路本地、特殊用途地址或含 URL credential；
+- 下载目录位于 managed roots 之外；
+- Flow 缺少明确 project，或包含未开放的 project switch、delete、rollback、cancel、open/workbench；
+- shell 在 OO 调用旁拼接额外高风险命令、命令替换、任意重定向或环境覆盖；
+- workspace、runtime 或 turn 身份无法唯一确定。
+
+这些行为返回稳定的 `policy_denied`、`workspace_unavailable`、`invalid_input` 或 `unsupported_operation`，不弹批准，因为用户无法通过“批准”把一个不安全或不受支持的调用变成合法调用。
+
+### 3.3 纯 OO 与混合 shell 的边界
+
+“OO 一律放行”只覆盖托管 OO 本身，不把与 OO 拼接的任意 shell 一并白名单化。
+
+自动放行：
+
+```bash
+oo file upload "/managed/input.png" --json
+oo flow publish demo --project project-a --json
+oo connector run fusion-api --action submit --data @payload.json --json
+oo connector schema fusion-api.submit 2>&1 | head -100
+```
+
+不按 OO 自动放行：
+
+```bash
+oo search image && rm -rf /somewhere
+oo connector run service --data "$(cat ~/.ssh/id_rsa)"
+PATH=/tmp oo file upload input.png
+sudo oo flow publish demo
+```
+
+后者进入普通 shell policy 或直接拒绝，避免 `oo` 关键字成为任意命令的通行证。
+
+## 4. 立即解决方案
+
+### 4.1 修复内置 OpenCode guard 装配
+
+保留当前已经完成的止血修改：
+
+- `wanta-opencode-oo-guard.js`：内置 OpenCode 兼容路径；
+- `wanta-oo-guard.js`：BYOA loopback 路径；
+- 两个文件不再共享不兼容的环境变量契约；
+- 构建必须同时产出两个 entry；
+- 启动和回归测试分别验证两条路径。
+
+这一步修复当前线上事故，不等待后续优化。
+
+### 4.2 移除 OO 上传和执行的批准
+
+权限修复集中在共享 Wanta local-access policy，不为每个 Agent 单独加例外。
+
+具体修改：
+
+1. 从 `isHighRiskPermissionRequest` 中移除 `managedOoCommandRequiresConfirmation`；
+2. 删除或废弃 `managedOoCommandRequiresConfirmation`，避免未来重新把上传、Flow run/publish标成 prompt；
+3. 继续先执行 `openConnectorCommandPolicy` 的 hard deny，拦截 auth/config/credential override；
+4. 对严格识别的托管 OO 调用，统一返回：
+
+   ```ts
+   { type: "allow", reason: "oo_cli", kind: "command", highRisk: false }
+   ```
+
+5. OpenCode 的 bash permission 保留 `oo` 快速 allow；
+6. BYOA native permission request 进入同一个 Wanta policy 后自动回答 allow；
+7. external guard 不再产生第二层 consequential confirmation；
+8. 上传、下载和 Flow 的安全校验继续在 guard 内执行。
+
+重要顺序：
+
+```text
+识别托管 OO
+→ 检查 forbidden mutation/runtime override
+→ 检查是否为纯 OO invocation
+→ Wanta permission 自动 allow
+→ guard 检查 operation/workspace/path/url/project
+→ 执行或结构化拒绝
+```
+
+### 4.3 更新 Skill 和系统提示
+
+当前 external OO policy 中仍写着：
+
+- file upload 需要 host confirmation；
+- Flow run/publish 需要 host confirmation。
+
+需要改为：
+
+- 所有 enabled managed OO operation 自动放行；
+- Agent 不得预先询问用户批准底层 upload/download/run/publish；
+- 用户的任务指令已经提供业务授权；
+- guard 拒绝时报告结构化 blocker，不改走 curl、本机原生 `oo`、直连 API 或 base64 绕过；
+- 只有业务目标本身缺少必要信息时才提问，例如用户没有指定要发布哪个 Flow，而不是询问“是否允许执行 oo flow publish”。
+
+### 4.4 修正测试
+
+必须修改现有明确期待 prompt 的测试：
+
+```text
+managed file upload and consequential Flow boundaries prompt in default mode
+```
+
+替换为参数化 parity 测试，验证在 OpenCode 和 external session 下均自动放行：
+
+- file upload；
+- file download；
+- connector run；
+- Flow run；
+- Flow publish；
+- Flow apply/edit；
+- safe output filter；
+- shell wrapper 中的纯 OO 调用。
+
+同时保留拒绝测试：
+
+- auth/login/logout/config；
+- endpoint/token override；
+- 路径逃逸；
+- unmanaged upload；
+- private-network download；
+- 混合高风险 shell；
+- 不明确 workspace；
+- 未开放 operation。
+
+## 5. OpenCode 与 BYOA 一致性方案
+
+### 5.1 一致的是产品语义，不强求相同传输
+
+短期内不做大一统重构：
+
+- OpenCode 继续以 Host Invoke 为 Link 主路径，受控 OOCLI 为 Skill/兼容路径；
+- BYOA 继续使用 managed OOCLI loopback；
+- 两者共享 Wanta local-access policy、operation contract、workspace 语义、错误和 UI metadata；
+- 不要求 OpenCode 和 ACP 使用同一种协议。
+
+这样遵循 OpenCode 基线，也避免为了形式统一进行过度设计。
+
+### 5.2 最小共享面
+
+当前只强制共享五项：
+
+1. operation 是否 enabled；
+2. permission decision；
+3. workspace/runtime 绑定结果；
+4. error code 与 authorization signal；
+5. display/persistence 脱敏规则。
+
+只有当同一逻辑已经在两条路径发生实际漂移时，才继续抽取执行 Runtime。
+
+### 5.3 Parity fixture
+
+建立一个小型 fake OOCLI parity fixture，用同一组输入分别经过：
+
+- OpenCode guard；
+- BYOA guard；
+- OpenCode Host Link action（适用时）。
+
+比较：
+
+- operation id；
+- 最终 argv 语义；
+- team/workspace；
+- allow/deny，不允许出现 prompt；
+- live output；
+- UI/persisted redaction；
+- error code；
+- 取消和退出状态。
+
+测试只比较产品语义，不要求内部事件字节级相同。
+
+## 6. 图片编辑专项路径
+
+内置 Agent 与 BYOA 都应执行同一条业务流程：
+
+```text
+加载图片 Skill
+→ inspect submit/result contracts
+→ oo file upload（自动放行）
+→ 获得实时 downloadUrl
+→ submit（自动放行）
+→ poll result（自动放行）
+→ oo file download（自动放行）
+→ 发布 Wanta artifact
+```
+
+验收要求：
+
+- 不出现任何 OO 批准卡；
+- 不出现 `managed OO execution boundary is unavailable`；
+- 不调用 curl/wget；
+- 不因 transport 故障改走 base64；
+- 不要求用户确认上传；
+- Agent 实时获得可用的临时 URL；
+- UI、日志和历史不保留完整签名 URL；
+- 图片模型之外的前置处理目标小于 20 秒；
+- 单图编辑正常目标为 1–2 分钟。
+
+## 7. 克制的优化计划
+
+### P0：本次必须完成
+
+1. 发布内置 OpenCode guard 修复；
+2. OO upload/download/execute/run/publish 全部移除批准；
+3. 更新 permission、Skill policy 和相关文档；
+4. 增加 OpenCode/BYOA permission parity 测试；
+5. 增加内置 Agent 图片编辑完整回归；
+6. 在真实开发版分别跑一次内置 Agent 和一个 BYOA smoke。
+
+### P1：只有出现证据再做
+
+1. 如果 operation 清单再次漂移，抽取共享 `OO_OPERATIONS`；
+2. 如果签名 URL 在不同 transport 再次处理不一致，抽取统一 live/redacted result helper；
+3. 如果多 team 并发真实失败，再引入精确 turn lease；
+4. 如果第三种 OO transport 出现，再抽取完整 `OoCapabilityRuntime`。
+
+### 当前明确不做
+
+- 不一次性重写 OpenCode Link Host Invoke；
+- 不立即建立庞大的 OO orchestration framework；
+- 不为了代码形式一致强制所有 Agent 使用同一协议；
+- 不新增用户能感知的 OO 设置或审批层；
+- 不把所有普通 shell 因为包含 `oo` 字样而自动放行；
+- 不取消 workspace、路径、URL、凭证和 operation 校验。
+
+## 8. 验收矩阵
+
+| 场景 | 内置 OpenCode | BYOA | 预期 |
+|---|---:|---:|---|
+| `oo search` | 必测 | 必测 | 自动放行 |
+| connector schema/apps/run | 必测 | 必测 | 自动放行、同一 workspace |
+| file upload | 必测 | 必测 | 自动放行，无批准卡 |
+| file download | 必测 | 必测 | 自动放行，只写 managed roots |
+| Flow edit/run/publish | 必测 | 必测 | 自动放行，无批准卡 |
+| auth/config/runtime override | 必测 | 必测 | 直接拒绝，不弹批准 |
+| unmanaged upload path | 必测 | 必测 | 直接拒绝 |
+| private-network download | 必测 | 必测 | 直接拒绝 |
+| mixed dangerous shell | 必测 | 必测 | 不按 OO 白名单放行 |
+| authorization required | 必测 | 必测 | 同一授权 CTA，不是 shell 批准 |
+| 图片编辑完整链路 | 必测 | 必测 | 无绕路，1–2 分钟目标 |
+| task cancel | 必测 | 必测 | OO 子进程终止 |
+| history restore | 必测 | 必测 | 不含签名 URL/credential |
+
+## 9. 完成标准
+
+本方案完成必须同时满足：
+
+- 内置 Agent 不再引用 BYOA guard 客户端；
+- 所有 enabled managed OO operation 在默认权限模式下返回 allow；
+- OO 上传、下载、执行、Flow run/publish 不再显示批准卡；
+- OpenCode 与 BYOA 对同一 OO operation 的 permission 结果一致；
+- 未开放或非法 OO 调用直接结构化拒绝，不让用户批准；
+- 图片编辑不再使用 curl/base64 作为 transport 故障恢复；
+- 没有 workspace、credential、签名 URL 或私有路径泄漏；
+- 相关 lint、format、type check、tests、build 和 OO bundle verification 全部通过；
+- 内置 Agent 与 BYOA 的真实 smoke 均通过。
+
+## 10. 最终建议
+
+本轮不实施完整大一统 Runtime。先完成明确且低风险的两项产品修复：
+
+1. 修复内置 OpenCode 的 OO 执行入口；
+2. 将所有合法托管 OO 操作改为自动放行。
+
+随后用最小 parity fixture 保证 OpenCode 与 BYOA 不再漂移。只有在出现新的真实重复问题时，才逐步抽取公共 Runtime。这样既兑现 OO 一等公民和跨 Agent 一致性，也避免过度设计。

--- a/electron/agent/external/oo-capability-contract.ts
+++ b/electron/agent/external/oo-capability-contract.ts
@@ -233,10 +233,11 @@ export function externalOoExecutionPolicy(): string {
     "This host execution profile overrides conflicting command examples or mandatory transport steps in the loaded Skill.",
     `The managed OO boundary supports these command domains: ${enabled}.`,
     `These domains are unavailable unless separately advertised: ${unavailable}.`,
-    "For oo file upload, use only a regular file inside the current turn's managed directories; the host asks for confirmation before bytes leave the machine.",
+    "For oo file upload, use only a regular file inside the current turn's managed directories; enabled managed OO uploads execute without a separate user confirmation.",
     "For oo file download, use only an explicit HTTP(S) artifact URL and a destination inside the current turn's managed directories; omitted destinations are pinned to the managed cwd.",
     "Flow commands require an OOMOL runtime and an explicit --project value after resolving oo flow project current; stdin, unmanaged @file references, project switching, deletion, rollback, cancellation, and browser-opening commands remain unavailable.",
-    "Flow run and publish are consequential boundaries and require the user's explicit requested scope plus host confirmation.",
+    "Enabled managed OO operations, including file transfer and Flow run/publish, execute without a separate user confirmation; the user's requested task is the authorization scope.",
+    "A managed OO policy or infrastructure failure is terminal for that path: do not bypass it with curl, wget, a native OO executable, direct provider APIs, or base64 unless the inspected action contract itself requires base64.",
     "Skip the Skill recommendation wrap-up; Wanta owns recommendation state and presentation.",
     "Do not replace an unavailable managed domain with an unmanaged OO executable.",
   ].join(" ")

--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -8,7 +8,7 @@ import {
   buildAgentSidecarEnv,
   buildArtifactSystem,
   buildWorkspaceIdentitySystem,
-  isPersistedConnectorToolPart,
+  isPersistedSensitiveOoToolPart,
   isUserVisibleSession,
 } from "./manager.ts"
 
@@ -18,57 +18,69 @@ afterEach(() => {
 })
 
 describe("AgentManager", () => {
-  it("limits persisted redaction to connector executions", () => {
-    expect(isPersistedConnectorToolPart({ tool: "call_action" })).toBe(true)
+  it("limits persisted redaction to connector executions and signed OO uploads", () => {
+    expect(isPersistedSensitiveOoToolPart({ tool: "call_action" })).toBe(true)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: "oo --lang zh connector run posthog --action list_projects --json" } },
       }),
     ).toBe(true)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: "printf 'password = \"example\"\\n'" } },
       }),
     ).toBe(false)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: "printf 'oo connector run demo'" } },
       }),
     ).toBe(false)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: "bash -lc 'oo connector apps posthog --json'" } },
       }),
     ).toBe(true)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: `printf '%s\\n' "$(oo connector run demo)"` } },
       }),
     ).toBe(true)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: `printf '%s\\n' '$(oo connector run demo)'` } },
       }),
     ).toBe(false)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: `connector_data="$(oo connector apps posthog --json)"` } },
       }),
     ).toBe(true)
     expect(
-      isPersistedConnectorToolPart({
+      isPersistedSensitiveOoToolPart({
         tool: "bash",
         state: { input: { command: "# $(oo connector run demo)" } },
       }),
     ).toBe(false)
-    expect(isPersistedConnectorToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
+    expect(
+      isPersistedSensitiveOoToolPart({
+        tool: "bash",
+        state: { input: { command: 'BUN_BE_BUN=1 oo file upload "/managed/input.png" --json' } },
+      }),
+    ).toBe(true)
+    expect(
+      isPersistedSensitiveOoToolPart({
+        tool: "bash",
+        state: { input: { command: 'oo file download "https://example.com/a" ./out' } },
+      }),
+    ).toBe(false)
+    expect(isPersistedSensitiveOoToolPart({ tool: "read", state: { input: { filePath: "README.md" } } })).toBe(false)
   })
 
   it("pins raw connector CLI guidance to the current team", () => {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -48,6 +48,7 @@ import { planAttachmentInputs } from "./attachment-input.ts"
 import { buildOpencodeConfig, customProviderId, WANTA_MODEL_ID, WANTA_PROVIDER_ID } from "./config.ts"
 import { ensureDirectCliCommandBin } from "./direct-cli-bin.ts"
 import { normalizeMessage, normalizePermissionRequest, normalizeQuestionRequest } from "./event-translator.ts"
+import { resolveExternalOoOperation } from "./external/oo-capability-contract.ts"
 import { isImageUrlContentSchemaMismatch, understandAttachedImages } from "./image-understanding.ts"
 import { ManagedTurnDirectories } from "./managed-turn-directories.ts"
 import { normalizeWantaAgentMode } from "./mode.ts"
@@ -75,8 +76,8 @@ export interface AgentManagerOptions {
   opencodeBinPath: string
   /** The oo binary is resolved and injected only when a Link runtime is configured. */
   ooBinPath?: string
-  /** Electron-as-Node entrypoint that scopes and redacts Agent-side oo business calls. */
-  ooGuardCliPath?: string
+  /** Electron-as-Node entrypoint that scopes and redacts built-in OpenCode oo business calls. */
+  opencodeOoGuardCliPath?: string
   /** Wanta-owned WikiGraph CLI entrypoint used by the sidecar PATH `wg` shim. */
   wikiGraphCliPath?: string
   wikiGraphStateDir?: string
@@ -485,12 +486,16 @@ function executableCommandSubstitutions(command: string): string[] {
   return substitutions
 }
 
-function shellExecutesConnectorBusinessCommand(command: string, depth = 0): boolean {
+function managedOoOutputNeedsPersistedRedaction(args: readonly string[]): boolean {
+  return isConnectorBusinessCommand(args) || resolveExternalOoOperation(args)?.id === "file.upload"
+}
+
+function shellExecutesSensitiveManagedOoCommand(command: string, depth = 0): boolean {
   if (depth >= maxConnectorShellDepth) return false
   const executableCommand = shellWithoutComments(command)
   if (
     executableCommandSubstitutions(executableCommand).some((body) =>
-      shellExecutesConnectorBusinessCommand(body, depth + 1),
+      shellExecutesSensitiveManagedOoCommand(body, depth + 1),
     )
   ) {
     return true
@@ -499,20 +504,20 @@ function shellExecutesConnectorBusinessCommand(command: string, depth = 0): bool
     const parsed = shellWords(text)
     if (!parsed?.length) return false
     const words = effectiveShellCommandWords(parsed)
-    if (isOoCommandWord(words[0])) return isConnectorBusinessCommand(words.slice(1))
+    if (isOoCommandWord(words[0])) return managedOoOutputNeedsPersistedRedaction(words.slice(1))
     const nested = nestedShellCommand(words)
-    return nested ? shellExecutesConnectorBusinessCommand(nested, depth + 1) : false
+    return nested ? shellExecutesSensitiveManagedOoCommand(nested, depth + 1) : false
   })
 }
 
-export function isPersistedConnectorToolPart(part: { state?: { input?: unknown }; tool?: unknown }): boolean {
+export function isPersistedSensitiveOoToolPart(part: { state?: { input?: unknown }; tool?: unknown }): boolean {
   if (typeof part.tool !== "string") return false
   if (persistedConnectorToolNames.has(part.tool)) return true
   if (part.tool !== "bash" && part.tool !== "shell") return false
   const input = part.state?.input
   if (!input || typeof input !== "object") return false
   const command = (input as { command?: unknown }).command
-  return typeof command === "string" && shellExecutesConnectorBusinessCommand(command)
+  return typeof command === "string" && shellExecutesSensitiveManagedOoCommand(command)
 }
 
 /** Agent 内核管理器：编排 OpenCode sidecar + 非编码 agent + 自定义连接器工具。electron-free，便于 headless 测试。 */
@@ -673,16 +678,16 @@ export class AgentManager {
     this.disposed = false
     await this.prepareWorkspace()
     await this.startSidecar()
-    void this.scrubPersistedConnectorOutputs().catch((error: unknown) => {
-      console.warn("[wanta] failed to scrub persisted connector outputs:", error)
-      logDiagnostic("agent", "persisted connector output scrub failed", { error }, "warn")
+    void this.scrubPersistedSensitiveOoOutputs().catch((error: unknown) => {
+      console.warn("[wanta] failed to scrub persisted sensitive OO outputs:", error)
+      logDiagnostic("agent", "persisted sensitive OO output scrub failed", { error }, "warn")
     })
   }
 
-  /** One-time defense for tool outputs saved before the managed oo guard existed. */
-  private async scrubPersistedConnectorOutputs(): Promise<void> {
+  /** One-time defense for tool outputs saved before live per-turn redaction. */
+  private async scrubPersistedSensitiveOoOutputs(): Promise<void> {
     if (!this.sidecar || this.disposed) return
-    const markerPath = path.join(this.options.rootDir, ".connector-output-redaction-v1")
+    const markerPath = path.join(this.options.rootDir, ".sensitive-oo-output-redaction-v2")
     try {
       await readFile(markerPath, "utf8")
       return
@@ -691,33 +696,41 @@ export class AgentManager {
     }
 
     const sessionsResult = await this.client.session.list({ limit: 10_000, roots: false })
-    assertOpencodeSuccess(sessionsResult, "session.list for connector output scrub")
+    assertOpencodeSuccess(sessionsResult, "session.list for sensitive OO output scrub")
     let redactedPartCount = 0
     for (const session of sessionsResult.data ?? []) {
       if (this.disposed) return
-      const messagesResult = await this.client.session.messages({ sessionID: session.id, limit: 10_000 })
-      assertOpencodeSuccess(messagesResult, "session.messages for connector output scrub")
-      for (const message of messagesResult.data ?? []) {
-        for (const part of message.parts) {
-          if (part.type !== "tool" || part.state.status !== "completed") continue
-          if (!isPersistedConnectorToolPart(part)) continue
-          const output = redactConnectorOutput(part.state.output)
-          if (output === part.state.output) continue
-          const updatedPart: OpencodePart = { ...part, state: { ...part.state, output } }
-          const updateResult = await this.client.part.update({
-            sessionID: part.sessionID,
-            messageID: part.messageID,
-            partID: part.id,
-            part: updatedPart,
-          })
-          assertOpencodeSuccess(updateResult, "part.update for connector output scrub")
-          redactedPartCount += 1
-        }
-      }
+      redactedPartCount += await this.scrubSessionSensitiveOoOutputs(session.id)
     }
     if (this.disposed) return
-    await atomicWriteText(markerPath, JSON.stringify({ redactedPartCount, version: 1 }))
-    logDiagnostic("agent", "persisted connector output scrub completed", { redactedPartCount })
+    await atomicWriteText(markerPath, JSON.stringify({ redactedPartCount, version: 2 }))
+    logDiagnostic("agent", "persisted sensitive OO output scrub completed", { redactedPartCount })
+  }
+
+  /** Redact signed upload URLs and connector secrets after the active turn has consumed them. */
+  public async scrubSessionSensitiveOoOutputs(sessionId: string): Promise<number> {
+    if (!this.sidecar || this.disposed) return 0
+    const messagesResult = await this.client.session.messages({ sessionID: sessionId, limit: 10_000 })
+    assertOpencodeSuccess(messagesResult, "session.messages for sensitive OO output scrub")
+    let redactedPartCount = 0
+    for (const message of messagesResult.data ?? []) {
+      for (const part of message.parts) {
+        if (part.type !== "tool" || part.state.status !== "completed") continue
+        if (!isPersistedSensitiveOoToolPart(part)) continue
+        const output = redactConnectorOutput(part.state.output)
+        if (output === part.state.output) continue
+        const updatedPart: OpencodePart = { ...part, state: { ...part.state, output } }
+        const updateResult = await this.client.part.update({
+          sessionID: part.sessionID,
+          messageID: part.messageID,
+          partID: part.id,
+          part: updatedPart,
+        })
+        assertOpencodeSuccess(updateResult, "part.update for sensitive OO output scrub")
+        redactedPartCount += 1
+      }
+    }
+    return redactedPartCount
   }
 
   private async prepareWorkspace(): Promise<void> {
@@ -740,7 +753,7 @@ export class AgentManager {
       modelAccess,
       opencodeBinPath,
       ooBinPath,
-      ooGuardCliPath,
+      opencodeOoGuardCliPath,
       rootDir,
       disableServerAuth,
       customModels,
@@ -772,11 +785,11 @@ export class AgentManager {
       wecomCliBinPath,
     })
     let managedOoBinPath = ooBinPath
-    if (linkRuntime && ooBinPath && ooGuardCliPath) {
+    if (linkRuntime && ooBinPath && opencodeOoGuardCliPath) {
       managedOoBinPath = await ensureOoGuardCommandBin({
         binDir: commandBinDir,
         nodeBin: process.execPath,
-        ooGuardCliPath,
+        ooGuardCliPath: opencodeOoGuardCliPath,
       })
     }
     if (wikiGraphCliPath && wikiGraphStateDir) {

--- a/electron/agent/oo-command-permission.test.ts
+++ b/electron/agent/oo-command-permission.test.ts
@@ -4,33 +4,15 @@ import {
   connectorBusinessCliTransport,
   isOoCliCommand,
   isPureOoCliCommand,
-  managedOoCommandRequiresConfirmation,
   openConnectorCommandPolicy,
 } from "./oo-command-permission.ts"
-
-test("managed OO consequential operations require confirmation", () => {
-  for (const command of [
-    'oo file upload "artifact.png" --json',
-    "oo flow run my-flow --project project-a --source draft --wait --json",
-    "oo flow publish my-flow --project project-a --json",
-    'bash -lc "oo flow rollback my-flow publication-a --project project-a"',
-  ]) {
-    assert.equal(managedOoCommandRequiresConfirmation(command), true, command)
-  }
-  for (const command of [
-    'oo file download "https://example.com/a" ./artifacts',
-    "oo flow inspect my-flow --project project-a --json",
-    "oo flow apply my-flow --project project-a --file request.json --json",
-  ]) {
-    assert.equal(managedOoCommandRequiresConfirmation(command), false, command)
-  }
-})
 
 test("isPureOoCliCommand allows single oo CLI invocations", () => {
   assert.equal(isPureOoCliCommand('oo search "秘塔搜索 metaso search" --json'), true)
   assert.equal(isPureOoCliCommand('oo connector run "metaso" --action "search" --data \'{"q":"a;b"}\' --json'), true)
   assert.equal(isPureOoCliCommand('"$WANTA_OO_BIN" version --json'), true)
   assert.equal(isPureOoCliCommand("${WANTA_OO_BIN} connector schema metaso.search --json"), true)
+  assert.equal(isPureOoCliCommand('BUN_BE_BUN=1 oo file upload "/managed/input.png" --json'), true)
 })
 
 test("isPureOoCliCommand rejects shell composition around oo", () => {
@@ -40,6 +22,17 @@ test("isPureOoCliCommand rejects shell composition around oo", () => {
   assert.equal(isPureOoCliCommand("sudo oo search metaso --json"), false)
   assert.equal(isPureOoCliCommand("echo oo search metaso --json"), false)
   assert.equal(isPureOoCliCommand("PATH=/tmp oo search metaso --json"), false)
+  assert.equal(isPureOoCliCommand("BUN_BE_BUN=0 oo search metaso --json"), false)
+})
+
+test("safe OO launcher prefixes cannot bypass managed mutation denials", () => {
+  for (const command of [
+    "BUN_BE_BUN=1 oo auth login",
+    "BUN_BE_BUN=1 oo config set endpoint https://other.example.test",
+    "BUN_BE_BUN=1 oo connector logout",
+  ]) {
+    assert.equal(openConnectorCommandPolicy(command), "deny", command)
+  }
 })
 
 test("shell wrapper inspection is bounded", () => {

--- a/electron/agent/oo-command-permission.ts
+++ b/electron/agent/oo-command-permission.ts
@@ -176,6 +176,7 @@ function shellWrapperCommand(command: string): ShellWrapper {
 // can never smuggle a forbidden subcommand past forbiddenOoMutation.
 const ooGlobalFlagWithValue = "--lang"
 const ooGlobalBooleanFlags = new Set(["--debug", "-h", "--help", "-V", "--version"])
+const safeOoEnvironmentAssignments = new Set(["BUN_BE_BUN=1"])
 
 /** Advance past oo global flags (commander accepts them before AND between subcommands). */
 function skipOoGlobalFlags(tokens: readonly string[], start: number): number {
@@ -195,13 +196,21 @@ function skipOoGlobalFlags(tokens: readonly string[], start: number): number {
   return index
 }
 
+function ooExecutableIndex(words: readonly string[]): number {
+  let index = 0
+  while (safeOoEnvironmentAssignments.has(words[index] ?? "")) index += 1
+  return isOoExecutable(words[index] ?? "") ? index : -1
+}
+
 /** Tokens of a single `oo ...` command after skipping leading global flags, or null if not a bare oo call. */
 function ooSubcommandTokens(command: string): string[] | null {
   const words = shellWords(command.trim())
-  if (!words || !isOoExecutable(words[0] ?? "")) {
+  if (!words) {
     return null
   }
-  return words.slice(skipOoGlobalFlags(words, 1))
+  const executableIndex = ooExecutableIndex(words)
+  if (executableIndex < 0) return null
+  return words.slice(skipOoGlobalFlags(words, executableIndex + 1))
 }
 
 export type ConnectorBusinessCliTransport = "bare" | "managed"
@@ -258,38 +267,6 @@ export function isForbiddenOoMutationCommand(command: string): boolean {
   return connectorSubcommand === "login" || connectorSubcommand === "logout"
 }
 
-function directOoCommandRequiresConfirmation(command: string): boolean {
-  const tokens = ooSubcommandTokens(command)
-  if (!tokens?.length) return false
-  const root = tokens[0]
-  if (root === "file") {
-    return tokens[skipOoGlobalFlags(tokens, 1)] === "upload"
-  }
-  if (root !== "flow") return false
-  const subcommandIndex = skipOoGlobalFlags(tokens, 1)
-  const subcommand = tokens[subcommandIndex]
-  if (["delete", "publish", "rollback", "run"].includes(subcommand ?? "")) return true
-  if (subcommand === "runs") {
-    return tokens[skipOoGlobalFlags(tokens, subcommandIndex + 1)] === "cancel"
-  }
-  if (subcommand === "project") {
-    return ["create", "use"].includes(tokens[skipOoGlobalFlags(tokens, subcommandIndex + 1)] ?? "")
-  }
-  return false
-}
-
-/** Managed OO operations that must cross Wanta's consequential-action prompt. */
-export function managedOoCommandRequiresConfirmation(command: string): boolean {
-  let current = command.trim()
-  for (let depth = 0; depth < maxShellWrapperDepth; depth += 1) {
-    if (directOoCommandRequiresConfirmation(current)) return true
-    const wrapper = shellWrapperCommand(current)
-    if (wrapper.kind !== "command") return false
-    current = wrapper.command
-  }
-  return false
-}
-
 export function isPureOoCliCommand(command: string): boolean {
   const trimmed = command.trim()
   if (!trimmed || hasUnsafeShellSyntax(trimmed)) {
@@ -301,8 +278,10 @@ export function isPureOoCliCommand(command: string): boolean {
     return false
   }
 
-  // 不自动放行前置 env 赋值，避免 PATH / endpoint / 二进制路径被这一条命令改写。
-  return isOoExecutable(words[0] ?? "")
+  // The bundled Bun launcher may add this one inert runtime marker. Continue
+  // rejecting arbitrary environment assignments so PATH, endpoints, tokens,
+  // and executable resolution cannot be changed by an auto-approved command.
+  return ooExecutableIndex(words) >= 0
 }
 
 export function isOoCliCommand(command: string): boolean {

--- a/electron/agent/opencode-adapter.ts
+++ b/electron/agent/opencode-adapter.ts
@@ -43,6 +43,16 @@ export class OpencodeAgentAdapter extends BaseAgentAdapter implements ChatAgentB
     }
     this.detachManagerEvents = this.manager.subscribe(
       (event) => {
+        if (event.type === "session.idle") {
+          const sessionId = (event.properties as { sessionID?: unknown } | undefined)?.sessionID
+          if (typeof sessionId === "string" && sessionId) {
+            void this.manager.scrubSessionSensitiveOoOutputs(sessionId).catch(() => {
+              // UI/history events are already redacted by the translator. The
+              // startup sweep retries persistence cleanup if this best-effort
+              // post-turn update loses a sidecar race.
+            })
+          }
+        }
         for (const translated of translateOpencodeEvent(event)) {
           this.emit(translated)
         }

--- a/electron/agent/opencode-oo-guard-runtime.test.ts
+++ b/electron/agent/opencode-oo-guard-runtime.test.ts
@@ -1,0 +1,141 @@
+import { execFile } from "node:child_process"
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+import { afterEach, describe, expect, test } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const roots: string[] = []
+const guardPath = path.resolve("electron/agent/opencode-oo-guard.ts")
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
+})
+
+async function fixture(
+  commandBody = '#!/bin/sh\nprintf "%s\\n" "$@"\n',
+): Promise<{ env: NodeJS.ProcessEnv; root: string }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-opencode-oo-guard-"))
+  roots.push(root)
+  const realOo = path.join(root, "real-oo")
+  const scopePath = path.join(root, "team-scope.json")
+  await writeFile(realOo, commandBody, "utf8")
+  await chmod(realOo, 0o755)
+  await writeFile(scopePath, JSON.stringify({ sessionTeams: { "session-a": "Team A" }, teamName: "Team A" }))
+  return {
+    env: {
+      ...process.env,
+      WANTA_LINK_RUNTIME: "oomol",
+      WANTA_REAL_OO_BIN: realOo,
+      WANTA_TEAM_SCOPE_PATH: scopePath,
+    },
+    root,
+  }
+}
+
+async function runGuard(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+  const result = await execFileAsync(process.execPath, ["--experimental-strip-types", guardPath, ...args], {
+    encoding: "utf8",
+    env,
+  })
+  return result.stdout
+}
+
+describe("built-in OpenCode OO guard runtime", () => {
+  test("runs without the external loopback descriptor and binds the active team", async () => {
+    const { env } = await fixture()
+
+    const output = await runGuard(["connector", "run", "posthog", "--action", "list_projects"], env)
+
+    expect(output.trim().split("\n")).toEqual([
+      "connector",
+      "run",
+      "posthog",
+      "--action",
+      "list_projects",
+      "--team",
+      "Team A",
+    ])
+  })
+
+  test("passes non-connector OO commands to the real bundled CLI", async () => {
+    const { env } = await fixture()
+
+    const output = await runGuard(["search", "generate an image", "--json"], env)
+
+    expect(output.trim().split("\n")).toEqual(["search", "generate an image", "--json"])
+  })
+
+  test("keeps the built-in image edit upload, submit, result, and download chain on managed OO", async () => {
+    const commandBody = `#!/bin/sh
+printf '%s\\n' "$*" >> "$WANTA_TEST_OO_TRACE"
+case "$1 $2" in
+  'file upload') printf '{"downloadUrl":"https://signed.example.test/input?token=live","fileName":"input.png"}\\n' ;;
+  'connector run')
+    case "$5" in
+      submit) printf '{"taskId":"image-task-1"}\\n' ;;
+      result) printf '{"status":"completed","imageUrl":"https://cdn.example.test/result.png"}\\n' ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  'file download') printf 'Saved result.png\\n' ;;
+  *) exit 2 ;;
+esac
+`
+    const { env, root } = await fixture(commandBody)
+    const tracePath = path.join(root, "oo-trace.txt")
+    env.WANTA_TEST_OO_TRACE = tracePath
+    const inputPath = path.join(root, "input.png")
+    await writeFile(inputPath, "image")
+
+    const upload = JSON.parse(await runGuard(["file", "upload", inputPath, "--json"], env)) as {
+      downloadUrl: string
+    }
+    expect(upload.downloadUrl).toBe("https://signed.example.test/input?token=live")
+
+    const submitted = JSON.parse(
+      await runGuard(
+        [
+          "connector",
+          "run",
+          "fusion-api",
+          "--action",
+          "submit",
+          "--data",
+          JSON.stringify({ imageUrl: upload.downloadUrl }),
+          "--json",
+        ],
+        env,
+      ),
+    ) as { taskId: string }
+    expect(submitted.taskId).toBe("image-task-1")
+
+    const result = JSON.parse(
+      await runGuard(
+        [
+          "connector",
+          "run",
+          "fusion-api",
+          "--action",
+          "result",
+          "--data",
+          JSON.stringify({ taskId: submitted.taskId }),
+          "--json",
+        ],
+        env,
+      ),
+    ) as { imageUrl: string; status: string }
+    expect(result).toEqual({ status: "completed", imageUrl: "https://cdn.example.test/result.png" })
+
+    await expect(
+      runGuard(["file", "download", result.imageUrl, root, "--name", "result", "--ext", ".png"], env),
+    ).resolves.toContain("Saved result.png")
+    const trace = await readFile(tracePath, "utf8")
+    expect(trace).toContain("file upload")
+    expect(trace).toContain("connector run fusion-api --action submit")
+    expect(trace).toContain("connector run fusion-api --action result")
+    expect(trace).toContain("file download https://cdn.example.test/result.png")
+    expect(trace).not.toMatch(/\b(?:curl|wget|base64)\b/u)
+  })
+})

--- a/electron/agent/opencode-oo-guard.ts
+++ b/electron/agent/opencode-oo-guard.ts
@@ -1,0 +1,102 @@
+import type { WorkspaceTeamScope } from "./oo-guard-core.ts"
+
+import { spawn } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import {
+  bindOomolWorkspace,
+  hasWorkspaceSelector,
+  isConnectorBusinessCommand,
+  redactConnectorOutput,
+  resolveGuardWorkspaceTeam,
+  stripIdentityIndependentWorkspaceSelectors,
+} from "./oo-guard-core.ts"
+
+const maxCapturedOutputBytes = 32 * 1024 * 1024
+
+async function currentWorkspaceTeam(): Promise<string> {
+  const scopePath = process.env.WANTA_TEAM_SCOPE_PATH?.trim()
+  if (!scopePath) return ""
+  const parsed = JSON.parse(await readFile(scopePath, "utf8")) as WorkspaceTeamScope
+  return resolveGuardWorkspaceTeam(parsed)
+}
+
+function appendBounded(chunks: Buffer[], chunk: Buffer, size: number): number {
+  const nextSize = size + chunk.length
+  if (nextSize > maxCapturedOutputBytes) {
+    throw new Error("Connector output exceeded Wanta's 32 MiB safety limit.")
+  }
+  chunks.push(chunk)
+  return nextSize
+}
+
+function killWithEscalation(child: ReturnType<typeof spawn>): void {
+  child.kill("SIGTERM")
+  const timer = setTimeout(() => child.kill("SIGKILL"), 5_000)
+  timer.unref()
+  child.once("close", () => clearTimeout(timer))
+}
+
+async function runGuarded(command: string, args: string[]): Promise<number> {
+  const child = spawn(command, args, { env: process.env, stdio: ["inherit", "pipe", "pipe"], windowsHide: true })
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  let stdoutSize = 0
+  let stderrSize = 0
+  let captureError: Error | null = null
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    if (captureError) return
+    try {
+      stdoutSize = appendBounded(stdout, chunk, stdoutSize)
+    } catch (error) {
+      captureError = error instanceof Error ? error : new Error(String(error))
+      killWithEscalation(child)
+    }
+  })
+  child.stderr.on("data", (chunk: Buffer) => {
+    if (captureError) return
+    try {
+      stderrSize = appendBounded(stderr, chunk, stderrSize)
+    } catch (error) {
+      captureError = error instanceof Error ? error : new Error(String(error))
+      killWithEscalation(child)
+    }
+  })
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", (code, signal) => resolve(code ?? (signal ? 1 : 0)))
+  })
+  if (captureError) throw captureError
+  process.stdout.write(redactConnectorOutput(Buffer.concat(stdout).toString("utf8")))
+  process.stderr.write(redactConnectorOutput(Buffer.concat(stderr).toString("utf8")))
+  return exitCode
+}
+
+async function runPassthrough(command: string, args: string[]): Promise<number> {
+  const child = spawn(command, args, { env: process.env, stdio: "inherit", windowsHide: true })
+  return await new Promise<number>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", (code, signal) => resolve(code ?? (signal ? 1 : 0)))
+  })
+}
+
+async function main(): Promise<void> {
+  const command = process.env.WANTA_REAL_OO_BIN?.trim()
+  if (!command) throw new Error("WANTA_REAL_OO_BIN is required for the managed oo command.")
+
+  const originalArgs = stripIdentityIndependentWorkspaceSelectors(process.argv.slice(2))
+  const needsOomolBinding =
+    process.env.WANTA_LINK_RUNTIME === "oomol" &&
+    isConnectorBusinessCommand(originalArgs) &&
+    !hasWorkspaceSelector(originalArgs)
+  const args = needsOomolBinding ? bindOomolWorkspace(originalArgs, await currentWorkspaceTeam()) : originalArgs
+  process.exitCode = isConnectorBusinessCommand(args)
+    ? await runGuarded(command, args)
+    : await runPassthrough(command, args)
+}
+
+await main().catch((error: unknown) => {
+  process.stderr.write(`Wanta oo guard: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -56,29 +56,33 @@ test("OpenCode, Claude, and ACP agents auto-approve Link business CLI", () => {
   }
 })
 
-test("managed file upload and consequential Flow boundaries prompt in default mode", () => {
-  for (const command of [
-    'oo file upload "artifact.png" --json',
+test("OpenCode, Claude, and ACP agents auto-approve every pure managed OO operation", () => {
+  const commands = [
+    'BUN_BE_BUN=1 oo file upload "/Users/example/Library/Application Support/LarkShell/input.png" --json',
+    'oo file download "https://example.com/a" ./artifacts',
+    "oo flow inspect demo --project project-a --json",
+    "oo flow apply demo --project project-a --file request.json --json",
     "oo flow run demo --project project-a --source draft --wait --json",
     "oo flow publish demo --project project-a --json",
-  ]) {
-    assert.deepEqual(
-      evaluateLocalAccessRequest(permission({ metadata: { command } }), {
-        isExternalSession: true,
-        linkRuntime: "oomol",
-        permissionMode: "default",
-      }),
-      { type: "prompt", kind: "command", highRisk: true },
-      command,
-    )
+  ]
+  for (const command of commands) {
+    const requests = [
+      permission({ metadata: { command } }),
+      permission({ action: "Bash", metadata: { toolInput: { command } } }),
+      permission({ action: "Run command", metadata: { rawInput: { command } } }),
+    ]
+    for (const [index, request] of requests.entries()) {
+      assert.deepEqual(
+        evaluateLocalAccessRequest(request, {
+          isExternalSession: index > 0,
+          linkRuntime: "oomol",
+          permissionMode: "default",
+        }),
+        { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
+        `${index}:${command}`,
+      )
+    }
   }
-  assert.deepEqual(
-    evaluateLocalAccessRequest(
-      permission({ metadata: { command: "oo flow inspect demo --project project-a --json" } }),
-      { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
-    ),
-    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
-  )
 })
 
 test("OOCLI parity preserves hard denials while allowing ordinary compound Link business commands", () => {
@@ -165,7 +169,7 @@ test("safe OOCLI classification is agent-independent even without an active Link
       }),
       { isExternalSession: true, linkRuntime: "oomol", permissionMode: "default" },
     ),
-    { type: "prompt", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
 })
 
@@ -227,7 +231,7 @@ test("local access policy allows direct and standard wrapped business oo command
         linkRuntime: "openconnector",
         permissionMode: "full_access",
       }),
-      { type: "allow", reason: "full_access", kind: "command", highRisk: false },
+      { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
       command,
     )
   }
@@ -282,7 +286,7 @@ test("full access auto-approves local oo commands even without an active Link ru
     evaluateLocalAccessRequest(permission({ metadata: { command: "oo connector apps --json" } }), {
       permissionMode: "full_access",
     }),
-    { type: "allow", reason: "full_access", kind: "command", highRisk: false },
+    { type: "allow", reason: "oo_cli", kind: "command", highRisk: false },
   )
 })
 

--- a/electron/chat/local-access-policy.ts
+++ b/electron/chat/local-access-policy.ts
@@ -125,6 +125,14 @@ function evaluateBaselineLocalAccessRequest(
   const openConnectorPolicy =
     kind === "command" ? openConnectorCommandPolicy(command ?? request.resources.join(" ")) : null
   if (openConnectorPolicy === "deny") return { type: "deny", kind, highRisk }
+  // OO is a first-party Wanta capability channel. Once a request is proven to
+  // be a pure managed OO invocation, do not add a shell, upload, download, or
+  // execution confirmation in any adapter. The managed OO guard remains the
+  // authority for operation admission, workspace identity, paths, URLs, and
+  // runtime overrides; invalid calls fail there instead of becoming approvable.
+  if (isOoCliPermissionRequest(request)) {
+    return { type: "allow", reason: "oo_cli", kind, highRisk: false }
+  }
   if (context.permissionMode === "full_access") {
     return { type: "allow", reason: "full_access", kind, highRisk }
   }
@@ -146,7 +154,6 @@ function evaluateBaselineLocalAccessRequest(
   if (highRisk) {
     return { type: "prompt", kind, highRisk }
   }
-  if (isOoCliPermissionRequest(request)) return { type: "allow", reason: "oo_cli", kind, highRisk }
   // OOMOL's bundled `oo` CLI is a first-party working channel. A parser miss
   // must not make an otherwise ordinary command stricter than the baseline
   // local-command policy merely because the command contains `oo`. Compound

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -120,6 +120,7 @@ function createBridgeAgent(): {
   const clearSessionKnowledgeBaseIds = vi.fn(async () => undefined)
   const setSessionKnowledgeBaseIds = vi.fn(async () => undefined)
   const setSessionTeamName = vi.fn(async () => undefined)
+  const scrubSessionSensitiveOoOutputs = vi.fn(async () => 0)
   const manager = {
     isReady: () => true,
     subscribe: (
@@ -141,6 +142,7 @@ function createBridgeAgent(): {
     rejectQuestion,
     setSessionTeamName,
     setSessionKnowledgeBaseIds,
+    scrubSessionSensitiveOoOutputs,
     promptStreaming,
     getMessages,
     getPendingPermissions,

--- a/electron/chat/permission-request.ts
+++ b/electron/chat/permission-request.ts
@@ -1,6 +1,6 @@
 import type { ChatPermissionRequest } from "./common.ts"
 
-import { managedOoCommandRequiresConfirmation, openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
+import { openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
 import {
   isManagedPythonExecutable,
   isManagedPythonPipExecutable,
@@ -185,7 +185,6 @@ export function isHighRiskPermissionRequest(request: ChatPermissionRequest): boo
   return (
     dependencyCommandRequiresConfirmation(shellControlText) ||
     commandRequiresConfirmation(shellControlText) ||
-    managedOoCommandRequiresConfirmation(shellControlText) ||
     HIGH_RISK_COMMAND_PATH_PATTERNS.some((pattern) => pattern.test(shellControlText))
   )
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -195,6 +195,7 @@ const wikiGraphStateDir = path.join(app.getPath("userData"), "wikigraph-state")
 const wikiGraphLibraryDir = path.join(wikiGraphStateDir, "library")
 const wikiGraphCliPath = path.join(dirname, "wanta-wg.js")
 const ooGuardCliPath = path.join(dirname, "wanta-oo-guard.js")
+const opencodeOoGuardCliPath = path.join(dirname, "wanta-opencode-oo-guard.js")
 // 二进制解析：生产从打包 Resources/bin（extraResources），dev 从 node_modules（opencode）与 .oo-bin（oo）。
 const opencodeBinPath = app.isPackaged
   ? resolveBundledBin(process.resourcesPath, opencodeBinaryName())
@@ -1116,7 +1117,7 @@ async function applyAuthAccountNow(account: AuthRuntimeAccount | null): Promise<
       modelAccess: runtime.modelAccess,
       opencodeBinPath,
       ooBinPath,
-      ooGuardCliPath,
+      opencodeOoGuardCliPath,
       wikiGraphCliPath,
       wikiGraphStateDir,
       listOpenConnectorAuthorizedServices: async (signal) =>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -154,6 +154,7 @@ export default defineConfig(({ command, mode }) => {
                   "spreadsheet-preview-worker": path.join(dirname, "electron/chat/spreadsheet-preview-worker.ts"),
                   "wanta-wg": path.join(dirname, "electron/knowledge/wg.ts"),
                   "wanta-oo-guard": path.join(dirname, "electron/agent/oo-guard.ts"),
+                  "wanta-opencode-oo-guard": path.join(dirname, "electron/agent/opencode-oo-guard.ts"),
                 },
                 // AI SDK / @opencode-ai/sdk 依赖含 CJS 动态 require，electron-updater 走 CJS 动态
                 // require，playwright-core 需要保留其运行时模块结构，都不能打进 ESM 主进程包；


### PR DESCRIPTION
## Summary

This change makes Wanta-managed OO execution reliable and permission-consistent across the built-in OpenCode agent and external BYOA agents.

The user-visible incident was an image edit started from the built-in agent that spent roughly fifteen minutes recovering from `Wanta's managed OO execution boundary is unavailable.` The image model itself completed in about a minute; most of the delay came from the agent trying alternate Link, upload, curl, and base64 paths after the normal Skill-recommended OOCLI path failed.

## Root cause

The built-in OpenCode sidecar and external agents were both pointed at the same `wanta-oo-guard` entrypoint even though that entrypoint had been repurposed as an authenticated loopback client for BYOA. The external client requires `WANTA_OO_GUARD_URL` and `WANTA_OO_GUARD_TOKEN`, while the built-in sidecar intentionally does not receive those external-agent descriptors. A built-in `oo` invocation therefore failed deterministically before reaching the bundled OOCLI.

The shared permission classifier also treated managed file uploads and Flow run/publish commands as consequential shell operations. That caused redundant Wanta approval prompts even though OO is a first-party managed capability and the managed guard already owns workspace, path, URL, runtime, and operation validation.

## Fix

- Add a dedicated `wanta-opencode-oo-guard` entrypoint for the built-in OpenCode compatibility path while retaining the authenticated loopback `wanta-oo-guard` for BYOA.
- Wire the built-in guard to `WANTA_REAL_OO_BIN` and the current OpenCode team scope, and keep the external guard descriptor exclusive to external-agent environments.
- Treat every pure, enabled managed OO operation as an automatic Wanta allow across OpenCode, Claude-style native permission payloads, and ACP/BYOA permission payloads.
- Remove the special confirmation classification for `oo file upload`, Flow run, and Flow publish while preserving direct denials for authentication/configuration mutation and runtime credential or endpoint overrides.
- Recognize the real bundled launcher form `BUN_BE_BUN=1 oo ...` without allowing arbitrary environment assignments such as PATH, endpoint, or token overrides.
- Keep guard-level validation for managed roots, regular-file and size constraints, public download URLs, output directories, explicit Flow projects, enabled operation domains, and workspace identity.
- Update the current-turn Skill execution policy so managed OO infrastructure failures do not trigger curl, wget, unmanaged native OO, direct provider API, or non-schema base64 workarounds.
- Preserve live signed upload URLs for the active turn, redact them from UI/history output, scrub sensitive OO tool parts after `session.idle`, and add a versioned startup sweep for older persisted OpenCode history.
- Add a built-in image-edit integration fixture covering upload, submit, result, and download with no curl/wget/base64 fallback.
- Document the product policy, implementation plan, and completion audit.

## User impact

Built-in image editing no longer enters the external BYOA guard or fails for missing external guard credentials. Enabled managed OO discovery, Connector execution, file upload/download, and Flow run/publish execute without redundant approval cards in both built-in and external agents. Invalid or unsupported OO operations still fail closed with the managed boundary instead of becoming user-approvable shell actions.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm test` — 368 test files passed, 2 skipped; 2948 tests passed, 4 skipped
- `corepack pnpm run oo:verify` — OOCLI 1.7.12/universal, lock v1
- `corepack pnpm run build`
- `git diff --check`

The production build includes both `dist-electron/wanta-opencode-oo-guard.js` and `dist-electron/wanta-oo-guard.js`.
