### PR TITLE
fix(skills): stabilize catalog loading and reduce redundant work

### DIFF
--- a/docs/skill-catalog-caching.md
+++ b/docs/skill-catalog-caching.md
@@ -12,8 +12,8 @@ detail of the same package gets fetched repeatedly through different entry point
 
 The cache goals are:
 
-- Within one app session, each catalog key issues at most one request; concurrent consumers share
-  the in-flight promise.
+- While an entry is fresh, consumers reuse it; concurrent consumers share the in-flight promise.
+  Explicit invalidation and TTL expiry allow a new request.
 - The public market, the team market, Provider recommendations, and exact-package-name lookups
   reuse the same package detail.
 - Only explicit changes — a user-initiated refresh, a successful publish — force-bypass or
@@ -29,7 +29,10 @@ The cache goals are:
 Pages / dialogs / Provider recommendations
           │
           ▼
-src/lib/skills-catalog-client.ts
+src/lib/skills-catalog-client.ts / provider resolution / maintainer client
+          │
+          ▼
+src/lib/skill-catalog-cache.ts
   - keyed cache
   - in-flight dedup
   - TTL / targeted invalidation
@@ -39,7 +42,8 @@ src/lib/skills-catalog-client.ts
           └── registry.<endpoint> (package detail)
 ```
 
-The cache lives in `skills-catalog-client.ts` because these requests all go directly from the
+The cache lives in `skill-catalog-cache.ts`, shared by the catalog, Provider resolution, and
+account-scoped maintainer clients. These requests all go directly from the
 renderer using the httpOnly session cookie; no main-process forwarding is introduced, and no token
 is brought into the renderer.
 
@@ -52,10 +56,29 @@ is brought into the renderer.
 | Public package detail                  | `public:package:{name,version}`                                       |                           10 min | Shared by exact-package-name lookup, search completion, and Provider recommendations                                                                      |
 | My published list                      | `my:{accountId}:{next}`                                               |                            2 min | Account-isolated in-memory cache only                                                                                                                     |
 | My published package detail            | `account:{accountId}:package:{name,version}`                          |                           10 min | Never reused across accounts                                                                                                                              |
-| Provider → package resolution          | `service + provider displayName`                                      |                           10 min | A "package not found" result is kept as a 24 h negative cache                                                                                             |
+| Provider → package resolution          | `public:provider:{service,providerDisplayName}`                       |                           10 min | A "package not found" result is kept as a 24 h negative cache                                                                                             |
 | Team Skill configuration               | `accountId + teamId`                                                  | 30 s freshness / 24 h local hold | See `useTeamSkills.ts`                                                                                                                                    |
 | Local installed Skill inventory        | global resource + main-process scan cache                             |                            5 min | Proactively invalidated on watcher changes; TTL is the fallback for missing directories                                                                   |
 | Installed Skill registry version check | auth snapshot + inventory fingerprint (`createVersionReportCacheKey`) |                           30 min | Main-process cache in `SkillServiceImpl.checkSkillVersions` with in-flight dedup; the renderer `skillVersions` resource mirrors it (30 min `staleTimeMs`) |
+
+## Page loading and supplemental details
+
+`useSkillCatalog` owns the Skills page's browse, search, and my-published pagination. Successful
+empty results settle as `ready`; only a new query, an explicit retry, or cache invalidation starts
+another load. Completed pages survive tab switches. Abandoned requests release their shared-request
+consumer, and cancelled pending requests are never reused by new consumers, including StrictMode
+remounts. A failed refresh keeps the previous rows and exposes an error for retry.
+
+My-published records that already contain a normalized Skill list render directly, without registry
+fan-out. Records without Skill metadata still need a package-info read to distinguish Skills from
+other package types. These supplemental reads retain the 20-record limit and concurrency cap of 10,
+use the listed version, and inherit `forceRefresh`. Failed supplements reject the page rather than
+silently dropping entries or caching an incomplete success. Valid non-Skill package details remain
+excluded. New work is not scheduled after a supplemental worker fails.
+
+Maintainer details share in-flight reads and a 30-second cache keyed by account, package, and version.
+Explicit retry bypasses that entry; invitations invalidate affected maintainer entries without
+refreshing or closing the catalog containing the invitation dialog. Unscoped callers remain uncached.
 
 ## Provider recommendation resolution
 
@@ -79,9 +102,11 @@ degradation path.
 ## Invalidation rules
 
 - Skill published successfully: invalidate the current account's "my published" list and private
-  package details, plus the public market / search caches.
+  package details, plus public market, search, and Provider resolution entries. Shared invalidation
+  revisions notify mounted catalog and Provider consumers; an unchanged search query still reloads.
 - Sign-in, sign-out, or account switch: clear the entire session-level catalog cache, so no
-  package response that may be permission-dependent is ever shown to another account.
+  package response that may be permission-dependent is ever shown to another account. Provider
+  resolution and account-scoped maintainer entries share this same cleanup lifecycle.
 - Installing, updating, or deleting a local Skill: only update `skillInventory`; do not invalidate
   the market catalog.
 - External agent or Wanta runtime Skill file changes: the main-process watcher immediately
@@ -89,7 +114,9 @@ degradation path.
   re-recurse and re-hash every Skill.
 - Skill version report: watcher-detected inventory changes and auth state changes both call
   `invalidateVersionReport`; the renderer `skillVersions` resource is invalidated on the
-  `skillInventoryChanged` event.
+  `skillInventoryChanged` event. While the Skills page is visible, the version-report resource
+  reloads after invalidation and deduplicates in-flight checks. There is no permanent page-level
+  once-only check flag; initial failures wait for retry/re-entry or a subsequent invalidation.
 - Team configuration create/update/delete: invalidate the current team's configuration cache; do
   not invalidate public market data.
 - Connector set changes: the Provider recommendation layer recomputes per candidate provider key;

--- a/src/components/AppDataHooks.ts
+++ b/src/components/AppDataHooks.ts
@@ -7,23 +7,36 @@ import { useAppDataResources } from "@/components/AppDataContext"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
 import { ResourceStore, toResourceView } from "@/lib/resource-store"
 
-function useResource<T>(resource: ResourceStore<T>, options: { autoLoad?: boolean } = {}): ResourceView<T> {
+function useResource<T>(
+  resource: ResourceStore<T>,
+  options: { autoLoad?: boolean; reloadOnInvalidate?: boolean } = {},
+): ResourceView<T> {
   const snapshot = React.useSyncExternalStore(
     React.useCallback((listener) => resource.subscribe(listener), [resource]),
     React.useCallback(() => resource.getSnapshot(), [resource]),
     React.useCallback(() => resource.getSnapshot(), [resource]),
   )
 
-  React.useEffect(() => {
-    if (options.autoLoad === false) {
-      return
-    }
-
-    void resource.refresh().catch((error: unknown) => {
-      // 错误保存在 resource snapshot 中，页面按状态展示。
+  const refresh = React.useCallback(() => {
+    void resource.refresh({ silent: options.reloadOnInvalidate }).catch((error: unknown) => {
       reportRendererHandledError("resource", "resource auto-load failed", error)
     })
-  }, [options.autoLoad, resource])
+  }, [resource, options.reloadOnInvalidate])
+
+  React.useEffect(() => {
+    if (options.autoLoad !== false) refresh()
+  }, [options.autoLoad, refresh])
+
+  React.useEffect(() => {
+    if (
+      options.autoLoad !== false &&
+      options.reloadOnInvalidate &&
+      snapshot.updatedAt === null &&
+      snapshot.error === null &&
+      (snapshot.status === "idle" || snapshot.status === "ready")
+    )
+      refresh()
+  }, [options.autoLoad, options.reloadOnInvalidate, refresh, snapshot])
 
   return React.useMemo(() => toResourceView(snapshot, resource), [resource, snapshot])
 }
@@ -36,6 +49,9 @@ export function useSkillInventoryResource(): ResourceView<SkillInventory> {
   return useResource(useAppDataResources().skillInventory)
 }
 
-export function useSkillVersionReportResource(): ResourceView<SkillVersionReport> {
-  return useResource(useAppDataResources().skillVersions, { autoLoad: false })
+export function useSkillVersionReportResource(options: { autoLoad?: boolean } = {}): ResourceView<SkillVersionReport> {
+  return useResource(useAppDataResources().skillVersions, {
+    autoLoad: options.autoLoad ?? false,
+    reloadOnInvalidate: true,
+  })
 }

--- a/src/components/skill-version-resource.test.tsx
+++ b/src/components/skill-version-resource.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import type { SkillVersionReport } from "../../electron/skills/common.ts"
+import type { AppDataResources } from "./AppDataContext"
+import type { Root } from "react-dom/client"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, expect, test, vi } from "vitest"
+import { AppDataContext } from "./AppDataContext"
+import { useSkillVersionReportResource } from "./AppDataHooks"
+import { createResource } from "@/lib/resource-store"
+
+let root: Root | undefined
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  root = undefined
+  vi.unstubAllGlobals()
+})
+
+const report: SkillVersionReport = {
+  checkedAt: "now",
+  cli: { command: [], status: "up-to-date" },
+  skills: [],
+  summary: { cliUpdates: 0, errors: 0, registrySkillUpdates: 0, totalUpdates: 0 },
+}
+
+async function mount(load: () => Promise<SkillVersionReport>) {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  const skillVersions = createResource({ load, staleTimeMs: 30 * 60_000 })
+  const resources = { skillVersions } as AppDataResources
+  function Probe({ autoLoad }: { autoLoad: boolean }) {
+    useSkillVersionReportResource({ autoLoad })
+    return null
+  }
+  root = createRoot(document.createElement("div"))
+  const render = async (autoLoad: boolean) => {
+    await act(async () =>
+      root!.render(
+        <AppDataContext.Provider value={resources}>
+          <Probe autoLoad={autoLoad} />
+        </AppDataContext.Provider>,
+      ),
+    )
+  }
+  await render(true)
+  return { skillVersions, render }
+}
+
+test("visible version reports reload after each invalidation and reuse fresh data otherwise", async () => {
+  const load = vi.fn(async () => report)
+  const probe = await mount(load)
+  expect(load).toHaveBeenCalledTimes(1)
+  await act(async () => probe.skillVersions.invalidate())
+  expect(load).toHaveBeenCalledTimes(2)
+  await probe.render(true)
+  expect(load).toHaveBeenCalledTimes(2)
+  await probe.render(false)
+  await act(async () => probe.skillVersions.invalidate())
+  expect(load).toHaveBeenCalledTimes(2)
+  await probe.render(true)
+  expect(load).toHaveBeenCalledTimes(3)
+})
+
+test("failed initial version checks do not create an automatic retry loop", async () => {
+  const load = vi.fn<() => Promise<SkillVersionReport>>(async () => {
+    throw new Error("offline")
+  })
+  const probe = await mount(load)
+  expect(load).toHaveBeenCalledTimes(1)
+  expect(probe.skillVersions.getSnapshot().status).toBe("error")
+  await act(async () => probe.skillVersions.invalidate())
+  expect(load).toHaveBeenCalledTimes(2)
+  await probe.render(false)
+  load.mockResolvedValue(report)
+  await probe.render(true)
+  expect(load).toHaveBeenCalledTimes(3)
+  expect(probe.skillVersions.getSnapshot().status).toBe("ready")
+})
+
+test("invalidation during a silent refresh starts a replacement and rejects stale writes", async () => {
+  let resolveOld!: (value: SkillVersionReport) => void
+  const load = vi.fn(async () => report)
+  const probe = await mount(load)
+  load.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolveOld = resolve
+      }),
+  )
+  await act(async () => probe.skillVersions.invalidate())
+  expect(load).toHaveBeenCalledTimes(2)
+  await act(async () => probe.skillVersions.invalidate())
+  expect(load).toHaveBeenCalledTimes(3)
+  await act(async () => resolveOld({ ...report, checkedAt: "stale" }))
+  expect(probe.skillVersions.getSnapshot().data?.checkedAt).toBe("now")
+})

--- a/src/lib/skill-catalog-cache.ts
+++ b/src/lib/skill-catalog-cache.ts
@@ -1,0 +1,152 @@
+import type { SharedRequest } from "@/lib/shared-request"
+
+import { createSharedRequest, waitForSharedRequest } from "@/lib/shared-request"
+
+const skillCatalogCacheMaxEntries = 256
+
+interface SkillCatalogCacheEntry {
+  expiresAt: number
+  value: unknown
+}
+
+interface SkillCatalogPendingRequest extends SharedRequest<unknown> {
+  epoch: number
+  generation: number
+}
+
+const skillCatalogCache = new Map<string, SkillCatalogCacheEntry>()
+const skillCatalogPendingRequests = new Map<string, SkillCatalogPendingRequest>()
+const skillCatalogKeyGenerations = new Map<string, number>()
+let skillCatalogEpoch = 0
+
+let invalidationRevision = 0
+const invalidationListeners = new Set<() => void>()
+
+export function getSkillCatalogInvalidationRevision(): number {
+  return invalidationRevision
+}
+
+export function subscribeSkillCatalogInvalidation(listener: () => void): () => void {
+  invalidationListeners.add(listener)
+  return () => {
+    invalidationListeners.delete(listener)
+  }
+}
+
+function notifySkillCatalogInvalidation(): void {
+  invalidationRevision += 1
+  for (const listener of invalidationListeners) listener()
+}
+
+export function readCachedSkillCatalogValue<T>(key: string): T | undefined {
+  const cached = skillCatalogCache.get(key)
+  if (!cached) {
+    return undefined
+  }
+  if (Date.now() >= cached.expiresAt) {
+    skillCatalogCache.delete(key)
+    if (!skillCatalogPendingRequests.has(key)) {
+      skillCatalogKeyGenerations.delete(key)
+    }
+    return undefined
+  }
+  return cached.value as T
+}
+
+export function readCachedSkillCatalog<T>(
+  key: string,
+  cacheMs: number | ((value: T) => number),
+  forceRefresh: boolean | undefined,
+  load: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  signal?.throwIfAborted()
+  if (forceRefresh) {
+    invalidateSkillCatalogKey(key)
+  }
+
+  if (!forceRefresh) {
+    const cached = readCachedSkillCatalogValue<T>(key)
+    if (cached !== undefined) {
+      return Promise.resolve(cached)
+    }
+  }
+
+  const epoch = skillCatalogEpoch
+  const generation = skillCatalogKeyGenerations.get(key) ?? 0
+  const pending = skillCatalogPendingRequests.get(key)
+  if (pending?.epoch === epoch && pending.generation === generation && !pending.controller.signal.aborted) {
+    return waitForSharedRequest(pending as SkillCatalogPendingRequest & SharedRequest<T>, signal)
+  }
+
+  const shared = createSharedRequest((requestSignal) =>
+    load(requestSignal).then((value) => {
+      if (
+        !requestSignal.aborted &&
+        skillCatalogEpoch === epoch &&
+        (skillCatalogKeyGenerations.get(key) ?? 0) === generation
+      ) {
+        skillCatalogCache.set(key, {
+          expiresAt: Date.now() + (typeof cacheMs === "function" ? cacheMs(value) : cacheMs),
+          value,
+        })
+        while (skillCatalogCache.size > skillCatalogCacheMaxEntries) {
+          const oldestKey = skillCatalogCache.keys().next().value as string | undefined
+          if (!oldestKey) {
+            break
+          }
+          skillCatalogCache.delete(oldestKey)
+          if (!skillCatalogPendingRequests.has(oldestKey)) {
+            skillCatalogKeyGenerations.delete(oldestKey)
+          }
+        }
+      }
+      return value
+    }),
+  )
+  const request: SkillCatalogPendingRequest = Object.assign(shared, { epoch, generation })
+  skillCatalogPendingRequests.set(key, request)
+  void request.promise.then(
+    () => {
+      if (skillCatalogPendingRequests.get(key) === request) skillCatalogPendingRequests.delete(key)
+    },
+    () => {
+      if (skillCatalogPendingRequests.get(key) === request) skillCatalogPendingRequests.delete(key)
+    },
+  )
+  return waitForSharedRequest(request as SkillCatalogPendingRequest & SharedRequest<T>, signal)
+}
+
+function invalidateSkillCatalogKey(key: string): void {
+  skillCatalogCache.delete(key)
+  skillCatalogPendingRequests.delete(key)
+  skillCatalogKeyGenerations.set(key, (skillCatalogKeyGenerations.get(key) ?? 0) + 1)
+}
+
+export function invalidateSkillCatalogKeys(
+  predicate: (key: string) => boolean,
+  options: { notify?: boolean } = {},
+): void {
+  const keys = new Set([
+    ...skillCatalogCache.keys(),
+    ...skillCatalogPendingRequests.keys(),
+    ...skillCatalogKeyGenerations.keys(),
+  ])
+  for (const key of keys) {
+    if (predicate(key)) {
+      invalidateSkillCatalogKey(key)
+    }
+  }
+  if (options.notify !== false) notifySkillCatalogInvalidation()
+}
+
+export function clearSkillCatalogCache(): void {
+  skillCatalogEpoch += 1
+  skillCatalogCache.clear()
+  for (const request of skillCatalogPendingRequests.values()) {
+    request.controller.abort(new DOMException("Skill catalog cache was cleared.", "AbortError"))
+  }
+  skillCatalogPendingRequests.clear()
+  skillCatalogKeyGenerations.clear()
+  notifySkillCatalogInvalidation()
+}

--- a/src/lib/skill-maintainers-client.test.ts
+++ b/src/lib/skill-maintainers-client.test.ts
@@ -6,8 +6,10 @@ import {
   inviteSkillPackageMaintainer,
 } from "./skill-maintainers-client.ts"
 import { apiBaseUrl, consoleBaseUrl, registryBaseUrl } from "@/lib/domain"
+import { clearSkillCatalogCache } from "@/lib/skill-catalog-cache"
 
 afterEach(() => {
+  clearSkillCatalogCache()
   vi.unstubAllGlobals()
 })
 
@@ -49,4 +51,20 @@ test("builds the Console invitation URL from the initiating user and package", (
     getSkillMaintainerInvitationUrl({ fromUsername: "owner", packageName: "@acme/demo" }),
     `${consoleBaseUrl}/skill-maintainer-invitation?package=%40acme%2Fdemo&from=owner`,
   )
+})
+
+test("maintainer reads share a short-lived account cache, while force refresh and invitations invalidate it", async () => {
+  const fetchMock = vi.fn(async () => Response.json({ maintainers: [{ id: "owner", name: "Owner" }] }))
+  vi.stubGlobal("fetch", fetchMock)
+  const input = { accountId: "a", packageName: "@acme/demo", version: "1.0.0" }
+  await Promise.all([getSkillPackageMaintainerDetail(input), getSkillPackageMaintainerDetail(input)])
+  await getSkillPackageMaintainerDetail(input)
+  assert.equal(fetchMock.mock.calls.length, 1)
+  await getSkillPackageMaintainerDetail({ ...input, accountId: "b" })
+  assert.equal(fetchMock.mock.calls.length, 2)
+  await getSkillPackageMaintainerDetail({ ...input, forceRefresh: true })
+  assert.equal(fetchMock.mock.calls.length, 3)
+  await inviteSkillPackageMaintainer({ packageName: input.packageName, username: "alice" })
+  await getSkillPackageMaintainerDetail(input)
+  assert.equal(fetchMock.mock.calls.length, 5)
 })

--- a/src/lib/skill-maintainers-client.ts
+++ b/src/lib/skill-maintainers-client.ts
@@ -1,5 +1,6 @@
 import { apiBaseUrl, consoleBaseUrl, registryBaseUrl } from "@/lib/domain"
 import { oomolFetchJson } from "@/lib/oomol-http"
+import { readCachedSkillCatalog, invalidateSkillCatalogKeys } from "@/lib/skill-catalog-cache"
 
 export interface SkillPackageMaintainer {
   id: string
@@ -60,10 +61,14 @@ function normalizeMaintainers(value: unknown): SkillPackageMaintainer[] {
 }
 
 export async function getSkillPackageMaintainerDetail({
+  accountId,
+  forceRefresh,
   packageName,
   signal,
   version = "latest",
 }: {
+  accountId?: string
+  forceRefresh?: boolean
   packageName: string
   signal?: AbortSignal
   version?: string
@@ -76,8 +81,18 @@ export async function getSkillPackageMaintainerDetail({
     `/-/oomol/detail/${encodeSkillPackagePath(normalizedPackageName)}/${encodeURIComponent(version.trim() || "latest")}`,
     registryBaseUrl,
   )
-  const detail = await oomolFetchJson<RawSkillPackageDetail>(url, { signal })
-  return { maintainers: normalizeMaintainers(detail?.maintainers) }
+  const load = async (requestSignal?: AbortSignal) => {
+    const detail = await oomolFetchJson<RawSkillPackageDetail>(url, { signal: requestSignal })
+    return { maintainers: normalizeMaintainers(detail?.maintainers) }
+  }
+  if (!accountId) return load(signal)
+  return readCachedSkillCatalog(
+    `account:${accountId}:maintainers:${normalizedPackageName}:${version.trim() || "latest"}`,
+    30_000,
+    forceRefresh,
+    load,
+    signal,
+  )
 }
 
 export async function inviteSkillPackageMaintainer({
@@ -99,6 +114,7 @@ export async function inviteSkillPackageMaintainer({
     ),
     { method: "POST" },
   )
+  invalidateSkillCatalogKeys((key) => key.includes(`:maintainers:${normalizedPackageName}:`), { notify: false })
 }
 
 export function getSkillMaintainerInvitationUrl({

--- a/src/lib/skills-catalog-client.test.ts
+++ b/src/lib/skills-catalog-client.test.ts
@@ -58,7 +58,6 @@ test("cancellable public Skill consumers still share one underlying request", as
 test("my published Skill pages cap registry detail fanout at 20 packages", async () => {
   const packages = Array.from({ length: 25 }, (_, index) => ({
     name: `@acme/package-${index}`,
-    skills: [{ name: `skill-${index}` }],
     version: "1.0.0",
   }))
   let registryReads = 0
@@ -219,4 +218,88 @@ test("searchPublicSkillPackages builds fallback package details from the search 
     `${packageAssetsBaseUrl}/packages/@acme/demo/1.0.0/files/package/assets/search-icon.svg`,
   )
   assert.equal(fetchMock.mock.calls.length, 1)
+})
+
+test("my published records with skill metadata skip all detail requests", async () => {
+  const fetchMock = vi.fn(async () =>
+    Response.json({
+      data: Array.from({ length: 20 }, (_, i) => ({
+        name: `@acme/skill-${i}`,
+        version: "2.0.0",
+        skills: [{ name: `skill-${i}` }],
+      })),
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  const result = await listMyPublishedSkillPackages({ account: { id: "a", name: "Alice" } })
+  assert.equal(result.items.length, 20)
+  assert.equal(fetchMock.mock.calls.length, 1)
+})
+
+test("failed supplemental details reject the page and are not cached as a successful empty list", async () => {
+  let failed = true
+  let listReads = 0
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input) => {
+      if (String(input).includes("/v1/packages/-/my")) {
+        listReads++
+        return Response.json({ data: [{ name: "@acme/demo", version: "1.0.0" }] })
+      }
+      return failed
+        ? new Response("unavailable", { status: 503 })
+        : Response.json({
+            packageName: "@acme/demo",
+            packageVersion: "1.0.0",
+            skills: [{ name: "demo" }],
+          })
+    }),
+  )
+  const account = { id: "a", name: "Alice" }
+  await assert.rejects(listMyPublishedSkillPackages({ account }), /503/)
+  failed = false
+  const recovered = await listMyPublishedSkillPackages({ account })
+  assert.equal(recovered.items.length, 1)
+  assert.equal(listReads, 2)
+})
+
+test("my published force refresh also refreshes supplemental detail at the listed version", async () => {
+  let details = 0
+  const detailUrls: string[] = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input) => {
+      if (String(input).includes("/v1/packages/-/my"))
+        return Response.json({ data: [{ name: "@acme/demo", version: "2.0.0" }] })
+      details++
+      detailUrls.push(String(input))
+      return Response.json({
+        packageName: "@acme/demo",
+        packageVersion: "2.0.0",
+        title: `Title ${details}`,
+        skills: [{ name: "demo" }],
+      })
+    }),
+  )
+  const account = { id: "a", name: "Alice" }
+  await listMyPublishedSkillPackages({ account })
+  const result = await listMyPublishedSkillPackages({ account, forceRefresh: true })
+  assert.equal(details, 2)
+  assert.equal(result.items[0]?.displayName, "Title 2")
+  assert.ok(detailUrls.every((url) => url.endsWith("/2.0.0")))
+})
+
+test("private details are isolated by account and legitimate non-skill packages are excluded", async () => {
+  let details = 0
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input) => {
+      if (String(input).includes("/v1/packages/-/my")) return Response.json({ data: [{ name: "@acme/demo" }] })
+      details++
+      return Response.json({ packageName: "@acme/demo", skills: details === 1 ? [] : [{ name: "demo" }] })
+    }),
+  )
+  assert.equal((await listMyPublishedSkillPackages({ account: { id: "a", name: "A" } })).items.length, 0)
+  assert.equal((await listMyPublishedSkillPackages({ account: { id: "b", name: "B" } })).items.length, 1)
+  assert.equal(details, 2)
 })

--- a/src/lib/skills-catalog-client.ts
+++ b/src/lib/skills-catalog-client.ts
@@ -3,13 +3,12 @@ import type {
   PublicSkillPackageCatalog,
   PublicSkillPackageMaintainer,
 } from "../../electron/skills/common.ts"
-import type { SharedRequest } from "@/lib/shared-request"
 
 import { normalizePublicSkillPackageCatalog, normalizeRegistrySkillPackageInfo } from "../../electron/skills/actions.ts"
 import { registryBaseUrl, searchBaseUrl } from "@/lib/domain"
 import { oomolFetch } from "@/lib/oomol-http"
-import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
-import { createSharedRequest, waitForSharedRequest } from "@/lib/shared-request"
+import { readCachedSkillCatalog, invalidateSkillCatalogKeys } from "@/lib/skill-catalog-cache"
+export { clearSkillCatalogCache } from "@/lib/skill-catalog-cache"
 import { resolvePackageAssetIconSource } from "@/lib/skill-icon-assets.ts"
 
 // 技能 Discover 标签的注册表浏览/搜索请求在渲染层直接发起：原先这些是渲染业务驱动、却由主进程
@@ -26,22 +25,6 @@ const publicSkillPackageListCacheMs = 5 * 60_000
 const publicSkillSearchCacheMs = 2 * 60_000
 const publicSkillPackageInfoCacheMs = 10 * 60_000
 const myPublishedSkillPackageCacheMs = 2 * 60_000
-const skillCatalogCacheMaxEntries = 256
-
-interface SkillCatalogCacheEntry {
-  expiresAt: number
-  value: unknown
-}
-
-interface SkillCatalogPendingRequest extends SharedRequest<unknown> {
-  epoch: number
-  generation: number
-}
-
-const skillCatalogCache = new Map<string, SkillCatalogCacheEntry>()
-const skillCatalogPendingRequests = new Map<string, SkillCatalogPendingRequest>()
-const skillCatalogKeyGenerations = new Map<string, number>()
-let skillCatalogEpoch = 0
 
 export interface MyPublishedSkillAccount {
   id: string
@@ -105,111 +88,6 @@ function skillCatalogPageKey(next: string | undefined, size: number | undefined)
 
 function skillCatalogPackageKey(scope: string, packageName: string, version: string): string {
   return `${scope}:package:${packageName.trim().toLowerCase()}:${version.trim().toLowerCase() || "latest"}`
-}
-
-function readCachedSkillCatalogValue<T>(key: string): T | undefined {
-  const cached = skillCatalogCache.get(key)
-  if (!cached) {
-    return undefined
-  }
-  if (Date.now() >= cached.expiresAt) {
-    skillCatalogCache.delete(key)
-    if (!skillCatalogPendingRequests.has(key)) {
-      skillCatalogKeyGenerations.delete(key)
-    }
-    return undefined
-  }
-  return cached.value as T
-}
-
-function readCachedSkillCatalog<T>(
-  key: string,
-  cacheMs: number,
-  forceRefresh: boolean | undefined,
-  load: (signal: AbortSignal) => Promise<T>,
-  signal?: AbortSignal,
-): Promise<T> {
-  signal?.throwIfAborted()
-  if (forceRefresh) {
-    invalidateSkillCatalogKey(key)
-  }
-
-  if (!forceRefresh) {
-    const cached = readCachedSkillCatalogValue<T>(key)
-    if (cached !== undefined) {
-      return Promise.resolve(cached)
-    }
-  }
-
-  const epoch = skillCatalogEpoch
-  const generation = skillCatalogKeyGenerations.get(key) ?? 0
-  const pending = skillCatalogPendingRequests.get(key)
-  if (pending?.epoch === epoch && pending.generation === generation) {
-    return waitForSharedRequest(pending as SkillCatalogPendingRequest & SharedRequest<T>, signal)
-  }
-
-  const shared = createSharedRequest((requestSignal) =>
-    load(requestSignal).then((value) => {
-      if (
-        !requestSignal.aborted &&
-        skillCatalogEpoch === epoch &&
-        (skillCatalogKeyGenerations.get(key) ?? 0) === generation
-      ) {
-        skillCatalogCache.set(key, { expiresAt: Date.now() + cacheMs, value })
-        while (skillCatalogCache.size > skillCatalogCacheMaxEntries) {
-          const oldestKey = skillCatalogCache.keys().next().value as string | undefined
-          if (!oldestKey) {
-            break
-          }
-          skillCatalogCache.delete(oldestKey)
-          if (!skillCatalogPendingRequests.has(oldestKey)) {
-            skillCatalogKeyGenerations.delete(oldestKey)
-          }
-        }
-      }
-      return value
-    }),
-  )
-  const request: SkillCatalogPendingRequest = Object.assign(shared, { epoch, generation })
-  skillCatalogPendingRequests.set(key, request)
-  void request.promise.then(
-    () => {
-      if (skillCatalogPendingRequests.get(key) === request) skillCatalogPendingRequests.delete(key)
-    },
-    () => {
-      if (skillCatalogPendingRequests.get(key) === request) skillCatalogPendingRequests.delete(key)
-    },
-  )
-  return waitForSharedRequest(request as SkillCatalogPendingRequest & SharedRequest<T>, signal)
-}
-
-function invalidateSkillCatalogKey(key: string): void {
-  skillCatalogCache.delete(key)
-  skillCatalogPendingRequests.delete(key)
-  skillCatalogKeyGenerations.set(key, (skillCatalogKeyGenerations.get(key) ?? 0) + 1)
-}
-
-function invalidateSkillCatalogKeys(predicate: (key: string) => boolean): void {
-  const keys = new Set([
-    ...skillCatalogCache.keys(),
-    ...skillCatalogPendingRequests.keys(),
-    ...skillCatalogKeyGenerations.keys(),
-  ])
-  for (const key of keys) {
-    if (predicate(key)) {
-      invalidateSkillCatalogKey(key)
-    }
-  }
-}
-
-export function clearSkillCatalogCache(): void {
-  skillCatalogEpoch += 1
-  skillCatalogCache.clear()
-  for (const request of skillCatalogPendingRequests.values()) {
-    request.controller.abort(new DOMException("Skill catalog cache was cleared.", "AbortError"))
-  }
-  skillCatalogPendingRequests.clear()
-  skillCatalogKeyGenerations.clear()
 }
 
 export function invalidatePublicSkillCatalog(): void {
@@ -415,13 +293,19 @@ async function mapWithConcurrency<T, R>(
 ): Promise<R[]> {
   const results: R[] = []
   let nextIndex = 0
+  let failed = false
   const workerCount = Math.min(Math.max(1, concurrency), items.length)
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
+      while (!failed && nextIndex < items.length) {
         const index = nextIndex
         nextIndex += 1
-        results[index] = await mapper(items[index] as T)
+        try {
+          results[index] = await mapper(items[index] as T)
+        } catch (cause) {
+          failed = true
+          throw cause
+        }
       }
     }),
   )
@@ -449,24 +333,18 @@ export async function listMyPublishedSkillPackages(
           myPublishedSkillPackageInfoConcurrency,
           async (publishedPackage) => {
             signal.throwIfAborted()
-            let packageInfo: PublicSkillPackage | undefined
-            try {
-              packageInfo = await readRegistrySkillPackageInfo(publishedPackage.name, maintainer, {
-                cacheScope: `account:${input.account.id}`,
-                signal,
-              })
-            } catch (error) {
-              if (signal.aborted) {
-                throw error
+            if (publishedPackage.skills.length > 0) {
+              return {
+                ...publishedPackage,
+                maintainers: publishedPackage.maintainers.length ? publishedPackage.maintainers : [maintainer],
               }
-              console.warn("[wanta] failed to read my published skill package info:", error)
-              reportRendererHandledError(
-                "skillsCatalog.readMyPublishedPackageInfo",
-                "Failed to read published Skill package info",
-                error,
-              )
-              packageInfo = undefined
             }
+            const packageInfo = await readRegistrySkillPackageInfo(publishedPackage.name, maintainer, {
+              cacheScope: `account:${input.account.id}`,
+              forceRefresh: input.forceRefresh,
+              signal,
+              version: publishedPackage.version,
+            })
             return mergeMyPublishedPackage(publishedPackage, packageInfo)
           },
         )

--- a/src/routes/Skills/DiscoverSkillsPane.tsx
+++ b/src/routes/Skills/DiscoverSkillsPane.tsx
@@ -165,12 +165,12 @@ export function DiscoverSkillsPane({
                 key={pkg.id}
                 groupById={groupById}
                 canInstall={canInstall}
-                installingKey={installingKey}
+                installingKey={installingKey?.startsWith(`${pkg.id}:`) ? installingKey : null}
                 pkg={pkg}
                 selected={selectedPackage?.id === pkg.id}
-                onInstall={(skillName) => onInstall(pkg, skillName)}
+                onInstall={onInstall}
                 onOpenManagedSkill={onOpenManagedSkill}
-                onSelect={() => onSelectPackage(pkg)}
+                onSelect={onSelectPackage}
               />
             ))}
           </div>
@@ -239,14 +239,14 @@ interface PublicSkillPackageRowProps {
   canInstall: boolean
   groupById: ManagedSkillGroupById
   installingKey: string | null
-  onInstall: (skillName?: string) => void
+  onInstall: (pkg: PublicSkillPackage, skillName?: string) => void
   onOpenManagedSkill: (skillName: string) => void
-  onSelect: () => void
+  onSelect: (pkg: PublicSkillPackage) => void
   pkg: PublicSkillPackage
   selected: boolean
 }
 
-function PublicSkillPackageRow({
+const PublicSkillPackageRow = React.memo(function PublicSkillPackageRow({
   canInstall,
   groupById,
   installingKey,
@@ -261,6 +261,7 @@ function PublicSkillPackageRow({
   const primaryInstallSkill = getPublicPackagePrimaryInstallSkill(groupById, pkg)
   const state = getPublicPackageInstallState(groupById, pkg)
   const isInstalling = installingKey === getPublicSkillInstallKey(pkg, primaryInstallSkill?.name)
+  const metaLine = getPublicPackageMetaLine(pkg, t)
   const stateBadge =
     state === "name-conflict" || state === "unavailable" ? (
       <Badge variant="outline">{getPublicSkillInstallStateLabel(state, t)}</Badge>
@@ -279,8 +280,8 @@ function PublicSkillPackageRow({
       description={pkg.description}
       badges={stateBadge}
       meta={
-        <div className="min-w-0 truncate" title={getPublicPackageMetaLine(pkg, t)}>
-          {getPublicPackageMetaLine(pkg, t)}
+        <div className="min-w-0 truncate" title={metaLine}>
+          {metaLine}
         </div>
       }
       actions={
@@ -298,7 +299,7 @@ function PublicSkillPackageRow({
             variant="outline"
             size="sm"
             disabled={!canInstall || isInstalling}
-            onClick={() => onInstall()}
+            onClick={() => onInstall(pkg)}
           >
             {isInstalling ? <AppIcons.status.loading className="animate-spin" /> : <AppIcons.action.installPackage />}
             {!canInstall
@@ -314,8 +315,8 @@ function PublicSkillPackageRow({
           onOpenManagedSkill(primarySkill.name)
           return
         }
-        onSelect()
+        onSelect(pkg)
       }}
     />
   )
-}
+})

--- a/src/routes/Skills/InstalledSkillsPane.tsx
+++ b/src/routes/Skills/InstalledSkillsPane.tsx
@@ -2,6 +2,7 @@ import type { ManagedSkillGroup, SkillVersionReport } from "../../../electron/sk
 import type { SkillVersionCheckByKey } from "./skill-route-model.ts"
 import type { ObjectStatusTone } from "@/components/ObjectRow"
 
+import * as React from "react"
 import {
   getGroupRowPackageLine,
   getGroupStatus,
@@ -76,9 +77,9 @@ export function InstalledSkillsPane({
                 group={group}
                 selected={selectedSkill?.id === group.id}
                 updateRegistrySkill={updateRegistrySkill}
-                updatingRegistrySkillId={updatingRegistrySkillId}
+                isUpdating={updatingRegistrySkillId === group.id}
                 versionCheck={getSkillVersionCheck(versionCheckByKey, group)}
-                onOpen={() => onSelectSkill(group.id)}
+                onOpen={onSelectSkill}
               />
             ))}
           </div>
@@ -129,19 +130,19 @@ function CliUpdateNotice({
 
 interface InstalledSkillRowProps {
   group: ManagedSkillGroup
-  onOpen: () => void
+  onOpen: (skillId: string) => void
   selected: boolean
   updateRegistrySkill: (skill: Pick<ManagedSkillGroup, "id" | "kind" | "packageName">) => void
-  updatingRegistrySkillId: string | null
+  isUpdating: boolean
   versionCheck: SkillVersionReport["skills"][number] | undefined
 }
 
-function InstalledSkillRow({
+const InstalledSkillRow = React.memo(function InstalledSkillRow({
   group,
   onOpen,
   selected,
   updateRegistrySkill,
-  updatingRegistrySkillId,
+  isUpdating,
   versionCheck,
 }: InstalledSkillRowProps) {
   const { t } = useAppI18n()
@@ -186,7 +187,7 @@ function InstalledSkillRow({
           : isPublishable
             ? t("skills.publishableDescription")
             : t("skills.installedDescription")
-  const isUpdating = updatingRegistrySkillId === group.id
+  const creatorLine = getSkillCreatorLine(group, t)
 
   return (
     <SkillListRow
@@ -207,8 +208,8 @@ function InstalledSkillRow({
       meta={
         <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
           <InstalledSkillPlatformBadges group={group} />
-          <span className="min-w-0 truncate" title={getSkillCreatorLine(group, t)}>
-            {getSkillCreatorLine(group, t)}
+          <span className="min-w-0 truncate" title={creatorLine}>
+            {creatorLine}
           </span>
           <span className="min-w-0 truncate" title={runtimeLabel}>
             {runtimeLabel}
@@ -228,15 +229,15 @@ function InstalledSkillRow({
             {isUpdating ? t("skills.updatingRegistry") : t("skills.updateRegistry")}
           </Button>
         ) : (
-          <Button type="button" variant="ghost" size="sm" onClick={onOpen}>
+          <Button type="button" variant="ghost" size="sm" onClick={() => onOpen(group.id)}>
             {t("skills.installedManage")}
           </Button>
         )
       }
-      onSelect={onOpen}
+      onSelect={() => onOpen(group.id)}
     />
   )
-}
+})
 
 function InstalledSkillPlatformBadges({ group }: { group: ManagedSkillGroup }) {
   const hosts = getInstalledPlatformHosts(group)

--- a/src/routes/Skills/SkillPackageMaintainers.tsx
+++ b/src/routes/Skills/SkillPackageMaintainers.tsx
@@ -49,33 +49,42 @@ export function SkillPackageMaintainers({ account, packageName, version }: Skill
     activeRequestRef.current = null
   }, [])
 
-  const loadMaintainers = React.useCallback(() => {
-    abortActiveRequest()
-    const controller = new AbortController()
-    activeRequestRef.current = controller
-    const requestId = requestIdRef.current + 1
-    requestIdRef.current = requestId
-    setLoading(true)
-    setError(null)
-    void getSkillPackageMaintainerDetail({ packageName, signal: controller.signal, version })
-      .then((nextDetail) => {
-        if (requestId === requestIdRef.current) {
-          setDetail(nextDetail)
-        }
+  const loadMaintainers = React.useCallback(
+    (forceRefresh = false) => {
+      abortActiveRequest()
+      const controller = new AbortController()
+      activeRequestRef.current = controller
+      const requestId = requestIdRef.current + 1
+      requestIdRef.current = requestId
+      setLoading(true)
+      setError(null)
+      void getSkillPackageMaintainerDetail({
+        accountId: account.id,
+        forceRefresh,
+        packageName,
+        signal: controller.signal,
+        version,
       })
-      .catch((cause: unknown) => {
-        if (!controller.signal.aborted && requestId === requestIdRef.current) {
-          setDetail(null)
-          setError(cause instanceof Error ? cause.message : String(cause))
-        }
-      })
-      .finally(() => {
-        if (requestId === requestIdRef.current && activeRequestRef.current === controller) {
-          activeRequestRef.current = null
-          setLoading(false)
-        }
-      })
-  }, [abortActiveRequest, packageName, version])
+        .then((nextDetail) => {
+          if (requestId === requestIdRef.current) {
+            setDetail(nextDetail)
+          }
+        })
+        .catch((cause: unknown) => {
+          if (!controller.signal.aborted && requestId === requestIdRef.current) {
+            setDetail(null)
+            setError(cause instanceof Error ? cause.message : String(cause))
+          }
+        })
+        .finally(() => {
+          if (requestId === requestIdRef.current && activeRequestRef.current === controller) {
+            activeRequestRef.current = null
+            setLoading(false)
+          }
+        })
+    },
+    [abortActiveRequest, account.id, packageName, version],
+  )
 
   React.useEffect(() => {
     loadMaintainers()
@@ -104,7 +113,7 @@ export function SkillPackageMaintainers({ account, packageName, version }: Skill
       ) : error ? (
         <div className="flex min-w-0 items-start gap-2">
           <SkillErrorNotice className="min-w-0 flex-1" error={error} />
-          <Button type="button" variant="outline" size="sm" onClick={loadMaintainers}>
+          <Button type="button" variant="outline" size="sm" onClick={() => loadMaintainers(true)}>
             {t("skills.retry")}
           </Button>
         </div>

--- a/src/routes/Skills/TeamManagement.tsx
+++ b/src/routes/Skills/TeamManagement.tsx
@@ -67,7 +67,7 @@ export function TeamManagementRoute({
   const { locale, t } = useAppI18n()
   const authResource = useAuthStateResource()
   const skillInventory = useSkillInventoryResource()
-  const skillVersions = useSkillVersionReportResource()
+  const skillVersions = useSkillVersionReportResource({ autoLoad: true })
   const skillService = useSkillService()
   const activeAccount = authResource.data?.status === "authenticated" ? authResource.data.account : undefined
   const activeAccountId = activeAccount?.id

--- a/src/routes/Skills/TeamSkillManageDialog.tsx
+++ b/src/routes/Skills/TeamSkillManageDialog.tsx
@@ -36,6 +36,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAppI18n } from "@/i18n"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
+import { getSkillCatalogInvalidationRevision, subscribeSkillCatalogInvalidation } from "@/lib/skill-catalog-cache"
 import {
   listPublicSkillPackages,
   readPublicSkillPackageByName,
@@ -102,6 +103,10 @@ export function TeamSkillManageDialog({
   variant?: "dialog" | "inline"
 }) {
   const { t } = useAppI18n()
+  const catalogRevision = React.useSyncExternalStore(
+    subscribeSkillCatalogInvalidation,
+    getSkillCatalogInvalidationRevision,
+  )
   const isActive = variant === "inline" || open
   const skillRemoval = useTeamSkillRemoval({ teamSkills })
   const busyConfigId = skillRemoval.busySkillId
@@ -255,7 +260,7 @@ export function TeamSkillManageDialog({
 
     const timer = window.setTimeout(load, 300)
     return () => window.clearTimeout(timer)
-  }, [activeTab, isActive, loadMarketPackages, marketQuery])
+  }, [activeTab, isActive, loadMarketPackages, marketQuery, catalogRevision])
 
   React.useEffect(() => {
     const query = searchQuery.trim()
@@ -293,7 +298,7 @@ export function TeamSkillManageDialog({
       window.clearTimeout(timer)
       controller.abort()
     }
-  }, [activeTab, isActive, searchQuery])
+  }, [activeTab, isActive, searchQuery, catalogRevision])
 
   const changeActiveTab = React.useCallback((tab: TeamSkillManageTab) => {
     setActiveTab(tab)

--- a/src/routes/Skills/TeamSkillManageDialog.tsx
+++ b/src/routes/Skills/TeamSkillManageDialog.tsx
@@ -141,10 +141,10 @@ export function TeamSkillManageDialog({
       buildTeamSkillRecommendationItems({
         filter: recommendationSourceFilter,
         normalizedQuery,
-        providerRecommendations: recommendedTeamSkills,
+        providerRecommendations,
         skills: teamSkills.skills,
       }),
-    [normalizedQuery, teamSkills.skills, recommendationSourceFilter, recommendedTeamSkills],
+    [normalizedQuery, teamSkills.skills, recommendationSourceFilter, providerRecommendations],
   )
   const allRecommendationItems = React.useMemo(
     () =>

--- a/src/routes/Skills/TeamSkillsPane.tsx
+++ b/src/routes/Skills/TeamSkillsPane.tsx
@@ -97,18 +97,16 @@ export function TeamSkillsPane({
 
   const normalizedQuery = teamQuery.trim().toLowerCase()
   const recommendationLookupLoading = providerRecommendationsLoading && teamFilter !== "configured"
-  const recommendedPlan = selectedTeamSkills
-    ? planProviderSkillRecommendationBulkLinks(providerRecommendations, selectedTeamSkills.skills)
-    : null
-  const recommendedTeamSkills = recommendedPlan?.linkable ?? []
-  const filteredTeamItems = selectedTeamSkills
-    ? buildTeamSkillRecommendationItems({
-        filter: teamFilter,
-        normalizedQuery,
-        providerRecommendations: recommendedTeamSkills,
-        skills: selectedTeamSkills.skills,
-      })
-    : []
+  const filteredTeamItems = React.useMemo(() => {
+    if (!selectedTeamSkills) return []
+    const recommendedPlan = planProviderSkillRecommendationBulkLinks(providerRecommendations, selectedTeamSkills.skills)
+    return buildTeamSkillRecommendationItems({
+      filter: teamFilter,
+      normalizedQuery,
+      providerRecommendations: recommendedPlan.linkable,
+      skills: selectedTeamSkills.skills,
+    })
+  }, [selectedTeamSkills?.skills, normalizedQuery, teamFilter, providerRecommendations])
   const selectedTeamItem = selectedItemId ? filteredTeamItems.find((item) => item.id === selectedItemId) : undefined
 
   return (
@@ -165,41 +163,19 @@ export function TeamSkillsPane({
             />
           ) : (
             <div className="overflow-hidden rounded-md border bg-background">
-              {filteredTeamItems.map((item) =>
-                item.type === "configured" ? (
-                  <TeamConfiguredSkillCard
-                    key={item.id}
-                    busy={busyConfigId === item.skill.id || busyAction === "installSkillBatch"}
-                    groupById={groupById}
-                    installBusy={
-                      busyAction === `installSkill:${item.skill.packageName}:${item.skill.skillName}` ||
-                      busyAction === "installSkillBatch"
-                    }
-                    selected={selectedItemId === item.id}
-                    skill={item.skill}
-                    onInstallRuntime={() =>
-                      onInstallRuntimeSkill({ packageName: item.skill.packageName, skillName: item.skill.skillName })
-                    }
-                    onOpenManagedSkill={() => openManagedSkill(item.skill.skillName)}
-                    onSelect={() => setSelectedItemId(item.id)}
-                  />
-                ) : (
-                  <TeamRecommendedSkillCard
-                    key={item.id}
-                    busyAction={busyAction}
-                    recommendation={item.recommendation}
-                    selected={selectedItemId === item.id}
-                    onInstallRuntime={() =>
-                      onInstallRuntimeSkill({
-                        packageName: item.recommendation.packageName,
-                        skillName: item.recommendation.skillId,
-                      })
-                    }
-                    onOpenManagedSkill={() => openManagedSkill(item.recommendation.skillId)}
-                    onSelect={() => setSelectedItemId(item.id)}
-                  />
-                ),
-              )}
+              {filteredTeamItems.map((item) => (
+                <TeamSkillItemRow
+                  key={item.id}
+                  item={item}
+                  groupById={groupById}
+                  busyAction={busyAction}
+                  configBusy={item.type === "configured" && busyConfigId === item.skill.id}
+                  selected={selectedItemId === item.id}
+                  onSelect={setSelectedItemId}
+                  onOpenManagedSkill={openManagedSkill}
+                  onInstallRuntimeSkill={onInstallRuntimeSkill}
+                />
+              ))}
               {recommendationLookupLoading ? (
                 <TeamSkillLookupLoadingRows
                   resolvedCount={Math.max(0, providerRecommendationsTotalCount - providerRecommendationsPendingCount)}
@@ -760,3 +736,57 @@ function TeamSkillMetaCard({
     </InspectorInsetCard>
   )
 }
+
+const TeamSkillItemRow = React.memo(function TeamSkillItemRow({
+  item,
+  groupById,
+  busyAction,
+  configBusy,
+  selected,
+  onSelect,
+  onOpenManagedSkill,
+  onInstallRuntimeSkill,
+}: {
+  item: TeamSkillRecommendationItem
+  groupById: ManagedSkillGroupById
+  busyAction: BusyAction | null
+  configBusy: boolean
+  selected: boolean
+  onSelect: (id: string) => void
+  onOpenManagedSkill: (name: string) => void
+  onInstallRuntimeSkill: TeamSkillsPaneProps["onInstallRuntimeSkill"]
+}) {
+  return item.type === "configured" ? (
+    <TeamConfiguredSkillCard
+      key={item.id}
+      busy={configBusy || busyAction === "installSkillBatch"}
+      groupById={groupById}
+      installBusy={
+        busyAction === `installSkill:${item.skill.packageName}:${item.skill.skillName}` ||
+        busyAction === "installSkillBatch"
+      }
+      selected={selected}
+      skill={item.skill}
+      onInstallRuntime={() =>
+        onInstallRuntimeSkill({ packageName: item.skill.packageName, skillName: item.skill.skillName })
+      }
+      onOpenManagedSkill={() => onOpenManagedSkill(item.skill.skillName)}
+      onSelect={() => onSelect(item.id)}
+    />
+  ) : (
+    <TeamRecommendedSkillCard
+      key={item.id}
+      busyAction={busyAction}
+      recommendation={item.recommendation}
+      selected={selected}
+      onInstallRuntime={() =>
+        onInstallRuntimeSkill({
+          packageName: item.recommendation.packageName,
+          skillName: item.recommendation.skillId,
+        })
+      }
+      onOpenManagedSkill={() => onOpenManagedSkill(item.recommendation.skillId)}
+      onSelect={() => onSelect(item.id)}
+    />
+  )
+})

--- a/src/routes/Skills/TeamSkillsPane.tsx
+++ b/src/routes/Skills/TeamSkillsPane.tsx
@@ -97,16 +97,32 @@ export function TeamSkillsPane({
 
   const normalizedQuery = teamQuery.trim().toLowerCase()
   const recommendationLookupLoading = providerRecommendationsLoading && teamFilter !== "configured"
-  const filteredTeamItems = React.useMemo(() => {
-    if (!selectedTeamSkills) return []
-    const recommendedPlan = planProviderSkillRecommendationBulkLinks(providerRecommendations, selectedTeamSkills.skills)
+  const configuredSkills = selectedTeamSkills?.skills
+  const includeConfigured = teamFilter !== "recommended"
+  const includeRecommended = teamFilter !== "configured"
+  const configuredItems = React.useMemo(() => {
+    if (!configuredSkills || !includeConfigured) return []
     return buildTeamSkillRecommendationItems({
-      filter: teamFilter,
+      filter: "configured",
+      normalizedQuery,
+      providerRecommendations: [],
+      skills: configuredSkills,
+    })
+  }, [configuredSkills, includeConfigured, normalizedQuery])
+  const recommendedItems = React.useMemo(() => {
+    if (!configuredSkills || !includeRecommended) return []
+    const recommendedPlan = planProviderSkillRecommendationBulkLinks(providerRecommendations, configuredSkills)
+    return buildTeamSkillRecommendationItems({
+      filter: "recommended",
       normalizedQuery,
       providerRecommendations: recommendedPlan.linkable,
-      skills: selectedTeamSkills.skills,
+      skills: configuredSkills,
     })
-  }, [selectedTeamSkills?.skills, normalizedQuery, teamFilter, providerRecommendations])
+  }, [configuredSkills, includeRecommended, normalizedQuery, providerRecommendations])
+  const filteredTeamItems = React.useMemo(
+    () => [...configuredItems, ...recommendedItems],
+    [configuredItems, recommendedItems],
+  )
   const selectedTeamItem = selectedItemId ? filteredTeamItems.find((item) => item.id === selectedItemId) : undefined
 
   return (
@@ -168,7 +184,13 @@ export function TeamSkillsPane({
                   key={item.id}
                   item={item}
                   groupById={groupById}
-                  busyAction={busyAction}
+                  busyAction={
+                    item.type === "recommended" ||
+                    busyAction === "installSkillBatch" ||
+                    busyAction === `installSkill:${item.skill.packageName}:${item.skill.skillName}`
+                      ? busyAction
+                      : null
+                  }
                   configBusy={item.type === "configured" && busyConfigId === item.skill.id}
                   selected={selectedItemId === item.id}
                   onSelect={setSelectedItemId}

--- a/src/routes/Skills/TeamSkillsPane.tsx
+++ b/src/routes/Skills/TeamSkillsPane.tsx
@@ -14,7 +14,6 @@ import {
 } from "./skill-route-model.ts"
 import { SkillListRow } from "./SkillListRow.tsx"
 import { SkillIconFrame, SkillManagementSheet, SkillPageScrollArea } from "./SkillUiParts.tsx"
-import { planProviderSkillRecommendationBulkLinks } from "./team-management-model.ts"
 import {
   buildTeamSkillRecommendationItems,
   canInstallProviderRecommendationRuntime,
@@ -111,11 +110,10 @@ export function TeamSkillsPane({
   }, [configuredSkills, includeConfigured, normalizedQuery])
   const recommendedItems = React.useMemo(() => {
     if (!configuredSkills || !includeRecommended) return []
-    const recommendedPlan = planProviderSkillRecommendationBulkLinks(providerRecommendations, configuredSkills)
     return buildTeamSkillRecommendationItems({
       filter: "recommended",
       normalizedQuery,
-      providerRecommendations: recommendedPlan.linkable,
+      providerRecommendations,
       skills: configuredSkills,
     })
   }, [configuredSkills, includeRecommended, normalizedQuery, providerRecommendations])

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -14,6 +14,7 @@ import type { BusyAction } from "./team-management-model.ts"
 import type { ProviderSkillRecommendationsState } from "@/hooks/useProviderSkillRecommendations"
 import type { UseTeamSkills } from "@/hooks/useTeamSkills"
 import type { UseTeamWorkspace } from "@/hooks/useTeamWorkspace"
+import type { ListPublicSkillPackagesInput } from "@/lib/skills-catalog-client"
 
 import * as React from "react"
 import { toast } from "sonner"
@@ -29,11 +30,9 @@ import {
   getSkillVersionCheck,
   getSkillVersionCheckKey,
   getSelectedManagedSkillGroup,
-  initialPublicPackageCatalogState,
   isInstalledSkillGroup,
   matchesInstalledSkillFilter,
   matchesPublicPackageQuery,
-  publicPackageCatalogReducer,
 } from "./skill-route-model.ts"
 import { SkillDetailContent } from "./SkillDetailContent.tsx"
 import { SkillPageHeader } from "./SkillPageHeader.tsx"
@@ -42,6 +41,7 @@ import { SkillManagementSheet } from "./SkillUiParts.tsx"
 import { TeamInstallMissingButton } from "./TeamSkillManageRows.tsx"
 import { TeamSkillsPane } from "./TeamSkillsPane.tsx"
 import { useRegistrySkillUpdate } from "./use-registry-skill-update.ts"
+import { useSkillCatalog } from "./use-skill-catalog.ts"
 import { useTeamSkillActions } from "./use-team-skill-actions.ts"
 import { useSkillService } from "@/components/AppContext"
 import {
@@ -102,7 +102,7 @@ export function SkillsRoute({
   const skillService = useSkillService()
   const authResource = useAuthStateResource()
   const inventoryResource = useSkillInventoryResource()
-  const versionResource = useSkillVersionReportResource()
+  const versionResource = useSkillVersionReportResource({ autoLoad: cloudEnabled })
   const inventory = inventoryResource.data
   const installedSkillGroupById = React.useMemo<ManagedSkillGroupById>(() => {
     return new Map((inventory?.groups ?? []).map((group) => [group.id, group]))
@@ -129,18 +129,6 @@ export function SkillsRoute({
   const deferredTeamQuery = React.useDeferredValue(teamQuery)
   const deferredDiscoveryQuery = React.useDeferredValue(discoveryQuery)
   const [debouncedDiscoveryQuery, setDebouncedDiscoveryQuery] = React.useState("")
-  const [publicPackageCatalog, dispatchPublicPackageCatalog] = React.useReducer(
-    publicPackageCatalogReducer,
-    initialPublicPackageCatalogState,
-  )
-  const [myPublishedPackageCatalog, dispatchMyPublishedPackageCatalog] = React.useReducer(
-    publicPackageCatalogReducer,
-    initialPublicPackageCatalogState,
-  )
-  const [publicPackageSearchCatalog, dispatchPublicPackageSearchCatalog] = React.useReducer(
-    publicPackageCatalogReducer,
-    initialPublicPackageCatalogState,
-  )
   const [installingRegistryResultId, setInstallingRegistryResultId] = React.useState<string | null>(null)
   const [planError, setPlanError] = React.useState<SkillOperationError | null>(null)
   const [cliUpdateError, setCliUpdateError] = React.useState<string | null>(null)
@@ -150,12 +138,6 @@ export function SkillsRoute({
   const [teamSkillBusyAction, setTeamSkillBusyAction] = React.useState<BusyAction | null>(null)
   const [isExecutingCliUpdate, setIsExecutingCliUpdate] = React.useState(false)
   const skillMutationInFlightRef = React.useRef(false)
-  const requestedVersionCheckRef = React.useRef(false)
-  const publicPackageRequestIdRef = React.useRef(0)
-  const myPublishedPackageRequestIdRef = React.useRef(0)
-  const myPublishedPackageControllerRef = React.useRef<AbortController | null>(null)
-  const publicPackageSearchRequestIdRef = React.useRef(0)
-  const publicPackageSearchControllerRef = React.useRef<AbortController | null>(null)
   const { copySkillPath, isRemovingSkill, openSkillFolder, removeSkill, removeTarget, setRemoveTarget } =
     useSkillObjectActions({
       onDeleted: () => {
@@ -223,21 +205,6 @@ export function SkillsRoute({
   }, [teamSkills.skills, selectedSkill?.packageName])
   const showSelectedSkillTeamLinkAction = Boolean(selectedSkill?.packageName?.trim() && managedTeamOptions.length > 0)
   React.useEffect(() => {
-    if (!cloudEnabled) {
-      requestedVersionCheckRef.current = false
-      return
-    }
-    if (requestedVersionCheckRef.current) {
-      return
-    }
-
-    requestedVersionCheckRef.current = true
-    void versionResource
-      .refresh({ silent: true })
-      .catch((error: unknown) => reportRendererHandledError("skills", "silent skill version refresh failed", error))
-  }, [cloudEnabled, versionResource])
-
-  React.useEffect(() => {
     if (versionResource.data?.cli?.status !== "update-available") {
       setCliUpdateError(null)
     }
@@ -277,171 +244,42 @@ export function SkillsRoute({
     setSelectedSkillId(skillId)
   }, [])
 
-  const loadPublicSkillPackages = React.useCallback(
-    async (options: { forceRefresh?: boolean; next?: string | null } = {}) => {
-      const next = options.next?.trim() || undefined
-      const append = Boolean(next && !options.forceRefresh)
-      const requestId = publicPackageRequestIdRef.current + 1
-      publicPackageRequestIdRef.current = requestId
-      dispatchPublicPackageCatalog({ append, requestId, type: "load-start" })
-
-      try {
-        const catalog = await listPublicSkillPackages({ forceRefresh: options.forceRefresh, next })
-        dispatchPublicPackageCatalog({ append, catalog, requestId, type: "load-success" })
-      } catch (cause) {
-        dispatchPublicPackageCatalog({
-          error: cause instanceof Error ? cause.message : String(cause),
-          requestId,
-          type: "load-error",
-        })
-      }
+  const account = authResource.data?.status === "authenticated" ? authResource.data.account : undefined
+  const loadPublished = React.useCallback(
+    (input: ListPublicSkillPackagesInput) => {
+      if (!account) throw new Error("Sign in is required.")
+      return listMyPublishedSkillPackages({ ...input, account })
     },
-    [],
+    [account?.id, account?.name, account?.avatarUrl],
   )
-
-  const loadMyPublishedSkillPackages = React.useCallback(
-    async (options: { forceRefresh?: boolean; next?: string | null } = {}) => {
-      const account = authResource.data?.status === "authenticated" ? authResource.data.account : undefined
-      if (!account) {
-        return
-      }
-      myPublishedPackageControllerRef.current?.abort()
-      const controller = new AbortController()
-      myPublishedPackageControllerRef.current = controller
-      const next = options.next?.trim() || undefined
-      const append = Boolean(next && !options.forceRefresh)
-      const requestId = myPublishedPackageRequestIdRef.current + 1
-      myPublishedPackageRequestIdRef.current = requestId
-      dispatchMyPublishedPackageCatalog({ append, requestId, type: "load-start" })
-
-      try {
-        const catalog = await listMyPublishedSkillPackages({
-          account: { avatarUrl: account.avatarUrl, id: account.id, name: account.name },
-          forceRefresh: options.forceRefresh,
-          next,
-          signal: controller.signal,
-        })
-        dispatchMyPublishedPackageCatalog({ append, catalog, requestId, type: "load-success" })
-      } catch (cause) {
-        if (controller.signal.aborted) {
-          return
-        }
-        dispatchMyPublishedPackageCatalog({
-          error: cause instanceof Error ? cause.message : String(cause),
-          requestId,
-          type: "load-error",
-        })
-      } finally {
-        if (myPublishedPackageControllerRef.current === controller) {
-          myPublishedPackageControllerRef.current = null
-        }
-      }
-    },
-    [authResource.data],
+  const loadSearch = React.useCallback(
+    (input: ListPublicSkillPackagesInput) => searchPublicSkillPackages({ ...input, query: debouncedDiscoveryQuery }),
+    [debouncedDiscoveryQuery],
   )
-
-  const loadPublicSkillSearch = React.useCallback(
-    async (query: string, options: { forceRefresh?: boolean; next?: string | null; replace?: boolean } = {}) => {
-      publicPackageSearchControllerRef.current?.abort()
-      const controller = new AbortController()
-      publicPackageSearchControllerRef.current = controller
-      const next = options.next?.trim() || undefined
-      const append = Boolean(next && !options.forceRefresh && !options.replace)
-      const requestId = publicPackageSearchRequestIdRef.current + 1
-      publicPackageSearchRequestIdRef.current = requestId
-      dispatchPublicPackageSearchCatalog({
-        append,
-        clearItems: options.replace,
-        requestId,
-        type: "load-start",
-      })
-
-      try {
-        const catalog = await searchPublicSkillPackages({
-          forceRefresh: options.forceRefresh,
-          next,
-          query,
-          signal: controller.signal,
-        })
-        dispatchPublicPackageSearchCatalog({ append, catalog, requestId, type: "load-success" })
-      } catch (cause) {
-        if (controller.signal.aborted) {
-          return
-        }
-        dispatchPublicPackageSearchCatalog({
-          error: cause instanceof Error ? cause.message : String(cause),
-          requestId,
-          type: "load-error",
-        })
-      } finally {
-        if (publicPackageSearchControllerRef.current === controller) {
-          publicPackageSearchControllerRef.current = null
-        }
-      }
-    },
-    [],
-  )
-
-  React.useEffect(
-    () => () => {
-      publicPackageSearchControllerRef.current?.abort()
-      myPublishedPackageControllerRef.current?.abort()
-    },
-    [],
-  )
-
-  React.useEffect(() => {
-    if (
-      activeTab !== "discover" ||
-      discoveryFilter !== "all" ||
-      publicPackageCatalog.items.length > 0 ||
-      publicPackageCatalog.status !== "idle"
-    ) {
-      return
-    }
-
-    void loadPublicSkillPackages().catch((error: unknown) => {
-      reportRendererHandledError("skills", "public skill package load failed", error)
-    })
-  }, [
-    activeTab,
-    discoveryFilter,
-    loadPublicSkillPackages,
-    publicPackageCatalog.items.length,
-    publicPackageCatalog.status,
-  ])
-
-  React.useEffect(() => {
-    if (
-      activeTab !== "discover" ||
-      discoveryFilter !== "mine" ||
-      authResource.data?.status !== "authenticated" ||
-      myPublishedPackageCatalog.items.length > 0 ||
-      myPublishedPackageCatalog.status !== "idle"
-    ) {
-      return
-    }
-
-    void loadMyPublishedSkillPackages().catch((error: unknown) => {
-      reportRendererHandledError("skills", "published skill package load failed", error)
-    })
-  }, [
-    activeTab,
-    authResource.data?.status,
-    discoveryFilter,
-    loadMyPublishedSkillPackages,
-    myPublishedPackageCatalog.items.length,
-    myPublishedPackageCatalog.status,
-  ])
-
-  React.useEffect(() => {
-    if (activeTab !== "discover" || discoveryFilter !== "all" || !debouncedDiscoveryQuery) {
-      return
-    }
-    void loadPublicSkillSearch(debouncedDiscoveryQuery, { replace: true }).catch((error: unknown) => {
-      reportRendererHandledError("skills", "public skill package search failed", error)
-    })
-  }, [activeTab, debouncedDiscoveryQuery, discoveryFilter, loadPublicSkillSearch])
+  const {
+    catalog: publicPackageCatalog,
+    dispatch: dispatchPublicPackageCatalog,
+    loadPage: loadPublicSkillPackages,
+  } = useSkillCatalog({
+    enabled: activeTab === "discover" && discoveryFilter === "all" && !debouncedDiscoveryQuery,
+    load: listPublicSkillPackages,
+  })
+  const {
+    catalog: myPublishedPackageCatalog,
+    dispatch: dispatchMyPublishedPackageCatalog,
+    loadPage: loadMyPublishedSkillPackages,
+  } = useSkillCatalog({
+    enabled: activeTab === "discover" && discoveryFilter === "mine" && Boolean(account),
+    load: loadPublished,
+  })
+  const {
+    catalog: publicPackageSearchCatalog,
+    dispatch: dispatchPublicPackageSearchCatalog,
+    loadPage: loadPublicSkillSearch,
+  } = useSkillCatalog({
+    enabled: activeTab === "discover" && discoveryFilter === "all" && Boolean(debouncedDiscoveryQuery),
+    load: loadSearch,
+  })
 
   const isPublicSearchActive = discoveryFilter === "all" && Boolean(debouncedDiscoveryQuery)
   const activePackageCatalog =
@@ -456,6 +294,10 @@ export function SkillsRoute({
       : isPublicSearchActive
         ? dispatchPublicPackageSearchCatalog
         : dispatchPublicPackageCatalog
+  const selectPublicPackage = React.useCallback(
+    (pkg: PublicSkillPackage) => activePackageDispatcher({ id: pkg.id, type: "select" }),
+    [activePackageDispatcher],
+  )
   const filteredPublicPackages = React.useMemo(() => {
     if (discoveryFilter === "all") {
       return activePackageCatalog.items
@@ -613,14 +455,6 @@ export function SkillsRoute({
             reportRendererHandledError("skills", "silent skill version refresh failed after publish", error),
           )
         toast.success(t("skills.publishDone", { name: skill.name }))
-        void loadMyPublishedSkillPackages({ forceRefresh: true }).catch((error: unknown) => {
-          reportRendererHandledError("skills", "published skill package refresh failed after publish", error)
-        })
-        if (publicPackageCatalog.items.length > 0) {
-          void loadPublicSkillPackages({ forceRefresh: true }).catch((error: unknown) => {
-            reportRendererHandledError("skills", "public skill package refresh failed after publish", error)
-          })
-        }
         return result
       } catch (cause) {
         setPlanError({
@@ -634,16 +468,7 @@ export function SkillsRoute({
         setPublishingSkillId(null)
       }
     },
-    [
-      authResource.data,
-      inventoryResource,
-      loadMyPublishedSkillPackages,
-      loadPublicSkillPackages,
-      publicPackageCatalog.items.length,
-      skillService,
-      t,
-      versionResource,
-    ],
+    [authResource.data, inventoryResource, skillService, t, versionResource],
   )
 
   const executeCliUpdate = React.useCallback(async () => {
@@ -776,7 +601,7 @@ export function SkillsRoute({
               void (discoveryFilter === "mine"
                 ? loadMyPublishedSkillPackages({ next: activePackageCatalog.next })
                 : isPublicSearchActive
-                  ? loadPublicSkillSearch(debouncedDiscoveryQuery, { next: activePackageCatalog.next })
+                  ? loadPublicSkillSearch({ next: activePackageCatalog.next })
                   : loadPublicSkillPackages({ next: activePackageCatalog.next }))
             }
             onOpenManagedSkill={openManagedPublicSkill}
@@ -789,10 +614,10 @@ export function SkillsRoute({
                 return
               }
               void (isPublicSearchActive
-                ? loadPublicSkillSearch(debouncedDiscoveryQuery, { forceRefresh: true, replace: true })
+                ? loadPublicSkillSearch({ forceRefresh: true, replace: true })
                 : loadPublicSkillPackages({ forceRefresh: true }))
             }}
-            onSelectPackage={(pkg) => activePackageDispatcher({ id: pkg.id, type: "select" })}
+            onSelectPackage={selectPublicPackage}
           />
         ) : (
           <InstalledSkillsPane

--- a/src/routes/Skills/provider-skill-package-lookup.test.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.test.ts
@@ -2,6 +2,7 @@ import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import { clearProviderSkillPackageCache, readProviderSkillPackage } from "./provider-skill-package-lookup.ts"
+import { invalidateSkillCatalogKeys, clearSkillCatalogCache } from "@/lib/skill-catalog-cache"
 import { readPublicSkillPackageByName, searchPublicSkillPackages } from "@/lib/skills-catalog-client"
 
 vi.mock("@/lib/skills-catalog-client", () => ({
@@ -127,4 +128,17 @@ describe("provider Skill package lookup", () => {
     expect(sharedSignal?.aborted).toBe(true)
     expect(searchPublicSkillPackages).not.toHaveBeenCalled()
   })
+})
+
+test("public invalidation and account cleanup invalidate provider results too", async () => {
+  clearSkillCatalogCache()
+  vi.mocked(readPublicSkillPackageByName).mockReset().mockResolvedValue(posthogPackage)
+  const candidate = { service: "posthog", providerDisplayName: "PostHog" }
+  await readProviderSkillPackage(candidate)
+  invalidateSkillCatalogKeys((key) => key.startsWith("public:"))
+  await readProviderSkillPackage(candidate)
+  clearSkillCatalogCache()
+  await readProviderSkillPackage(candidate)
+  expect(readPublicSkillPackageByName).toHaveBeenCalledTimes(3)
+  clearSkillCatalogCache()
 })

--- a/src/routes/Skills/provider-skill-package-lookup.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.ts
@@ -1,7 +1,6 @@
 import type { ConnectionProvider } from "../../../electron/connections/common.ts"
 import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
 import type { ProviderSkillCandidate } from "./provider-skill-recommendations.ts"
-import type { SharedRequest } from "@/lib/shared-request"
 
 import * as React from "react"
 import {
@@ -13,16 +12,17 @@ import {
   selectProviderSkillPackage,
 } from "./provider-skill-recommendations.ts"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
-import { createSharedRequest, waitForSharedRequest } from "@/lib/shared-request"
+import {
+  readCachedSkillCatalog,
+  readCachedSkillCatalogValue,
+  invalidateSkillCatalogKeys,
+  getSkillCatalogInvalidationRevision,
+  subscribeSkillCatalogInvalidation,
+} from "@/lib/skill-catalog-cache"
 import { readPublicSkillPackageByName, searchPublicSkillPackages } from "@/lib/skills-catalog-client"
 
 const providerSkillPackageCacheMs = 10 * 60_000
 const missingProviderSkillPackageCacheMs = 24 * 60 * 60_000
-
-interface ProviderSkillPackageCacheEntry {
-  expiresAt: number
-  package: PublicSkillPackage | null
-}
 
 export interface ProviderSkillPackageLookup {
   error: string | null
@@ -34,13 +34,11 @@ export interface ProviderSkillPackageLookup {
   totalCount: number
 }
 
-const providerSkillPackageCache = new Map<string, ProviderSkillPackageCacheEntry>()
-const providerSkillPackagePendingRequests = new Map<string, SharedRequest<PublicSkillPackage | null>>()
 const emptyProviderSkillPackages = new Map<string, PublicSkillPackage | null>()
 const providerSkillPackageLookupConcurrency = 4
 
 function providerSkillPackageCacheKey(candidate: ProviderSkillCandidate): string {
-  return `${candidate.service}:${candidate.providerDisplayName.trim().toLowerCase()}`
+  return `public:provider:${candidate.service}:${candidate.providerDisplayName.trim().toLowerCase()}`
 }
 
 function providerSkillPackageRequestKey(candidates: readonly ProviderSkillCandidate[]): string {
@@ -52,14 +50,6 @@ function providerSkillPackageRequestKey(candidates: readonly ProviderSkillCandid
 
 function errorMessage(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause)
-}
-
-function cachedProviderSkillPackage(
-  candidate: ProviderSkillCandidate,
-  now = Date.now(),
-): PublicSkillPackage | null | undefined {
-  const cached = providerSkillPackageCache.get(providerSkillPackageCacheKey(candidate))
-  return cached && now < cached.expiresAt ? cached.package : undefined
 }
 
 async function mapProviderSkillCandidatesWithConcurrency(
@@ -82,6 +72,7 @@ async function mapProviderSkillCandidatesWithConcurrency(
 }
 
 export function useProviderSkillPackageLookup(providers: readonly ConnectionProvider[]): ProviderSkillPackageLookup {
+  const revision = React.useSyncExternalStore(subscribeSkillCatalogInvalidation, getSkillCatalogInvalidationRevision)
   const candidates = React.useMemo(() => getConnectedProviderSkillCandidates(providers), [providers])
   const requestKey = React.useMemo(() => providerSkillPackageRequestKey(candidates), [candidates])
   const [packagesByService, setPackagesByService] = React.useState<ReadonlyMap<string, PublicSkillPackage | null>>(
@@ -106,29 +97,17 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
       }
     }
 
-    const now = Date.now()
-    const initialPackagesByService = new Map<string, PublicSkillPackage | null>()
-    const pendingCandidates: ProviderSkillCandidate[] = []
-    for (const candidate of candidates) {
-      const cached = cachedProviderSkillPackage(candidate, now)
-      if (cached === undefined) {
-        pendingCandidates.push(candidate)
-      } else {
-        initialPackagesByService.set(candidate.service, cached)
-      }
-    }
-
-    setPackagesByService(initialPackagesByService)
+    const initialPackages = new Map<string, PublicSkillPackage | null>()
+    const pendingCandidates = candidates.filter((candidate) => {
+      const cached = readCachedSkillCatalogValue<PublicSkillPackage | null>(providerSkillPackageCacheKey(candidate))
+      if (cached === undefined) return true
+      initialPackages.set(candidate.service, cached)
+      return false
+    })
+    setPackagesByService(initialPackages)
     setResolvedRequestKey(requestKey)
     setIsLoading(pendingCandidates.length > 0)
     setError(null)
-    if (pendingCandidates.length === 0) {
-      return () => {
-        cancelled = true
-        controller.abort()
-      }
-    }
-
     void (async () => {
       let firstFailure: unknown
 
@@ -182,7 +161,7 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
       cancelled = true
       controller.abort()
     }
-  }, [candidates, requestKey])
+  }, [candidates, requestKey, revision])
 
   const isStale = resolvedRequestKey !== requestKey
   const visiblePackagesByService = isStale ? emptyProviderSkillPackages : packagesByService
@@ -199,53 +178,20 @@ export function useProviderSkillPackageLookup(providers: readonly ConnectionProv
 }
 
 export function clearProviderSkillPackageCache(): void {
-  providerSkillPackageCache.clear()
-  for (const request of providerSkillPackagePendingRequests.values()) {
-    request.controller.abort(new DOMException("Provider Skill package cache was cleared.", "AbortError"))
-  }
-  providerSkillPackagePendingRequests.clear()
+  invalidateSkillCatalogKeys((key) => key.startsWith("public:provider:"))
 }
 
 export async function readProviderSkillPackage(
   candidate: ProviderSkillCandidate,
   signal?: AbortSignal,
 ): Promise<PublicSkillPackage | null> {
-  signal?.throwIfAborted()
-  const cacheKey = providerSkillPackageCacheKey(candidate)
-  const cached = providerSkillPackageCache.get(cacheKey)
-  if (cached && Date.now() < cached.expiresAt) {
-    return cached.package
-  }
-  const pending = providerSkillPackagePendingRequests.get(cacheKey)
-  if (pending) {
-    return waitForSharedRequest(pending, signal)
-  }
-
-  const request = createSharedRequest((requestSignal) =>
-    searchProviderSkillPackage(candidate, requestSignal).then((pkg) => {
-      if (!requestSignal.aborted) {
-        providerSkillPackageCache.set(cacheKey, {
-          expiresAt: Date.now() + (pkg ? providerSkillPackageCacheMs : missingProviderSkillPackageCacheMs),
-          package: pkg,
-        })
-      }
-      return pkg
-    }),
+  return readCachedSkillCatalog(
+    providerSkillPackageCacheKey(candidate),
+    (pkg: PublicSkillPackage | null) => (pkg ? providerSkillPackageCacheMs : missingProviderSkillPackageCacheMs),
+    false,
+    (requestSignal) => searchProviderSkillPackage(candidate, requestSignal),
+    signal,
   )
-  providerSkillPackagePendingRequests.set(cacheKey, request)
-  void request.promise.then(
-    () => {
-      if (providerSkillPackagePendingRequests.get(cacheKey) === request) {
-        providerSkillPackagePendingRequests.delete(cacheKey)
-      }
-    },
-    () => {
-      if (providerSkillPackagePendingRequests.get(cacheKey) === request) {
-        providerSkillPackagePendingRequests.delete(cacheKey)
-      }
-    },
-  )
-  return waitForSharedRequest(request, signal)
 }
 
 async function searchProviderSkillPackage(

--- a/src/routes/Skills/skill-list-rendering.test.tsx
+++ b/src/routes/Skills/skill-list-rendering.test.tsx
@@ -6,6 +6,7 @@ import { act } from "react"
 import { createRoot } from "react-dom/client"
 import { expect, test, vi } from "vitest"
 import { DiscoverSkillsPane } from "./DiscoverSkillsPane.tsx"
+import { TeamSkillsPane } from "./TeamSkillsPane.tsx"
 
 const { rowRender, translate } = vi.hoisted(() => ({
   rowRender: vi.fn(() => null),
@@ -64,6 +65,101 @@ test("a 500-package list skips unchanged rows and renders only the affected inst
       ),
     )
     expect(rowRender).toHaveBeenCalledTimes(1)
+  } finally {
+    await act(async () => root.unmount())
+    vi.unstubAllGlobals()
+  }
+})
+
+test("configured team rows ignore unrelated actions and recommendation updates", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  rowRender.mockClear()
+  const root = createRoot(document.createElement("div"))
+  type Props = React.ComponentProps<typeof TeamSkillsPane>
+  const configuredSkills: Props["teamSkills"]["skills"] = Array.from({ length: 100 }, (_, index) => ({
+    id: `configured-${index}`,
+    displayName: `Configured ${index}`,
+    enabled: true,
+    order: index,
+    packageName: `configured-${index}`,
+    skillName: `configured-${index}`,
+    version: "1.0.0",
+    versionPolicy: "pinned",
+    visibility: "public",
+  }))
+  const recommendation: Props["providerRecommendations"][number] = {
+    providerDisplayName: "Demo",
+    service: "demo",
+    packageName: "oo-demo",
+    skillId: "demo",
+    installState: "installable",
+    package: {
+      id: "oo-demo@1.0.0",
+      name: "oo-demo",
+      displayName: "Demo",
+      skills: [{ name: "demo", title: "Demo" }],
+      version: "1.0.0",
+      isTemplate: false,
+      maintainers: [],
+      visibility: "public",
+    },
+  }
+  const props: Props = {
+    busyAction: null,
+    groupById: new Map(),
+    teamFilter: "all",
+    teamQuery: "",
+    teamSkills: {
+      skills: configuredSkills,
+      teamId: "team",
+      teamName: "Team",
+      canManage: true,
+      apiEnabled: true,
+      loading: false,
+      hasLoaded: true,
+      error: null,
+      chatContextSkills: [],
+      addSkill: vi.fn(),
+      removePackage: vi.fn(),
+      refresh: vi.fn(),
+    },
+    workspace: { activeWorkspace: { teamId: "team", canManage: true } } as Props["workspace"],
+    providerRecommendations: [recommendation],
+    providerRecommendationsLoading: false,
+    providerRecommendationsPendingCount: 0,
+    providerRecommendationsTotalCount: 1,
+    onAddRecommendation: vi.fn(),
+    onInstallRuntimeSkill: vi.fn(),
+    onOpenManagedSkill: vi.fn(),
+  }
+  try {
+    await act(async () => root.render(<TeamSkillsPane {...props} />))
+    expect(rowRender).toHaveBeenCalledTimes(101)
+    rowRender.mockClear()
+    await act(async () => root.render(<TeamSkillsPane {...props} busyAction="addSkill:other:other" />))
+    expect(rowRender).toHaveBeenCalledTimes(1)
+    rowRender.mockClear()
+    const updated = [{ ...recommendation, package: { ...recommendation.package, displayName: "Updated" } }]
+    await act(async () =>
+      root.render(<TeamSkillsPane {...props} busyAction="addSkill:other:other" providerRecommendations={updated} />),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(1)
+    rowRender.mockClear()
+    await act(async () =>
+      root.render(
+        <TeamSkillsPane
+          {...props}
+          busyAction="installSkill:configured-5:configured-5"
+          providerRecommendations={updated}
+        />,
+      ),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(2)
+    rowRender.mockClear()
+    await act(async () =>
+      root.render(<TeamSkillsPane {...props} busyAction="installSkillBatch" providerRecommendations={updated} />),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(101)
   } finally {
     await act(async () => root.unmount())
     vi.unstubAllGlobals()

--- a/src/routes/Skills/skill-list-rendering.test.tsx
+++ b/src/routes/Skills/skill-list-rendering.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import type { PublicSkillPackage } from "../../../electron/skills/common.ts"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { expect, test, vi } from "vitest"
+import { DiscoverSkillsPane } from "./DiscoverSkillsPane.tsx"
+
+const { rowRender, translate } = vi.hoisted(() => ({
+  rowRender: vi.fn(() => null),
+  translate: (key: string) => key,
+}))
+vi.mock("./SkillListRow.tsx", () => ({ SkillListRow: rowRender }))
+vi.mock("./PublicSkillPackageSheet.tsx", () => ({ PublicSkillPackageSheet: () => null }))
+vi.mock("@/i18n", () => ({ useAppI18n: () => ({ t: translate, locale: "en" }) }))
+
+test("a 500-package list skips unchanged rows and renders only the affected install or selection row", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  const root = createRoot(document.createElement("div"))
+  const packages: PublicSkillPackage[] = Array.from({ length: 500 }, (_, index) => ({
+    id: `demo-${index}@1.0.0`,
+    name: `demo-${index}`,
+    displayName: `Demo ${index}`,
+    skills: [{ name: `skill-${index}`, title: `Skill ${index}` }],
+    version: "1.0.0",
+    isTemplate: false,
+    maintainers: [],
+    visibility: "public",
+  }))
+  const props = {
+    error: null,
+    filter: "all" as const,
+    groupById: new Map(),
+    installingKey: null as string | null,
+    isLoading: false,
+    isLoadingMore: false,
+    isSignedIn: true,
+    canInstall: true,
+    locale: "en",
+    next: null,
+    packages,
+    providerRecommendations: [],
+    selectedPackage: undefined as PublicSkillPackage | undefined,
+    onClosePackage: vi.fn(),
+    onInstall: vi.fn(),
+    onLoadMore: vi.fn(),
+    onOpenManagedSkill: vi.fn(),
+    onRetry: vi.fn(),
+    onSelectPackage: vi.fn(),
+  }
+  try {
+    await act(async () => root.render(<DiscoverSkillsPane {...props} />))
+    expect(rowRender).toHaveBeenCalledTimes(500)
+    rowRender.mockClear()
+    await act(async () => root.render(<DiscoverSkillsPane {...props} />))
+    expect(rowRender).not.toHaveBeenCalled()
+    await act(async () => root.render(<DiscoverSkillsPane {...props} installingKey="demo-12@1.0.0:skill-12" />))
+    expect(rowRender).toHaveBeenCalledTimes(1)
+    rowRender.mockClear()
+    await act(async () =>
+      root.render(
+        <DiscoverSkillsPane {...props} installingKey="demo-12@1.0.0:skill-12" selectedPackage={packages[20]} />,
+      ),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(1)
+  } finally {
+    await act(async () => root.unmount())
+    vi.unstubAllGlobals()
+  }
+})

--- a/src/routes/Skills/skill-list-rendering.test.tsx
+++ b/src/routes/Skills/skill-list-rendering.test.tsx
@@ -160,6 +160,30 @@ test("configured team rows ignore unrelated actions and recommendation updates",
       root.render(<TeamSkillsPane {...props} busyAction="installSkillBatch" providerRecommendations={updated} />),
     )
     expect(rowRender).toHaveBeenCalledTimes(101)
+    rowRender.mockClear()
+    const samePackage = {
+      ...recommendation.package,
+      skills: [
+        { name: "demo", title: "Demo" },
+        { name: "needle", title: "Needle", description: "Matched skill" },
+      ],
+    }
+    const duplicatePackageRecommendations = [
+      { ...recommendation, package: samePackage },
+      { ...recommendation, package: samePackage, skillId: "needle" },
+    ]
+    await act(async () =>
+      root.render(
+        <TeamSkillsPane {...props} teamQuery="needle" providerRecommendations={duplicatePackageRecommendations} />,
+      ),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(1)
+    expect(rowRender).toHaveBeenLastCalledWith(expect.objectContaining({ description: "Matched skill" }), undefined)
+    rowRender.mockClear()
+    await act(async () =>
+      root.render(<TeamSkillsPane {...props} providerRecommendations={duplicatePackageRecommendations} />),
+    )
+    expect(rowRender).toHaveBeenCalledTimes(101)
   } finally {
     await act(async () => root.unmount())
     vi.unstubAllGlobals()

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -26,7 +26,7 @@ export type PublicSkillInstallState =
   | "installable"
   | "name-conflict"
   | "unavailable"
-export type PublicPackageCatalogStatus = "idle" | "load-error" | "loading" | "loading-more" | "refreshing"
+export type PublicPackageCatalogStatus = "idle" | "ready" | "load-error" | "loading" | "loading-more" | "refreshing"
 export type ManagedSkillGroupById = ReadonlyMap<string, ManagedSkillGroup>
 export type SkillVersionCheckByKey = ReadonlyMap<string, SkillVersionReport["skills"][number]>
 export type TeamSkillRuntimeState =
@@ -175,7 +175,7 @@ export function publicPackageCatalogReducer(
           : appendUniquePublicPackages([], action.catalog.items),
         next: action.catalog.next,
         selectedId: action.append ? state.selectedId : null,
-        status: "idle",
+        status: "ready",
       }
     case "load-error":
       if (action.requestId !== state.requestId) {

--- a/src/routes/Skills/use-skill-catalog.test.tsx
+++ b/src/routes/Skills/use-skill-catalog.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import type { Root } from "react-dom/client"
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, expect, test, vi } from "vitest"
+import { useSkillCatalog } from "./use-skill-catalog.ts"
+import {
+  clearSkillCatalogCache,
+  listPublicSkillPackages,
+  invalidatePublicSkillCatalog,
+} from "@/lib/skills-catalog-client"
+
+let root: Root | undefined
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  root = undefined
+  clearSkillCatalogCache()
+  vi.unstubAllGlobals()
+})
+
+async function mount(load = listPublicSkillPackages) {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  root = createRoot(document.createElement("div"))
+  let view!: ReturnType<typeof useSkillCatalog>
+  function Probe({ enabled }: { enabled: boolean }) {
+    view = useSkillCatalog({ enabled, load })
+    return null
+  }
+  const render = async (enabled: boolean) => {
+    await act(async () =>
+      root!.render(
+        <React.StrictMode>
+          <Probe enabled={enabled} />
+        </React.StrictMode>,
+      ),
+    )
+  }
+  await render(true)
+  return {
+    get view() {
+      return view
+    },
+    render,
+  }
+}
+
+test("empty successful pages settle and do not loop, including StrictMode and tab reentry", async () => {
+  const fetchMock = vi.fn(async () => Response.json({ data: [] }))
+  vi.stubGlobal("fetch", fetchMock)
+  const probe = await mount()
+  expect(probe.view.catalog.status).toBe("ready")
+  expect(probe.view.catalog.items).toEqual([])
+  const settledCalls = fetchMock.mock.calls.length
+  await probe.render(false)
+  await probe.render(true)
+  expect(fetchMock).toHaveBeenCalledTimes(settledCalls)
+  expect(probe.view.catalog.status).toBe("ready")
+})
+
+test("invalidation reloads a visible catalog even when its query did not change", async () => {
+  let name = "old"
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ data: [{ name, skills: [{ name }] }] })),
+  )
+  const probe = await mount()
+  expect(probe.view.catalog.items[0]?.name).toBe("old")
+  name = "new"
+  await act(async () => invalidatePublicSkillCatalog())
+  expect(probe.view.catalog.items[0]?.name).toBe("new")
+})
+
+test("failed refresh preserves visible rows, exposes the error and can be retried", async () => {
+  let failing = false
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      failing ? new Response("failed", { status: 503 }) : Response.json({ data: [{ name: "demo" }] }),
+    ),
+  )
+  const probe = await mount()
+  failing = true
+  await act(async () => probe.view.loadPage({ forceRefresh: true }))
+  expect(probe.view.catalog.status).toBe("load-error")
+  expect(probe.view.catalog.items[0]?.name).toBe("demo")
+  expect(probe.view.catalog.error).toContain("503")
+  failing = false
+  await act(async () => probe.view.loadPage({ forceRefresh: true }))
+  expect(probe.view.catalog.status).toBe("ready")
+})
+
+test("a late cancelled page cannot replace a newer result or update an unmounted consumer", async () => {
+  let resolveOld!: (value: { items: []; next: null; updatedAt: string }) => void
+  let calls = 0
+  const load = vi.fn(async () => {
+    calls++
+    if (calls <= 2) return { items: [], next: null, updatedAt: "initial" }
+    if (calls === 3)
+      return new Promise<{ items: []; next: null; updatedAt: string }>((resolve) => {
+        resolveOld = resolve
+      })
+    return { items: [], next: "new-page", updatedAt: "new" }
+  })
+  const probe = await mount(load)
+  let old!: Promise<void>
+  await act(async () => {
+    old = probe.view.loadPage({ next: "old-page" })
+  })
+  await act(async () => probe.view.loadPage({ forceRefresh: true }))
+  await act(async () => {
+    resolveOld({ items: [], next: null, updatedAt: "old" })
+    await old
+  })
+  expect(probe.view.catalog.next).toBe("new-page")
+})
+
+test("switching tabs preserves previously appended pages", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input) => {
+      const next = new URL(String(input)).searchParams.get("next")
+      return Response.json({ data: [{ name: next ? "second" : "first" }], next: next ? null : "page-two" })
+    }),
+  )
+  const probe = await mount()
+  await act(async () => probe.view.loadPage({ next: probe.view.catalog.next }))
+  expect(probe.view.catalog.items.map((item) => item.name)).toEqual(["first", "second"])
+  await probe.render(false)
+  await probe.render(true)
+  expect(probe.view.catalog.items.map((item) => item.name)).toEqual(["first", "second"])
+})

--- a/src/routes/Skills/use-skill-catalog.ts
+++ b/src/routes/Skills/use-skill-catalog.ts
@@ -1,0 +1,69 @@
+import type { PublicSkillPackageCatalog } from "../../../electron/skills/common.ts"
+import type { ListPublicSkillPackagesInput } from "@/lib/skills-catalog-client"
+
+import * as React from "react"
+import { initialPublicPackageCatalogState, publicPackageCatalogReducer } from "./skill-route-model.ts"
+import { getSkillCatalogInvalidationRevision, subscribeSkillCatalogInvalidation } from "@/lib/skill-catalog-cache"
+
+export interface SkillCatalogPageOptions {
+  forceRefresh?: boolean
+  next?: string | null
+  replace?: boolean
+}
+
+/** Owns pagination and request lifetime; cached responses remain in the shared client. */
+export function useSkillCatalog({
+  enabled,
+  load,
+}: {
+  enabled: boolean
+  load: (input: ListPublicSkillPackagesInput) => Promise<PublicSkillPackageCatalog>
+}) {
+  const [catalog, dispatch] = React.useReducer(publicPackageCatalogReducer, initialPublicPackageCatalogState)
+  const activeRequest = React.useRef<AbortController | null>(null)
+  const requestId = React.useRef(0)
+  const loadedScope = React.useRef<{ load: typeof load; revision: number } | null>(null)
+  const previousLoader = React.useRef(load)
+  const revision = React.useSyncExternalStore(subscribeSkillCatalogInvalidation, getSkillCatalogInvalidationRevision)
+
+  const loadPage = React.useCallback(
+    async (options: SkillCatalogPageOptions = {}) => {
+      activeRequest.current?.abort()
+      const controller = new AbortController()
+      activeRequest.current = controller
+      const id = ++requestId.current
+      const startedRevision = getSkillCatalogInvalidationRevision()
+      loadedScope.current = null
+      const next = options.next?.trim() || undefined
+      const append = Boolean(next && !options.forceRefresh && !options.replace)
+      dispatch({ type: "load-start", append, clearItems: options.replace, requestId: id })
+      try {
+        const result = await load({ next, forceRefresh: options.forceRefresh, signal: controller.signal })
+        if (!controller.signal.aborted) {
+          loadedScope.current = { load, revision: startedRevision }
+          dispatch({ type: "load-success", append, catalog: result, requestId: id })
+        }
+      } catch (cause) {
+        if (!controller.signal.aborted) {
+          dispatch({ type: "load-error", error: cause instanceof Error ? cause.message : String(cause), requestId: id })
+        }
+      } finally {
+        if (activeRequest.current === controller) activeRequest.current = null
+      }
+    },
+    [load],
+  )
+
+  React.useEffect(() => {
+    if (enabled && (loadedScope.current?.load !== load || loadedScope.current.revision !== revision)) {
+      const replace = previousLoader.current !== load
+      previousLoader.current = load
+      void loadPage({ replace })
+    }
+    return () => {
+      activeRequest.current?.abort()
+    }
+  }, [enabled, load, loadPage, revision])
+
+  return { catalog, dispatch, loadPage }
+}


### PR DESCRIPTION
## Summary

Fix Skills catalog reload loops on successful empty results, prevent supplemental detail failures from being cached as silently truncated published lists, and make cache invalidation reach visible catalogs, team markets, Provider recommendations, and version reports. Direct navigation to team management now loads the version report without requiring a prior visit to Skills.

Consolidate pagination and request lifetime management while retaining completed pages across tab switches and existing rows after failed refreshes. Reuse published records that contain Skill metadata; missing metadata uses bounded supplemental reads at the listed version, with force refresh propagated. Share account-scoped maintainer reads through a 30-second cache and in-flight deduplication.

Isolate list row rendering with stable callbacks and item-specific state. Configured team items are memoized independently of Provider recommendations and receive only their relevant busy action; recommended rows retain global disabling behavior. Existing offscreen rendering containment and keyboard behavior are preserved. Cache documentation and regression tests were updated.

Recommendation searches in both the Skills team pane and team management dialog filter before package deduplication, so a later matching Skill in the same package remains visible. A regression reproduces the previously missing result and verifies that clearing the query still produces one recommendation per package. Bulk-link actions retain their package-level deduplication.

## Verification

- [x] `pnpm run ts-check`
- [x] `pnpm run lint`
- [ ] `pnpm run format` — not rerun repository-wide locally; `oxfmt --check` passed for all changed files in the initial commit and all three files in the review follow-up.
- [ ] `pnpm test` — the initial optimization commit's local full run had **3033 passed, 4 skipped, 1 failed**. The only failure was the generated `resources/skills/oo/SKILL.md` hash differing from `resources/skill-lock/oo.json` in `scripts/skills.test.ts:81`; those files and the verifier are unchanged. The original PR commit subsequently passed GitHub's `check` job. The review follow-up passed **87 targeted regression tests across 15 files**; its new CI run is authoritative for the updated head.
- [x] `pnpm run build:app` — passed again after the review fixes, including renderer, Electron main, preload, and TypeScript checks.
- [ ] Runtime/UI verification completed or not applicable — automated React/DOM tests passed; no interactive Electron session, live service mutation, or FPS profiling was performed.

Measured in component tests: a 500-package discovery list renders zero rows on an unchanged update and one on an individual install or selection change. A team list with 100 configured items and one recommendation renders only the recommendation for unrelated actions or recommendation updates, two rows for a targeted install, and all 101 rows for a batch install. Empty catalogs, cancellation, invalidation, failed refresh recovery, pagination retention, private cache isolation, and visible version-report refreshes are also covered.

A published page containing 20 metadata-complete records performs one business request. Records without Skill metadata retain the compatibility path of up to 20 supplemental reads, with concurrency capped at 10. Render counts are not Electron FPS measurements.

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately. Skills version auto-loading remains gated by cloud availability; team management is mounted only for the OOMOL-enabled route.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files. Private detail and maintainer caches retain account isolation and the existing httpOnly-cookie transport.
- [x] Agent tools, permissions, and system prompts are not affected; installation and filesystem mutations remain in their existing main-process boundary.
- [x] Migration, packaging, endpoint, and update implications were considered. No new dependency, endpoint, persisted schema, or packaging change is introduced; version-report refresh behavior is updated. The local generated-skill hash discrepancy is documented above without changing its lock.
- [x] Relevant documentation and tests were updated.
