### PR TITLE
fix: preserve OOPilot routing and install Console skill

### DIFF
--- a/electron/agent/manager.test.ts
+++ b/electron/agent/manager.test.ts
@@ -2,7 +2,6 @@ import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { IMAGE_UNDERSTANDING_BUILTIN_MODEL_ID, resolveBuiltinModel } from "../models/builtin.ts"
 import {
   AgentManager,
   buildAgentSidecarEnv,
@@ -888,20 +887,15 @@ describe("AgentManager", () => {
         type: "text",
         text: expect.stringContaining("A test photo"),
       })
-      expect(calls[1]?.[0]).toMatchObject({ model: { modelID: "deepseek-v4-flash", providerID: "oomol" } })
-      expect(calls[1]?.[0].parts[0]).toMatchObject({
-        metadata: { wantaPurpose: "attachment-reference", wantaVisibility: "internal" },
-        synthetic: true,
-        type: "text",
-      })
-      expect(calls[1]?.[0].parts[1]).toMatchObject({
-        metadata: { wantaPurpose: "image-understanding", wantaVisibility: "internal" },
-        synthetic: true,
-        type: "text",
-        text: expect.stringContaining(resolveBuiltinModel(IMAGE_UNDERSTANDING_BUILTIN_MODEL_ID).displayName),
-      })
+      expect(calls[1]?.[0]).toMatchObject({ model: { modelID: "oopilot", providerID: "oomol" } })
+      expect(calls[1]?.[0].parts[0]).toMatchObject({ mime: "image/png", type: "file" })
+      expect(calls[1]?.[0].parts).not.toContainEqual(
+        expect.objectContaining({
+          metadata: { wantaPurpose: "image-understanding", wantaVisibility: "internal" },
+        }),
+      )
       expect(calls[2]?.[0].parts[0]).toMatchObject({ mime: "image/png", type: "file" })
-      expect(imageUnderstandingFetch).toHaveBeenCalledTimes(2)
+      expect(imageUnderstandingFetch).toHaveBeenCalledTimes(1)
       const visionRequest = imageUnderstandingFetch.mock.calls[0]?.[1]
       expect(visionRequest?.headers).toMatchObject({ Authorization: "Bearer test" })
       expect(JSON.parse(String(visionRequest?.body))).toMatchObject({
@@ -936,7 +930,7 @@ describe("AgentManager", () => {
     try {
       await manager.promptStreaming("session-1", "what is shown?", {
         attachments: [{ id: "image-1", mime: "image/png", name: "photo.png", path: imagePath, size: 10 }],
-        model: { kind: "builtin", id: "oopilot" },
+        model: { kind: "builtin", id: "deepseek-v4-flash" },
         teamName: "acme",
       })
 
@@ -1035,7 +1029,7 @@ describe("AgentManager", () => {
     try {
       const prompting = manager.promptStreaming("session-1", "what is shown?", {
         attachments: [{ id: "image-1", mime: "image/png", name: "photo.png", path: imagePath, size: 10 }],
-        model: { kind: "builtin", id: "oopilot" },
+        model: { kind: "builtin", id: "deepseek-v4-flash" },
         signal: controller.signal,
         teamName: "acme",
       })
@@ -1325,6 +1319,32 @@ describe("AgentManager", () => {
       response_format: { type: "json_object" },
     })
     expect(request?.headers).toMatchObject({ Authorization: "Bearer test" })
+  })
+
+  it("keeps the oopilot gateway alias when Auto generates a session title", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ choices: [{ message: { content: '{"title":"动态路由标题"}' } }] }), {
+        status: 200,
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const manager = new AgentManager({
+      linkRuntime: { kind: "oomol", sessionToken: "test" },
+      modelAccess: { kind: "oomol", sessionToken: "test" },
+      opencodeBinPath: "/tmp/opencode",
+      ooBinPath: "/tmp/oo",
+      rootDir: "/tmp/wanta-agent",
+    })
+
+    const title = await manager.generateSessionTitle({
+      model: { kind: "builtin", id: "oopilot" },
+      text: "生成标题",
+    })
+
+    expect(title).toEqual({ generated: true, title: "动态路由标题" })
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(JSON.parse(String(request?.body))).toMatchObject({ model: "oopilot" })
   })
 
   it("disables thinking and requests structured output for DeepSeek session titles", async () => {

--- a/electron/agent/manager.ts
+++ b/electron/agent/manager.ts
@@ -41,7 +41,6 @@ import {
   IMAGE_UNDERSTANDING_BUILTIN_MODEL_ID,
   isBuiltinModelId,
   resolveBuiltinModel,
-  resolveExecutionBuiltinModelId,
 } from "../models/builtin.ts"
 import { buildArtifactSystem } from "./artifact-system.ts"
 import { planAttachmentInputs } from "./attachment-input.ts"
@@ -1513,7 +1512,7 @@ export class AgentManager {
     if (!effectiveChoice || effectiveChoice.kind === "builtin") {
       const modelID =
         effectiveChoice && isBuiltinModelId(effectiveChoice.id) ? effectiveChoice.id : DEFAULT_BUILTIN_MODEL_ID
-      return resolveBuiltinModel(resolveExecutionBuiltinModelId(modelID)).runtime
+      return resolveBuiltinModel(modelID).runtime
     }
     const model = this.options.customModels?.find((item) => item.id === effectiveChoice.id)
     if (!model) {
@@ -1541,7 +1540,7 @@ export class AgentManager {
     }
     const modelID =
       effectiveChoice && isBuiltinModelId(effectiveChoice.id) ? effectiveChoice.id : DEFAULT_BUILTIN_MODEL_ID
-    const model = resolveBuiltinModel(resolveExecutionBuiltinModelId(modelID))
+    const model = resolveBuiltinModel(modelID)
     return model.capabilities.reasoningVariants?.includes(variant) ? variant : undefined
   }
 
@@ -1557,7 +1556,7 @@ export class AgentManager {
     }
     const modelID =
       effectiveChoice && isBuiltinModelId(effectiveChoice.id) ? effectiveChoice.id : DEFAULT_BUILTIN_MODEL_ID
-    const capabilities = resolveBuiltinModel(resolveExecutionBuiltinModelId(modelID)).capabilities
+    const capabilities = resolveBuiltinModel(modelID).capabilities
     return { images: capabilities.supportsImages, pdf: capabilities.supportsPdf }
   }
 

--- a/electron/models/builtin.test.ts
+++ b/electron/models/builtin.test.ts
@@ -8,7 +8,6 @@ import {
   builtinModelSummaries,
   isBuiltinModelId,
   resolveBuiltinModel,
-  resolveExecutionBuiltinModelId,
 } from "./builtin.ts"
 import { DEFAULT_MAX_OUTPUT_TOKENS, QWEN_37_MAX_OUTPUT_TOKENS, STANDARD_INPUT_TOKEN_LIMIT_TOKENS } from "./limits.ts"
 
@@ -152,12 +151,11 @@ test("Auto built-in model remains on the OOMOL compatible runtime", () => {
   assert.deepEqual(model.runtime, { providerID: "oomol", modelID: "oopilot" })
 })
 
-test("Auto executes with DeepSeek V4 Flash while explicit models keep their identity", () => {
-  assert.equal(resolveExecutionBuiltinModelId("oopilot"), "deepseek-v4-flash")
-  for (const id of BUILTIN_MODEL_IDS) {
-    if (id === DEFAULT_BUILTIN_MODEL_ID) continue
-    assert.equal(resolveExecutionBuiltinModelId(id), id, `${id} must keep its identity`)
-  }
+test("Auto keeps the oopilot gateway alias and native image capability", () => {
+  const model = resolveBuiltinModel(DEFAULT_BUILTIN_MODEL_ID)
+
+  assert.deepEqual(model.runtime, { providerID: "oomol", modelID: "oopilot" })
+  assert.equal(model.capabilities.supportsImages, true)
 })
 
 test("GPT models use OpenAI Responses runtime routing", () => {

--- a/electron/models/builtin.ts
+++ b/electron/models/builtin.ts
@@ -57,12 +57,7 @@ export const BUILTIN_MODEL_IDS = [
 export type BuiltinModelId = (typeof BUILTIN_MODEL_IDS)[number]
 
 export const DEFAULT_BUILTIN_MODEL_ID: BuiltinModelId = "oopilot"
-export const AUTO_PRIMARY_BUILTIN_MODEL_ID: BuiltinModelId = "deepseek-v4-flash"
 export const IMAGE_UNDERSTANDING_BUILTIN_MODEL_ID: BuiltinModelId = "qwen3.7-plus"
-
-export function resolveExecutionBuiltinModelId(modelID: BuiltinModelId): BuiltinModelId {
-  return modelID === DEFAULT_BUILTIN_MODEL_ID ? AUTO_PRIMARY_BUILTIN_MODEL_ID : modelID
-}
 
 export const BUILTIN_PROVIDER_DEFINITIONS: BuiltinProviderDefinition[] = [
   {

--- a/electron/skills/default-registry-skills.test.ts
+++ b/electron/skills/default-registry-skills.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from "vitest"
 import { defaultRegistrySkillSetVersion, defaultRegistrySkills } from "./default-registry-skills.ts"
 
 describe("default Registry Skills", () => {
-  it("installs the public social research adapter through the Registry runtime", () => {
-    expect(defaultRegistrySkillSetVersion).toBe(4)
+  it("includes the enabled Registry skills installed by default", () => {
+    expect(defaultRegistrySkillSetVersion).toBe(5)
+    expect(defaultRegistrySkills).toContainEqual({
+      category: "other",
+      enabled: true,
+      minimumVersion: "1.0.0",
+      packageName: "oo-oomol-console",
+      skillId: "oo-oomol-console",
+    })
     expect(defaultRegistrySkills).toContainEqual({
       category: "image-generation",
       enabled: true,

--- a/electron/skills/default-registry-skills.ts
+++ b/electron/skills/default-registry-skills.ts
@@ -6,10 +6,17 @@ export interface DefaultRegistrySkillSpec {
   skillId: string
 }
 
-export const defaultRegistrySkillSetVersion = 4
+export const defaultRegistrySkillSetVersion = 5
 
 // 默认安装清单：登录后后台补装，必须使用 registry 中稳定的 packageName + skillId。
 export const defaultRegistrySkills: readonly DefaultRegistrySkillSpec[] = [
+  {
+    category: "other",
+    enabled: true,
+    minimumVersion: "1.0.0",
+    packageName: "oo-oomol-console",
+    skillId: "oo-oomol-console",
+  },
   {
     category: "image-generation",
     enabled: true,


### PR DESCRIPTION
## Issue

Selecting Auto should send the `oopilot` gateway alias so the backend can dynamically choose the serving model. The client instead expanded Auto to `deepseek-v4-flash` before every prompt, which bypassed backend OOPilot routing. The same expansion also affected session-title requests.

For image turns, resolving Auto as DeepSeek additionally marked the selected model as lacking native vision support. That caused Wanta to invoke the Qwen image-understanding bridge even though OOPilot is backed by a vision-capable model.

OOMOL Console operations are exposed through the published `oo-oomol-console` Registry Skill, but Wanta did not install that Skill by default. Users therefore could not rely on Console capabilities being available immediately after login.

## Root cause

The built-in model registry defined `AUTO_PRIMARY_BUILTIN_MODEL_ID` as `deepseek-v4-flash`, and `AgentManager` called `resolveExecutionBuiltinModelId` when resolving the request model, reasoning variants, and attachment capabilities. As a result, the gateway received the concrete DeepSeek model ID instead of the `oopilot` alias.

The default Registry Skill set did not include the catalog-confirmed `oo-oomol-console` package and skill ID.

## Fix

- Remove the client-side Auto-to-DeepSeek execution mapping.
- Resolve Auto directly from its registered runtime so chat and title requests send `oomol/oopilot`.
- Read Auto's declared native image capability directly, allowing image files to pass through to OOPilot without invoking the image-understanding bridge.
- Keep the bridge behavior for explicitly selected models and custom models that do not support image input.
- Add regression coverage for the chat model ID, native image forwarding, bridge suppression, and session-title model ID.
- Add `oo-oomol-console` with a `1.0.0` minimum version to the enabled default Registry Skill set.
- Bump the default Registry Skill set version from 4 to 5 and cover the new entry with a regression test.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run ts-check`
- `corepack pnpm exec vitest run electron/models/builtin.test.ts electron/agent/manager.test.ts electron/skills/default-registry-skills.test.ts electron/skills/default-registry-install.test.ts electron/skills/default-install-store.test.ts` — 63 tests passed
- `corepack pnpm exec oxfmt --check electron/models/builtin.ts electron/models/builtin.test.ts electron/agent/manager.ts electron/agent/manager.test.ts`
- `git diff --check`
