### PR TITLE
fix(chat): recover failed cancellation and fill artifact previews

### DIFF
--- a/electron/chat/generation-registry.ts
+++ b/electron/chat/generation-registry.ts
@@ -1,6 +1,8 @@
 export interface SessionGeneration {
   cancellationRequested?: boolean
   cancellationSettled?: boolean
+  cancellationFailed?: boolean
+  completionObserved?: boolean
   controller: AbortController
   id: string
   userMessageId: string

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -4665,7 +4665,66 @@ test("late tool events cannot use an old assistant to complete the current user 
   })
 })
 
-test("completion during cancellation cannot release the session or report success", async () => {
+test.each(["before", "after"] as const)(
+  "normal completion arriving %s a failed cancellation releases the turn and permits another send",
+  async (completionTiming) => {
+    const bridge = createBridgeAgent()
+    const service = new ChatServiceImpl(bridge.agent)
+    const events = captureServiceEvents(service)
+    service.startEventBridge()
+    await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+    bridge.emit({
+      type: "message.updated",
+      properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+    })
+    const runId = (await service.getActiveRun("session-1"))?.runId
+    let rejectCancel!: (error: Error) => void
+    bridge.abort.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectCancel = reject
+        }),
+    )
+    const finalizer = vi
+      .spyOn(
+        service as unknown as { finalizeTurnOutput: (sessionId: string, messageId?: string) => Promise<void> },
+        "finalizeTurnOutput",
+      )
+      .mockResolvedValue(undefined)
+    const stopping = service.stopGeneration("session-1")
+    const rejected = expect(stopping).rejects.toThrow("cancel transport unavailable")
+    await waitForCondition(() => bridge.abort.mock.calls.length === 1)
+    if (completionTiming === "before") {
+      bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+      expect(finalizer).not.toHaveBeenCalled()
+    }
+    expect(await service.hasActiveGeneration()).toBe(true)
+    rejectCancel(new Error("cancel transport unavailable"))
+    await rejected
+    if (completionTiming === "after") {
+      // Failure alone does not prove the runtime stopped or completed.
+      expect(await service.hasActiveGeneration()).toBe(true)
+      expect(finalizer).not.toHaveBeenCalled()
+      await expect(
+        service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "too early" }),
+      ).rejects.toThrow("A generation is already active")
+      bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+    }
+    await waitForCondition(() => events.some((event) => event.event === "messageCompleted"))
+    expect(await service.getActiveRun("session-1")).toBeNull()
+    expect(finalizer).toHaveBeenCalledExactlyOnceWith("session-1", "assistant-1")
+    expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
+      { sessionId: "session-1", runId, kind: "completed", messageId: "assistant-1" },
+    ])
+    expect(events.filter((event) => event.event === "generationStopped")).toHaveLength(0)
+    finalizer.mockRestore()
+    await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "second" })
+    expect(await service.hasActiveGeneration()).toBe(true)
+    await service.stopGeneration("session-1")
+  },
+)
+
+test("failed cancellation completion waits for terminal history instead of releasing on idle alone", async () => {
   const bridge = createBridgeAgent()
   const service = new ChatServiceImpl(bridge.agent)
   const events = captureServiceEvents(service)
@@ -4675,26 +4734,63 @@ test("completion during cancellation cannot release the session or report succes
     type: "message.updated",
     properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
   })
-  let release!: () => void
-  bridge.abort.mockImplementationOnce(
-    () =>
-      new Promise<void>((resolve) => {
-        release = resolve
-      }),
-  )
-  const runId = (await service.getActiveRun("session-1"))?.runId
-  const stopping = service.stopGeneration("session-1")
-  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
-  await new Promise((resolve) => setTimeout(resolve, 0))
-  expect(await service.getActiveRun("session-1")).not.toBeNull()
-  expect(events.filter((event) => event.event === "messageCompleted")).toHaveLength(0)
-  release()
-  await stopping
-  expect(await service.getActiveRun("session-1")).toBeNull()
-  expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
-    { sessionId: "session-1", runId, kind: "cancelled", messageId: "assistant-1" },
+  bridge.abort.mockRejectedValueOnce(new Error("cancel transport unavailable"))
+  await expect(service.stopGeneration("session-1")).rejects.toThrow("cancel transport unavailable")
+  const userMessageId = bridge.promptStreaming.mock.calls[0]?.[2]?.messageId as string
+  bridge.getMessages.mockResolvedValue([
+    { id: userMessageId, role: "user", createdAt: 1, parts: [] },
+    { id: "assistant-1", role: "assistant", createdAt: 2, completedAt: 3, finishReason: "tool-calls", parts: [] },
   ])
+  bridge.getMessages.mockClear()
+  bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+  await waitForCondition(() => bridge.getMessages.mock.calls.length >= 2)
+  expect(await service.hasActiveGeneration()).toBe(true)
+  expect(events.filter((event) => event.event === "messageCompleted")).toHaveLength(0)
+  bridge.getMessages.mockResolvedValue([
+    { id: userMessageId, role: "user", createdAt: 1, parts: [] },
+    { id: "assistant-1", role: "assistant", createdAt: 2, completedAt: 3, finishReason: "stop", parts: [] },
+  ])
+  await waitForCondition(() => events.some((event) => event.event === "messageCompleted"))
+  expect(await service.hasActiveGeneration()).toBe(false)
 })
+
+test.each([false, true])(
+  "completion during cancellation cannot release the session (previous failure: %s)",
+  async (previousFailure) => {
+    const bridge = createBridgeAgent()
+    const service = new ChatServiceImpl(bridge.agent)
+    const events = captureServiceEvents(service)
+    service.startEventBridge()
+    await service.sendMessage({ scope: testTeamScope, sessionId: "session-1", text: "first" })
+    bridge.emit({
+      type: "message.updated",
+      properties: { info: { id: "assistant-1", sessionID: "session-1", role: "assistant" } },
+    })
+    if (previousFailure) {
+      bridge.abort.mockRejectedValueOnce(new Error("cancel transport unavailable"))
+      await expect(service.stopGeneration("session-1")).rejects.toThrow("cancel transport unavailable")
+    }
+    let release!: () => void
+    bridge.abort.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        }),
+    )
+    const runId = (await service.getActiveRun("session-1"))?.runId
+    const stopping = service.stopGeneration("session-1")
+    bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(await service.getActiveRun("session-1")).not.toBeNull()
+    expect(events.filter((event) => event.event === "messageCompleted")).toHaveLength(0)
+    release()
+    await stopping
+    expect(await service.getActiveRun("session-1")).toBeNull()
+    expect(events.filter((event) => event.event === "turnOutcome").map((event) => event.data)).toEqual([
+      { sessionId: "session-1", runId, kind: "cancelled", messageId: "assistant-1" },
+    ])
+  },
+)
 
 test("late tool and activity events cannot mutate the replacement run or register child sessions", async () => {
   const bridge = createBridgeAgent()

--- a/electron/chat/node.test.ts
+++ b/electron/chat/node.test.ts
@@ -4696,6 +4696,7 @@ test.each(["before", "after"] as const)(
     await waitForCondition(() => bridge.abort.mock.calls.length === 1)
     if (completionTiming === "before") {
       bridge.emit({ type: "session.idle", properties: { sessionID: "session-1" } })
+      await new Promise((resolve) => setTimeout(resolve, 0))
       expect(finalizer).not.toHaveBeenCalled()
     }
     expect(await service.hasActiveGeneration()).toBe(true)

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1603,6 +1603,8 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     sessionId: string,
     generation: SessionGeneration,
   ): Promise<void> {
+    generation.completionObserved = true
+    if (!this.canCompleteGeneration(sessionId, generation)) return
     const completionKey = `${sessionId}\0${generation.id}`
     if (this.completionChecks.has(completionKey)) return
     this.clearCompletionRetry(completionKey, false)
@@ -1613,7 +1615,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         this.scheduleCompletionRetry(emit, sessionId, generation)
         return
       }
-      if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
+      if (!this.canCompleteGeneration(sessionId, generation)) return
       this.clearCompletionRetry(completionKey)
       const messageId = completedAssistant.id
       const completedRun = this.activeRuns.get(sessionId)
@@ -1621,7 +1623,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
       await this.finalizeTurnOutput(sessionId, messageId).catch((error: unknown) => {
         console.warn("[wanta] failed to finalize turn output", error)
       })
-      if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
+      if (!this.canCompleteGeneration(sessionId, generation)) return
       this.clearSessionGeneration(sessionId, generation.id)
       this.activeAssistantMessages.delete(sessionId)
       this.activeToolParts.delete(sessionId)
@@ -1645,6 +1647,16 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     }
   }
 
+  private canCompleteGeneration(sessionId: string, generation: SessionGeneration): boolean {
+    // Keep the dispatch signal aborted: replacing it could resume cancelled setup.
+    // A failed cancel may still be followed by a verified normal runtime completion.
+    return (
+      this.isCurrentGeneration(sessionId, generation.id) &&
+      !this.stoppingGenerations.has(generation.id) &&
+      (!generation.controller.signal.aborted || generation.cancellationFailed === true)
+    )
+  }
+
   private async completedTurnAssistant(
     sessionId: string,
     generation: SessionGeneration,
@@ -1658,7 +1670,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     const userIndex = messages.findIndex(
       (message) => message.id === generation.userMessageId && message.role === "user",
     )
-    if (userIndex < 0 || generation.controller.signal.aborted) return undefined
+    if (userIndex < 0 || !this.canCompleteGeneration(sessionId, generation)) return undefined
     // Only messages after this turn's user message can prove its completion.
     // A delayed tool event may still point activeAssistantMessages at an old turn.
     const turnMessages = messages.slice(userIndex + 1)
@@ -1678,7 +1690,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     sessionId: string,
     generation: SessionGeneration,
   ): void {
-    if (!this.isCurrentGeneration(sessionId, generation.id) || generation.controller.signal.aborted) return
+    if (!this.canCompleteGeneration(sessionId, generation)) return
     const completionKey = `${sessionId}\0${generation.id}`
     if (this.completionRetryTimers.has(completionKey)) return
     const attempt = this.completionRetryAttempts.get(completionKey) ?? 0
@@ -1922,11 +1934,17 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
     const key = generation?.id ?? `session:${sessionId}`
     const existing = this.stoppingGenerations.get(key)
     if (existing) return existing
+    if (generation) generation.cancellationFailed = false
     if (generation && options.reason === "user") generation.cancellationRequested = true
     const stopping = Promise.resolve()
       .then(() => this.performStopSessionGeneration(sessionId, generation, options))
       .finally(() => {
         if (this.stoppingGenerations.get(key) === stopping) this.stoppingGenerations.delete(key)
+        if (generation?.cancellationFailed && generation.completionObserved) {
+          // An idle event may have arrived while cancellation was still pending.
+          // Recheck history only after the stop operation releases its ownership.
+          void this.completeSessionGeneration(this.send.bind(this), sessionId, generation)
+        }
       })
     this.stoppingGenerations.set(key, stopping)
     generation?.controller.abort()
@@ -1957,6 +1975,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           options.throwOnAbortFailure &&
           (messageId || !generation || externalAgentKindForSessionId(sessionId))
         ) {
+          if (generation && this.generations.get(sessionId) === generation) generation.cancellationFailed = true
           this.userStops.delete(sessionId)
           throw error
         }

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1943,7 +1943,11 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
         if (generation?.cancellationFailed && generation.completionObserved) {
           // An idle event may have arrived while cancellation was still pending.
           // Recheck history only after the stop operation releases its ownership.
-          void this.completeSessionGeneration(this.send.bind(this), sessionId, generation)
+          void this.completeSessionGeneration(
+            this.send.bind(this) as (event: string, data: unknown) => Promise<void>,
+            sessionId,
+            generation,
+          )
         }
       })
     this.stoppingGenerations.set(key, stopping)

--- a/src/routes/Chat/ArtifactDocxPreview.tsx
+++ b/src/routes/Chat/ArtifactDocxPreview.tsx
@@ -111,7 +111,7 @@ export default function ArtifactDocxPreview({
   }, [onResourceError, onResourceLoaded, source])
 
   return (
-    <div className="flex min-h-full min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)]">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)]">
       <div className="oo-border-divider flex h-10 shrink-0 items-center border-b bg-background px-3">
         <div className="oo-text-caption-compact truncate font-medium text-foreground">{name}</div>
       </div>

--- a/src/routes/Chat/ArtifactPreviewPane.tsx
+++ b/src/routes/Chat/ArtifactPreviewPane.tsx
@@ -224,7 +224,7 @@ export function ArtifactPreview({
         )}
       >
         {spreadsheetSelected ? (
-          <div className={cn("min-h-full", (activeMode !== "preview" || !spreadsheetReady) && "hidden")}>
+          <div className={cn("h-full min-h-0", (activeMode !== "preview" || !spreadsheetReady) && "hidden")}>
             <ErrorBoundary
               resetKey={preview ?? fileKey}
               fallback={<ArtifactUnavailablePreview item={item} preview={preview} onOpen={onOpen} onRetry={retry} />}
@@ -238,8 +238,8 @@ export function ArtifactPreview({
         <div
           key={fileKey}
           className={cn(
-            !(spreadsheetSelected && spreadsheetReady && activeMode === "preview") && "min-h-full",
-            activeMode === "preview" && (preview?.kind === "pdf" || isHtmlArtifact(item)) && "h-full",
+            "h-full min-h-0",
+            spreadsheetSelected && spreadsheetReady && activeMode === "preview" && "hidden",
           )}
         >
           {activeMode === "info" ? (
@@ -404,8 +404,8 @@ function ArtifactSpreadsheetLoadingPreview() {
   const t = useT()
 
   return (
-    <div className="flex min-h-full min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)] p-3">
-      <div className="oo-univer-spreadsheet-preview oo-border-divider relative min-h-[420px] flex-1 overflow-hidden rounded-md border bg-background">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)] p-3">
+      <div className="oo-univer-spreadsheet-preview oo-border-divider relative min-h-0 flex-1 overflow-hidden rounded-md border bg-background">
         <div className="oo-text-body absolute inset-0 flex items-center justify-center px-4 py-8 text-muted-foreground">
           {t("artifacts.previewLoading")}
         </div>
@@ -515,13 +515,13 @@ function ArtifactVideoPreview({
   }
 
   return (
-    <div className="flex min-h-full items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
+    <div className="flex h-full min-h-0 items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
       <video
         src={source}
         controls
         playsInline
         preload="metadata"
-        className="max-h-full max-w-full rounded-md bg-black shadow-sm"
+        className="max-h-full max-w-full rounded-md bg-black object-contain shadow-sm"
         onLoadedData={onResourceLoaded}
         onError={(event) => {
           if (event.currentTarget.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
@@ -575,7 +575,7 @@ export function ArtifactConsumablePreview({
 
   if (preview?.kind === "image" && resourceSource) {
     return (
-      <div className="flex min-h-full items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
+      <div className="flex h-full min-h-0 items-center justify-center bg-[var(--oo-artifact-preview-canvas)] p-4">
         <img
           src={resourceSource}
           alt={item.name}

--- a/src/routes/Chat/ArtifactUniverSpreadsheetPreview.tsx
+++ b/src/routes/Chat/ArtifactUniverSpreadsheetPreview.tsx
@@ -213,8 +213,8 @@ export function ArtifactUniverSpreadsheetPreview({
   }, [enUSMessages, univerLocale])
 
   return (
-    <div className={cn("flex min-h-full min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)] p-3", className)}>
-      <div className="oo-univer-spreadsheet-preview oo-border-divider relative min-h-[420px] flex-1 overflow-hidden rounded-md border bg-background">
+    <div className={cn("flex h-full min-h-0 min-w-0 flex-col bg-[var(--oo-artifact-preview-canvas)] p-3", className)}>
+      <div className="oo-univer-spreadsheet-preview oo-border-divider relative min-h-0 flex-1 overflow-hidden rounded-md border bg-background">
         {localeMessages ? (
           <ArtifactUniverRuntimeHost
             key={runtimeConfigKey}


### PR DESCRIPTION
A failed Stop request could leave a chat task permanently active even after the runtime finished normally. Artifact previews also lost their height constraint after the preview lifecycle refactor, leaving spreadsheet canvases at 420px and other preview surfaces short of the panel bottom.

The chat service now distinguishes failed cancellation from cancellation still in progress. It permits normal completion only after verifying the current turn's terminal assistant response, and rechecks completion notifications received while Stop was pending. It preserves the aborted dispatch signal and guards against competing cancellation cleanup. Regression tests cover completion before/after cancellation failure, delayed terminal history, and a successful second Stop.

Preview wrappers now provide a definite, shrinkable height. Spreadsheet canvases and loading placeholders fill the available space while retaining runtime reuse; the unused preview wrapper is hidden. Images and video fit and center without stretching, audio regains its full-height surrounding area, and DOCX scrolls inside a full-height viewport.

Validation during implementation:
- `corepack pnpm run lint` passed again before this PR.
- Production build, TypeScript checking, formatting, and diff whitespace checks passed on the combined fixes.
- Full unit suite after the cancellation fix: 3141 passed, 4 skipped. After the layout changes, all 22 tests in the four targeted preview test files passed.
- 41 local Electron geometry and interaction checks passed with synthetic preview fixtures: short/tall windows, reduced preview area, CSV/XLSX runtime reuse, info/preview toggles, truncation notices, PDF/HTML/DOCX, and ordinary/gallery media.

The Electron fixture checks do not validate a signed installer or live agent transport failure. Local audit documents, screenshots, and temporary harnesses are excluded from this PR.
