### PR TITLE
fix(chat): prevent lifecycle races and reduce streaming render overhead

### DIFF
--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -247,6 +247,22 @@ before changing run state or clearing pending interactions. Local async actions
 capture an ownership token; optimistic sends bind that token to the host run on
 acknowledgement, and replacement or termination invalidates late callbacks.
 
+## Progress event ownership
+
+The host retains a bounded session/message-to-run index across turn completion.
+Known old message events cannot advance a replacement run, reset its watchdogs,
+or register tool child sessions. OpenCode assistant `parentID` is preserved as
+`parentMessageId` so a first-seen assistant belonging to a different user turn
+can also be rejected. Internal compaction messages are filtered before indexing.
+
+Message, tool, and activity progress sent to the renderer carries the captured
+`runId`, including buffered text. The renderer accepts tagged progress only for
+its live run; progress received after termination cannot restore a busy state.
+Backend history remains authoritative: ignored live updates can still appear
+in the next transcript snapshot, without changing the current run's phase.
+Uncorrelated native events without a known message owner or parent remain
+session-scoped; the host does not infer their age from text or identifier order.
+
 ## Checklist: adding a new agent
 
 0. **ACP-speaking agent?** Then it is ONE registration entry in

--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -234,6 +234,19 @@ notifications remain non-blocking; the explicit cancel request owns the wait.
 The chat service suppresses abort echoes and prevents cancelled generations
 from taking the successful-completion path during this wait.
 
+ACP marks a drained cancelled prompt with `messageCompleted.outcome = "cancelled"`,
+including process loss during cancellation. This acknowledgement resumes host
+cleanup after a cancellation timeout; it never becomes a successful turn. Stop
+attempts and acknowledgements share one generation-scoped cleanup promise, so
+repeated stop requests cannot finalize or publish the outcome twice. While the
+native turn remains active, the renderer keeps the stop control and queue gate
+active even when the stop RPC reports an error.
+
+Host terminal notifications carry `runId`. The renderer checks that identity
+before changing run state or clearing pending interactions. Local async actions
+capture an ownership token; optimistic sends bind that token to the host run on
+acknowledgement, and replacement or termination invalidates late callbacks.
+
 ## Checklist: adding a new agent
 
 0. **ACP-speaking agent?** Then it is ONE registration entry in

--- a/docs/ai/agent-adapter.md
+++ b/docs/ai/agent-adapter.md
@@ -224,6 +224,16 @@ External agents build on `electron/agent/external/`:
   only host-capability guards and runtime paths, never model credentials or
   provider endpoints.
 
+## Cancellation settlement
+
+A host `cancel` request resolves only after the ACP prompt and its final events
+have settled. Sending `session/cancel` alone is not proof that the session can
+accept another prompt. The adapter waits up to ten seconds, then reports a
+cancellation timeout while retaining the native active-turn guard. AbortSignal
+notifications remain non-blocking; the explicit cancel request owns the wait.
+The chat service suppresses abort echoes and prevents cancelled generations
+from taking the successful-completion path during this wait.
+
 ## Checklist: adding a new agent
 
 0. **ACP-speaking agent?** Then it is ONE registration entry in

--- a/docs/quality/baseline.md
+++ b/docs/quality/baseline.md
@@ -35,8 +35,9 @@ Source size is only for scoping the audit, not a quality target:
 - This round had no real account, so login, team switching, connector OAuth, payment return, and
   the Agent conversation golden path were not exercised;
 - notifications were not verified against a signed packaged app;
-- long-session React Profiler, Chromium Performance traces, and multi-process memory curves have
-  not yet been collected;
+- the September 2026 measurement below covers long-session text streaming; large tool outputs,
+  manual scrolling, production-build interaction latency, and multi-process memory curves still
+  need separate measurements;
 - the current shell's Node version is below the repo minimum and cannot substitute for the Node 24
   CI results.
 
@@ -129,3 +130,84 @@ Later performance findings must stay `hypothesis` until there is same-environmen
   appears, and Univer is not deleted, downgraded, or replaced on that basis;
 - after the conclusions were written in, `ts-check`, `lint`, `format`, 234 test files, 1569 tests,
   and the production build all pass.
+
+## 2026-09-05: long-session streaming and sidebar invalidation
+
+The measured issue is unnecessary sidebar rendering during assistant text updates.
+Four callback props changed identity on each parent render: login, task management,
+pointer resize start, and keyboard resize. Stable callbacks now preserve the existing
+memoized sidebar boundary. Resize callbacks retain their collapsed/width dependencies;
+keyboard updates continue to use functional state updates.
+
+### Reproducible scenario
+
+- Apple M1 Pro, 32 GiB RAM, macOS 26.6.2 arm64, Node 22.22.2;
+- Electron 43.4.1 / Chromium 150.0.7871.224, development build, cache enabled,
+  DevTools window closed, viewport 1080 × 720 CSS pixels at DPR 2;
+- the real AppShell, sidebar, ChatArea, ChatTimeline, turn rows and composer run in
+  Electron with identical React Profiler wrappers before and after;
+- an in-memory service fixture replaces only session/chat data, with 200 historical
+  messages (100 user/assistant pairs; 93,180 text characters), Markdown, no images,
+  no artifacts, and one sidebar task;
+- each turn emits 625 cumulative text updates at 32 ms intervals, producing 10,000
+  characters over 20 seconds; scripted textarea input runs every 250 ms;
+- each condition has five runs, discards run zero as warm-up, and measures five seconds
+  before and after the streaming window; heap is sampled again 30 seconds after all runs;
+- input latency is dispatch-to-next-animation-frame for scripted textarea input,
+  excluding the final draft-clear event. It is a scheduling proxy, **not native-input INP**.
+  Percentiles use the nearest-rank method.
+
+The fixture bypasses model latency and main-process chat IPC, so this measures renderer
+behavior rather than provider throughput or end-to-end request latency. It does not modify
+backend chat history. Existing runtime/account setup is used only to load the app shell.
+
+### Before/after results
+
+Values below are measured during each 20-second streaming window. Aggregate durations are
+medians of the four valid runs. Profiler subtree durations are inclusive and must not be
+summed across nested components.
+
+| Metric                                            |    Before |      After | Interpretation                                                      |
+| ------------------------------------------------- | --------: | ---------: | ------------------------------------------------------------------- |
+| Sidebar Profiler updates per run                  |   626–627 |        1–2 | Token-driven invalidation removed; real status/clock updates remain |
+| Sidebar cumulative render time, median            |  719.7 ms |    4.25 ms | 99.4% reduction in this subtree                                     |
+| AppShell subtree cumulative render time, median   | 5067.2 ms | 4739.45 ms | 6.5% reduction in inclusive React render work                       |
+| Historical turn Profiler updates during streaming |         0 |          0 | Existing turn identity/memoization remains effective                |
+| Scripted input-to-frame p95, median across runs   |   14.2 ms |   13.15 ms | Variable; insufficient to claim a general typing improvement        |
+| Animation-frame interval p95, median across runs  |    9.1 ms |     9.8 ms | No overall frame-latency improvement established                    |
+| Long tasks over 50 ms during streaming            |         0 |          0 | This fixture did not reproduce a severe stall                       |
+
+Per-run render data, in milliseconds:
+
+| Valid run | Sidebar before | Sidebar after | AppShell before | AppShell after |
+| --------- | -------------: | ------------: | --------------: | -------------: |
+| 1         |          719.2 |           6.2 |          5078.8 |         4736.0 |
+| 2         |          721.9 |           2.7 |          5071.5 |         4768.9 |
+| 3         |          718.1 |           5.6 |          5062.9 |         4727.9 |
+| 4         |          720.2 |           2.9 |          5021.2 |         4742.9 |
+
+The active timeline continues to do most rendering work. Its commit frequency and cumulative
+cost increased after the sidebar fix, while inclusive AppShell render time decreased. Do not
+translate the sidebar percentage into a whole-app speedup or claim that smooth-text rendering
+has been optimized. The current measurements justify removing callback-induced invalidation,
+not replacing the timeline with a virtual list or adding blanket memoization.
+
+### Evidence and remaining coverage
+
+Local raw artifacts are under `.wanta-dev/quality/chat-perf/` and intentionally excluded from
+Git: `baseline-confirm.json`, `after-fixed.json`, their `*-summary.json` files, CPU profiles,
+Chromium traces, `environment.json`, archived baseline source, and the fixture/collector.
+The collector uses only profiling commands over loopback CDP. `diagnostic.json` records prop
+names and change counts, without serializing prop values. Prop-identity diagnostics established that all four callbacks must be stable to preserve
+the memo boundary.
+
+Full-duration React/RAF/long-task samples were saved. Chromium tracing reached its buffer
+limit and retained only the beginning of the run, so it is not evidence for a full-duration
+layout/paint/GC comparison. Memory observations are not a leak diagnosis. Native keyboard
+latency, manual scroll interaction, large tool results, larger sidebar inventories and
+production-build profiles remain separate follow-up scenarios.
+
+Validation includes a React hook regression covering stable callbacks on unrelated renders,
+dragging from a keyboard-updated width, Shift+Arrow/Home/End behavior, width persistence and
+collapsed-state guards. No changes were made to text batching, message identity, Markdown
+semantics or artifact presentation.

--- a/docs/quality/baseline.md
+++ b/docs/quality/baseline.md
@@ -211,3 +211,86 @@ Validation includes a React hook regression covering stable callbacks on unrelat
 dragging from a keyboard-updated width, Shift+Arrow/Home/End behavior, width persistence and
 collapsed-state guards. No changes were made to text batching, message identity, Markdown
 semantics or artifact presentation.
+
+## 2026-09-05: active Markdown renderer identity
+
+This round starts after the sidebar fix and isolates MessageResponse preprocessing,
+MessageStreamdown rendering, and Chromium layout/paint work. It uses the same 200-message,
+93,180-character history, 625 updates over 20 seconds, 10,000-character output and scripted
+input scenario described above. There are five runs per condition; run zero is warm-up.
+These are separate paired measurements, not percentages to multiply with the sidebar result.
+
+The instrumentation preserves each component's existing memoization behavior. In particular,
+ordinary function components are profiled without adding a memo boundary. Exploratory runs
+with additional wrapper memoization were discarded. Only `message-before-exact` and
+`message-after-exact` are used below. Chromium tracing covers the complete first valid
+before/stream/after window, instead of tracing the entire campaign and filling its buffer.
+React, frame and input records cover all runs.
+
+### Confirmed cause and minimal fix
+
+MessageResponse created a new `components` object on every render. Streamdown 2.5.0 derives
+an inline-code wrapper function from that object's identity; the generated function then
+changes the component map passed to its memoized Markdown blocks. Consequently, even
+finished paragraphs with unchanged content fail their renderer comparison and are parsed
+again. The installed Streamdown implementation and the runtime measurements both support
+this mechanism.
+
+The merged component map is now memoized on the caller's `components` override. It remains
+stable across text updates while explicit override changes still take effect. This does not
+change the smoothing timer/step, Markdown normalization, code-language routing, image policy,
+Mermaid safety controls, text batching or message identity. Preprocessing costs were small
+relative to Markdown rendering and did not justify a new text cache or worker in this round.
+
+### Measured results
+
+Cumulative durations below are medians of four valid 20-second streaming windows. Profiler
+subtree durations are inclusive; MessageResponse and MessageStreamdown must not be added to
+AppShell. Input is the scripted dispatch-to-next-frame proxy, not native keyboard INP.
+
+| Metric                                   |     Before |      After |
+| ---------------------------------------- | ---------: | ---------: |
+| MessageStreamdown subtree render time    |  2875.0 ms |   789.3 ms |
+| MessageResponse subtree render time      | 2999.45 ms |   942.1 ms |
+| AppShell subtree render time             | 4925.75 ms | 2890.25 ms |
+| Input-to-frame p95, median across runs   |   11.75 ms |     7.4 ms |
+| Frame-interval p95, median across runs   |     9.2 ms |    9.05 ms |
+| Historical-turn updates during streaming |          0 |          0 |
+| Long tasks over 50 ms during streaming   |          0 |          0 |
+
+The Markdown subtree's cumulative render time decreased by 72.5%; inclusive AppShell render
+work decreased by 41.3% in this development fixture. These are renderer-work measurements,
+not provider-response speedups or production-build guarantees. The amount and rate of input
+text remained unchanged.
+
+| Valid run | Markdown before | Markdown after | AppShell before | AppShell after |
+| --------- | --------------: | -------------: | --------------: | -------------: |
+| 1         |       2818.3 ms |       801.0 ms |       4916.2 ms |      2976.9 ms |
+| 2         |       3081.0 ms |       774.9 ms |       5145.8 ms |      2881.3 ms |
+| 3         |       2915.1 ms |       789.5 ms |       4935.3 ms |      2845.6 ms |
+| 4         |       2834.9 ms |       789.1 ms |       4859.0 ms |      2899.2 ms |
+
+The complete representative trace provides an important qualification:
+
+| First valid stream window        |          Before |           After |
+| -------------------------------- | --------------: | --------------: |
+| Layout count / cumulative time   | 416 / 174.24 ms | 571 / 322.69 ms |
+| Paint count / cumulative time    |  974 / 72.85 ms | 1346 / 122.0 ms |
+| Minor GC count / cumulative time | 109 / 191.34 ms |  59 / 133.27 ms |
+
+Smoothing updates became more frequent as rendering became cheaper. Layout and paint work
+increased rather than disappearing; the large reduction was in Markdown rendering. There
+are still roughly 600 invocations per run where the text passed to Markdown has not changed,
+and preprocessing continues to run. Their remaining cost needs measurement at larger input
+sizes before further restructuring. Native input, large code/tool results, manual scrolling,
+and production-build profiles remain follow-up scenarios.
+
+Evidence is local under `.wanta-dev/quality/message-perf/`: the accepted JSON samples, summaries,
+representative Chromium traces, full CPU profiles, archived baseline source, and fixture/collector.
+Raw artifacts are excluded from Git. A regression test verifies stable component identity across
+text changes, explicit inline-code overrides, default image-renderer retention, and restoration
+of defaults when the override is removed.
+
+The normal development app also passed a live smoke check with a heading, inline code,
+a fenced JSON block, the code-copy control, a two-item list, and the return to idle after
+completion. Full validation passed 2996 tests with four skips, TypeScript, lint and formatting.

--- a/docs/quality/baseline.md
+++ b/docs/quality/baseline.md
@@ -293,4 +293,6 @@ of defaults when the override is removed.
 
 The normal development app also passed a live smoke check with a heading, inline code,
 a fenced JSON block, the code-copy control, a two-item list, and the return to idle after
-completion. Full validation passed 2996 tests with four skips, TypeScript, lint and formatting.
+completion. The full test suite passed 2996 tests with four skips; TypeScript and lint also
+passed. Formatting validation was limited to the modified files with `oxfmt --check`;
+full-repository formatting validation and a production build were not run in this round.

--- a/electron/agent/acp/adapter-edge.test.ts
+++ b/electron/agent/acp/adapter-edge.test.ts
@@ -317,9 +317,10 @@ describe("AcpAgentAdapter turn lifecycle edges", () => {
       },
     })
     await busy.adapter.send(promptInput())
-    await busy.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
-    await busy.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
+    const firstCancel = busy.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
+    const secondCancel = busy.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
     release.resolve()
+    await Promise.all([firstCancel, secondCancel])
     await busy.waitFor((event) => event.event === "messageCompleted")
     expect(completedCount(busy.events)).toBe(1)
     expect(promptCalls).toBe(1)
@@ -710,9 +711,8 @@ describe("AcpAgentAdapter turn lifecycle edges", () => {
     expect(harness.fake.newSessionRequests).toHaveLength(2)
   })
 
-  test("a new prompt after cancel but before the cancelled turn settles is rejected as in flight", async () => {
-    // Documented backpressure: ACP considers the turn active until the agent
-    // answers the prompt request, so an immediate resend is refused.
+  test("cancel waits for native settlement before allowing the next prompt", async () => {
+    // The host must not report stop completion while the native turn is still active.
     const release = deferred<void>()
     let promptCalls = 0
     const harness = await createHarness({
@@ -727,10 +727,16 @@ describe("AcpAgentAdapter turn lifecycle edges", () => {
       },
     })
     await harness.adapter.send(promptInput())
-    await harness.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
+    let cancelFinished = false
+    const cancelling = harness.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID }).then(() => {
+      cancelFinished = true
+    })
     await vi.waitFor(() => expect(harness.fake.cancelledSessionIds).toHaveLength(1))
+    expect(cancelFinished).toBe(false)
     await expect(harness.adapter.send(promptInput("too soon"))).rejects.toThrow(/already in flight/u)
     release.resolve()
+    await cancelling
+    expect(cancelFinished).toBe(true)
     await harness.waitFor((event) => event.event === "messageCompleted")
     await harness.adapter.send(promptInput("after settle"))
     await vi.waitFor(() => expect(completedCount(harness.events)).toBe(2))
@@ -744,4 +750,27 @@ describe("AcpAgentAdapter turn lifecycle edges", () => {
     expect(harness.fake.newSessionRequests).toHaveLength(0)
     expect(harness.fake.promptRequests).toHaveLength(0)
   })
+})
+
+test("cancel times out without freeing an unsettled native turn", async () => {
+  const release = deferred<void>()
+  const harness = await createHarness({
+    prompt: async () => {
+      await release.promise
+      return { stopReason: "cancelled" }
+    },
+  })
+  await harness.adapter.send(promptInput())
+  vi.useFakeTimers()
+  try {
+    const cancelling = harness.adapter.send({ type: "cancel", sessionId: WANTA_SESSION_ID })
+    const rejected = expect(cancelling).rejects.toThrow(/timed out waiting for the cancelled turn/u)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await rejected
+    await expect(harness.adapter.send(promptInput("too soon"))).rejects.toThrow(/already in flight/u)
+  } finally {
+    vi.useRealTimers()
+    release.resolve()
+  }
+  await harness.waitFor((event) => event.event === "messageCompleted")
 })

--- a/electron/agent/acp/adapter-edge.test.ts
+++ b/electron/agent/acp/adapter-edge.test.ts
@@ -19,6 +19,8 @@ import { mkdtemp } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, describe, expect, test, vi } from "vitest"
+import { ChatServiceImpl } from "../../chat/node.ts"
+import { ManagedTurnDirectories } from "../managed-turn-directories.ts"
 import { AcpAgentAdapter } from "./adapter.ts"
 import { ACP_AGENT_REGISTRY } from "./registry.ts"
 
@@ -773,4 +775,65 @@ test("cancel times out without freeing an unsettled native turn", async () => {
     release.resolve()
   }
   await harness.waitFor((event) => event.event === "messageCompleted")
+})
+
+test("the host releases a timed-out cancellation on late ACP settlement without disturbing another session", async () => {
+  const cancelledDrain = deferred<void>()
+  const otherDrain = deferred<void>()
+  let promptCount = 0
+  const harness = await createHarness({
+    prompt: async (turn) => {
+      promptCount += 1
+      const index = promptCount
+      await turn.sendUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: `turn-${index}` } })
+      if (index === 1) {
+        await turn.cancelled
+        await cancelledDrain.promise
+        return { stopReason: "cancelled" }
+      }
+      if (index === 2) await otherDrain.promise
+      return { stopReason: "end_turn" }
+    },
+  })
+  const root = await mkdtemp(path.join(os.tmpdir(), "wanta-cancel-recovery-"))
+  const service = new ChatServiceImpl(null, { managedTurnDirectories: new ManagedTurnDirectories(root) })
+  const events: Array<{ event: string; data: unknown }> = []
+  vi.spyOn(service as unknown as { send: (event: string, data: unknown) => Promise<void> }, "send").mockImplementation(
+    async (event, data) => {
+      events.push({ event, data })
+    },
+  )
+  service.setExternalAgents(new Map([["codex", harness.adapter]]))
+  const sessionId = "wanta-ext:codex:11111111-1111-4111-8111-111111111111"
+  const otherId = "wanta-ext:codex:22222222-2222-4222-8222-222222222222"
+  const scope = { kind: "local" as const, workspaceId: "local", workspaceName: "Local" }
+  await service.sendMessage({ sessionId, text: "cancel me", scope })
+  await harness.waitFor((event) => event.event === "messageDelta" && event.data.text === "turn-1")
+  await service.sendMessage({ sessionId: otherId, text: "keep running", scope })
+  await harness.waitFor((event) => event.event === "messageDelta" && event.data.text === "turn-2")
+  const runId = (await service.getActiveRun(sessionId))?.runId
+  const otherRunId = (await service.getActiveRun(otherId))?.runId
+  vi.useFakeTimers()
+  try {
+    const stopping = service.stopGeneration(sessionId)
+    const rejected = expect(stopping).rejects.toThrow(/timed out waiting for the cancelled turn/u)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await rejected
+    expect((await service.getActiveRun(sessionId))?.runId).toBe(runId)
+    await expect(service.sendMessage({ sessionId, text: "too soon", scope })).rejects.toThrow(/already active/u)
+  } finally {
+    vi.useRealTimers()
+    cancelledDrain.resolve()
+  }
+  await vi.waitFor(async () => expect(await service.getActiveRun(sessionId)).toBeNull())
+  expect((await service.getActiveRun(otherId))?.runId).toBe(otherRunId)
+  expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
+    expect.objectContaining({ sessionId, runId, kind: "cancelled" }),
+  ])
+  expect(events.filter((event) => event.event === "generationStopped")).toHaveLength(1)
+  await service.sendMessage({ sessionId, text: "retry", scope })
+  await vi.waitFor(async () => expect(await service.getActiveRun(sessionId)).toBeNull())
+  expect(harness.fake.promptRequests).toHaveLength(3)
+  otherDrain.resolve()
+  await vi.waitFor(async () => expect(await service.getActiveRun(otherId)).toBeNull())
 })

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -67,6 +67,7 @@ import { createAcpSessionTranslator, sanitizeAcpMessages } from "./translator.ts
 const ACP_AUTH_REQUIRED_CODE = -32000
 const ACP_REQUEST_CANCELLED_CODE = -32800
 const PROBE_CACHE_TTL_MS = 30_000
+const CANCEL_SETTLE_TIMEOUT_MS = 10_000
 
 /** Test seam: a connected ACP wire plus subprocess lifecycle hooks. */
 export interface AcpTransport {
@@ -143,6 +144,8 @@ interface AcpTurn {
   /** An errored tool has not yet received a user-facing assistant explanation. */
   failedToolNeedsExplanation: boolean
   settled: boolean
+  /** Resolves after the native prompt and its final event have drained. */
+  completion?: Promise<void>
 }
 
 interface AcpSessionState {
@@ -735,6 +738,7 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       }),
     })
     const completion = this.trackTurn(session, turn, promptPromise, options?.signal)
+    turn.completion = completion
     onCompletion?.(completion)
     // Session-scoped routes resolve on dispatch. Process-scoped routes hold the
     // queue until completion so another session cannot replace the live model.
@@ -768,7 +772,23 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
     if (options?.signal?.aborted) {
       return
     }
-    await this.cancelSession(input.sessionId)
+    const turn = this.sessionsByWantaId.get(input.sessionId)?.activeTurn
+    // Notification delivery is not cancellation completion. Keep the host's
+    // generation occupied until the old prompt can no longer reject a retry.
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        this.cancelSession(input.sessionId).then(() => turn?.completion),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`${this.kind}: timed out waiting for the cancelled turn to finish`)),
+            CANCEL_SETTLE_TIMEOUT_MS,
+          )
+        }),
+      ])
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+    }
   }
 
   protected override async handlePermissionResponse(

--- a/electron/agent/acp/adapter.ts
+++ b/electron/agent/acp/adapter.ts
@@ -1104,7 +1104,7 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
             { adapter: this.kind, outcome: "cancelled", sessionId: wantaSessionId, stopReason: response.stopReason },
             "info",
           )
-          this.emit({ event: "messageCompleted", data: { sessionId: wantaSessionId } })
+          this.emit({ event: "messageCompleted", data: { sessionId: wantaSessionId, outcome: "cancelled" } })
           return
         }
         const incompleteToolTurn = turn.activeToolCallIds.size > 0 || turn.failedToolNeedsExplanation
@@ -1148,7 +1148,7 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
         }
         if (session.cancelling || requestErrorCode(error) === ACP_REQUEST_CANCELLED_CODE) {
           // Cancelled turns still end; the UI must leave the streaming state.
-          this.emit({ event: "messageCompleted", data: { sessionId: wantaSessionId } })
+          this.emit({ event: "messageCompleted", data: { sessionId: wantaSessionId, outcome: "cancelled" } })
           return
         }
         const message = this.isAuthRequiredError(error)
@@ -1378,10 +1378,14 @@ export class AcpAgentAdapter extends ExternalAgentAdapter {
       if (turn && !turn.settled) {
         turn.settled = true
         session.activeTurn = undefined
-        this.emit({
-          event: "agentError",
-          data: { sessionId: session.wantaSessionId, message: `${displayName} exited unexpectedly` },
-        })
+        this.emit(
+          session.cancelling
+            ? { event: "messageCompleted", data: { sessionId: session.wantaSessionId, outcome: "cancelled" } }
+            : {
+                event: "agentError",
+                data: { sessionId: session.wantaSessionId, message: `${displayName} exited unexpectedly` },
+              },
+        )
       }
     }
     // ACP session ids died with the subprocess; drop the mappings so the next

--- a/electron/agent/contract/event.ts
+++ b/electron/agent/contract/event.ts
@@ -254,6 +254,8 @@ const permissionModeUpdatedSchema = z.object({
 })
 
 const messageCompletedSchema = z.object({
+  outcome: z.literal("cancelled").optional(),
+  runId: z.string().optional(),
   sessionId: z.string(),
 })
 

--- a/electron/agent/contract/event.ts
+++ b/electron/agent/contract/event.ts
@@ -161,6 +161,8 @@ export const permissionRequestSchema = z.object({
 })
 
 const messageStartedSchema = z.object({
+  parentMessageId: z.string().optional(),
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   role: chatRoleSchema,
@@ -170,6 +172,7 @@ const messageStartedSchema = z.object({
 })
 
 const messageDeltaSchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   partId: z.string(),
@@ -179,6 +182,7 @@ const messageDeltaSchema = z.object({
 })
 
 const messageReasoningDeltaSchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   partId: z.string(),
@@ -187,6 +191,7 @@ const messageReasoningDeltaSchema = z.object({
 })
 
 const messageAttachmentSchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   partId: z.string(),
@@ -194,6 +199,7 @@ const messageAttachmentSchema = z.object({
 })
 
 const assistantActivitySchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string().optional(),
   phase: z.enum(["thinking", "finalizing", "retrying", "compacting", "resuming"]),
@@ -204,6 +210,7 @@ const assistantActivitySchema = z.object({
 })
 
 const toolCallStartedSchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   partId: z.string(),
@@ -217,6 +224,7 @@ const toolCallStartedSchema = z.object({
 })
 
 const toolCallResultSchema = z.object({
+  runId: z.string().optional(),
   sessionId: z.string(),
   messageId: z.string(),
   partId: z.string(),

--- a/electron/agent/event-translator.test.ts
+++ b/electron/agent/event-translator.test.ts
@@ -907,3 +907,25 @@ test("normalizeMessage skips aborted message-level errors for stopped history", 
   assert.ok(msg)
   assert.deepEqual(msg.parts, [{ kind: "text", partId: "p1", text: "Partial answer" }])
 })
+
+test("assistant parent identity survives normalization for turn ownership checks", () => {
+  assert.deepEqual(
+    translateOpencodeEvent({
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "assistant",
+          sessionID: "session",
+          role: "assistant",
+          parentID: "user-turn",
+        },
+      },
+    }),
+    [
+      {
+        event: "messageStarted",
+        data: { sessionId: "session", messageId: "assistant", role: "assistant", parentMessageId: "user-turn" },
+      },
+    ],
+  )
+})

--- a/electron/agent/event-translator.ts
+++ b/electron/agent/event-translator.ts
@@ -299,6 +299,7 @@ export function translateOpencodeEvent(event: OpencodeEvent): ChatEmit[] {
         | {
             id?: string
             sessionID?: string
+            parentID?: string
             role?: ChatRole
             error?: unknown
             finish?: unknown
@@ -318,6 +319,7 @@ export function translateOpencodeEvent(event: OpencodeEvent): ChatEmit[] {
             sessionId: info.sessionID,
             messageId: info.id,
             role: info.role,
+            ...(info.parentID ? { parentMessageId: info.parentID } : {}),
             ...(info.summary === true ? { internal: true } : {}),
             ...(finishReason ? { finishReason } : {}),
             ...(completedAt === undefined ? {} : { completedAt }),

--- a/electron/chat/active-run-registry.test.ts
+++ b/electron/chat/active-run-registry.test.ts
@@ -90,3 +90,12 @@ test("a user prompt echo never flips the run to answering", () => {
   assert.equal(registry.get("session-1")?.phase, "answering")
   assert.equal(registry.get("session-1")?.activeAssistantMessageId, "assistant-1")
 })
+
+test("a delayed reply for an unknown blocking request cannot reset the current tool phase", () => {
+  const registry = new ActiveRunRegistry(() => undefined)
+  registry.create("session", "new-run", { kind: "local", workspaceId: "local", workspaceName: "Local" })
+  registry.update("session", { phase: "tool_running", activeToolPartIds: ["new-tool"] })
+  const before = registry.get("session")
+  registry.removeBlockingRequest("session", "old-permission")
+  assert.equal(registry.get("session"), before)
+})

--- a/electron/chat/active-run-registry.ts
+++ b/electron/chat/active-run-registry.ts
@@ -142,6 +142,7 @@ export class ActiveRunRegistry {
 
   public removeBlockingRequest(sessionId: string, requestId: string): void {
     const blocks = this.blockingPhases.get(sessionId)
+    if (!blocks?.has(requestId)) return
     if (blocks) {
       blocks.delete(requestId)
       if (blocks.size === 0) {

--- a/electron/chat/common.ts
+++ b/electron/chat/common.ts
@@ -46,6 +46,10 @@ export interface ToolTiming {
 
 // ── ServerEvents 负载（R7 流式：主进程把 OpenCode SSE 转译为这些事件推给渲染层）──
 export interface MessageStartedEvent {
+  /** Native user-message parent, when supplied by the backend. */
+  parentMessageId?: string
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   role: ChatRole
@@ -56,6 +60,8 @@ export interface MessageStartedEvent {
   completedAt?: number
 }
 export interface MessageDeltaEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   partId: string
@@ -67,6 +73,8 @@ export interface MessageDeltaEvent {
   synthetic?: boolean
 }
 export interface MessageReasoningDeltaEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   partId: string
@@ -75,6 +83,8 @@ export interface MessageReasoningDeltaEvent {
   delta?: string
 }
 export interface MessageAttachmentEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   partId: string
@@ -91,6 +101,8 @@ export interface TurnOutputUpdatedEvent {
 export type AssistantActivityPhase = "thinking" | "finalizing" | "retrying" | "compacting" | "resuming"
 
 export interface AssistantActivityEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId?: string
   phase: AssistantActivityPhase
@@ -101,6 +113,8 @@ export interface AssistantActivityEvent {
   nextRetryAt?: number
 }
 export interface ToolCallStartedEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   partId: string
@@ -122,6 +136,8 @@ export type ToolFailureKind =
   | "unknown"
 export type ToolUserImpact = "none" | "read_only" | "side_effect_possible"
 export interface ToolCallResultEvent {
+  /** Host generation identity, attached before IPC buffering. */
+  runId?: string
   sessionId: string
   messageId: string
   partId: string

--- a/electron/chat/common.ts
+++ b/electron/chat/common.ts
@@ -225,6 +225,10 @@ export interface SetChatPermissionModeRequest {
   version?: number
 }
 export interface MessageCompletedEvent {
+  /** Native acknowledgement that a cancelled prompt has fully drained. */
+  outcome?: "cancelled"
+  /** Host generation identity; absent on native adapter input. */
+  runId?: string
   sessionId: string
 }
 /**
@@ -234,6 +238,8 @@ export interface MessageCompletedEvent {
  */
 export type ChatTurnOutcomeKind = "completed" | "cancelled" | "failed" | "interrupted"
 export interface TurnOutcomeEvent {
+  /** Host generation identity; absent on native adapter input. */
+  runId?: string
   sessionId: string
   kind: ChatTurnOutcomeKind
   messageId?: string
@@ -266,6 +272,8 @@ export interface MessagePartRemovedEvent {
   partId: string
 }
 export interface MessageErrorEvent {
+  /** Host generation identity; absent on native adapter input. */
+  runId?: string
   sessionId: string
   messageId?: string
   partId: string
@@ -274,6 +282,8 @@ export interface MessageErrorEvent {
   errorCode?: string
 }
 export interface GenerationStoppedEvent {
+  /** Host generation identity; absent on native adapter input. */
+  runId?: string
   sessionId: string
   messageId?: string
   partIds?: string[]
@@ -289,6 +299,8 @@ export type GenerationInterruptedReason =
   | "submit_timeout"
 
 export interface GenerationInterruptedEvent {
+  /** Host generation identity; absent on native adapter input. */
+  runId?: string
   sessionId: string
   messageId?: string
   partIds?: string[]

--- a/electron/chat/external-dx-edge.test.ts
+++ b/electron/chat/external-dx-edge.test.ts
@@ -1381,3 +1381,36 @@ test("edge5b: a malformed external session uuid is never routed to an adapter", 
   )
   assert.equal(codex.prompts.length, 0)
 })
+
+test("late external tool results remain in history without advancing the replacement run", async () => {
+  const { service, adapters, events } = createHarness(["codex"])
+  const adapter = adapters.get("codex")!
+  const sessionId = mintExternalSessionId("codex")
+  await service.sendMessage(sendRequest(sessionId, "first"))
+  await waitForCondition(() => adapter.prompts.length === 1)
+  adapter.startAssistantReply(sessionId, "old-assistant", "first reply")
+  await service.stopGeneration(sessionId)
+  await service.sendMessage(sendRequest(sessionId, "second"))
+  await waitForCondition(() => adapter.prompts.length === 2)
+  adapter.startAssistantReply(sessionId, "new-assistant", "second reply")
+  const before = await service.getActiveRun(sessionId)
+  const count = events.length
+  adapter.emitEvent({
+    event: "toolCallResult",
+    data: {
+      sessionId,
+      messageId: "old-assistant",
+      partId: "old-part",
+      callId: "old-call",
+      tool: "bash",
+      input: {},
+      output: "late historical output",
+      status: "completed",
+    },
+  })
+  assert.deepEqual(await service.getActiveRun(sessionId), before)
+  assert.equal(events.length, count)
+  const oldMessage = (await adapter.getMessages(sessionId)).find((message) => message.id === "old-assistant")
+  assert.ok(oldMessage?.parts.some((part) => part.kind === "tool" && part.output === "late historical output"))
+  await service.stopGeneration(sessionId)
+})

--- a/electron/chat/generation-registry.ts
+++ b/electron/chat/generation-registry.ts
@@ -1,4 +1,6 @@
 export interface SessionGeneration {
+  cancellationRequested?: boolean
+  cancellationSettled?: boolean
   controller: AbortController
   id: string
   userMessageId: string

--- a/electron/chat/message-run-registry.test.ts
+++ b/electron/chat/message-run-registry.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest"
+import { MessageRunRegistry } from "./message-run-registry.ts"
+
+test("message ownership survives completion, retry, and interleaved sessions", () => {
+  const registry = new MessageRunRegistry()
+  expect(registry.isCurrent("a", "message", "old")).toBe(true)
+  expect(registry.isCurrent("a", "message", undefined)).toBe(false)
+  expect(registry.isCurrent("a", "message", "new")).toBe(false)
+  expect(registry.isCurrent("b", "message", "other")).toBe(true)
+  expect(registry.isCurrent("a", "new-message", "new")).toBe(true)
+})
+
+test("a mismatched native parent makes subsequent parts stale as well", () => {
+  const registry = new MessageRunRegistry()
+  expect(registry.isCurrent("a", "late", "new", { parentMessageId: "old-user", userMessageId: "new-user" })).toBe(false)
+  expect(registry.isCurrent("a", "late", "new")).toBe(false)
+  expect(registry.isCurrent("a", "current", "new", { parentMessageId: "new-user", userMessageId: "new-user" })).toBe(
+    true,
+  )
+})
+
+test("the bounded index can be forgotten per session or reset with the backend", () => {
+  const registry = new MessageRunRegistry(2)
+  registry.isCurrent("a", "one", "old")
+  registry.isCurrent("b", "two", "old")
+  registry.isCurrent("b", "three", "old")
+  // Only the oldest entry has been evicted.
+  expect(registry.isCurrent("b", "two", "new")).toBe(false)
+  expect(registry.isCurrent("a", "one", "new")).toBe(true)
+  registry.forgetSession("a")
+  expect(registry.isCurrent("a", "one", "replacement")).toBe(true)
+  registry.clear()
+  expect(registry.isCurrent("b", "three", "replacement")).toBe(true)
+})

--- a/electron/chat/message-run-registry.ts
+++ b/electron/chat/message-run-registry.ts
@@ -1,0 +1,47 @@
+/** Bounded message ownership retained across turns, so delayed parts keep their original owner. */
+export class MessageRunRegistry {
+  private readonly owners = new Map<string, string | undefined>()
+  private readonly limit: number
+
+  public constructor(limit = 5_000) {
+    this.limit = limit
+  }
+
+  public isCurrent(
+    sessionId: string,
+    messageId: string,
+    runId: string | undefined,
+    options: { parentMessageId?: string; userMessageId?: string } = {},
+  ): boolean {
+    const key = `${sessionId}\0${messageId}`
+    // Native parent identity also catches an old assistant first observed only
+    // after a retry. Never rebind that message to the new turn.
+    if (options.parentMessageId && options.userMessageId && options.parentMessageId !== options.userMessageId) {
+      this.remember(key, undefined)
+      return false
+    }
+    if (this.owners.has(key)) return this.owners.get(key) === runId
+    this.remember(key, runId)
+    return true
+  }
+
+  public forgetSession(sessionId: string): void {
+    for (const key of this.owners.keys()) {
+      if (key.startsWith(`${sessionId}\0`)) this.owners.delete(key)
+    }
+  }
+
+  public clear(): void {
+    this.owners.clear()
+  }
+
+  private remember(key: string, runId: string | undefined): void {
+    if (this.owners.has(key)) return
+    while (this.owners.size >= this.limit) {
+      const oldest = this.owners.keys().next().value
+      if (oldest === undefined) break
+      this.owners.delete(oldest)
+    }
+    this.owners.set(key, runId)
+  }
+}

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -910,7 +910,12 @@ test("stopping during compaction clears internal state before the next generatio
   assert.deepEqual(events.slice(eventCount), [
     {
       event: "messageStarted",
-      data: { sessionId: "session-1", messageId: "reused-message", role: "user" },
+      data: {
+        sessionId: "session-1",
+        messageId: "reused-message",
+        role: "user",
+        runId: (await service.getActiveRun("session-1"))?.runId,
+      },
     },
   ])
 })
@@ -4689,4 +4694,144 @@ test("completion during cancellation cannot release the session or report succes
   expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
     { sessionId: "session-1", runId, kind: "cancelled", messageId: "assistant-1" },
   ])
+})
+
+test("late tool and activity events cannot mutate the replacement run or register child sessions", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "old-assistant", sessionID: "session-1", role: "assistant" } },
+  })
+  await service.stopGeneration("session-1")
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "new-assistant", sessionID: "session-1", role: "assistant" } },
+  })
+  const before = await service.getActiveRun("session-1")
+  const eventCount = events.length
+  for (const status of ["running", "completed"] as const) {
+    bridge.emit({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "old-tool",
+          sessionID: "session-1",
+          messageID: "old-assistant",
+          type: "tool",
+          callID: "old-call",
+          tool: "task",
+          state: { status, input: {}, output: "old output", metadata: { sessionId: "late-child" } },
+        },
+      },
+    })
+  }
+  bridge.emit({
+    type: "message.part.updated",
+    properties: { part: { id: "old-step", sessionID: "session-1", messageID: "old-assistant", type: "step-start" } },
+  })
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: { id: "old-text", sessionID: "session-1", messageID: "old-assistant", type: "text", text: "late" },
+    },
+  })
+  expect(await service.getActiveRun("session-1")).toEqual(before)
+  expect(events).toHaveLength(eventCount)
+  expect(bridge.inheritSessionKnowledgeBaseIds).not.toHaveBeenCalled()
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "new-tool",
+        sessionID: "session-1",
+        messageID: "new-assistant",
+        type: "tool",
+        callID: "new-call",
+        tool: "bash",
+        state: { status: "running", input: {} },
+      },
+    },
+  })
+  expect(await service.getActiveRun("session-1")).toMatchObject({
+    phase: "tool_running",
+    activeToolPartIds: ["new-tool"],
+    activeAssistantMessageId: "new-assistant",
+  })
+  expect(events.at(-1)).toMatchObject({ event: "toolCallStarted", data: { runId: before?.runId, partId: "new-tool" } })
+  await service.stopGeneration("session-1")
+  const stoppedCount = events.length
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: { id: "old-text", sessionID: "session-1", messageID: "old-assistant", type: "text", text: "late again" },
+    },
+  })
+  expect(events).toHaveLength(stoppedCount)
+})
+
+test("native parent identity rejects a first-seen old assistant after a retry", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+  const oldParent = bridge.promptStreaming.mock.calls[0]?.[2]?.messageId
+  await service.stopGeneration("session-1")
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+  const newParent = bridge.promptStreaming.mock.calls[1]?.[2]?.messageId
+  const before = await service.getActiveRun("session-1")
+  const count = events.length
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "unseen-old", sessionID: "session-1", role: "assistant", parentID: oldParent } },
+  })
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: { id: "unseen-text", sessionID: "session-1", messageID: "unseen-old", type: "text", text: "late" },
+    },
+  })
+  expect(await service.getActiveRun("session-1")).toEqual(before)
+  expect(events).toHaveLength(count)
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "current", sessionID: "session-1", role: "assistant", parentID: newParent } },
+  })
+  expect(await service.getActiveRun("session-1")).toMatchObject({
+    activeAssistantMessageId: "current",
+    phase: "thinking",
+  })
+  await service.stopGeneration("session-1")
+})
+
+test("current compaction continuation parents still advance the active run", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "continue work" })
+  bridge.emit({
+    type: "message.part.updated",
+    properties: { part: { id: "compact", sessionID: "session-1", messageID: "summary", type: "compaction" } },
+  })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "continuation", sessionID: "session-1", role: "user" } },
+  })
+  bridge.emit({
+    type: "message.updated",
+    properties: {
+      info: { id: "continued-assistant", sessionID: "session-1", role: "assistant", parentID: "continuation" },
+    },
+  })
+  expect(await service.getActiveRun("session-1")).toMatchObject({
+    phase: "thinking",
+    activeAssistantMessageId: "continued-assistant",
+  })
+  await service.stopGeneration("session-1")
 })

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -784,9 +784,9 @@ test("stopGeneration suppresses delayed streaming events until the next send", a
     type: "session.error",
     properties: { sessionID: "session-1", error: { name: "AbortError" } },
   })
-  await waitForEventCount(events, beforeAbortEventCount + 1)
-  assert.equal(events.length, beforeAbortEventCount + 1)
-  assert.equal(events.at(-1)?.event, "generationStopped")
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert.equal(events.length, beforeAbortEventCount)
+  assert.equal(events.filter((event) => event.event === "generationStopped").length, 1)
   const abortEventCount = events.length
   bridge.emit({
     type: "message.part.updated",
@@ -1526,6 +1526,11 @@ test("message completion exposes a failed artifact bundle when an image preview 
     service.startEventBridge()
 
     await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "Create an image" })
+    const assistantHistory = await bridge.agent.getMessages("session-1")
+    bridge.getMessages.mockResolvedValue([
+      { id: bridge.promptStreaming.mock.calls[0]?.[2]?.messageId as string, role: "user", createdAt: 0, parts: [] },
+      ...assistantHistory,
+    ])
     bridge.emit({
       type: "message.updated",
       properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
@@ -1574,6 +1579,11 @@ test("message completion materializes a data image preview into a ready artifact
     service.startEventBridge()
 
     await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "Create an image" })
+    const assistantHistory = await bridge.agent.getMessages("session-1")
+    bridge.getMessages.mockResolvedValue([
+      { id: bridge.promptStreaming.mock.calls[0]?.[2]?.messageId as string, role: "user", createdAt: 0, parts: [] },
+      ...assistantHistory,
+    ])
     bridge.emit({
       type: "message.updated",
       properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
@@ -1633,6 +1643,11 @@ test("message completion materializes assistant file attachments into managed ar
     service.startEventBridge()
 
     await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "Create an image" })
+    const assistantHistory = await bridge.agent.getMessages("session-1")
+    bridge.getMessages.mockResolvedValue([
+      { id: bridge.promptStreaming.mock.calls[0]?.[2]?.messageId as string, role: "user", createdAt: 0, parts: [] },
+      ...assistantHistory,
+    ])
     bridge.emit({
       type: "message.updated",
       properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
@@ -4546,4 +4561,129 @@ test("getLocalArtifactPreview rejects binary-looking text files", async () => {
 
   assert.equal(result.kind, "unsupported")
   assert.equal(result.mime, "text/plain")
+})
+
+test("same-session concurrent sends reject the losing request instead of silently replacing it", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  captureServiceEvents(service)
+  const results = await Promise.allSettled([
+    service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" }),
+    service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" }),
+  ])
+  expect(results[0]?.status).toBe("fulfilled")
+  expect(results[1]).toMatchObject({
+    status: "rejected",
+    reason: new Error("A generation is already active for this session."),
+  })
+  expect(bridge.promptStreaming.mock.calls.map((call) => call[1])).toEqual(["first"])
+  await service.stopGeneration("session-1")
+})
+
+test("abort echoes do not start competing finalizers or stop the next turn", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+  let release!: () => void
+  const outputPending = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const finalizer = vi
+    .spyOn(
+      service as unknown as { finalizeTurnOutput: (sessionId: string, messageId?: string) => Promise<void> },
+      "finalizeTurnOutput",
+    )
+    .mockReturnValue(outputPending)
+  const stopping = service.stopGeneration("session-1")
+  await waitForCondition(() => finalizer.mock.calls.length === 1)
+  bridge.emit({ type: "session.error", properties: { sessionID: "session-1", error: { name: "AbortError" } } })
+  expect(finalizer).toHaveBeenCalledTimes(1)
+  expect(await service.getActiveRun("session-1")).not.toBeNull()
+  release()
+  await stopping
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+  expect(await service.getActiveRun("session-1")).not.toBeNull()
+  expect(events.filter((event) => event.event === "generationStopped")).toHaveLength(1)
+  finalizer.mockRestore()
+  await service.stopGeneration("session-1")
+})
+
+test("late tool events cannot use an old assistant to complete the current user turn", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "old-assistant", sessionID: "session-1", role: "assistant" } },
+  })
+  await service.stopGeneration("session-1")
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+  const userMessageId = bridge.promptStreaming.mock.calls[1]?.[2]?.messageId as string
+  bridge.emit({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "old-tool",
+        sessionID: "session-1",
+        messageID: "old-assistant",
+        type: "tool",
+        callID: "old-call",
+        tool: "bash",
+        state: { status: "running", input: {} },
+      },
+    },
+  })
+  bridge.getMessages.mockResolvedValue([
+    { id: "old-assistant", role: "assistant", createdAt: 1, completedAt: 2, finishReason: "stop", parts: [] },
+    { id: userMessageId, role: "user", createdAt: 3, parts: [] },
+  ])
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await new Promise((resolve) => setTimeout(resolve, 175))
+  expect(await service.getActiveRun("session-1")).not.toBeNull()
+  expect(events.filter((event) => event.event === "messageCompleted")).toHaveLength(0)
+  bridge.getMessages.mockResolvedValue([
+    { id: "old-assistant", role: "assistant", createdAt: 1, completedAt: 2, finishReason: "stop", parts: [] },
+    { id: userMessageId, role: "user", createdAt: 3, parts: [] },
+    { id: "current-assistant", role: "assistant", createdAt: 4, completedAt: 5, finishReason: "stop", parts: [] },
+  ])
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await waitForCondition(() => events.some((event) => event.event === "messageCompleted"))
+  expect(events.filter((event) => event.event === "turnOutcome").at(-1)?.data).toMatchObject({
+    kind: "completed",
+    messageId: "current-assistant",
+  })
+})
+
+test("completion during cancellation cannot release the session or report success", async () => {
+  const bridge = createBridgeAgent()
+  const service = new ChatServiceImpl(bridge.agent)
+  const events = captureServiceEvents(service)
+  service.startEventBridge()
+  await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+  bridge.emit({
+    type: "message.updated",
+    properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+  })
+  let release!: () => void
+  bridge.abort.mockImplementationOnce(
+    () =>
+      new Promise<void>((resolve) => {
+        release = resolve
+      }),
+  )
+  const stopping = service.stopGeneration("session-1")
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(await service.getActiveRun("session-1")).not.toBeNull()
+  expect(events.filter((event) => event.event === "messageCompleted")).toHaveLength(0)
+  release()
+  await stopping
+  expect(await service.getActiveRun("session-1")).toBeNull()
+  expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
+    { sessionId: "session-1", kind: "cancelled", messageId: "assistant-1" },
+  ])
 })

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -928,6 +928,7 @@ test("a late idle from a stopped generation does not complete the retried genera
   })
   await service.stopGeneration("session-1")
   await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+  const runId = (await service.getActiveRun("session-1"))?.runId
   const userMessageId = bridge.promptStreaming.mock.calls[1]?.[2]?.messageId as string
   bridge.emit({
     type: "message.updated",
@@ -954,6 +955,7 @@ test("a late idle from a stopped generation does not complete the retried genera
   assert.deepEqual(events.filter((event) => event.event === "turnOutcome").at(-1)?.data, {
     sessionId: "session-1",
     kind: "completed",
+    runId,
     messageId: "assistant-2",
   })
   assert.equal(events.filter((event) => event.event === "messageCompleted").length, 1)
@@ -4675,6 +4677,7 @@ test("completion during cancellation cannot release the session or report succes
         release = resolve
       }),
   )
+  const runId = (await service.getActiveRun("session-1"))?.runId
   const stopping = service.stopGeneration("session-1")
   bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
   await new Promise((resolve) => setTimeout(resolve, 0))
@@ -4684,6 +4687,6 @@ test("completion during cancellation cannot release the session or report succes
   await stopping
   expect(await service.getActiveRun("session-1")).toBeNull()
   expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
-    { sessionId: "session-1", kind: "cancelled", messageId: "assistant-1" },
+    { sessionId: "session-1", runId, kind: "cancelled", messageId: "assistant-1" },
   ])
 })

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -116,6 +116,7 @@ import {
   localAccessPromptReason,
 } from "./local-access-policy.ts"
 import { directoryArtifacts, fileArtifact, localArtifactItem, readArtifactPack } from "./local-artifacts.ts"
+import { MessageRunRegistry } from "./message-run-registry.ts"
 import { OutputPersistence } from "./output-persistence.ts"
 import { PermissionDiagnostics } from "./permission-diagnostics.ts"
 import { permissionCommand } from "./permission-request.ts"
@@ -356,6 +357,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private readonly userStops = new UserStopTracker()
   private emittedMessageErrors = new Map<string, Set<string>>()
   private readonly generations = new GenerationRegistry()
+  private readonly messageRuns = new MessageRunRegistry()
   private readonly stoppingGenerations = new Map<string, Promise<void>>()
   private readonly activeRuns = new ActiveRunRegistry(({ ended, run, sessionId }) => {
     this.sendBestEffort(this.send.bind(this) as (event: string, data: unknown) => Promise<void>, "activeRunUpdated", {
@@ -460,6 +462,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.outputPersistence.reset()
     this.desiredWorkspaceTeamName = undefined
     this.startedMessages.clear()
+    this.messageRuns.clear()
     this.internalMessageIds.clear()
     this.compactingSessions.clear()
     this.completionChecks.clear()
@@ -705,6 +708,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
 
   /** 会话永久删除后释放运行态索引，并删除授权/停止 overlay。 */
   public async forgetSession(sessionId: string): Promise<void> {
+    this.messageRuns.forgetSession(sessionId)
     this.deletedExternalSelectionSessions.add(sessionId)
     this.generations.get(sessionId)?.controller.abort()
     const selectionMutationsSettled = this.settleExternalSelectionMutations(sessionId)
@@ -825,10 +829,6 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     ) {
       return
     }
-    const activitySessionId = generationSessionId ?? sourceSessionId
-    if (activitySessionId) {
-      this.generations.clearAcknowledgementWatchdog(activitySessionId)
-    }
     if (translated.event === "messageStarted") {
       if (translated.data.internal === true) {
         this.rememberInternalMessage(translated.data.sessionId, translated.data.messageId)
@@ -836,12 +836,6 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       }
       if (translated.data.role === "user" && this.compactingSessions.has(translated.data.sessionId)) {
         this.rememberInternalMessage(translated.data.sessionId, translated.data.messageId)
-        return
-      }
-      if (translated.data.role === "assistant") {
-        this.compactingSessions.delete(translated.data.sessionId)
-      }
-      if (!this.rememberMessageStarted(translated)) {
         return
       }
     }
@@ -852,6 +846,32 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       (translated.event === "messageDelta" && translated.data.synthetic === true)
     ) {
       return
+    }
+    // Resolve message ownership before watchdogs, active-run mutation, tool
+    // diagnostics or child-session registration can observe this event.
+    const progressGeneration = generationSessionId ? this.generations.get(generationSessionId) : undefined
+    if ("messageId" in translated.data && translated.data.messageId) {
+      if (
+        !this.messageRuns.isCurrent(sourceSessionId!, translated.data.messageId, progressGeneration?.id, {
+          ...(translated.event === "messageStarted" && translated.data.role === "assistant"
+            ? {
+                parentMessageId:
+                  translated.data.parentMessageId &&
+                  !this.isInternalMessage(sourceSessionId!, translated.data.parentMessageId)
+                    ? translated.data.parentMessageId
+                    : undefined,
+              }
+            : {}),
+          ...(sourceSessionId === generationSessionId ? { userMessageId: progressGeneration?.userMessageId } : {}),
+        })
+      )
+        return
+    }
+    const activitySessionId = generationSessionId ?? sourceSessionId
+    if (activitySessionId) this.generations.clearAcknowledgementWatchdog(activitySessionId)
+    if (translated.event === "messageStarted") {
+      if (!this.rememberMessageStarted(translated)) return
+      if (translated.data.role === "assistant") this.compactingSessions.delete(translated.data.sessionId)
     }
     if (translated.event === "assistantActivity" && translated.data.phase === "compacting") {
       this.compactingSessions.add(translated.data.sessionId)
@@ -993,11 +1013,19 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         this.scheduleGenerationInactivityWatchdog(generationSessionId)
       }
     }
-    if ((displayed.event === "messageDelta" || displayed.event === "messageReasoningDelta") && this.streamEventBuffer) {
-      this.eventMetrics.record(`stream-input:${displayed.event}`)
-      this.streamEventBuffer.enqueue(displayed)
+    // Capture the owner before IPC buffering; never look it up again at flush time.
+    const progressEvent =
+      progressGeneration && ("messageId" in displayed.data || displayed.event === "assistantActivity")
+        ? ({ ...displayed, data: { ...displayed.data, runId: progressGeneration.id } } as ChatEmit)
+        : displayed
+    if (
+      (progressEvent.event === "messageDelta" || progressEvent.event === "messageReasoningDelta") &&
+      this.streamEventBuffer
+    ) {
+      this.eventMetrics.record(`stream-input:${progressEvent.event}`)
+      this.streamEventBuffer.enqueue(progressEvent)
     } else {
-      this.sendBestEffort(emit, displayed.event, displayed.data, { sessionId: displayedSessionId })
+      this.sendBestEffort(emit, progressEvent.event, progressEvent.data, { sessionId: displayedSessionId })
     }
   }
 

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -356,6 +356,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
   private readonly userStops = new UserStopTracker()
   private emittedMessageErrors = new Map<string, Set<string>>()
   private readonly generations = new GenerationRegistry()
+  private readonly stoppingGenerations = new Map<string, Promise<void>>()
   private readonly activeRuns = new ActiveRunRegistry(({ ended, run, sessionId }) => {
     this.sendBestEffort(this.send.bind(this) as (event: string, data: unknown) => Promise<void>, "activeRunUpdated", {
       ...ended,
@@ -772,6 +773,25 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       // off messages on reload, mirroring the kernel history path.
       return
     }
+    if (translated.event === "messageCompleted" && translated.data.outcome === "cancelled") {
+      const sessionId = translated.data.sessionId
+      const generation = this.generations.get(sessionId)
+      if (generation) {
+        generation.cancellationSettled = true
+        // An explicit stop already owns its cleanup. After a timeout this
+        // acknowledgement resumes the same cleanup without cancelling again.
+        if (!generation.controller.signal.aborted || generation.cancellationRequested) {
+          void this.stopSessionGeneration(sessionId, {
+            abortAgent: false,
+            reason: "user",
+            throwOnAbortFailure: false,
+          }).catch((error: unknown) =>
+            logDiagnostic("chat-service", "failed to settle cancelled turn", { error, sessionId }, "warn"),
+          )
+        }
+      }
+      return
+    }
     const sourceSessionId = translated.data.sessionId
     const generationSessionId = sourceSessionId ? this.generationWatchdogSessionId(sourceSessionId) : null
     const failedSessionId = generationSessionId ?? sourceSessionId
@@ -1047,6 +1067,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     sessionId: string,
     message: string,
     messageId?: string,
+    runId?: string,
   ): void {
     if (!this.rememberMessageError(sessionId, message)) {
       return
@@ -1058,10 +1079,15 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         logDiagnostic("chat-service", "failed to expire OOMOL session after chat 401", { error }, "warn")
       })
     }
-    this.sendBestEffort(emit, "messageError", payload, {
-      messageId,
-      sessionId,
-    })
+    this.sendBestEffort(
+      emit,
+      "messageError",
+      { ...payload, ...(runId ? { runId } : {}) },
+      {
+        messageId,
+        sessionId,
+      },
+    )
   }
 
   private sendBestEffort(
@@ -1535,6 +1561,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       {
         sessionId,
         kind,
+        ...(options.generationId ? { runId: options.generationId } : {}),
         ...(options.messageId ? { messageId: options.messageId } : {}),
         ...(options.reason ? { reason: options.reason } : {}),
       },
@@ -1573,7 +1600,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       this.activeRuns.delete(sessionId, generation.id)
       this.emitSessionActivity(sessionId)
       this.emitTurnOutcome(emit, sessionId, "completed", { generationId: generation.id, messageId })
-      this.sendBestEffort(emit, "messageCompleted", { sessionId }, { sessionId })
+      this.sendBestEffort(emit, "messageCompleted", { sessionId, runId: generation.id }, { sessionId })
       if (completedRun?.workspace.kind === "team") {
         void Promise.resolve(
           this.deps.onSessionCompleted?.({
@@ -1817,12 +1844,13 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         ...(messageId ? { messageId } : {}),
         ...(partIds.length > 0 ? { partIds } : {}),
         interruptedAt,
+        ...(generationId ? { runId: generationId } : {}),
         reason,
         message,
       },
       { messageId, sessionId },
     )
-    this.emitMessageError(emit, sessionId, message, messageId)
+    this.emitMessageError(emit, sessionId, message, messageId, generationId)
   }
 
   private generationWatchdogSessionId(sessionId: string): string | null {
@@ -1861,14 +1889,33 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     }
   }
 
-  private async stopSessionGeneration(sessionId: string, options: StopSessionGenerationOptions): Promise<void> {
+  private stopSessionGeneration(sessionId: string, options: StopSessionGenerationOptions): Promise<void> {
+    const generation = this.generations.get(sessionId)
+    const key = generation?.id ?? `session:${sessionId}`
+    const existing = this.stoppingGenerations.get(key)
+    if (existing) return existing
+    if (generation && options.reason === "user") generation.cancellationRequested = true
+    const stopping = Promise.resolve()
+      .then(() => this.performStopSessionGeneration(sessionId, generation, options))
+      .finally(() => {
+        if (this.stoppingGenerations.get(key) === stopping) this.stoppingGenerations.delete(key)
+      })
+    this.stoppingGenerations.set(key, stopping)
+    generation?.controller.abort()
+    return stopping
+  }
+
+  private async performStopSessionGeneration(
+    sessionId: string,
+    generation: SessionGeneration | undefined,
+    options: StopSessionGenerationOptions,
+  ): Promise<void> {
+    if (this.generations.get(sessionId) !== generation) return
     const backend = this.chatBackendFor(sessionId)
     if (!backend) {
       return
     }
-    const generation = this.generations.get(sessionId)
     const generationId = generation?.id
-    generation?.controller.abort()
     this.deps.hostQuestions?.cancelSession(sessionId)
     const messageId = this.activeAssistantMessages.get(sessionId)
     const partIds = [...(this.activeToolParts.get(sessionId) ?? [])]
@@ -1877,7 +1924,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       try {
         await backend.send({ type: "cancel", sessionId })
       } catch (error) {
-        if (options.throwOnAbortFailure && (messageId || !generation || externalAgentKindForSessionId(sessionId))) {
+        if (
+          !generation?.cancellationSettled &&
+          options.throwOnAbortFailure &&
+          (messageId || !generation || externalAgentKindForSessionId(sessionId))
+        ) {
           this.userStops.delete(sessionId)
           throw error
         }
@@ -1904,6 +1955,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       this.logTurnOutcome(sessionId, "cancelled", { generationId, messageId })
       const outcome = this.send("turnOutcome", {
         sessionId,
+        ...(generationId ? { runId: generationId } : {}),
         kind: "cancelled",
         ...(messageId ? { messageId } : {}),
       }).catch((error: unknown) => {
@@ -1912,6 +1964,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       })
       const stopped = this.send("generationStopped", {
         sessionId,
+        ...(generationId ? { runId: generationId } : {}),
         ...(messageId ? { messageId, partIds, stoppedAt } : {}),
       }).catch((error: unknown) => {
         console.warn("[wanta] failed to emit generation stopped:", error)
@@ -2181,7 +2234,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           this.clearSessionGeneration(req.sessionId, promptGeneration.id)
           this.activeAssistantMessages.delete(req.sessionId)
           this.activeToolParts.delete(req.sessionId)
-          this.emitMessageError(emit, req.sessionId, errorMessage(error), messageId)
+          this.emitMessageError(emit, req.sessionId, errorMessage(error), messageId, promptGeneration.id)
         })
     } catch (error) {
       if (generation) {
@@ -2506,7 +2559,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           this.clearSessionGeneration(req.sessionId, generation.id)
           this.activeAssistantMessages.delete(req.sessionId)
           this.activeToolParts.delete(req.sessionId)
-          this.emitMessageError(emit, req.sessionId, errorMessage(error), messageId)
+          this.emitMessageError(emit, req.sessionId, errorMessage(error), messageId, generation.id)
         })
     } catch (error) {
       await this.rollbackPromptSelectionPersistence(req.sessionId, promptSelectionOwners, previousSelection)

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -785,32 +785,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
             .find((sessionId) => this.userStops.consumeAbort(sessionId, translated.data.message))
         : undefined
     if (translated.event === "agentError" && userStoppedSessionId) {
-      const sessionId = generationSessionId ?? userStoppedSessionId
-      const messageId = this.activeAssistantMessages.get(sessionId)
-      const partIds = [...(this.activeToolParts.get(sessionId) ?? [])]
-      const stoppedAt = Date.now()
-      if (messageId) {
-        void this.rememberStoppedGeneration(sessionId, messageId, partIds, stoppedAt).catch((error: unknown) => {
-          console.warn("[wanta] failed to record stopped generation", error)
-        })
-      }
-      void this.finalizeTurnOutput(sessionId, messageId)
-        .catch((error: unknown) => {
-          console.warn("[wanta] failed to finalize stopped turn output", error)
-        })
-        .finally(() => {
-          this.clearSessionGeneration(sessionId)
-          this.activeAssistantMessages.delete(sessionId)
-          this.activeToolParts.delete(sessionId)
-          this.activeRuns.delete(sessionId)
-          this.emitSessionActivity(sessionId)
-          this.sendBestEffort(
-            emit,
-            "generationStopped",
-            { sessionId, ...(messageId ? { messageId, partIds, stoppedAt } : {}) },
-            { sessionId },
-          )
-        })
+      // stopSessionGeneration owns cancellation finalization. An abort echo must
+      // never start a second async cleanup that can outlive the stopped turn.
       return
     }
     if (this.userStops.shouldSuppressEvent(translated)) {
@@ -1577,19 +1553,20 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.clearCompletionRetry(completionKey, false)
     this.completionChecks.add(completionKey)
     try {
-      if (!(await this.currentTurnIsComplete(sessionId, generation))) {
+      const completedAssistant = await this.completedTurnAssistant(sessionId, generation)
+      if (!completedAssistant) {
         this.scheduleCompletionRetry(emit, sessionId, generation)
         return
       }
-      if (!this.isCurrentGeneration(sessionId, generation.id)) return
+      if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
       this.clearCompletionRetry(completionKey)
-      const messageId = this.activeAssistantMessages.get(sessionId)
+      const messageId = completedAssistant.id
       const completedRun = this.activeRuns.get(sessionId)
       this.generations.clearInactivityWatchdog(sessionId)
       await this.finalizeTurnOutput(sessionId, messageId).catch((error: unknown) => {
         console.warn("[wanta] failed to finalize turn output", error)
       })
-      if (!this.isCurrentGeneration(sessionId, generation.id)) return
+      if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
       this.clearSessionGeneration(sessionId, generation.id)
       this.activeAssistantMessages.delete(sessionId)
       this.activeToolParts.delete(sessionId)
@@ -1613,31 +1590,32 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     }
   }
 
-  private async currentTurnIsComplete(sessionId: string, generation: SessionGeneration): Promise<boolean> {
+  private async completedTurnAssistant(
+    sessionId: string,
+    generation: SessionGeneration,
+  ): Promise<ChatMessage | undefined> {
     const backend = this.chatBackendFor(sessionId)
-    if (!backend) return false
+    if (!backend) return undefined
     const messages = await withTimeout(backend.getMessages(sessionId), 1_000, "idle history verification").catch(
       () => null,
     )
-    if (!messages || messages.length === 0) return false
+    if (!messages || messages.length === 0) return undefined
     const userIndex = messages.findIndex(
       (message) => message.id === generation.userMessageId && message.role === "user",
     )
-    const assistantId = this.activeAssistantMessages.get(sessionId)
-    const activeAssistant = assistantId
-      ? messages.find((message) => message.id === assistantId && message.role === "assistant")
-      : undefined
-    const assistant =
-      activeAssistant ??
-      (userIndex >= 0 ? messages.slice(userIndex + 1).find((message) => message.role === "assistant") : undefined)
-    if (!assistant) return false
+    if (userIndex < 0 || generation.controller.signal.aborted) return undefined
+    // Only messages after this turn's user message can prove its completion.
+    // A delayed tool event may still point activeAssistantMessages at an old turn.
+    const turnMessages = messages.slice(userIndex + 1)
+    const assistant = turnMessages.findLast((message) => message.role === "assistant")
+    if (!assistant) return undefined
     const finishReason = assistant.finishReason?.trim().toLowerCase().replaceAll("_", "-")
     // A completed tool-call message is only one step in the agent loop. Some
     // runtimes briefly emit session.idle after a rejected or failed tool; do
     // not turn that transient boundary into a completed user turn before the
     // agent produces a terminal response.
-    if (["tool-calls", "tool-use"].includes(finishReason ?? "")) return false
-    return Boolean(finishReason || assistant.completedAt !== undefined)
+    if (["tool-calls", "tool-use"].includes(finishReason ?? "")) return undefined
+    return finishReason || assistant.completedAt !== undefined ? assistant : undefined
   }
 
   private scheduleCompletionRetry(
@@ -1645,7 +1623,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     sessionId: string,
     generation: SessionGeneration,
   ): void {
-    if (!this.isCurrentGeneration(sessionId, generation.id)) return
+    if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
     const completionKey = `${sessionId}\0${generation.id}`
     if (this.completionRetryTimers.has(completionKey)) return
     const attempt = this.completionRetryAttempts.get(completionKey) ?? 0
@@ -1899,21 +1877,24 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       try {
         await backend.send({ type: "cancel", sessionId })
       } catch (error) {
-        if (options.throwOnAbortFailure && (messageId || !generation)) {
+        if (options.throwOnAbortFailure && (messageId || !generation || externalAgentKindForSessionId(sessionId))) {
           this.userStops.delete(sessionId)
           throw error
         }
         console.warn("[wanta] generation abort failed:", error)
       }
     }
+    if (this.generations.get(sessionId) !== generation) return
     if (options.reason === "user" && messageId) {
       await this.rememberStoppedGeneration(sessionId, messageId, partIds, stoppedAt).catch((error: unknown) => {
         console.warn("[wanta] failed to record stopped generation", error)
       })
     }
+    if (this.generations.get(sessionId) !== generation) return
     await this.finalizeTurnOutput(sessionId, messageId).catch((error: unknown) => {
       console.warn("[wanta] failed to finalize stopped turn output", error)
     })
+    if (this.generations.get(sessionId) !== generation) return
     this.clearSessionGeneration(sessionId, generation?.id)
     this.turnOutputs.clearPending(sessionId)
     this.turnOutputs.delete(sessionId, generation?.id)
@@ -1921,7 +1902,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     this.activeToolParts.delete(sessionId)
     if (options.reason === "user") {
       this.logTurnOutcome(sessionId, "cancelled", { generationId, messageId })
-      await this.send("turnOutcome", {
+      const outcome = this.send("turnOutcome", {
         sessionId,
         kind: "cancelled",
         ...(messageId ? { messageId } : {}),
@@ -1929,13 +1910,14 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         console.warn("[wanta] failed to emit turn outcome:", error)
         logDiagnostic("chat-service", "failed to emit turn outcome", { error, sessionId }, "warn")
       })
-      await this.send("generationStopped", {
+      const stopped = this.send("generationStopped", {
         sessionId,
         ...(messageId ? { messageId, partIds, stoppedAt } : {}),
       }).catch((error: unknown) => {
         console.warn("[wanta] failed to emit generation stopped:", error)
         logDiagnostic("chat-service", "failed to emit generation stopped", { error, sessionId }, "warn")
       })
+      await Promise.all([outcome, stopped])
     }
   }
 
@@ -1989,11 +1971,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     if (!this.agent) {
       throw new Error("Agent not configured (sign in first)")
     }
+    const turnAttachments = attachmentsForAgentTurn(bugReport, req.attachments)
+    await this.assertTrustedAttachments(turnAttachments)
     if (this.generations.has(req.sessionId)) {
       throw new Error("A generation is already active for this session.")
     }
-    const turnAttachments = attachmentsForAgentTurn(bugReport, req.attachments)
-    await this.assertTrustedAttachments(turnAttachments)
     this.setSessionPermissionModeValue(
       req.sessionId,
       req.permissionMode ?? this.sessionPermissionMode(req.sessionId),
@@ -2001,7 +1983,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     )
     const userMessageId = createOpencodeMessageId()
     const teamName = teamNameFromRequest(req)
-    let generation: SessionGeneration | undefined
+    const generation = this.beginChatTurn(req, userMessageId)
     let artifactDir: string | undefined
     let processDir: string | undefined
     let attachmentsRecorded = false
@@ -2023,11 +2005,15 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           ),
         )
       }
-      generation = this.beginChatTurn(req, userMessageId)
       const activeGeneration = generation
       const knowledgeBaseIds = (req.contextMentions ?? []).flatMap((mention) =>
         mention.kind === "knowledge" && mention.id.trim() ? [mention.id.trim()] : [],
       )
+      if (!this.isCurrentGeneration(req.sessionId, activeGeneration.id) || activeGeneration.controller.signal.aborted) {
+        if (attachmentsRecorded)
+          await this.rollbackUnsubmittedUserAttachments(req.sessionId, userMessageId, turnAttachments)
+        return
+      }
       await Promise.all([
         this.agent.setSessionTeamName(req.sessionId, teamName),
         this.agent.setSessionKnowledgeBaseIds(req.sessionId, knowledgeBaseIds),

--- a/src/components/ai-elements/message-rendering.test.ts
+++ b/src/components/ai-elements/message-rendering.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import type { MessageStreamdownProps } from "./message-streamdown.tsx"
+
+import * as React from "react"
+import { createRoot } from "react-dom/client"
+import { expect, test, vi } from "vitest"
+import { MessageResponse } from "./message.tsx"
+
+const rendered = vi.hoisted(() => ({ props: [] as MessageStreamdownProps[] }))
+vi.mock("./message-streamdown.tsx", () => ({
+  MessageStreamdown: (props: MessageStreamdownProps) => {
+    rendered.props.push(props)
+    return React.createElement("div", null, props.children)
+  },
+}))
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+test("text updates reuse Markdown components while explicit overrides still update", async () => {
+  const root = createRoot(document.createElement("div"))
+  rendered.props.length = 0
+  const Inline = ({ children }: { children?: React.ReactNode }) => React.createElement("code", null, children)
+  try {
+    await React.act(async () => {
+      root.render(React.createElement(MessageResponse, null, "First paragraph."))
+    })
+    const defaults = rendered.props.at(-1)?.components
+    expect(defaults?.inlineCode).toBeDefined()
+    expect(defaults?.img).toBeDefined()
+    await React.act(async () => {
+      root.render(React.createElement(MessageResponse, null, "First paragraph. More text."))
+    })
+    expect(rendered.props.at(-1)?.components).toBe(defaults)
+
+    const overrides = { inlineCode: Inline }
+    await React.act(async () => {
+      root.render(React.createElement(MessageResponse, { components: overrides }, "First paragraph. More text."))
+    })
+    const custom = rendered.props.at(-1)?.components
+    expect(custom).not.toBe(defaults)
+    expect(custom?.inlineCode).toBe(Inline)
+    expect(custom?.img).toBe(defaults?.img)
+    await React.act(async () => {
+      root.render(React.createElement(MessageResponse, { components: overrides }, "Continued output."))
+    })
+    expect(rendered.props.at(-1)?.components).toBe(custom)
+    await React.act(async () => {
+      root.render(React.createElement(MessageResponse, null, "Continued output."))
+    })
+    expect(rendered.props.at(-1)?.components?.inlineCode).toBe(defaults?.inlineCode)
+  } finally {
+    await React.act(async () => root.unmount())
+  }
+})

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -593,17 +593,19 @@ export const MessageResponse = memo(
       () => messageResponseRenderers(typeof responseChildren === "string" ? responseChildren : ""),
       [responseChildren],
     )
+    // Streamdown derives an inline-code wrapper from this object. Keep it
+    // stable so unchanged Markdown blocks retain their memoized renderers.
+    const resolvedComponents = useMemo(
+      () => ({ ...messageResponseComponents, inlineCode: MarkdownInlineCode, ...components }),
+      [components],
+    )
     return (
       // fallback 直接铺原始 markdown 文本：streamdown chunk 首次加载时内容即可见，加载完再升级为富渲染。
       <Suspense fallback={<div className={cn("w-full whitespace-pre-wrap", className)}>{responseChildren}</div>}>
         <>
           <Streamdown
             className={cn("oo-message-response w-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
-            components={{
-              ...messageResponseComponents,
-              inlineCode: MarkdownInlineCode,
-              ...components,
-            }}
+            components={resolvedComponents}
             controls={messageResponseControls(controls)}
             defaultRenderers={defaultRenderers}
             lineNumbers={lineNumbers ?? false}

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1722,6 +1722,10 @@ export function AppShell({ auth }: { auth: UseAuth }) {
     ],
   )
   const handleOpenSearch = React.useCallback((): void => setSearchOpen(true), [])
+  const handleLogin = React.useCallback((): void => {
+    void auth.login()
+  }, [auth.login])
+  const handleManageTasks = React.useCallback((): void => setTasksDialogOpen(true), [])
   const handleChatStop = React.useCallback(async (): Promise<void> => {
     if (activeChatSessionId) {
       await stop(activeChatSessionId)
@@ -2124,8 +2128,8 @@ export function AppShell({ auth }: { auth: UseAuth }) {
         onArchiveProjectRequest={projectActions.requestArchive}
         onArchiveSessionRequest={sessionActions.requestArchive}
         onLogout={auth.logout}
-        onLogin={() => void auth.login()}
-        onManageTasks={() => setTasksDialogOpen(true)}
+        onLogin={handleLogin}
+        onManageTasks={handleManageTasks}
         onNavigate={setRoute}
         onNewSession={handleNewSessionWithKnowledgeReset}
         onOpenConnections={handleOpenConnectionsCommand}

--- a/src/components/app-shell/use-sidebar-chrome-state.test.ts
+++ b/src/components/app-shell/use-sidebar-chrome-state.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import * as React from "react"
+import { createRoot } from "react-dom/client"
+import { expect, test, vi } from "vitest"
+import { SIDEBAR_MAX_WIDTH_PX, SIDEBAR_MIN_WIDTH_PX, SIDEBAR_WIDTH_STORAGE_KEY } from "./app-shell-model.ts"
+import { writeStoredSidebarCollapsed } from "./sidebar-persistence.ts"
+import { useSidebarChromeState } from "./use-sidebar-chrome-state.ts"
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+test("stable sidebar callbacks retain current width and collapsed-state behavior", () => {
+  localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "264")
+  writeStoredSidebarCollapsed(localStorage, false)
+  const container = document.createElement("div")
+  const root = createRoot(container)
+  let state!: ReturnType<typeof useSidebarChromeState>
+  function Probe({ revision: _revision }: { revision: number }) {
+    const ref = React.useRef<HTMLDivElement>(null)
+    state = useSidebarChromeState(ref)
+    return React.createElement("div", { ref })
+  }
+  const key = (value: string, shiftKey = false) =>
+    ({ key: value, shiftKey, preventDefault: vi.fn() }) as unknown as React.KeyboardEvent<HTMLDivElement>
+  const pointer = () => ({ clientX: 100, preventDefault: vi.fn() }) as unknown as React.PointerEvent<HTMLDivElement>
+  try {
+    React.act(() => root.render(React.createElement(Probe, { revision: 0 })))
+    const initialStart = state.handleSidebarResizeStart
+    const initialKeyDown = state.handleSidebarResizeKeyDown
+    React.act(() => root.render(React.createElement(Probe, { revision: 1 })))
+    expect(state.handleSidebarResizeStart).toBe(initialStart)
+    expect(state.handleSidebarResizeKeyDown).toBe(initialKeyDown)
+
+    React.act(() => state.handleSidebarResizeKeyDown(key("Home")))
+    expect(state.sidebarWidth).toBe(SIDEBAR_MIN_WIDTH_PX)
+    React.act(() => state.handleSidebarResizeStart(pointer()))
+    React.act(() => {
+      window.dispatchEvent(new PointerEvent("pointermove", { clientX: 112 }))
+      window.dispatchEvent(new PointerEvent("pointerup"))
+    })
+    expect(state.sidebarWidth).toBe(SIDEBAR_MIN_WIDTH_PX + 12)
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe(String(SIDEBAR_MIN_WIDTH_PX + 12))
+
+    React.act(() => state.handleSidebarResizeKeyDown(key("End")))
+    React.act(() => state.handleSidebarResizeKeyDown(key("ArrowLeft", true)))
+    expect(state.sidebarWidth).toBe(SIDEBAR_MAX_WIDTH_PX - 24)
+    React.act(() => state.setSidebarCollapsed(true))
+    React.act(() => {
+      state.handleSidebarResizeKeyDown(key("Home"))
+      state.handleSidebarResizeStart(pointer())
+    })
+    expect(state.sidebarWidth).toBe(SIDEBAR_MAX_WIDTH_PX - 24)
+    expect(state.isSidebarResizing).toBe(false)
+  } finally {
+    React.act(() => root.unmount())
+    localStorage.clear()
+  }
+})

--- a/src/components/app-shell/use-sidebar-chrome-state.ts
+++ b/src/components/app-shell/use-sidebar-chrome-state.ts
@@ -128,35 +128,41 @@ export function useSidebarChromeState(
     })
   }, [])
 
-  const handleSidebarResizeStart = (event: React.PointerEvent<HTMLDivElement>): void => {
-    if (sidebarCollapsed) {
-      return
-    }
-    event.preventDefault()
-    sidebarResizeStart.current = { pointerX: event.clientX, width: sidebarWidth }
-    setIsSidebarResizing(true)
-  }
+  const handleSidebarResizeStart = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>): void => {
+      if (sidebarCollapsed) {
+        return
+      }
+      event.preventDefault()
+      sidebarResizeStart.current = { pointerX: event.clientX, width: sidebarWidth }
+      setIsSidebarResizing(true)
+    },
+    [sidebarCollapsed, sidebarWidth],
+  )
 
-  const handleSidebarResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    if (sidebarCollapsed) {
-      return
-    }
+  const handleSidebarResizeKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>): void => {
+      if (sidebarCollapsed) {
+        return
+      }
 
-    const step = event.shiftKey ? 24 : 12
-    if (event.key === "ArrowLeft") {
-      event.preventDefault()
-      setSidebarWidth((width) => clampSidebarWidth(width - step))
-    } else if (event.key === "ArrowRight") {
-      event.preventDefault()
-      setSidebarWidth((width) => clampSidebarWidth(width + step))
-    } else if (event.key === "Home") {
-      event.preventDefault()
-      setSidebarWidth(SIDEBAR_MIN_WIDTH_PX)
-    } else if (event.key === "End") {
-      event.preventDefault()
-      setSidebarWidth(SIDEBAR_MAX_WIDTH_PX)
-    }
-  }
+      const step = event.shiftKey ? 24 : 12
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        setSidebarWidth((width) => clampSidebarWidth(width - step))
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        setSidebarWidth((width) => clampSidebarWidth(width + step))
+      } else if (event.key === "Home") {
+        event.preventDefault()
+        setSidebarWidth(SIDEBAR_MIN_WIDTH_PX)
+      } else if (event.key === "End") {
+        event.preventDefault()
+        setSidebarWidth(SIDEBAR_MAX_WIDTH_PX)
+      }
+    },
+    [sidebarCollapsed],
+  )
 
   return {
     handleSidebarResizeKeyDown,

--- a/src/hooks/chat-run-ownership.ts
+++ b/src/hooks/chat-run-ownership.ts
@@ -1,0 +1,73 @@
+/** Mutable tokens are private to one hook instance, never persisted or sent over IPC. */
+export interface ChatRunToken {
+  runId?: string
+  ended: boolean
+  optimistic: boolean
+}
+
+/** Owns callback identity across optimistic submission, host acknowledgement and termination. */
+export class ChatRunOwnership {
+  private readonly sessions = new Map<string, ChatRunToken>()
+
+  public beginSubmission(sessionId: string): ChatRunToken {
+    const token = { ended: false, optimistic: true }
+    this.sessions.set(sessionId, token)
+    return token
+  }
+
+  public capture(sessionId: string): ChatRunToken {
+    let token = this.sessions.get(sessionId)
+    if (!token) {
+      token = { ended: false, optimistic: false }
+      this.sessions.set(sessionId, token)
+    }
+    return token
+  }
+
+  public isCurrent(sessionId: string, token: ChatRunToken): boolean {
+    return this.sessions.get(sessionId) === token && !token.ended
+  }
+
+  public hasActiveRun(sessionId: string): boolean {
+    const token = this.sessions.get(sessionId)
+    return Boolean(token?.runId && !token.ended)
+  }
+
+  public acceptsTerminal(sessionId: string, runId?: string): boolean {
+    const current = this.sessions.get(sessionId)
+    if (!current) return true
+    // Untagged legacy events cannot end a known or optimistically pending run.
+    if (!runId) return !current.runId && !current.optimistic
+    return current.runId === runId
+  }
+
+  public applyRun(sessionId: string, runId: string | null, endedRunId?: string): boolean {
+    const current = this.sessions.get(sessionId)
+    if (runId) {
+      if (current?.runId === runId) return !current.ended
+      if (current?.optimistic && !current.runId) {
+        // Bind the server identity without invalidating this send's callback.
+        current.runId = runId
+        current.optimistic = false
+      } else {
+        this.sessions.set(sessionId, { runId, ended: false, optimistic: false })
+      }
+      return true
+    }
+    // An empty snapshot during dispatch is not an acknowledgement that the
+    // optimistic submission ended; wait for the host to bind or reject it.
+    if (!endedRunId && current?.optimistic) return false
+    if (endedRunId && current && current.runId !== endedRunId) return false
+    if (current) current.ended = true
+    else if (endedRunId) this.sessions.set(sessionId, { runId: endedRunId, ended: true, optimistic: false })
+    return true
+  }
+
+  public forget(sessionId: string): void {
+    this.sessions.delete(sessionId)
+  }
+
+  public reset(): void {
+    this.sessions.clear()
+  }
+}

--- a/src/hooks/chat-run-ownership.ts
+++ b/src/hooks/chat-run-ownership.ts
@@ -33,6 +33,14 @@ export class ChatRunOwnership {
     return Boolean(token?.runId && !token.ended)
   }
 
+  public acceptsProgress(sessionId: string, runId?: string): boolean {
+    const current = this.sessions.get(sessionId)
+    if (!current) return !runId
+    if (current.ended) return false
+    if (!runId) return !current.runId
+    return current.runId === runId
+  }
+
   public acceptsTerminal(sessionId: string, runId?: string): boolean {
     const current = this.sessions.get(sessionId)
     if (!current) return true

--- a/src/hooks/use-chat-run-state-edge.test.ts
+++ b/src/hooks/use-chat-run-state-edge.test.ts
@@ -4,7 +4,7 @@ import type { ChatRunState } from "./use-chat-run-state.ts"
 
 import * as React from "react"
 import { createRoot } from "react-dom/client"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, test } from "vitest"
 import { reduceChatRunSessions, useChatRunState } from "./use-chat-run-state.ts"
 
 // Adversarial edge tests for the renderer run/activity state:
@@ -240,4 +240,20 @@ describe("useChatRunState: cleared-run tombstones", () => {
       harness.unmount()
     }
   })
+})
+
+test("an empty snapshot cannot clear an optimistic submission before host acknowledgement", () => {
+  const harness = renderRunState()
+  try {
+    harness.act((state) => {
+      state.ownership.beginSubmission("session-1")
+      state.setStatus("session-1", "submitted")
+      state.applyActiveRun("session-1", null)
+    })
+    expect(harness.state.getSessionStatus("session-1")).toBe("submitted")
+    harness.act((state) => state.applyActiveRun("session-1", run()))
+    expect(harness.state.getSessionStatus("session-1")).toBe("streaming")
+  } finally {
+    harness.unmount()
+  }
 })

--- a/src/hooks/use-chat-run-state.ts
+++ b/src/hooks/use-chat-run-state.ts
@@ -2,6 +2,7 @@ import type { AssistantActivityEvent, ChatActiveRun } from "../../electron/chat/
 import type { ChatStatus } from "ai"
 
 import * as React from "react"
+import { ChatRunOwnership } from "./chat-run-ownership.ts"
 
 const maxClearedActiveRunIds = 512
 
@@ -21,8 +22,9 @@ export type ChatRunSessionsAction =
   | { type: "reset" }
 
 export interface ChatRunState {
+  ownership: ChatRunOwnership
   activities: Record<string, AssistantActivityEvent | undefined>
-  applyActiveRun: (sessionId: string, run: ChatActiveRun | null, endedRunId?: string) => void
+  applyActiveRun: (sessionId: string, run: ChatActiveRun | null, endedRunId?: string) => boolean
   forgetSession: (sessionId: string) => void
   getSessionRunStartedAt: (sessionId: string) => number | null
   getSessionStatus: (sessionId: string) => ChatStatus
@@ -33,6 +35,7 @@ export interface ChatRunState {
 }
 
 export function useChatRunState(): ChatRunState {
+  const [ownership] = React.useState(() => new ChatRunOwnership())
   const [sessions, dispatch] = React.useReducer(reduceChatRunSessions, {})
   const clearedActiveRunIds = React.useRef(new Set<string>())
 
@@ -44,23 +47,29 @@ export function useChatRunState(): ChatRunState {
     dispatch({ activity, sessionId, type: "set_activity" })
   }, [])
 
-  const applyActiveRun = React.useCallback((sessionId: string, run: ChatActiveRun | null, endedRunId?: string) => {
-    if (run) {
-      if (clearedActiveRunIds.current.has(run.runId)) {
-        return
+  const applyActiveRun = React.useCallback(
+    (sessionId: string, run: ChatActiveRun | null, endedRunId?: string) => {
+      if (run) {
+        if (clearedActiveRunIds.current.has(run.runId)) {
+          return false
+        }
+        if (!ownership.applyRun(run.sessionId, run.runId)) return false
+        dispatch({ run, sessionId: run.sessionId, type: "apply_run" })
+        return true
       }
-      dispatch({ run, sessionId: run.sessionId, type: "apply_run" })
-      return
-    }
-    if (endedRunId) {
-      clearedActiveRunIds.current.add(endedRunId)
-      if (clearedActiveRunIds.current.size > maxClearedActiveRunIds) {
-        const oldestRunId = clearedActiveRunIds.current.values().next().value
-        if (oldestRunId) clearedActiveRunIds.current.delete(oldestRunId)
+      if (endedRunId) {
+        clearedActiveRunIds.current.add(endedRunId)
+        if (clearedActiveRunIds.current.size > maxClearedActiveRunIds) {
+          const oldestRunId = clearedActiveRunIds.current.values().next().value
+          if (oldestRunId) clearedActiveRunIds.current.delete(oldestRunId)
+        }
       }
-    }
-    dispatch({ run: null, sessionId, type: "apply_run" })
-  }, [])
+      if (!ownership.applyRun(sessionId, null, endedRunId)) return false
+      dispatch({ run: null, sessionId, type: "apply_run" })
+      return true
+    },
+    [ownership],
+  )
 
   const getSessionStatus = React.useCallback(
     (sessionId: string): ChatStatus => sessions[sessionId]?.status ?? "ready",
@@ -71,14 +80,19 @@ export function useChatRunState(): ChatRunState {
     [sessions],
   )
 
-  const forgetSession = React.useCallback((sessionId: string): void => {
-    dispatch({ sessionId, type: "forget_session" })
-  }, [])
+  const forgetSession = React.useCallback(
+    (sessionId: string): void => {
+      ownership.forget(sessionId)
+      dispatch({ sessionId, type: "forget_session" })
+    },
+    [ownership],
+  )
 
   const reset = React.useCallback((): void => {
     dispatch({ type: "reset" })
     clearedActiveRunIds.current.clear()
-  }, [])
+    ownership.reset()
+  }, [ownership])
 
   const statuses = React.useMemo<Record<string, ChatStatus>>(
     () => Object.fromEntries(Object.entries(sessions).map(([sessionId, view]) => [sessionId, view.status])),
@@ -95,6 +109,7 @@ export function useChatRunState(): ChatRunState {
   )
 
   return {
+    ownership,
     activities,
     applyActiveRun,
     forgetSession,

--- a/src/hooks/useChat-lifecycle.test.ts
+++ b/src/hooks/useChat-lifecycle.test.ts
@@ -236,3 +236,69 @@ test("a send failure remains visible after its optimistic token binds to the hos
   expect(h.state.status).toBe("error")
   expect(h.state.messages.flatMap((message) => message.parts).some((part) => part.kind === "error")).toBe(true)
 })
+
+test("old progress events cannot change the new activity, tools, or optimistic messages", async () => {
+  const h = await mount()
+  React.act(() => startNewRun())
+  const beforeMessages = h.state.messages
+  const old = { sessionId, runId: "old", messageId: "old-assistant", partId: "old-part" }
+  React.act(() => {
+    emit("messageStarted", { ...old, role: "assistant" })
+    emit("messageDelta", { ...old, text: "late text" })
+    emit("messageReasoningDelta", { ...old, text: "late reasoning" })
+    emit("messageAttachment", {
+      ...old,
+      attachment: { id: "old", path: "/tmp/old", name: "old", mime: "text/plain", size: 1 },
+    })
+    emit("toolCallStarted", { ...old, callId: "old-call", tool: "bash", input: {}, status: "running" })
+    emit("toolCallResult", {
+      ...old,
+      callId: "old-call",
+      tool: "bash",
+      input: {},
+      status: "completed",
+      output: "late result",
+    })
+    emit("assistantActivity", { ...old, phase: "retrying" })
+  })
+  expect(h.state.status).toBe("streaming")
+  expect(h.state.activity).toBeNull()
+  expect(h.state.messages).toBe(beforeMessages)
+  expect(h.state.pendingPermissions.map((request) => request.id)).toEqual(["new-permission"])
+  React.act(() => {
+    emit("toolCallStarted", {
+      sessionId,
+      runId: "new",
+      messageId: "new-assistant",
+      partId: "new-part",
+      callId: "new-call",
+      tool: "bash",
+      input: {},
+      status: "running",
+    })
+  })
+  await React.act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+  })
+  expect(h.state.messages.flatMap((message) => message.parts)).toEqual([
+    expect.objectContaining({ kind: "tool", partId: "new-part", status: "running" }),
+  ])
+  React.act(() => {
+    emit("activeRunUpdated", { sessionId, run: null, endedRunId: "new" })
+    emit("toolCallResult", {
+      sessionId,
+      runId: "new",
+      messageId: "new-assistant",
+      partId: "new-part",
+      callId: "new-call",
+      tool: "bash",
+      input: {},
+      status: "completed",
+      output: "after end",
+    })
+    emit("assistantActivity", { sessionId, runId: "new", phase: "thinking" })
+    emit("assistantActivity", { sessionId, phase: "thinking" })
+  })
+  expect(h.state.status).toBe("ready")
+  expect(h.state.activity).toBeNull()
+})

--- a/src/hooks/useChat-lifecycle.test.ts
+++ b/src/hooks/useChat-lifecycle.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+import type { ChatActiveRun } from "../../electron/chat/common.ts"
+import type { UseChat } from "./useChat.ts"
+
+import * as React from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { useChat } from "./useChat.ts"
+
+const transport = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(data: unknown) => void>>()
+  return {
+    listeners,
+    invoke: vi.fn<(method: string, argument?: unknown) => Promise<unknown>>(),
+    serverEvents: {
+      on: (event: string, listener: (data: unknown) => void) => {
+        const group = listeners.get(event) ?? new Set()
+        group.add(listener)
+        listeners.set(event, group)
+        return () => {
+          group.delete(listener)
+        }
+      },
+    },
+  }
+})
+vi.mock("@/components/AppContext", () => ({ useChatService: () => transport }))
+vi.mock("@/i18n/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/i18n/i18n")>()),
+  useI18n: () => ({ locale: "en" }),
+}))
+vi.mock("@/lib/renderer-diagnostics", () => ({ reportRendererHandledError: vi.fn() }))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+const scope = { kind: "local" as const, workspaceId: "local", workspaceName: "Local" }
+const sessionId = "session-1"
+const roots: ReturnType<typeof createRoot>[] = []
+
+function run(runId: string): ChatActiveRun {
+  return {
+    sessionId,
+    runId,
+    generationId: runId,
+    phase: "thinking",
+    startedAt: runId === "old" ? 1 : 2,
+    updatedAt: 2,
+    workspace: scope,
+    activeToolPartIds: [],
+    blockingRequestIds: [],
+  }
+}
+function emit(event: string, data: unknown): void {
+  for (const listener of transport.listeners.get(event) ?? []) listener(data)
+}
+function deferred() {
+  let resolve!: () => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<void>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+async function mount() {
+  let current!: UseChat
+  function Probe() {
+    current = useChat(sessionId)
+    return null
+  }
+  const root = createRoot(document.createElement("div"))
+  roots.push(root)
+  await React.act(async () => {
+    root.render(React.createElement(Probe))
+  })
+  return {
+    get state() {
+      return current
+    },
+  }
+}
+function startNewRun() {
+  emit("activeRunUpdated", { sessionId, run: run("new") })
+  emit("permissionAsked", {
+    sessionId,
+    request: { id: "new-permission", sessionId, action: "read", resources: ["/tmp/new"] },
+  })
+}
+beforeEach(() => {
+  transport.listeners.clear()
+  transport.invoke.mockReset().mockImplementation(async (method, argument) => {
+    if (method === "getSessionSnapshot")
+      return { sessionId: argument, activeRun: null, messages: [], pendingQuestions: [], pendingPermissions: [] }
+    if (method === "getActiveRuns" || method === "getMessages") return []
+    return undefined
+  })
+})
+afterEach(async () => {
+  await React.act(async () => {
+    for (const root of roots.splice(0)) root.unmount()
+  })
+})
+
+test.each(["resolve", "reject"] as const)(
+  "a late stop RPC %s cannot overwrite the replacement run",
+  async (settlement) => {
+    const h = await mount()
+    React.act(() => emit("activeRunUpdated", { sessionId, run: run("old") }))
+    const pending = deferred()
+    transport.invoke.mockImplementationOnce(() => pending.promise)
+    let stop!: Promise<void>
+    React.act(() => {
+      stop = h.state.stop(sessionId).catch(() => undefined)
+    })
+    React.act(() => {
+      emit("activeRunUpdated", { sessionId, run: null, endedRunId: "old" })
+      startNewRun()
+    })
+    await React.act(async () => {
+      if (settlement === "resolve") pending.resolve()
+      else pending.reject(new Error("old cancellation failed"))
+      await stop
+    })
+    expect(h.state.status).toBe("streaming")
+    expect(h.state.error).toBeNull()
+    expect(h.state.getSessionRunStartedAt(sessionId)).toBe(2)
+    expect(h.state.pendingPermissions.map((request) => request.id)).toEqual(["new-permission"])
+  },
+)
+
+test("old terminal events cannot clear a newer run or its pending permissions", async () => {
+  const h = await mount()
+  React.act(() => startNewRun())
+  React.act(() => {
+    emit("activeRunUpdated", { sessionId, run: null, endedRunId: "old" })
+    emit("turnOutcome", { sessionId, runId: "old", kind: "cancelled" })
+    emit("generationStopped", { sessionId, runId: "old" })
+    emit("generationInterrupted", {
+      sessionId,
+      runId: "old",
+      interruptedAt: 1,
+      reason: "runtime_error",
+      message: "old",
+    })
+    emit("messageError", { sessionId, runId: "old", partId: "old-error", message: "old" })
+    emit("messageCompleted", { sessionId, runId: "old" })
+  })
+  expect(h.state.status).toBe("streaming")
+  expect(h.state.error).toBeNull()
+  expect(h.state.pendingPermissions.map((request) => request.id)).toEqual(["new-permission"])
+})
+
+test("a cancellation timeout retains the stop control until late cancellation settlement", async () => {
+  const h = await mount()
+  React.act(() => emit("activeRunUpdated", { sessionId, run: run("old") }))
+  transport.invoke.mockRejectedValueOnce(new Error("Cancellation timed out"))
+  await React.act(async () => {
+    await h.state.stop(sessionId).catch(() => undefined)
+  })
+  expect(h.state.status).toBe("streaming")
+  expect(h.state.error).toContain("Cancellation timed out")
+  React.act(() => {
+    emit("activeRunUpdated", { sessionId, run: null, endedRunId: "old" })
+    emit("turnOutcome", { sessionId, runId: "old", kind: "cancelled" })
+    emit("generationStopped", { sessionId, runId: "old" })
+  })
+  expect(h.state.status).toBe("ready")
+  expect(h.state.error).toBeNull()
+})
+
+test("a stale send failure and terminal event cannot erase a new optimistic submission", async () => {
+  const h = await mount()
+  const first = deferred()
+  transport.invoke.mockImplementationOnce(() => first.promise)
+  let sending!: Promise<void>
+  React.act(() => {
+    sending = h.state.send(sessionId, "first", [], { sessionScope: scope }).catch(() => undefined)
+  })
+  React.act(() => {
+    emit("activeRunUpdated", { sessionId, run: run("old") })
+    emit("activeRunUpdated", { sessionId, run: null, endedRunId: "old" })
+  })
+  await React.act(async () => {
+    await h.state.send(sessionId, "second", [], { sessionScope: scope })
+  })
+  await React.act(async () => {
+    emit("generationStopped", { sessionId, runId: "old" })
+    first.reject(new Error("old dispatch failed"))
+    await sending
+  })
+  expect(h.state.status).toBe("submitted")
+  expect(h.state.error).toBeNull()
+  expect(h.state.messages.flatMap((message) => message.parts).some((part) => part.kind === "error")).toBe(false)
+})
+
+test.each(["answerQuestion", "answerPermission", "rejectQuestion"] as const)(
+  "a late %s failure cannot replace the next run with an error",
+  async (method) => {
+    const h = await mount()
+    React.act(() => emit("activeRunUpdated", { sessionId, run: run("old") }))
+    const pending = deferred()
+    transport.invoke.mockImplementationOnce(() => pending.promise)
+    let reply!: Promise<void>
+    React.act(() => {
+      if (method === "answerQuestion") reply = h.state.answerQuestion(sessionId, "old-question", [["yes"]])
+      else if (method === "rejectQuestion") reply = h.state.rejectQuestion(sessionId, "old-question")
+      else reply = h.state.answerPermission(sessionId, "old-permission", "once")
+      reply = reply.catch(() => undefined)
+    })
+    React.act(() => {
+      emit("activeRunUpdated", { sessionId, run: null, endedRunId: "old" })
+      startNewRun()
+    })
+    await React.act(async () => {
+      pending.reject(new Error("old reply failed"))
+      await reply
+    })
+    expect(h.state.status).toBe("streaming")
+    expect(h.state.error).toBeNull()
+    expect(h.state.pendingPermissions.map((request) => request.id)).toEqual(["new-permission"])
+  },
+)
+
+test("a send failure remains visible after its optimistic token binds to the host run", async () => {
+  const h = await mount()
+  const pending = deferred()
+  transport.invoke.mockImplementationOnce(() => pending.promise)
+  let sending!: Promise<void>
+  React.act(() => {
+    sending = h.state.send(sessionId, "first", [], { sessionScope: scope }).catch(() => undefined)
+  })
+  React.act(() => emit("activeRunUpdated", { sessionId, run: run("old") }))
+  await React.act(async () => {
+    pending.reject(new Error("current dispatch failed"))
+    await sending
+  })
+  expect(h.state.status).toBe("error")
+  expect(h.state.messages.flatMap((message) => message.parts).some((part) => part.kind === "error")).toBe(true)
+})

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -109,6 +109,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
   const { locale } = useI18n()
   const {
     activities,
+    ownership,
     applyActiveRun,
     forgetSession: forgetRunStateSession,
     getSessionRunStartedAt,
@@ -386,10 +387,12 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
 
   const replyPermissionRequest = React.useCallback(
     async (sessionId: string, requestId: string, reply: ChatPermissionReply): Promise<void> => {
+      const operation = ownership.capture(sessionId)
       await chatService.invoke("answerPermission", { sessionId, requestId, reply })
+      if (!ownership.isCurrent(sessionId, operation)) return
       removePendingPermission(sessionId, requestId)
     },
-    [chatService, removePendingPermission],
+    [chatService, ownership, removePendingPermission],
   )
 
   const setLocalPermissionMode = React.useCallback((sessionId: string, mode: AgentPermissionMode): number => {
@@ -598,8 +601,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
   React.useEffect(() => {
     const offs = [
       chatService.serverEvents.on("activeRunUpdated", (e) => {
-        markActiveRunMutated(e.sessionId)
-        applyActiveRun(e.sessionId, e.run, e.endedRunId)
+        if (applyActiveRun(e.sessionId, e.run, e.endedRunId)) markActiveRunMutated(e.sessionId)
       }),
       chatService.serverEvents.on("messageStarted", (e) => {
         removeAnsweredPendingQuestions(e.sessionId)
@@ -732,6 +734,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         patch(e.sessionId, (msgs) => removePart(msgs, e))
       }),
       chatService.serverEvents.on("messageCompleted", (e) => {
+        if (!ownership.acceptsTerminal(e.sessionId, e.runId)) return
+        if (e.runId) {
+          markActiveRunMutated(e.sessionId)
+          applyActiveRun(e.sessionId, null, e.runId)
+        }
         removeAnsweredPendingQuestions(e.sessionId)
         flushPendingToolParts()
         setStatus(e.sessionId, "ready")
@@ -739,6 +746,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         void reload(e.sessionId)
       }),
       chatService.serverEvents.on("turnOutcome", (e) => {
+        if (!ownership.acceptsTerminal(e.sessionId, e.runId)) return
+        if (e.runId) {
+          markActiveRunMutated(e.sessionId)
+          applyActiveRun(e.sessionId, null, e.runId)
+        }
         removeAnsweredPendingQuestions(e.sessionId)
         if (e.kind === "completed" || e.kind === "cancelled") {
           setStatus(e.sessionId, "ready")
@@ -748,6 +760,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         setActivity(e.sessionId, undefined)
       }),
       chatService.serverEvents.on("messageError", (e) => {
+        if (!ownership.acceptsTerminal(e.sessionId, e.runId)) return
+        if (e.runId) {
+          markActiveRunMutated(e.sessionId)
+          applyActiveRun(e.sessionId, null, e.runId)
+        }
         removeAnsweredPendingQuestions(e.sessionId)
         flushPendingToolParts()
         setStatus(e.sessionId, "error")
@@ -756,6 +773,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         patch(e.sessionId, (msgs) => setErrorPart(msgs, e))
       }),
       chatService.serverEvents.on("generationInterrupted", (e) => {
+        if (!ownership.acceptsTerminal(e.sessionId, e.runId)) return
+        if (e.runId) {
+          markActiveRunMutated(e.sessionId)
+          applyActiveRun(e.sessionId, null, e.runId)
+        }
         flushPendingToolParts()
         setStatus(e.sessionId, "error")
         setActivity(e.sessionId, undefined)
@@ -771,6 +793,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         patch(e.sessionId, (msgs) => setGenerationNoticePart(msgs, e))
       }),
       chatService.serverEvents.on("generationStopped", (e) => {
+        if (!ownership.acceptsTerminal(e.sessionId, e.runId)) return
+        if (e.runId) {
+          markActiveRunMutated(e.sessionId)
+          applyActiveRun(e.sessionId, null, e.runId)
+        }
         flushPendingToolParts()
         setStatus(e.sessionId, "ready")
         setActivity(e.sessionId, undefined)
@@ -799,6 +826,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
     }
   }, [
     applyActiveRun,
+    ownership,
     chatService,
     clearPendingPermissions,
     clearSessionError,
@@ -925,6 +953,8 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       cancelledToolParts.current.delete(sessionId)
       const selectedPermissionMode = options.permissionMode ?? sessionPermissionMode(sessionId)
       const permissionModeVersion = setLocalPermissionMode(sessionId, selectedPermissionMode)
+      const operation = ownership.beginSubmission(sessionId)
+      markActiveRunMutated(sessionId)
       setStatus(sessionId, "submitted")
       setActivity(sessionId, { sessionId, phase: "thinking" })
       patch(sessionId, (msgs) => appendOptimisticConversationTurn(msgs, text, attachments, options.contextMentions))
@@ -947,6 +977,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
           scope: options.sessionScope,
         })
       } catch (err) {
+        if (!ownership.isCurrent(sessionId, operation)) throw err
         reportRendererHandledError("chat", "sendMessage invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
@@ -962,9 +993,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       }
     },
     [
+      ownership,
       chatService,
       clearSessionError,
       locale,
+      markActiveRunMutated,
       patch,
       sessionPermissionMode,
       setActivity,
@@ -975,26 +1008,30 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
 
   const stop = React.useCallback(
     async (sessionId: string) => {
+      const operation = ownership.capture(sessionId)
       setGlobalError(null)
       clearSessionError(sessionId)
       markSessionUserStopped(sessionId)
       try {
         await chatService.invoke("stopGeneration", sessionId)
+        if (!ownership.isCurrent(sessionId, operation)) return
         markCurrentToolsCancelled(sessionId)
         clearPendingQuestions(sessionId)
         clearPendingPermissions(sessionId)
         setStatus(sessionId, "ready")
         setActivity(sessionId, undefined)
       } catch (err) {
+        if (!ownership.isCurrent(sessionId, operation)) throw err
         unmarkSessionUserStopped(sessionId)
         reportRendererHandledError("chat", "stopGeneration invoke failed", err)
-        setStatus(sessionId, "error")
+        setStatus(sessionId, ownership.hasActiveRun(sessionId) ? "streaming" : "error")
         setActivity(sessionId, undefined)
         setSessionError(sessionId, String(err))
         throw err
       }
     },
     [
+      ownership,
       chatService,
       clearPendingPermissions,
       clearSessionError,
@@ -1010,6 +1047,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
 
   const answerQuestion = React.useCallback(
     async (sessionId: string, requestId: string, answers: string[][]) => {
+      const operation = ownership.capture(sessionId)
       setGlobalError(null)
       clearSessionError(sessionId)
       const request = (pendingQuestionsMapRef.current[sessionId] ?? []).find((item) => item.id === requestId)
@@ -1017,9 +1055,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       setActivity(sessionId, { sessionId, phase: "thinking" })
       try {
         await chatService.invoke("answerQuestion", { sessionId, requestId, answers })
+        if (!ownership.isCurrent(sessionId, operation)) return
         markQuestionRequestAnswered(sessionId, request, answers)
         markPendingQuestionAnswered(sessionId, requestId)
       } catch (err) {
+        if (!ownership.isCurrent(sessionId, operation)) throw err
         reportRendererHandledError("chat", "answerQuestion invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
@@ -1028,6 +1068,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       }
     },
     [
+      ownership,
       chatService,
       clearSessionError,
       markPendingQuestionAnswered,
@@ -1040,6 +1081,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
 
   const answerPermission = React.useCallback(
     async (sessionId: string, requestId: string, reply: ChatPermissionReply) => {
+      const operation = ownership.capture(sessionId)
       setGlobalError(null)
       clearSessionError(sessionId)
       setStatus(sessionId, "streaming")
@@ -1047,6 +1089,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       try {
         await replyPermissionRequest(sessionId, requestId, reply)
       } catch (err) {
+        if (!ownership.isCurrent(sessionId, operation)) throw err
         reportRendererHandledError("chat", "answerPermission invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
@@ -1054,11 +1097,12 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         throw err
       }
     },
-    [clearSessionError, replyPermissionRequest, setActivity, setSessionError, setStatus],
+    [ownership, clearSessionError, replyPermissionRequest, setActivity, setSessionError, setStatus],
   )
 
   const rejectQuestion = React.useCallback(
     async (sessionId: string, requestId: string) => {
+      const operation = ownership.capture(sessionId)
       setGlobalError(null)
       clearSessionError(sessionId)
       const request = (pendingQuestionsMapRef.current[sessionId] ?? []).find((item) => item.id === requestId)
@@ -1066,9 +1110,11 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       setActivity(sessionId, { sessionId, phase: "thinking" })
       try {
         await chatService.invoke("rejectQuestion", { sessionId, requestId })
+        if (!ownership.isCurrent(sessionId, operation)) return
         removePendingQuestion(sessionId, requestId)
         markQuestionRequestsCancelled(sessionId, request ? [request] : [])
       } catch (err) {
+        if (!ownership.isCurrent(sessionId, operation)) throw err
         reportRendererHandledError("chat", "rejectQuestion invoke failed", err)
         setStatus(sessionId, "error")
         setActivity(sessionId, undefined)
@@ -1077,6 +1123,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
       }
     },
     [
+      ownership,
       chatService,
       clearSessionError,
       markQuestionRequestsCancelled,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -604,6 +604,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         if (applyActiveRun(e.sessionId, e.run, e.endedRunId)) markActiveRunMutated(e.sessionId)
       }),
       chatService.serverEvents.on("messageStarted", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         patch(e.sessionId, (msgs) => setMessageInfo(msgs, e))
         if (e.role === "assistant") {
@@ -614,6 +615,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         }
       }),
       chatService.serverEvents.on("messageDelta", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         setStatus(e.sessionId, "streaming")
         // A user-echo delta is not assistant progress; keep the thinking
@@ -625,23 +627,27 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         delayPendingToolFlushForText(e)
       }),
       chatService.serverEvents.on("messageReasoningDelta", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         setStatus(e.sessionId, "streaming")
         setActivity(e.sessionId, { sessionId: e.sessionId, messageId: e.messageId, phase: "thinking" })
         enqueueTextDelta("reasoning", e)
       }),
       chatService.serverEvents.on("messageAttachment", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         flushPendingTextDeltas()
         patch(e.sessionId, (msgs) => setAttachmentPart(msgs, e))
       }),
       chatService.serverEvents.on("toolCallStarted", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         setStatus(e.sessionId, "streaming")
         setActivity(e.sessionId, undefined)
         enqueueToolCallStarted(e)
       }),
       chatService.serverEvents.on("toolCallResult", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         removeAnsweredPendingQuestions(e.sessionId)
         const cancelled = e.status === "error" && isSessionUserStopped(e.sessionId)
         setStatus(e.sessionId, cancelled ? "ready" : "streaming")
@@ -704,6 +710,7 @@ export function useChat(activeSessionId: string | null, activeRunsRefreshKey?: s
         setLocalPermissionMode(e.sessionId, e.permissionMode)
       }),
       chatService.serverEvents.on("assistantActivity", (e) => {
+        if (!ownership.acceptsProgress(e.sessionId, e.runId)) return
         setStatus(e.sessionId, "streaming")
         setActivity(e.sessionId, e)
         const { finishReason, messageId } = e


### PR DESCRIPTION
## Summary

Fix chat lifecycle races that let an old turn clear or complete a replacement turn, and reduce unnecessary rendering during streaming.

- Enforce same-session submission ownership and bind completion verification to the current user turn and its final assistant message.
- Wait for ACP cancellation settlement, recover after cancellation timeouts, and share generation-scoped cleanup so delayed acknowledgements cannot finalize twice. Keep another session running independently.
- Attach run identity to host terminal/progress events and guard renderer callbacks. Retain bounded message ownership across turns, preserve native parent identity, and prevent late tools, activity, or permission replies from changing the current run.
- Stabilize sidebar callbacks and the Markdown component map so existing memoization can reuse unchanged UI. Preserve resize behavior, Markdown semantics, custom renderer overrides, and smoothing cadence.

The development-renderer benchmarks use 200 synthetic historical messages and fixed 20-second streams, with five runs per condition and the warm-up excluded. Sidebar render time decreased from 719.7ms to 4.25ms in its paired experiment; Markdown subtree render time decreased from 2875.0ms to 789.3ms in a separate paired experiment. These are inclusive React rendering measurements, not production or model-throughput speedups. Raw traces remain local; methodology, per-run results, tradeoffs, and remaining coverage are in `docs/quality/baseline.md`.

## Verification

- [x] `pnpm run ts-check` passed on the final code.
- [x] `pnpm run lint` passed; rerun immediately before opening this PR.
- [ ] Full-repository `pnpm run format` — modified files passed `oxfmt --check` instead.
- [x] `pnpm exec vitest run --maxWorkers=2` — 2996 passed, 4 skipped.
- [ ] Production `pnpm run build` — not run for this PR preparation.
- [x] Runtime/UI verification completed: normal Electron startup, real built-in-agent chat/tool completion, Markdown heading/inline code/JSON block/list presentation, and return to idle. Cancellation races and ACP recovery use deterministic adapter/host tests, including in-memory ACP SDK transport. Performance fixtures run the actual Electron renderer.

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately; model authentication/routing is unchanged. Live smoke checks used the signed-in development profile; local/external lifecycle paths are covered by tests.
- [x] No credential was added to renderer code, fixtures, or committed files; raw profiling artifacts are excluded from Git.
- [x] Agent tools, permissions, and system prompts remain aligned. Changes concern lifecycle ownership and rendering; permission-reply handling now ignores requests that are no longer blocking the active run.
- [x] Migration, packaging, endpoint, and update implications were considered. There is no storage migration, dependency upgrade, or endpoint/packaging change.
- [x] Relevant documentation and regression tests were updated.

Progress events without a known message owner or native parent remain session-scoped. Large tool outputs, manual scrolling, native keyboard INP, and production-build performance remain follow-up measurement scenarios.
