### PR TITLE
Upgrade oo CLI and enable single HTML website deployment

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -40,7 +40,7 @@ is included in this repository's [`LICENSE`](LICENSE) file.
 
 ## oo CLI and Bundled Skills
 
-Wanta downloads and packages `@oomol-lab/oo-cli@1.7.12` platform binaries from the public npm
+Wanta downloads and packages `@oomol-lab/oo-cli@1.9.0` platform binaries from the public npm
 registry. The default package also contains four Skills exported by that distribution:
 
 - `oo`;

--- a/docs/ai/host-capabilities.md
+++ b/docs/ai/host-capabilities.md
@@ -199,6 +199,14 @@ run and publish execute without a separate user confirmation. Project
 switching, Flow deletion or rollback, run cancellation, and browser-opening
 commands remain closed until they receive separate host semantics.
 
+Single-file website deployment uses `oo website upload` with an active OOMOL
+runtime. The managed external-agent boundary accepts one regular `.html` or
+`.htm` file under the active turn's managed roots, capped at 20,000,000 bytes.
+The enabled default Registry Skill `@alwaysmavs/oo-deploy-single-html` is installed
+after login without a version selector, so a new installation fetches the latest
+published version. Existing installations retain the normal Skill update and
+user-removal behavior.
+
 ### Phase 4: Skill registry and task snapshots
 
 Delivered foundation: `SkillRegistry` resolves a deterministic current-turn

--- a/electron/agent/external/oo-capability-contract.test.ts
+++ b/electron/agent/external/oo-capability-contract.test.ts
@@ -31,6 +31,12 @@ describe("external OO capability contract", () => {
     })
     expect(resolveExternalOoOperation(["logout"])).toMatchObject({ availability: "denied", id: "logout" })
     expect(resolveExternalOoOperation(["unknown"])).toBeUndefined()
+    expect(resolveExternalOoOperation(["website", "upload", "index.html", "--json"])).toMatchObject({
+      availability: "enabled",
+      effect: "external_action",
+      id: "website.upload",
+    })
+    expect(resolveExternalOoOperation(["website", "delete", "demo"])).toBeUndefined()
   })
 
   it("generates Skill guidance from the same operation table", () => {

--- a/electron/agent/external/oo-capability-contract.ts
+++ b/electron/agent/external/oo-capability-contract.ts
@@ -68,6 +68,13 @@ export const EXTERNAL_OO_OPERATIONS = [
     workspace: "optional",
   },
   {
+    id: "website.upload",
+    command: ["website", "upload"],
+    availability: "enabled",
+    effect: "external_action",
+    workspace: "optional",
+  },
+  {
     id: "file.download",
     command: ["file", "download"],
     availability: "enabled",

--- a/electron/agent/external/oo-command-safety.test.ts
+++ b/electron/agent/external/oo-command-safety.test.ts
@@ -30,6 +30,40 @@ async function fixture(runtime: "none" | "oomol" | "openconnector" = "oomol") {
 }
 
 describe("managed OO command safety", () => {
+  test("allows one managed HTML upload and rejects invalid deployment inputs", async () => {
+    const { binding, cwd, scope } = await fixture()
+    const input = path.join(cwd, "index.html")
+    await writeFile(input, "<!doctype html><title>Test</title>")
+    await expect(
+      prepareManagedExternalOoCommand(
+        ["website", "upload", "index.html", "--team", "Team A", "--json"],
+        binding,
+        scope,
+      ),
+    ).resolves.toEqual(["website", "upload", input, "--team", "Team A", "--json"])
+    await expect(
+      prepareManagedExternalOoCommand(["website", "upload", "index.html", "index.html"], binding, scope),
+    ).rejects.toThrow(/exactly one HTML/u)
+    await writeFile(path.join(cwd, "input.txt"), "text")
+    await expect(prepareManagedExternalOoCommand(["website", "upload", "input.txt"], binding, scope)).rejects.toThrow(
+      /requires an HTML/u,
+    )
+    await writeFile(input, Buffer.alloc(20_000_001))
+    await expect(prepareManagedExternalOoCommand(["website", "upload", input], binding, scope)).rejects.toThrow(
+      /larger than 20 MB/u,
+    )
+    const other = await fixture("openconnector")
+    await expect(
+      prepareManagedExternalOoCommand(["website", "upload", input], other.binding, other.scope),
+    ).rejects.toThrow(/active OOMOL workspace/u)
+    const outside = await fixture()
+    await writeFile(path.join(outside.cwd, "index.html"), "<!doctype html>")
+    await symlink(path.join(outside.cwd, "index.html"), path.join(cwd, "escape.html"))
+    await expect(prepareManagedExternalOoCommand(["website", "upload", "escape.html"], binding, scope)).rejects.toThrow(
+      /outside the active turn/u,
+    )
+  })
+
   test("canonicalizes managed uploads and rejects reads outside the turn", async () => {
     const { binding, cwd, root, scope } = await fixture()
     const input = path.join(cwd, "input.txt")

--- a/electron/agent/external/oo-command-safety.ts
+++ b/electron/agent/external/oo-command-safety.ts
@@ -8,6 +8,7 @@ import path from "node:path"
 import { externalOoRootCommandIndex, resolveExternalOoOperation } from "./oo-capability-contract.ts"
 
 const maxUploadBytes = 500 * 1024 * 1024
+const maxWebsiteUploadBytes = 20_000_000
 const maxFlowRequestBytes = 8 * 1024 * 1024
 const forbiddenRuntimeOptions = new Set([
   "--config-dir",
@@ -285,6 +286,23 @@ async function prepareFileCommand(
   return args
 }
 
+function prepareWebsiteUpload(args: string[], binding: ExternalGuardCwdBinding, scope: WorkspaceTeamScope): string[] {
+  requireOomolRuntime(scope, "website upload")
+  const root = externalOoRootCommandIndex(args)
+  const inputs = positionalIndices(args, root + 2, new Set(["--format", "--team", "--lang"]))
+  if (inputs.length !== 1) throw new Error("Wanta managed website upload requires exactly one HTML file path.")
+  const inputIndex = inputs[0]!
+  const canonical = requireManagedExistingFile(args[inputIndex]!, binding, scope)
+  if (!/\.html?$/iu.test(canonical)) {
+    throw new Error("Wanta managed website upload requires an HTML file.")
+  }
+  if (statSync(canonical).size > maxWebsiteUploadBytes) {
+    throw new Error("Wanta managed website upload rejected a file larger than 20 MB.")
+  }
+  args[inputIndex] = canonical
+  return args
+}
+
 function rewriteManagedFileReferences(
   args: string[],
   binding: ExternalGuardCwdBinding,
@@ -338,6 +356,9 @@ export async function prepareManagedExternalOoCommand(
   const args = [...input]
   rejectRuntimeOverrides(args)
   const operation = resolveExternalOoOperation(args)
+  if (operation?.id === "website.upload") {
+    return prepareWebsiteUpload(args, binding, scope)
+  }
   if (operation?.id === "file.upload" || operation?.id === "file.download") {
     return prepareFileCommand(args, binding, scope)
   }

--- a/electron/agent/oo-guard-runtime.test.ts
+++ b/electron/agent/oo-guard-runtime.test.ts
@@ -65,6 +65,19 @@ async function runGuard(args: string[], env: NodeJS.ProcessEnv): Promise<string>
   return result.stdout
 }
 
+test("routes website uploads through the external managed CLI", async () => {
+  const { env, root } = await fixture({
+    external: true,
+    runtime: "oomol",
+    sessionRuntimes: { "session-a": "oomol" },
+    sessionTeams: { "session-a": "Team A" },
+  })
+  const input = path.join(root, "index.html")
+  await writeFile(input, "<!doctype html><title>Test</title>")
+  const output = await runGuard(["website", "upload", "index.html", "--json"], env)
+  expect(output.trim().split("\n")).toEqual(["website", "upload", input, "--json"])
+})
+
 describe("external OO guard runtime", () => {
   test("preserves a managed shell cwd for relative OOCLI data files", async () => {
     const { env, root } = await fixture(

--- a/electron/agent/oo-version.ts
+++ b/electron/agent/oo-version.ts
@@ -1,2 +1,2 @@
 /** Pinned OOCLI version shared by build scripts and packaged runtime verification. */
-export const OO_CLI_VERSION = "1.7.12"
+export const OO_CLI_VERSION = "1.9.0"

--- a/electron/agent/opencode-oo-guard-runtime.test.ts
+++ b/electron/agent/opencode-oo-guard-runtime.test.ts
@@ -43,6 +43,14 @@ async function runGuard(args: string[], env: NodeJS.ProcessEnv): Promise<string>
 }
 
 describe("built-in OpenCode OO guard runtime", () => {
+  test("passes website deployment to the bundled CLI", async () => {
+    const { env, root } = await fixture()
+    const input = path.join(root, "index.html")
+    await writeFile(input, "<!doctype html><title>Test</title>")
+    const output = await runGuard(["website", "upload", input, "--json"], env)
+    expect(output.trim().split("\n")).toEqual(["website", "upload", input, "--json"])
+  })
+
   test("runs without the external loopback descriptor and binds the active team", async () => {
     const { env } = await fixture()
 

--- a/electron/skills/default-registry-skills.test.ts
+++ b/electron/skills/default-registry-skills.test.ts
@@ -3,7 +3,13 @@ import { defaultRegistrySkillSetVersion, defaultRegistrySkills } from "./default
 
 describe("default Registry Skills", () => {
   it("includes the enabled Registry skills installed by default", () => {
-    expect(defaultRegistrySkillSetVersion).toBe(5)
+    expect(defaultRegistrySkillSetVersion).toBe(6)
+    expect(defaultRegistrySkills).toContainEqual({
+      category: "productivity",
+      enabled: true,
+      packageName: "@alwaysmavs/oo-deploy-single-html",
+      skillId: "oo-deploy-single-html",
+    })
     expect(defaultRegistrySkills).toContainEqual({
       category: "other",
       enabled: true,

--- a/electron/skills/default-registry-skills.ts
+++ b/electron/skills/default-registry-skills.ts
@@ -6,10 +6,16 @@ export interface DefaultRegistrySkillSpec {
   skillId: string
 }
 
-export const defaultRegistrySkillSetVersion = 5
+export const defaultRegistrySkillSetVersion = 6
 
 // 默认安装清单：登录后后台补装，必须使用 registry 中稳定的 packageName + skillId。
 export const defaultRegistrySkills: readonly DefaultRegistrySkillSpec[] = [
+  {
+    category: "productivity",
+    enabled: true,
+    packageName: "@alwaysmavs/oo-deploy-single-html",
+    skillId: "oo-deploy-single-html",
+  },
   {
     category: "other",
     enabled: true,

--- a/resources/skill-lock/oo.json
+++ b/resources/skill-lock/oo.json
@@ -1,17 +1,17 @@
 {
   "lockVersion": 1,
-  "ooCliVersion": "1.7.12",
+  "ooCliVersion": "1.9.0",
   "agentFormat": "universal",
   "files": {
-    "SKILL.md": "96d837855764c1b7623692c47ebf9705540ce049a3b586aeb905253ddad1f647",
+    "SKILL.md": "3d462a7aa1723f2c49e0437de2f5ffe27fec96241885f952bb6d076c2f2f97fc",
     "agents/openai.yaml": "50fa43d22512453554fecb66c37bd051bb1bb37d3daf6c25d4c362f9444c2202",
     "references/auth-and-billing.md": "b1161057eca019cdd0b5897ae8a7004b2bb70e988ea892a55d6142614133c5d0",
-    "references/connector-execution.md": "737468e1ae0f4bda32e4f2fba0b50bdb52ac0663087e04f51833d9f1c7844c52",
+    "references/connector-execution.md": "b47c72d3c09917d1badd327f1e01c51835b3e4c7d8ec4385a0930a71c9852d95",
     "references/file-transfer.md": "1547f3c3811f0bc6038ea9e9987d2cb2c18688ad1b8382e723c0d41ea34c9e46",
     "references/flow-authoring.md": "e988be4ceb95445e3406cb0cdf0ee0b52b827844ad49496a1d1efa83f3b53498",
     "references/flow-n8n-conversion.md": "0cd42a2b69f640637ecb60c7d67bc6ffcb2fcf32da11979a362242cab96ef578",
     "references/llm-client.md": "1e89085c9e936b4d3963894e52fe47d6afdf69b8b12c5fb702f9dc148bc97abf",
-    "references/search-and-selection.md": "85080486cfbb4c39043212ab341f482a6418a8bc8c99936e666d7681bcd70442"
+    "references/search-and-selection.md": "cde2b5d4d7a0702511cb0c05a86e8d9aeff2f20b9704497bd6f76f151c978a57"
   },
   "requiredOperations": [
     "auth",

--- a/scripts/open-source-readiness.test.ts
+++ b/scripts/open-source-readiness.test.ts
@@ -71,7 +71,7 @@ describe("open-source installation contract", () => {
     expect(notices).toContain("@opencode-ai/sdk@1.18.21")
     expect(notices).toContain("@agentclientprotocol/codex-acp@1.6.2")
     expect(notices).toContain("@agentclientprotocol/claude-agent-acp@0.70.0")
-    expect(notices).toContain("@oomol-lab/oo-cli@1.7.12")
+    expect(notices).toContain("@oomol-lab/oo-cli@1.9.0")
     for (const fileName of ["LICENSE", "NOTICE", "TRADEMARKS.md", "THIRD_PARTY_NOTICES.md"]) {
       expect(existsSync(path.join(repoRoot, fileName))).toBe(true)
       expect(builderConfig).toContain(`from: "${fileName}"`)


### PR DESCRIPTION
Wanta can now install the single HTML deployment Skill by default and execute its native `oo website upload` command. Previously the default Skill list omitted this workflow, and the external agent CLI boundary did not recognize website uploads.

Upgrade oo CLI from 1.7.12 to 1.9.0 and refresh the bundled Skill hashes and third-party notices. Add `@alwaysmavs/oo-deploy-single-html` to the enabled default Registry Skills without a version selector, so new installations fetch the latest published version after login. Existing Skill update and user-removal behavior is preserved.

Enable website uploads in the shared capability contract. External managed uploads require an OOMOL runtime and one regular HTML file within the active turn's managed directories, with a 20,000,000-byte limit. Regression coverage checks command routing through OpenCode and the external guard, invalid inputs, size limits, and symlink escapes.

Validation:
- Full-project `corepack pnpm run lint` passed.
- `corepack pnpm run ts-check` passed.
- Related Skill, capability, command safety, guard runtime, and parity tests: 66 passed.
- CLI upgrade and bundle validation tests: 45 passed; 3 opt-in real external-agent smoke tests skipped.
- `oo:verify` and `prepare:binaries` passed; development and packaged binaries report 1.9.0, and the packaged integrity descriptor matches the Skill lock.
- Changed-file formatting and `git diff --check` passed.

Live Registry download in an isolated environment returned `not_authenticated`; authenticated installation after login has not been exercised. No website was published during validation.
