### PR TITLE
fix(skills): preserve catalog freshness and isolate team requests

### DIFF
--- a/docs/skill-catalog-caching.md
+++ b/docs/skill-catalog-caching.md
@@ -56,7 +56,7 @@ is brought into the renderer.
 | Public package detail                  | `public:package:{name,version}`                                       |                           10 min | Shared by exact-package-name lookup, search completion, and Provider recommendations                                                                      |
 | My published list                      | `my:{accountId}:{next}`                                               |                            2 min | Account-isolated in-memory cache only                                                                                                                     |
 | My published package detail            | `account:{accountId}:package:{name,version}`                          |                           10 min | Never reused across accounts                                                                                                                              |
-| Provider → package resolution          | `public:provider:{service,providerDisplayName}`                       |                           10 min | A "package not found" result is kept as a 24 h negative cache                                                                                             |
+| Provider → package resolution          | `public:provider:{service,providerDisplayName}`                       |                           10 min | A confirmed "package not found" result is kept as a 24 h negative cache                                                                                   |
 | Team Skill configuration               | `accountId + teamId`                                                  | 30 s freshness / 24 h local hold | See `useTeamSkills.ts`                                                                                                                                    |
 | Local installed Skill inventory        | global resource + main-process scan cache                             |                            5 min | Proactively invalidated on watcher changes; TTL is the fallback for missing directories                                                                   |
 | Installed Skill registry version check | auth snapshot + inventory fingerprint (`createVersionReportCacheKey`) |                           30 min | Main-process cache in `SkillServiceImpl.checkSkillVersions` with in-flight dedup; the renderer `skillVersions` resource mirrors it (30 min `staleTimeMs`) |
@@ -65,7 +65,7 @@ is brought into the renderer.
 
 `useSkillCatalog` owns the Skills page's browse, search, and my-published pagination. Successful
 empty results settle as `ready`; only a new query, an explicit retry, or cache invalidation starts
-another load. Completed pages survive tab switches. Abandoned requests release their shared-request
+another load. Completed pages survive tab switches while fresh. On tab reentry, the page checks the oldest loaded page timestamp against the list/search TTL and refreshes expired data. Appending a page does not extend the lifetime of older pages. Abandoned requests release their shared-request
 consumer, and cancelled pending requests are never reused by new consumers, including StrictMode
 remounts. A failed refresh keeps the previous rows and exposes an error for retry.
 
@@ -141,3 +141,20 @@ degradation path.
 - Team Skill artifact/runtime sync is not mixed into the catalog cache. That layer depends on the
   `resolved` artifact, checksums, and a main-process private directory, and belongs to later
   runtime-sync work.
+
+## Team request lifetime and error semantics
+
+Team configuration reads share pending requests by account and team. Each hook releases its
+consumers when its scope changes or it unmounts; the last consumer cancels the network request.
+A microtask before network dispatch avoids dispatching work already cancelled by same-turn
+StrictMode cleanup. Force refresh and mutations invalidate older pending reads, whose results
+cannot repopulate the cache. Failed refreshes preserve the last successful configuration.
+Persistent cache initialization and maintenance run outside render, and UI state is scoped by
+account plus team rather than team alone.
+
+A successful HTTP response must contain an array-valued `data` field. Malformed top-level
+responses fail explicitly; only a valid empty array is a successful empty configuration.
+
+Provider resolution may recover a failed conventional package lookup through a matching search
+result. If the conventional lookup failed and search finds nothing, resolution propagates the
+failure instead of storing a 24-hour missing-package result.

--- a/docs/skill-catalog-caching.md
+++ b/docs/skill-catalog-caching.md
@@ -64,7 +64,7 @@ is brought into the renderer.
 ## Page loading and supplemental details
 
 `useSkillCatalog` owns the Skills page's browse, search, and my-published pagination. Successful
-empty results settle as `ready`; only a new query, an explicit retry, or cache invalidation starts
+empty results settle as `ready`; a new query, an explicit retry, cache invalidation, or TTL expiry on tab reentry starts
 another load. Completed pages survive tab switches while fresh. On tab reentry, the page checks the oldest loaded page timestamp against the list/search TTL and refreshes expired data. Appending a page does not extend the lifetime of older pages. Abandoned requests release their shared-request
 consumer, and cancelled pending requests are never reused by new consumers, including StrictMode
 remounts. A failed refresh keeps the previous rows and exposes an error for retry.
@@ -147,8 +147,9 @@ degradation path.
 Team configuration reads share pending requests by account and team. Each hook releases its
 consumers when its scope changes or it unmounts; the last consumer cancels the network request.
 A microtask before network dispatch avoids dispatching work already cancelled by same-turn
-StrictMode cleanup. Force refresh and mutations invalidate older pending reads, whose results
-cannot repopulate the cache. Failed refreshes preserve the last successful configuration.
+StrictMode cleanup. Force refresh and mutations detach older pending reads so new requests can start. Existing
+consumers can finish those reads, but detached results cannot repopulate the cache. Force refresh
+releases only the calling hook's old consumers; other hooks keep their shared request alive. Failed refreshes preserve the last successful configuration.
 Persistent cache initialization and maintenance run outside render, and UI state is scoped by
 account plus team rather than team alone.
 

--- a/src/hooks/useTeamSkills.lifecycle.test.tsx
+++ b/src/hooks/useTeamSkills.lifecycle.test.tsx
@@ -1,0 +1,133 @@
+import type { UseTeamSkills } from "./useTeamSkills.ts"
+import type { Root } from "react-dom/client"
+
+// @vitest-environment happy-dom
+import * as React from "react"
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, expect, test, vi } from "vitest"
+import { useTeamSkills } from "./useTeamSkills.ts"
+
+let root: Root | undefined
+let view: UseTeamSkills
+let sequence = 0
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  root = undefined
+  vi.unstubAllGlobals()
+})
+
+async function mount(strict = false) {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  root = createRoot(document.createElement("div"))
+  const initialTeam = `lifecycle-${++sequence}`
+  function Probe({ team, account }: { team: string; account: string }) {
+    view = useTeamSkills({ canManage: true, team: null, teamId: team, role: null }, account)
+    return null
+  }
+  const render = async (team = initialTeam, account = "account-a") => {
+    await act(async () =>
+      root!.render(
+        strict ? (
+          <React.StrictMode>
+            <Probe team={team} account={account} />
+          </React.StrictMode>
+        ) : (
+          <Probe team={team} account={account} />
+        ),
+      ),
+    )
+  }
+  await render()
+  return render
+}
+
+function pendingFetch() {
+  const requests: Array<{ signal: AbortSignal; resolve: (response: Response) => void }> = []
+  const fetcher = vi.fn(
+    (_url: unknown, init: RequestInit) =>
+      new Promise<Response>((resolve) => {
+        requests.push({ signal: init.signal as AbortSignal, resolve })
+      }),
+  )
+  vi.stubGlobal("fetch", fetcher)
+  return { requests, fetcher }
+}
+
+test("StrictMode cancels before network dispatch and concurrent refreshes share one GET", async () => {
+  const { requests, fetcher } = pendingFetch()
+  await mount(true)
+  expect(fetcher).toHaveBeenCalledTimes(1)
+  let refresh!: Promise<void>
+  await act(async () => {
+    refresh = view.refresh()
+  })
+  expect(fetcher).toHaveBeenCalledTimes(1)
+  await act(async () => {
+    requests[0]!.resolve(Response.json({ data: [] }))
+    await refresh
+  })
+  expect(view.hasLoaded).toBe(true)
+  expect(view.error).toBeNull()
+})
+
+test("team switch cancels abandoned network work and late responses cannot replace the new team", async () => {
+  const { requests } = pendingFetch()
+  const render = await mount()
+  await render("different-team")
+  expect(requests[0]!.signal.aborted).toBe(true)
+  await act(async () => {
+    requests[1]!.resolve(Response.json({ data: [{ name: "new", skills: [{ name: "new" }] }] }))
+  })
+  await act(async () => requests[0]!.resolve(Response.json({ data: [{ name: "old", skills: [{ name: "old" }] }] })))
+  expect(view.skills.map((s) => s.skillName)).toEqual(["new"])
+})
+
+test("malformed refresh preserves the last successful team configuration and exposes an error", async () => {
+  const fetcher = vi.fn(async () => Response.json({ data: [{ name: "demo", skills: [{ name: "alpha" }] }] }))
+  vi.stubGlobal("fetch", fetcher)
+  await mount()
+  fetcher.mockImplementation(async () => Response.json({ data: "invalid" }))
+  await act(async () => view.refresh({ forceRefresh: true }))
+  expect(view.skills.map((s) => s.skillName)).toEqual(["alpha"])
+  expect(view.error).not.toBeNull()
+})
+
+test("account switch does not share a previous account's pending team request", async () => {
+  const { requests } = pendingFetch()
+  const render = await mount()
+  await render(undefined, "account-b")
+  expect(requests).toHaveLength(2)
+  expect(requests[0]!.signal.aborted).toBe(true)
+  expect(view.skills).toEqual([])
+  await act(async () => requests[1]!.resolve(Response.json({ data: [] })))
+})
+
+test("a malformed cold load exposes an error instead of an empty success", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ error: "invalid" })),
+  )
+  await mount()
+  expect(view.error).not.toBeNull()
+  expect(view.hasLoaded).toBe(false)
+})
+
+test("force refresh prevents a superseded response from replacing fresh data or cache", async () => {
+  const { requests, fetcher } = pendingFetch()
+  await mount()
+  let refresh!: Promise<void>
+  await act(async () => {
+    refresh = view.refresh({ forceRefresh: true })
+  })
+  expect(requests[0]!.signal.aborted).toBe(true)
+  await act(async () => {
+    requests[1]!.resolve(Response.json({ data: [{ name: "fresh", skills: [{ name: "fresh" }] }] }))
+    await refresh
+  })
+  await act(async () => requests[0]!.resolve(Response.json({ data: [{ name: "old", skills: [{ name: "old" }] }] })))
+  await act(async () => view.refresh())
+  expect(fetcher).toHaveBeenCalledTimes(2)
+  expect(view.skills.map((s) => s.skillName)).toEqual(["fresh"])
+  expect(view.error).toBeNull()
+})

--- a/src/hooks/useTeamSkills.lifecycle.test.tsx
+++ b/src/hooks/useTeamSkills.lifecycle.test.tsx
@@ -6,7 +6,7 @@ import * as React from "react"
 import { act } from "react"
 import { createRoot } from "react-dom/client"
 import { afterEach, expect, test, vi } from "vitest"
-import { useTeamSkills } from "./useTeamSkills.ts"
+import { invalidateTeamSkillCache, useTeamSkills } from "./useTeamSkills.ts"
 
 let root: Root | undefined
 let view: UseTeamSkills
@@ -130,4 +130,54 @@ test("force refresh prevents a superseded response from replacing fresh data or 
   expect(fetcher).toHaveBeenCalledTimes(2)
   expect(view.skills.map((s) => s.skillName)).toEqual(["fresh"])
   expect(view.error).toBeNull()
+})
+
+test.each([
+  ["force-refresh", 200],
+  ["force-refresh", 404],
+  ["invalidation", 200],
+  ["invalidation", 404],
+] as const)("%s preserves another consumer and rejects stale cache writes (status %i)", async (mode, status) => {
+  const { requests, fetcher } = pendingFetch()
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  root = createRoot(document.createElement("div"))
+  const teamId = `shared-${++sequence}`
+  const views: UseTeamSkills[] = []
+  function Consumer({ index }: { index: number }) {
+    views[index] = useTeamSkills({ canManage: true, team: null, teamId, role: null }, "shared-account")
+    return null
+  }
+  await act(async () =>
+    root!.render(
+      <>
+        <Consumer index={0} />
+        <Consumer index={1} />
+      </>,
+    ),
+  )
+  expect(fetcher).toHaveBeenCalledTimes(1)
+  let refresh!: Promise<void>
+  await act(async () => {
+    if (mode === "invalidation") invalidateTeamSkillCache("shared-account", teamId)
+    refresh = views[0]!.refresh({ forceRefresh: mode === "force-refresh" })
+  })
+  expect(fetcher).toHaveBeenCalledTimes(2)
+  expect(requests[0]!.signal.aborted).toBe(false)
+  await act(async () => {
+    requests[1]!.resolve(Response.json({ data: [{ name: "fresh", skills: [{ name: "fresh" }] }] }))
+    await refresh
+  })
+  await act(async () =>
+    requests[0]!.resolve(
+      status === 404
+        ? new Response("not found", { status: 404 })
+        : Response.json({ data: [{ name: "old", skills: [{ name: "old" }] }] }),
+    ),
+  )
+  expect(views[1]!.error).toBeNull()
+  expect(views[1]!.hasLoaded).toBe(true)
+  expect(views[0]!.skills.map((s) => s.skillName)).toEqual(["fresh"])
+  await act(async () => views[1]!.refresh())
+  expect(fetcher).toHaveBeenCalledTimes(2)
+  expect(views[1]!.skills.map((s) => s.skillName)).toEqual(["fresh"])
 })

--- a/src/hooks/useTeamSkills.ts
+++ b/src/hooks/useTeamSkills.ts
@@ -64,7 +64,10 @@ function readSharedTeamSkills(cacheKey: string, teamId: string, signal: AbortSig
       // Let a same-turn effect cleanup cancel before starting network work.
       await Promise.resolve()
       requestSignal.throwIfAborted()
-      const config = await listTeamSkills(teamId, requestSignal)
+      const config = await listTeamSkills(teamId, requestSignal).catch((cause: unknown) => {
+        if (!isTeamSkillsUnavailable(cause)) throw cause
+        return { skills: [], updatedAt: new Date().toISOString() }
+      })
       requestSignal.throwIfAborted()
       if (pendingTeamSkills.get(cacheKey) === shared) {
         setTeamSkillCacheEntry({ cacheKey, fetchedAt: Date.now(), teamId, skills: config.skills })
@@ -181,7 +184,6 @@ function setTeamSkillCacheEntry(entry: TeamSkillCacheEntry): void {
 }
 
 function deleteTeamSkillCacheEntry(cacheKey: string): void {
-  pendingTeamSkills.get(cacheKey)?.controller.abort()
   pendingTeamSkills.delete(cacheKey)
   if (teamSkillCache.delete(cacheKey)) {
     persistTeamSkillCache()
@@ -268,8 +270,10 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
       }
 
       if (options.forceRefresh) {
-        pendingTeamSkills.get(cacheKey)?.controller.abort()
         pendingTeamSkills.delete(cacheKey)
+        // Release only this hook's consumers; other hooks may still need the old read.
+        for (const controller of activeRequests.current) controller.abort()
+        activeRequests.current.clear()
       }
       const now = Date.now()
       const cached = getTeamSkillCacheEntry(cacheKey, teamId)
@@ -298,19 +302,11 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
         setHasLoaded(true)
       } catch (cause) {
         if (!controller.signal.aborted && requestIdRef.current === requestId) {
-          if (isTeamSkillsUnavailable(cause)) {
-            setTeamSkillCacheEntry({ cacheKey, fetchedAt: Date.now(), teamId, skills: [] })
-            setSkills([])
-            setSkillsCacheKey(cacheKey)
-            setError(null)
-            setHasLoaded(true)
-          } else {
-            const fallback = getTeamSkillCacheEntry(cacheKey, teamId)
-            setSkills(fallback?.skills ?? [])
-            setSkillsCacheKey(cacheKey)
-            setError(teamSkillError(cause))
-            setHasLoaded(Boolean(fallback))
-          }
+          const fallback = getTeamSkillCacheEntry(cacheKey, teamId)
+          setSkills(fallback?.skills ?? [])
+          setSkillsCacheKey(cacheKey)
+          setError(teamSkillError(cause))
+          setHasLoaded(Boolean(fallback))
         }
       } finally {
         activeRequests.current.delete(controller)

--- a/src/hooks/useTeamSkills.ts
+++ b/src/hooks/useTeamSkills.ts
@@ -1,10 +1,12 @@
 import type { WorkspaceSelection } from "@/hooks/useTeamWorkspace"
-import type { AddTeamSkillInput, TeamSkillConfigItem } from "@/lib/team-skills-client"
+import type { SharedRequest } from "@/lib/shared-request"
+import type { AddTeamSkillInput, TeamSkillConfig, TeamSkillConfigItem } from "@/lib/team-skills-client"
 import type { UserFacingError } from "@/lib/user-facing-error"
 
 import * as React from "react"
 import { OomolHttpError } from "@/lib/oomol-http"
 import { reportRendererHandledError } from "@/lib/renderer-diagnostics"
+import { createSharedRequest, waitForSharedRequest } from "@/lib/shared-request"
 import {
   addTeamSkill,
   listTeamSkills,
@@ -53,6 +55,31 @@ const teamSkillPersistentCacheStorageKey = "wanta.team-skill-cache.v3"
 const legacyTeamSkillPersistentCacheStorageKey = "wanta.organization-skill-cache.v2"
 const teamSkillCache = new Map<string, TeamSkillCacheEntry>()
 let teamSkillPersistentCacheRead = false
+const pendingTeamSkills = new Map<string, SharedRequest<TeamSkillConfig>>()
+
+function readSharedTeamSkills(cacheKey: string, teamId: string, signal: AbortSignal): Promise<TeamSkillConfig> {
+  let request = pendingTeamSkills.get(cacheKey)
+  if (!request || request.controller.signal.aborted) {
+    const shared = createSharedRequest(async (requestSignal) => {
+      // Let a same-turn effect cleanup cancel before starting network work.
+      await Promise.resolve()
+      requestSignal.throwIfAborted()
+      const config = await listTeamSkills(teamId, requestSignal)
+      requestSignal.throwIfAborted()
+      if (pendingTeamSkills.get(cacheKey) === shared) {
+        setTeamSkillCacheEntry({ cacheKey, fetchedAt: Date.now(), teamId, skills: config.skills })
+      }
+      return config
+    })
+    request = shared
+    pendingTeamSkills.set(cacheKey, shared)
+    const cleanup = () => {
+      if (pendingTeamSkills.get(cacheKey) === shared) pendingTeamSkills.delete(cacheKey)
+    }
+    void shared.promise.then(cleanup, cleanup)
+  }
+  return waitForSharedRequest(request, signal)
+}
 
 export function selectTeamSkillCacheEntries(
   entries: readonly TeamSkillCacheEntry[],
@@ -120,7 +147,6 @@ function readPersistentTeamSkillCache(): void {
         teamSkillCache.set(entry.cacheKey, entry)
       }
     }
-    pruneTeamSkillCache()
     persistTeamSkillCache()
     if (legacySerialized !== null) {
       window.localStorage.removeItem(legacyTeamSkillPersistentCacheStorageKey)
@@ -145,18 +171,18 @@ function persistTeamSkillCache(): void {
 }
 
 function getTeamSkillCacheEntry(cacheKey: string, teamId: string): TeamSkillCacheEntry | undefined {
-  readPersistentTeamSkillCache()
   const entry = teamSkillCache.get(cacheKey)
   return entry?.teamId === teamId ? entry : undefined
 }
 
 function setTeamSkillCacheEntry(entry: TeamSkillCacheEntry): void {
   teamSkillCache.set(entry.cacheKey, entry)
-  pruneTeamSkillCache()
   persistTeamSkillCache()
 }
 
 function deleteTeamSkillCacheEntry(cacheKey: string): void {
+  pendingTeamSkills.get(cacheKey)?.controller.abort()
+  pendingTeamSkills.delete(cacheKey)
   if (teamSkillCache.delete(cacheKey)) {
     persistTeamSkillCache()
   }
@@ -204,26 +230,28 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
   const remoteApiEnabled = teamSkillsApiEnabled()
   const canManage = workspace.canManage
   const [skills, setSkills] = React.useState<TeamSkillConfigItem[]>([])
-  const [skillsTeamId, setSkillsTeamId] = React.useState<string | null>(null)
+  const [skillsCacheKey, setSkillsCacheKey] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<UserFacingError | null>(null)
   const [hasLoaded, setHasLoaded] = React.useState(false)
   const requestIdRef = React.useRef(0)
   const latestTeamIdRef = React.useRef<string | null>(teamId)
   const latestCacheKeyRef = React.useRef(cacheKey)
+  const activeRequests = React.useRef(new Set<AbortController>())
 
   React.useEffect(() => {
+    readPersistentTeamSkillCache()
     latestTeamIdRef.current = teamId
     latestCacheKeyRef.current = cacheKey
     requestIdRef.current += 1
     const cached = teamId ? getTeamSkillCacheEntry(cacheKey, teamId) : undefined
     setSkills(cached?.skills ?? [])
-    setSkillsTeamId(cached ? teamId : null)
+    setSkillsCacheKey(cached ? cacheKey : null)
     setError(null)
     setHasLoaded(Boolean(cached))
     if (!teamId || !remoteApiEnabled) {
       setLoading(false)
-      setSkillsTeamId(teamId)
+      setSkillsCacheKey(cacheKey)
       setHasLoaded(Boolean(teamId && !remoteApiEnabled))
     }
   }, [cacheKey, teamId, remoteApiEnabled, workspaceKey])
@@ -232,54 +260,60 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
     async (options: { forceRefresh?: boolean } = {}): Promise<void> => {
       if (!teamId || !remoteApiEnabled) {
         setSkills([])
-        setSkillsTeamId(teamId)
+        setSkillsCacheKey(cacheKey)
         setError(null)
         setHasLoaded(Boolean(teamId && !remoteApiEnabled))
         setLoading(false)
         return
       }
 
+      if (options.forceRefresh) {
+        pendingTeamSkills.get(cacheKey)?.controller.abort()
+        pendingTeamSkills.delete(cacheKey)
+      }
       const now = Date.now()
       const cached = getTeamSkillCacheEntry(cacheKey, teamId)
       if (!options.forceRefresh && cached && now - cached.fetchedAt < teamSkillCacheMs) {
         setSkills(cached.skills)
-        setSkillsTeamId(teamId)
+        setSkillsCacheKey(cacheKey)
         setError(null)
         setHasLoaded(true)
         setLoading(false)
         return
       }
 
+      const controller = new AbortController()
+      activeRequests.current.add(controller)
       const requestId = requestIdRef.current + 1
       requestIdRef.current = requestId
       setLoading(true)
       try {
-        const config = await listTeamSkills(teamId)
-        if (requestIdRef.current !== requestId) {
+        const config = await readSharedTeamSkills(cacheKey, teamId, controller.signal)
+        if (controller.signal.aborted || requestIdRef.current !== requestId) {
           return
         }
-        setTeamSkillCacheEntry({ cacheKey, fetchedAt: Date.now(), teamId, skills: config.skills })
         setSkills(config.skills)
-        setSkillsTeamId(teamId)
+        setSkillsCacheKey(cacheKey)
         setError(null)
         setHasLoaded(true)
       } catch (cause) {
-        if (requestIdRef.current === requestId) {
+        if (!controller.signal.aborted && requestIdRef.current === requestId) {
           if (isTeamSkillsUnavailable(cause)) {
             setTeamSkillCacheEntry({ cacheKey, fetchedAt: Date.now(), teamId, skills: [] })
             setSkills([])
-            setSkillsTeamId(teamId)
+            setSkillsCacheKey(cacheKey)
             setError(null)
             setHasLoaded(true)
           } else {
             const fallback = getTeamSkillCacheEntry(cacheKey, teamId)
             setSkills(fallback?.skills ?? [])
-            setSkillsTeamId(fallback ? teamId : null)
+            setSkillsCacheKey(cacheKey)
             setError(teamSkillError(cause))
             setHasLoaded(Boolean(fallback))
           }
         }
       } finally {
+        activeRequests.current.delete(controller)
         if (requestIdRef.current === requestId) {
           setLoading(false)
         }
@@ -292,6 +326,11 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
     void refresh().catch((error: unknown) => {
       reportRendererHandledError("team-skills", "team skills refresh failed", error)
     })
+    return () => {
+      requestIdRef.current += 1
+      for (const controller of activeRequests.current) controller.abort()
+      activeRequests.current.clear()
+    }
   }, [refresh])
 
   const reloadAfterMutation = React.useCallback(
@@ -342,7 +381,7 @@ export function useTeamSkills(workspace: WorkspaceSelection, accountId?: string)
   )
 
   const cached = teamId ? getTeamSkillCacheEntry(cacheKey, teamId) : undefined
-  const skillsBelongToCurrentTeam = skillsTeamId === teamId
+  const skillsBelongToCurrentTeam = skillsCacheKey === cacheKey
   const currentSkills = skillsBelongToCurrentTeam ? skills : (cached?.skills ?? [])
   const currentError = skillsBelongToCurrentTeam ? error : null
   const currentHasLoaded = skillsBelongToCurrentTeam ? hasLoaded : Boolean(cached)

--- a/src/lib/skills-catalog-client.ts
+++ b/src/lib/skills-catalog-client.ts
@@ -21,10 +21,10 @@ const publicSkillSearchResultSize = 100
 const myPublishedSkillPackagePageSize = 20
 const myPublishedSkillPackageInfoConcurrency = 10
 const skillCatalogRequestTimeoutMs = 10_000
-const publicSkillPackageListCacheMs = 5 * 60_000
-const publicSkillSearchCacheMs = 2 * 60_000
+export const publicSkillPackageListCacheMs = 5 * 60_000
+export const publicSkillSearchCacheMs = 2 * 60_000
 const publicSkillPackageInfoCacheMs = 10 * 60_000
-const myPublishedSkillPackageCacheMs = 2 * 60_000
+export const myPublishedSkillPackageCacheMs = 2 * 60_000
 
 export interface MyPublishedSkillAccount {
   id: string

--- a/src/lib/team-skills-client.test.ts
+++ b/src/lib/team-skills-client.test.ts
@@ -118,3 +118,10 @@ test("teamSkillsApiEnabled prefers the team flag and supports the legacy flag", 
   vi.stubEnv("VITE_WANTA_ORGANIZATION_SKILLS_API", "true")
   assert.equal(teamSkillsApiEnabled(), true)
 })
+
+test("malformed team responses throw while a valid empty list succeeds", () => {
+  for (const value of [null, {}, { data: "invalid" }, { error: "unavailable" }]) {
+    assert.throws(() => normalizeTeamSkillPackages(value), /unsupported response/)
+  }
+  assert.deepEqual(normalizeTeamSkillPackages({ data: [] }).skills, [])
+})

--- a/src/lib/team-skills-client.ts
+++ b/src/lib/team-skills-client.ts
@@ -99,7 +99,10 @@ function compareTeamSkills(left: TeamSkillConfigItem, right: TeamSkillConfigItem
 
 export function normalizeTeamSkillPackages(value: unknown): TeamSkillConfig {
   const payload = asPlainObject(value)
-  const rawPackages = Array.isArray(payload?.["data"]) ? payload["data"] : []
+  if (!Array.isArray(payload?.["data"])) {
+    throw new Error("Team Skill list returned an unsupported response.")
+  }
+  const rawPackages = payload["data"]
   return {
     skills: rawPackages
       .flatMap((entry, packageIndex) => normalizeTeamSkillPackage(entry, packageIndex))
@@ -200,10 +203,10 @@ export function teamSkillMentionId(skill: Pick<TeamSkillConfigItem, "id" | "pack
   return `team:${skill.id || `${skill.packageName}:${skill.skillName}`}`
 }
 
-export async function listTeamSkills(teamId: string): Promise<TeamSkillConfig> {
+export async function listTeamSkills(teamId: string, signal?: AbortSignal): Promise<TeamSkillConfig> {
   const response = await oomolFetchJson<TeamSkillPackageResponse>(
     new URL(`/-/oomol/orgs/${encodeURIComponent(teamId.trim())}/package-infos`, registryBaseUrl),
-    { timeoutMs: teamSkillRequestTimeoutMs },
+    { signal, timeoutMs: teamSkillRequestTimeoutMs },
   )
   return normalizeTeamSkillPackages(response)
 }

--- a/src/routes/Skills/index.tsx
+++ b/src/routes/Skills/index.tsx
@@ -58,6 +58,8 @@ import {
   invalidateMyPublishedSkillCatalog,
   invalidatePublicSkillCatalog,
   listMyPublishedSkillPackages,
+  myPublishedSkillPackageCacheMs,
+  publicSkillSearchCacheMs,
   listPublicSkillPackages,
   searchPublicSkillPackages,
 } from "@/lib/skills-catalog-client"
@@ -271,6 +273,7 @@ export function SkillsRoute({
   } = useSkillCatalog({
     enabled: activeTab === "discover" && discoveryFilter === "mine" && Boolean(account),
     load: loadPublished,
+    staleTimeMs: myPublishedSkillPackageCacheMs,
   })
   const {
     catalog: publicPackageSearchCatalog,
@@ -279,6 +282,7 @@ export function SkillsRoute({
   } = useSkillCatalog({
     enabled: activeTab === "discover" && discoveryFilter === "all" && Boolean(debouncedDiscoveryQuery),
     load: loadSearch,
+    staleTimeMs: publicSkillSearchCacheMs,
   })
 
   const isPublicSearchActive = discoveryFilter === "all" && Boolean(debouncedDiscoveryQuery)

--- a/src/routes/Skills/provider-skill-package-lookup.test.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.test.ts
@@ -142,3 +142,26 @@ test("public invalidation and account cleanup invalidate provider results too", 
   expect(readPublicSkillPackageByName).toHaveBeenCalledTimes(3)
   clearSkillCatalogCache()
 })
+
+test("a failed conventional lookup cannot become a cached missing package", async () => {
+  clearSkillCatalogCache()
+  vi.mocked(readPublicSkillPackageByName).mockReset().mockRejectedValueOnce(new Error("503"))
+  vi.mocked(searchPublicSkillPackages).mockReset().mockResolvedValue({ items: [], next: null, updatedAt: "now" })
+  const candidate = { service: "posthog", providerDisplayName: "PostHog" }
+  await expect(readProviderSkillPackage(candidate)).rejects.toThrow("503")
+  vi.mocked(readPublicSkillPackageByName).mockResolvedValue(posthogPackage)
+  await expect(readProviderSkillPackage(candidate)).resolves.toBe(posthogPackage)
+  clearSkillCatalogCache()
+})
+
+test("search may recover a failed conventional lookup with a matching package", async () => {
+  clearSkillCatalogCache()
+  vi.mocked(readPublicSkillPackageByName).mockReset().mockRejectedValue(new Error("503"))
+  vi.mocked(searchPublicSkillPackages)
+    .mockReset()
+    .mockResolvedValue({ items: [posthogPackage], next: null, updatedAt: "now" })
+  await expect(readProviderSkillPackage({ service: "posthog", providerDisplayName: "PostHog" })).resolves.toBe(
+    posthogPackage,
+  )
+  clearSkillCatalogCache()
+})

--- a/src/routes/Skills/provider-skill-package-lookup.ts
+++ b/src/routes/Skills/provider-skill-package-lookup.ts
@@ -198,6 +198,7 @@ async function searchProviderSkillPackage(
   candidate: ProviderSkillCandidate,
   signal?: AbortSignal,
 ): Promise<PublicSkillPackage | null> {
+  let conventionalFailure: unknown
   const conventionalPackageName = getConventionalProviderSkillPackageName(candidate)
   if (conventionalPackageName) {
     try {
@@ -209,6 +210,7 @@ async function searchProviderSkillPackage(
       if (signal?.aborted) {
         throw error
       }
+      conventionalFailure = error
       reportRendererHandledError(
         "providerSkillPackageLookup.readConventionalPackage",
         "Failed to read conventional provider Skill package",
@@ -237,5 +239,7 @@ async function searchProviderSkillPackage(
     }
   }
 
-  return selectProviderSkillPackage(candidate, packages)
+  const selected = selectProviderSkillPackage(candidate, packages)
+  if (!selected && conventionalFailure) throw conventionalFailure
+  return selected
 }

--- a/src/routes/Skills/skill-route-model.test.ts
+++ b/src/routes/Skills/skill-route-model.test.ts
@@ -485,3 +485,10 @@ function externalManagedSkillGroup(
 function t(key: string, vars?: Record<string, string | number>): string {
   return vars ? `${key}:${JSON.stringify(vars)}` : key
 }
+
+test("packages without skills are unavailable even when a matching local group exists", () => {
+  const pkg = { ...publicPackage("demo"), skills: [] }
+  assert.equal(getPublicPackageInstallState(undefined, pkg), "unavailable")
+  assert.equal(getPublicPackageInstallState(new Map([["demo", managedSkillGroup("demo", "demo")]]), pkg), "unavailable")
+  assert.equal(shouldOpenPublicSkillManagement(getPublicPackageInstallState(undefined, pkg)), false)
+})

--- a/src/routes/Skills/skill-route-model.ts
+++ b/src/routes/Skills/skill-route-model.ts
@@ -603,7 +603,7 @@ export function getPublicPackageInstallState(
 
   const skillStates = pkg.skills.map((skill) => getPublicSkillInstallState(groupById, pkg, skill.name))
 
-  if (skillStates.length > 0 && skillStates.every((state) => state === "installed")) {
+  if (skillStates.every((state) => state === "installed")) {
     return "installed"
   }
 
@@ -679,11 +679,12 @@ export function getPublicPackageMaintainerLine(pkg: PublicSkillPackage, t: TFunc
 }
 
 export function getPublicPackageMetaLine(pkg: PublicSkillPackage, t: TFunction): string {
+  const maintainerLine = getPublicPackageMaintainerLine(pkg, t)
   return (
     joinSkillMeta([
-      getPublicPackageMaintainerLine(pkg, t),
+      maintainerLine,
       pkg.downloadCount === undefined ? undefined : t("skills.discoverDownloads", { count: pkg.downloadCount }),
-    ]) ?? getPublicPackageMaintainerLine(pkg, t)
+    ]) ?? maintainerLine
   )
 }
 

--- a/src/routes/Skills/use-skill-catalog.test.tsx
+++ b/src/routes/Skills/use-skill-catalog.test.tsx
@@ -17,6 +17,7 @@ afterEach(async () => {
   await act(async () => root?.unmount())
   root = undefined
   clearSkillCatalogCache()
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
@@ -130,4 +131,35 @@ test("switching tabs preserves previously appended pages", async () => {
   await probe.render(false)
   await probe.render(true)
   expect(probe.view.catalog.items.map((item) => item.name)).toEqual(["first", "second"])
+})
+
+test("expired tab reentry refreshes while fresh appended pages remain intact", async () => {
+  let now = Date.now()
+  vi.spyOn(Date, "now").mockImplementation(() => now)
+  const fetcher = vi.fn(async () => Response.json({ data: [{ name: "fresh" }] }))
+  vi.stubGlobal("fetch", fetcher)
+  const probe = await mount()
+  const calls = fetcher.mock.calls.length
+  await probe.render(false)
+  now += 6 * 60_000
+  await probe.render(true)
+  expect(fetcher).toHaveBeenCalledTimes(calls + 1)
+  expect(probe.view.catalog.status).toBe("ready")
+})
+
+test("appending a fresh page does not extend the oldest page lifetime", async () => {
+  let now = Date.now()
+  vi.spyOn(Date, "now").mockImplementation(() => now)
+  const load = vi.fn(async () => ({ items: [], next: "next", updatedAt: new Date(now).toISOString() }))
+  const probe = await mount(load)
+  now += 4 * 60_000
+  await act(async () => probe.view.loadPage({ next: "next" }))
+  const calls = load.mock.calls.length
+  await probe.render(false)
+  await probe.render(true)
+  expect(load).toHaveBeenCalledTimes(calls)
+  await probe.render(false)
+  now += 2 * 60_000
+  await probe.render(true)
+  expect(load).toHaveBeenCalledTimes(calls + 1)
 })

--- a/src/routes/Skills/use-skill-catalog.ts
+++ b/src/routes/Skills/use-skill-catalog.ts
@@ -4,6 +4,7 @@ import type { ListPublicSkillPackagesInput } from "@/lib/skills-catalog-client"
 import * as React from "react"
 import { initialPublicPackageCatalogState, publicPackageCatalogReducer } from "./skill-route-model.ts"
 import { getSkillCatalogInvalidationRevision, subscribeSkillCatalogInvalidation } from "@/lib/skill-catalog-cache"
+import { publicSkillPackageListCacheMs } from "@/lib/skills-catalog-client"
 
 export interface SkillCatalogPageOptions {
   forceRefresh?: boolean
@@ -15,14 +16,16 @@ export interface SkillCatalogPageOptions {
 export function useSkillCatalog({
   enabled,
   load,
+  staleTimeMs = publicSkillPackageListCacheMs,
 }: {
   enabled: boolean
+  staleTimeMs?: number
   load: (input: ListPublicSkillPackagesInput) => Promise<PublicSkillPackageCatalog>
 }) {
   const [catalog, dispatch] = React.useReducer(publicPackageCatalogReducer, initialPublicPackageCatalogState)
   const activeRequest = React.useRef<AbortController | null>(null)
   const requestId = React.useRef(0)
-  const loadedScope = React.useRef<{ load: typeof load; revision: number } | null>(null)
+  const loadedScope = React.useRef<{ load: typeof load; revision: number; expiresAt: number } | null>(null)
   const previousLoader = React.useRef(load)
   const revision = React.useSyncExternalStore(subscribeSkillCatalogInvalidation, getSkillCatalogInvalidationRevision)
 
@@ -33,6 +36,7 @@ export function useSkillCatalog({
       activeRequest.current = controller
       const id = ++requestId.current
       const startedRevision = getSkillCatalogInvalidationRevision()
+      const previousExpiry = loadedScope.current?.expiresAt
       loadedScope.current = null
       const next = options.next?.trim() || undefined
       const append = Boolean(next && !options.forceRefresh && !options.replace)
@@ -40,7 +44,13 @@ export function useSkillCatalog({
       try {
         const result = await load({ next, forceRefresh: options.forceRefresh, signal: controller.signal })
         if (!controller.signal.aborted) {
-          loadedScope.current = { load, revision: startedRevision }
+          const fetchedAt = Date.parse(result.updatedAt)
+          const expiresAt = (Number.isFinite(fetchedAt) ? fetchedAt : Date.now()) + staleTimeMs
+          loadedScope.current = {
+            load,
+            revision: startedRevision,
+            expiresAt: append ? Math.min(previousExpiry ?? expiresAt, expiresAt) : expiresAt,
+          }
           dispatch({ type: "load-success", append, catalog: result, requestId: id })
         }
       } catch (cause) {
@@ -51,11 +61,16 @@ export function useSkillCatalog({
         if (activeRequest.current === controller) activeRequest.current = null
       }
     },
-    [load],
+    [load, staleTimeMs],
   )
 
   React.useEffect(() => {
-    if (enabled && (loadedScope.current?.load !== load || loadedScope.current.revision !== revision)) {
+    if (
+      enabled &&
+      (loadedScope.current?.load !== load ||
+        loadedScope.current.revision !== revision ||
+        Date.now() >= loadedScope.current.expiresAt)
+    ) {
       const replace = previousLoader.current !== load
       previousLoader.current = load
       void loadPage({ replace })


### PR DESCRIPTION
## Summary

Skill catalogs now refresh expired data when their tab is reopened while retaining fresh appended pages. The page and client share TTL constants, and loading another page does not extend the lifetime of older results.

Provider resolution no longer turns a temporary registry failure followed by an empty search into a 24-hour missing-package cache entry. A matching search result can still recover the lookup. Team configuration responses now reject malformed top-level data instead of replacing a valid configuration with an empty success.

Team reads share pending GETs by account and team, cancel when their last consumer leaves, and prevent superseded requests from repopulating the cache. UI state is also account-scoped, failed refreshes preserve previous data, and cold-load errors remain visible. Persistent cache initialization moves outside render and redundant normalization work is removed.

## Verification

- [x] `pnpm run ts-check`
- [x] `pnpm run lint`
- [x] `pnpm run format`
- [x] `pnpm exec vitest run --maxWorkers=2` — 3051 passed, 4 skipped
- [x] `pnpm run build:app`
- [x] Runtime/UI smoke: launched Wanta Local using `VITE_WANTA_ROUTE=skills corepack pnpm run dev:worktree`; verified market rows and package details render.

Regression coverage includes expired tab reentry, fresh pagination retention, oldest-page expiry after append, provider failure/recovery, malformed team responses, StrictMode request sharing, team/account switching, cancellation, forced-refresh races, and error visibility. Runtime smoke does not measure FPS or input latency; no install, publish, or delete operation was performed.

## Safety and Compatibility

- [x] Public catalog access and signed-in account/team request scopes remain separate; local BYOK behavior is unchanged.
- [x] No credential is introduced into renderer data, logs, fixtures, or committed files.
- [x] Agent tools, permissions, and system prompts are unaffected.
- [x] Endpoint derivation and pinned package versions are unchanged. Existing team-cache migration remains supported.
- [x] Relevant documentation and tests are updated.

Virtualization and parallel team writes are intentionally deferred pending performance measurements and server concurrency guarantees. Local audit artifacts are excluded from this PR.


Review follow-up: invalidation no longer aborts requests owned by other consumers; tests cover two consumers and late success/404 cache writes. Empty skill packages intentionally remain unavailable, with explicit regression coverage. The default-worker full run hit the existing 5-second Claude ACP bridge-test timeout; that test passed standalone and the complete suite passed with two workers, without changing timeouts or skipping tests.
