### PR TITLE
fix(skills): correct launcher environment approval classification

### DIFF
--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -86,10 +86,13 @@ permission classifier—not an adapter-specific rule—decides whether a command
 safe to run without a redundant approval card.
 
 Shell setup is classified by its operation: a plain `export NAME=value`
-assignment is ordinary local work, while environment dumps (`export`,
-`export -p`, `env`, `printenv`) remain blocked. Assignment values containing
-executable shell syntax do not qualify for this exception. Every subsequent
-command still receives the credential, runtime-override, and consequential
+assignment is ordinary local work only when it does not involve protected
+credentials or runtime configuration. Assignments containing `OO_API_KEY` or
+`OO_CONNECTOR_TOKEN` remain denied as `credential_reference`; assignments to
+`OO_ENDPOINT` remain denied as `runtime_environment_override`. Environment
+dumps (`export`, `export -p`, `env`, `printenv`) remain blocked. Assignment
+values containing executable shell syntax do not qualify for this exception.
+Every subsequent command still receives the credential, runtime-override, and consequential
 operation checks, including commands wrapped in a shell. Managed Skill
 runners should reuse the host-injected PATH and `WANTA_OO_BIN`, passing the
 managed executable to child CLI calls instead of rebuilding PATH. The GPT

--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -85,6 +85,18 @@ Loaded Skill instructions keep Connector work on that managed CLI. The shared
 permission classifier—not an adapter-specific rule—decides whether a command is
 safe to run without a redundant approval card.
 
+Shell setup is classified by its operation: a plain `export NAME=value`
+assignment is ordinary local work, while environment dumps (`export`,
+`export -p`, `env`, `printenv`) remain blocked. Assignment values containing
+executable shell syntax do not qualify for this exception. Every subsequent
+command still receives the credential, runtime-override, and consequential
+operation checks, including commands wrapped in a shell. Managed Skill
+runners should reuse the host-injected PATH and `WANTA_OO_BIN`, passing the
+managed executable to child CLI calls instead of rebuilding PATH. The GPT
+Image 2 runtime-copy guidance documents its `--oo` option for this purpose.
+Automatic local-access decisions record a stable reason in diagnostics;
+denial reasons contain no command arguments or credential values.
+
 ## Kernel contract
 
 `HostCapabilityKernel` is the single registry and execution boundary for

--- a/electron/agent/oo-command-permission.test.ts
+++ b/electron/agent/oo-command-permission.test.ts
@@ -118,3 +118,37 @@ test("OpenConnector policy denies mutations hidden behind leading oo global flag
     assert.equal(openConnectorCommandPolicy(command), "allow", command)
   }
 })
+
+test("export assignments are ordinary commands while environment dumps remain denied", () => {
+  for (const command of [
+    'export PATH="/managed/bin:$PATH"',
+    'export PATH="/managed/bin:${PATH}"; cd /tmp; BUN_BE_BUN=1 oo /managed/run_image.js --mode edit',
+    "export LANG=en_US.UTF-8 OUTPUT='/tmp/output with spaces'",
+    "export LABEL='literal $(printenv)'",
+    `bash -lc 'export PATH="/managed/bin:/usr/bin"; node /tmp/run_image.js'`,
+  ]) {
+    assert.equal(openConnectorCommandPolicy(command), null, command)
+  }
+  for (const command of [
+    "export",
+    "export -p",
+    "export PATH",
+    "export PATH=/tmp -p",
+    "export -p PATH=/tmp",
+    'export PATH="$(printenv)"',
+    "export PATH=`printenv`",
+    'export PATH="/managed/bin:$PATH"; printenv',
+    'export PATH="/managed/bin:$PATH" && export -p',
+    'export PATH="/managed/bin:$PATH"; oo --debug config set endpoint https://other.test',
+    `export PATH="/managed/bin:$PATH"; bash -lc 'oo --debug auth login'`,
+    `export PATH="/managed/bin:$PATH"; bash -lc 'export -p'`,
+    "export OO_ENDPOINT=https://other.test",
+    'export OUTPUT="$OO_API_KEY"',
+    "env",
+    "set",
+    "declare -x",
+    "typeset -x",
+  ]) {
+    assert.equal(openConnectorCommandPolicy(command), "deny", command)
+  }
+})

--- a/electron/agent/oo-command-permission.ts
+++ b/electron/agent/oo-command-permission.ts
@@ -1,3 +1,5 @@
+import { topLevelShellSegments } from "../chat/shell-syntax.ts"
+
 export const OO_CLI_BASH_PERMISSION = {
   // 直接 oo 调用走 OpenCode 快速路径；其它 shell 进入 ChatService 默认访问策略，
   // 由主进程自动批准普通 bash，仅在基础安全边界暂停。
@@ -132,7 +134,21 @@ function shellWords(command: string): string[] | null {
 }
 
 function isEnvironmentDump(command: string): boolean {
-  if (environmentDumpCommand.test(command)) return true
+  for (const { text } of topLevelShellSegments(command)) {
+    if (!environmentDumpCommand.test(text)) continue
+    const words = shellWords(text)
+    // `export NAME=value` sets variables without printing the environment.
+    // Admit only assignments with no executable shell syntax; all remaining
+    // segments still pass through the normal command and credential policies.
+    if (
+      words?.[0] === "export" &&
+      words.length > 1 &&
+      words.slice(1).every((word) => /^[A-Za-z_][A-Za-z0-9_]*=/u.test(word)) &&
+      !hasUnsafeShellSyntax(text)
+    )
+      continue
+    return true
+  }
   const words = shellWords(command)
   if (!words || !["bash", "sh", "zsh"].includes(words[0] ?? "")) return false
   return words.slice(1).some((word) => ["env", "printenv", "set", "export"].includes(word))
@@ -295,19 +311,53 @@ export function isOoCliCommand(command: string): boolean {
   return false
 }
 
+export type OoCommandDenyReason =
+  | "credential_reference"
+  | "environment_dump"
+  | "runtime_environment_override"
+  | "runtime_auth_mutation"
+  | "runtime_option_override"
+
+function directCommandDenyReason(command: string): OoCommandDenyReason | null {
+  if (credentialEnvironmentReference.test(command)) return "credential_reference"
+  if (isEnvironmentDump(command)) return "environment_dump"
+  if (linkEnvironmentAssignment.test(command)) return "runtime_environment_override"
+  if (forbiddenOoMutation.test(command) || isForbiddenOoMutationCommand(command)) return "runtime_auth_mutation"
+  if (ooCommandSegment.test(command) && forbiddenOoOption.test(command)) return "runtime_option_override"
+  return null
+}
+
+/** Stable metadata only: never return command text, values, or credentials. */
+export function ooCommandDenyReason(command: string): OoCommandDenyReason | null {
+  return inspectCommandDenyReason(command, 0)
+}
+
+function inspectCommandDenyReason(command: string, startDepth: number): OoCommandDenyReason | null {
+  let current = command.trim()
+  for (let depth = startDepth; depth < maxShellWrapperDepth; depth += 1) {
+    const reason = directCommandDenyReason(current)
+    if (reason) return reason
+    // Inspect each command after an assignment prefix too, including global
+    // flags before protected OO subcommands.
+    for (const { text } of topLevelShellSegments(current)) {
+      const segmentReason = directCommandDenyReason(text)
+      if (segmentReason) return segmentReason
+      if (text !== current) {
+        const nestedReason = inspectCommandDenyReason(text, depth + 1)
+        if (nestedReason) return nestedReason
+      }
+    }
+    const wrapper = shellWrapperCommand(current)
+    if (wrapper.kind !== "command") return null
+    current = wrapper.command
+  }
+  return null
+}
+
 export function openConnectorCommandPolicy(command: string): "allow" | "deny" | null {
+  if (ooCommandDenyReason(command)) return "deny"
   let current = command.trim()
   for (let depth = 0; depth < maxShellWrapperDepth; depth += 1) {
-    if (
-      credentialEnvironmentReference.test(current) ||
-      isEnvironmentDump(current) ||
-      linkEnvironmentAssignment.test(current) ||
-      forbiddenOoMutation.test(current) ||
-      isForbiddenOoMutationCommand(current) ||
-      (ooCommandSegment.test(current) && forbiddenOoOption.test(current))
-    ) {
-      return "deny"
-    }
     if (isPureOoCliCommand(current)) return "allow"
     const wrapper = shellWrapperCommand(current)
     if (wrapper.kind === "unsupported" || wrapper.kind === "not_wrapper") return null

--- a/electron/chat/local-access-policy.test.ts
+++ b/electron/chat/local-access-policy.test.ts
@@ -319,7 +319,7 @@ test("local access policy rejects OpenConnector credential and configuration com
     "echo $OO_CONNECTOR_TOKEN",
     "echo ${OO_API_KEY}",
   ]) {
-    assert.deepEqual(
+    assert.partialDeepStrictEqual(
       evaluateLocalAccessRequest(permission({ metadata: { command } }), {
         linkRuntime: "openconnector",
         permissionMode: "full_access",
@@ -852,7 +852,7 @@ test("unexpanded env and tilde paths are not treated as in-project .env files", 
   )
 })
 
-test("compound redirects after a dependency install still prompt", () => {
+test("environment dumps after a dependency install remain denied", () => {
   const processRoot = "/tmp/wanta/process/turn-1"
   assert.equal(
     evaluateLocalAccessRequest(permission({ metadata: { command: "npm install marked > /tmp/install.log;env" } }), {
@@ -860,7 +860,7 @@ test("compound redirects after a dependency install still prompt", () => {
       taskProcessRoot: processRoot,
       commandCwd: processRoot,
     }).type,
-    "prompt",
+    "deny",
   )
 })
 
@@ -1562,5 +1562,52 @@ test("BYOA never makes the pre-BYOA OpenCode local-operation floor stricter", ()
       `BYOA decision diverged for ${item.request.action}: ${item.request.metadata?.command ?? item.request.resources.join(" ")}`,
     )
     if (item.ordinary) assert.equal(builtInDecision.type, "allow")
+  }
+})
+
+test("skill launch assignments preserve shared adapter permissions and consequential boundaries", () => {
+  const prefix = 'export PATH="/managed/agent/bin:$PATH"; cd /tmp; '
+  const runner =
+    'BUN_BE_BUN=1 oo "/managed/skills/gpt-image-2/scripts/run_image.js" --mode edit --prompt "Edit the tablecloth" --image /tmp/input.png --out-dir /tmp/result'
+  for (const isExternalSession of [false, true]) {
+    const context = { permissionMode: "default" as const, isExternalSession, linkRuntime: "oomol" as const }
+    assert.deepEqual(evaluateLocalAccessRequest(permission({ metadata: { command: prefix + runner } }), context), {
+      type: "allow",
+      reason: "default_command",
+      kind: "command",
+      highRisk: false,
+    })
+    for (const suffix of ["; git push origin main", "; cat ~/.ssh/id_rsa", "; rm -rf /Users/example/Documents"]) {
+      assert.equal(
+        evaluateLocalAccessRequest(permission({ metadata: { command: prefix + runner + suffix } }), context).type,
+        "prompt",
+      )
+    }
+    assert.deepEqual(evaluateLocalAccessRequest(permission({ metadata: { command: prefix + "printenv" } }), context), {
+      type: "deny",
+      reason: "environment_dump",
+      kind: "command",
+      highRisk: false,
+    })
+  }
+})
+
+test("automatic denials carry specific metadata without command values", () => {
+  for (const [command, reason] of [
+    ["echo $OO_API_KEY", "credential_reference"],
+    ["export -p", "environment_dump"],
+    ["export OO_ENDPOINT=https://other.test", "runtime_environment_override"],
+    ["oo auth login", "runtime_auth_mutation"],
+    ["oo connector apps --connector-token secret-value", "runtime_option_override"],
+  ]) {
+    assert.deepEqual(
+      evaluateLocalAccessRequest(permission({ metadata: { command } }), { permissionMode: "full_access" }),
+      {
+        type: "deny",
+        reason,
+        kind: "command",
+        highRisk: false,
+      },
+    )
   }
 })

--- a/electron/chat/local-access-policy.ts
+++ b/electron/chat/local-access-policy.ts
@@ -1,8 +1,9 @@
+import type { OoCommandDenyReason } from "../agent/oo-command-permission.ts"
 import type { ActiveLinkRuntime } from "../link-runtime/common.ts"
 import type { AgentPermissionMode, ChatPermissionRequest, LocalPermissionPromptReason } from "./common.ts"
 import type { PermissionRequestKind, SessionPermissionGrant } from "./permission-request.ts"
 
-import { openConnectorCommandPolicy } from "../agent/oo-command-permission.ts"
+import { ooCommandDenyReason } from "../agent/oo-command-permission.ts"
 import { isLowConsequenceCleanupCommand } from "./bounded-cleanup.ts"
 import {
   createSessionPermissionGrant,
@@ -57,6 +58,7 @@ export type LocalAccessDecision =
   | {
       highRisk: boolean
       kind: PermissionRequestKind
+      reason: OoCommandDenyReason | "diagnostic_capability" | "diagnostic_scope"
       type: "deny"
     }
 
@@ -181,10 +183,10 @@ function evaluateDiagnosticTurnAccess(
   const kind = permissionRequestKind(request)
   const highRisk = isHighRiskPermissionRequest(request, permissionScope(request, context))
   if (kind === "network" || isWantaHostToolPermissionRequest(request) || isOoCliPermissionRequest(request)) {
-    return { type: "deny", kind, highRisk }
+    return { type: "deny", reason: "diagnostic_capability", kind, highRisk }
   }
   if (!diagnosticRequestInsideRoots(request, roots)) {
-    return { type: "deny", kind, highRisk }
+    return { type: "deny", reason: "diagnostic_scope", kind, highRisk }
   }
   return undefined
 }
@@ -205,9 +207,8 @@ function evaluateBaselineLocalAccessRequest(
   // so switching from OpenCode to Claude/Codex does not add a redundant shell
   // approval. Unknown shell composition, sensitive resources, and high-risk
   // commands continue through the shared Wanta permission flow.
-  const openConnectorPolicy =
-    kind === "command" ? openConnectorCommandPolicy(command ?? request.resources.join(" ")) : null
-  if (openConnectorPolicy === "deny") return { type: "deny", kind, highRisk }
+  const denyReason = kind === "command" ? ooCommandDenyReason(command ?? request.resources.join(" ")) : null
+  if (denyReason) return { type: "deny", reason: denyReason, kind, highRisk }
   // OO is a first-party Wanta capability channel. Once a request is proven to
   // be a pure managed OO invocation, do not add a shell, upload, download, or
   // execution confirmation in any adapter. The managed OO guard remains the

--- a/electron/chat/node.ts
+++ b/electron/chat/node.ts
@@ -1318,6 +1318,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           {
             adapter: this.agentAdapterForDiagnostic(displaySessionId),
             decision: decision.type,
+            reason: decision.reason,
             generationId: activeGenerationId,
             permissionKind: decision.kind,
             requestId: request.id,
@@ -1343,7 +1344,7 @@ export class ChatServiceImpl extends ConnectionService<ChatService> implements I
           {
             action: request.action,
             error,
-            reason: decision.type === "allow" ? decision.reason : "openconnector_denied",
+            reason: decision.reason,
             sessionId: request.sessionId,
           },
           "warn",

--- a/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.test.ts
@@ -65,6 +65,8 @@ describe("GPT Image 2 runtime compatibility", () => {
 
     expect(patched).toContain("do not pass `--team`")
     expect(patched).toContain("`OO_TEAM_ID` or `OO_TEAM_NAME`")
+    expect(patched).toContain("Reuse the inherited PATH and WANTA_OO_BIN")
+    expect(patched).toContain("runner's `--oo` option")
     expect(patched).not.toContain("Wanta local image delivery")
     expect(patched).not.toContain("Duplicate local image delivery guidance")
     expect(patchGptImage2RuntimeInstructions(patched)).toBe(patched)

--- a/electron/skills/gpt-image-2-windows-runtime-fix.ts
+++ b/electron/skills/gpt-image-2-windows-runtime-fix.ts
@@ -18,6 +18,8 @@ const teamScopeInstructions = [
   "For direct raw `oo` commands used by this GPT Image 2 runner, do not pass `--team`; the bundled oo CLI does not support that global flag.",
   "When authentication uses `OO_API_KEY`, `oo team use` does not persist a default team. Set `OO_TEAM_ID` or `OO_TEAM_NAME` in the environment for that command instead.",
   "This guidance applies to direct `oo` calls only and does not change Wanta-managed connector workspace selection.",
+  "Wanta supplies the CLI environment. Reuse the inherited PATH and WANTA_OO_BIN; do not prepend `export PATH=...` or discover a different oo binary for this runner.",
+  "When invoking the runner with a JavaScript runtime, use that runtime to execute the script and, when WANTA_OO_BIN is set, pass its value through the runner's `--oo` option for child CLI calls. Keep the inherited environment and Wanta-managed workspace scope.",
   teamScopeInstructionsEnd,
 ].join("\n")
 
@@ -45,7 +47,7 @@ export function patchWindowsGptImage2Runner(source: string): string {
     )
 }
 
-/** Keeps only Wanta-specific team guidance; image delivery is native in gpt-image-2 1.1.2+. */
+/** Keeps Wanta's CLI environment/team guidance; image delivery is native in gpt-image-2 1.1.2+. */
 export function patchGptImage2RuntimeInstructions(source: string): string {
   const lineEnding = source.includes("\r\n") ? "\r\n" : "\n"
   const withoutLegacyImageInstructions = removeRuntimeInstructions(


### PR DESCRIPTION
## Summary

Skill launchers that start with `export PATH="...:$PATH"; cd ...; BUN_BE_BUN=1 oo ...` were rejected as environment dumps. Treat plain export assignments as ordinary local work while preserving checks on subsequent commands, executable substitutions, sensitive resources, and managed runtime overrides.

- Inspect compound commands and nested shell wrappers for environment dumps and protected OO mutations.
- Add specific denial reasons to local-access decisions and metadata-only diagnostics.
- Update GPT Image 2 runtime-copy guidance to reuse the inherited PATH and pass WANTA_OO_BIN through the runner's `--oo` option.
- Add regression coverage for the image-runner command shape, adapter parity, and protected operations; document the behavior.

## Verification

- [x] `corepack pnpm run ts-check`
- [x] `corepack pnpm run lint` (entire repository)
- [ ] `corepack pnpm run format`
- [ ] `corepack pnpm test`
- [ ] `corepack pnpm run build`
- [x] Runtime/UI verification completed or not applicable

Targeted verification: 206 tests passed across command policy, local-access policy, chat service, permission diagnostics/state, renderer permission helpers, ACP/external command environments, and GPT Image 2 runtime compatibility. Changed files were formatted and `git diff --check` passed.

Started the development app with `corepack pnpm run dev`; Electron and the agent sidecar started successfully, then the dev process was stopped. Startup also reported a knowledge database schema migration warning. A real image-generation end-to-end run was not performed. The full test suite, full format check, and production build were not run.

## Safety and Compatibility

- [x] Local BYOK and signed-in OOMOL modes were considered separately.
- [x] No credential was exposed to the renderer, logs, fixtures, screenshots, or committed files.
- [x] Agent tools, permissions, and system prompts remain aligned, or the change does not affect them.
- [x] Migration, packaging, endpoint, and update implications were considered.
- [x] Relevant documentation and tests were updated.

The shared local-access policy keeps adapter parity and does not depend on model-provider authentication. Environment dumps, credential references, and managed runtime mutations remain blocked, including in full-access mode. Consequential commands still require confirmation in default mode. No Skill-directory trust exemption or credential/endpoint changes were introduced. Runtime guidance is applied only to Wanta's private Skill copy; no data migration is required.
