### PR TITLE
fix: expose actionable team member read diagnostics

### DIFF
--- a/electron/knowledge/runtime.test.ts
+++ b/electron/knowledge/runtime.test.ts
@@ -155,7 +155,10 @@ describe("WikiGraph 0.6 host integration", () => {
       addWikiGraphLibraryArchive(rt, source.path),
     ])
     expect(new Set(imports.map((archive) => archive.id)).size).toBe(2)
-    expect(imports.map((archive) => archive.relativePath)).toEqual(["fixture-v4.wikg", "fixture-v4 2.wikg"])
+    // Concurrent requests can reach the import queue in either order after asynchronous preparation.
+    expect(new Set(imports.map((archive) => archive.relativePath))).toEqual(
+      new Set(["fixture-v4.wikg", "fixture-v4 2.wikg"]),
+    )
     expect((await listWikiGraphLibraryArchives(rt)).length).toBe(2)
     expect(await readdir(path.join(rt.stateDir, "wanta-imports"))).toEqual([])
   }, 20_000)

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "{{count}} miembros visibles",
   "teams.memberCountUnavailable": "Recuento de miembros no disponible",
   "teams.copyMemberDiagnostics": "Copiar diagnóstico de la lista de miembros",
+  "teams.memberDiagnosticsDetails": "Ver detalles del error para compartir con soporte",
   "teams.addMemberConfirmed": "Se ha añadido el usuario {{userId}}.",
   "teams.addMemberRefreshFailed": "Se añadió el miembro, pero no se pudo actualizar la lista. Vuelve a cargar la lista; no necesitas añadirlo de nuevo.",
   "teams.memberCountLoading": "Cargando miembros",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "{{count}} membres visibles",
   "teams.memberCountUnavailable": "Nombre de membres indisponible",
   "teams.copyMemberDiagnostics": "Copier les diagnostics de la liste des membres",
+  "teams.memberDiagnosticsDetails": "Afficher les détails de l’erreur à transmettre au support",
   "teams.addMemberConfirmed": "L'utilisateur {{userId}} a été ajouté.",
   "teams.addMemberRefreshFailed": "Le membre a été ajouté, mais la liste n'a pas pu être actualisée. Réessayez de charger la liste ; vous n'avez pas besoin de l'ajouter à nouveau.",
   "teams.memberCountLoading": "Chargement des membres",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "{{count}}人の表示中のメンバー",
   "teams.memberCountUnavailable": "メンバー数を取得できません",
   "teams.copyMemberDiagnostics": "メンバーリストの診断情報をコピー",
+  "teams.memberDiagnosticsDetails": "エラー詳細を表示してサポートに共有",
   "teams.addMemberConfirmed": "ユーザー{{userId}}を追加しました。",
   "teams.addMemberRefreshFailed": "メンバーは追加されましたが、リストを更新できませんでした。リストを再読み込みしてください。再度追加する必要はありません。",
   "teams.memberCountLoading": "メンバーを読み込み中",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "표시된 멤버 {{count}}명",
   "teams.memberCountUnavailable": "멤버 수를 확인할 수 없음",
   "teams.copyMemberDiagnostics": "멤버 목록 진단 정보 복사",
+  "teams.memberDiagnosticsDetails": "지원팀에 공유할 오류 세부 정보 보기",
   "teams.addMemberConfirmed": "사용자 {{userId}}님이 추가되었습니다.",
   "teams.addMemberRefreshFailed": "멤버는 추가되었지만 목록을 새로 고치지 못했습니다. 목록을 다시 로드하세요. 멤버를 다시 추가할 필요는 없습니다.",
   "teams.memberCountLoading": "멤버 불러오는 중",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "Видимых участников: {{count}}",
   "teams.memberCountUnavailable": "Количество участников недоступно",
   "teams.copyMemberDiagnostics": "Копировать диагностику списка участников",
+  "teams.memberDiagnosticsDetails": "Посмотреть подробности ошибки для отправки в поддержку",
   "teams.addMemberConfirmed": "Пользователь {{userId}} добавлен.",
   "teams.addMemberRefreshFailed": "Участник добавлен, но список не удалось обновить. Повторите загрузку списка; добавлять его снова не нужно.",
   "teams.memberCountLoading": "Загрузка участников",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1905,6 +1905,7 @@
   "teams.memberVisibleCountCompact": "{{count}} 位可見成員",
   "teams.memberCountUnavailable": "無法取得成員數量",
   "teams.copyMemberDiagnostics": "複製成員清單診斷資訊",
+  "teams.memberDiagnosticsDetails": "查看錯誤詳情，可複製給支援人員",
   "teams.addMemberConfirmed": "已新增使用者 {{userId}}。",
   "teams.addMemberRefreshFailed": "成員已新增，但無法重新整理清單。請重試載入清單；您不需要再次新增。",
   "teams.memberCountLoading": "正在載入成員",

--- a/src/i18n/skills-messages.ts
+++ b/src/i18n/skills-messages.ts
@@ -65,6 +65,7 @@ export const skillsMessages = {
     "teams.memberVisibleCountCompact": "可见 {{count}} 名成员",
     "teams.memberCountUnavailable": "成员数暂不可用",
     "teams.copyMemberDiagnostics": "复制成员读取诊断",
+    "teams.memberDiagnosticsDetails": "查看错误详情，可复制给支持人员",
     "teams.addMemberConfirmed": "已添加用户 {{userId}}。",
     "teams.addMemberRefreshFailed": "成员已添加，但列表暂时无法刷新。请重试读取列表，无需重复添加。",
     "teams.memberCountLoading": "成员加载中",
@@ -494,6 +495,7 @@ export const skillsMessages = {
     "teams.memberVisibleCountCompact": "{{count}} visible members",
     "teams.memberCountUnavailable": "Member count unavailable",
     "teams.copyMemberDiagnostics": "Copy member list diagnostics",
+    "teams.memberDiagnosticsDetails": "View error details to share with support",
     "teams.addMemberConfirmed": "User {{userId}} has been added.",
     "teams.addMemberRefreshFailed":
       "The member was added, but the list could not refresh. Retry loading the list; you do not need to add them again.",

--- a/src/lib/teams-client.test.ts
+++ b/src/lib/teams-client.test.ts
@@ -376,3 +376,66 @@ describe("member read diagnostics", () => {
     expect((error as Error).message).not.toContain("secret-token")
   })
 })
+
+describe("member failure explanations", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it.each([
+    [{ members: null }, "Expected members array; received null"],
+    [
+      { members: [{ user_id: "private-id", role: "private-role" }] },
+      "members[0]: role must be creator, admin, or member",
+    ],
+    [{ members: [{ role: "member" }] }, "members[0]: user_id must be a non-empty string; received missing"],
+    ["<html>private-response</html>", "Expected JSON object; received string"],
+  ])("explains invalid response structure without including member values", async (payload, reason) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(payload)),
+    )
+    const error = (await listTeamMembers("team-1").catch((cause: unknown) => cause)) as Error
+    expect(error.message).toContain(reason)
+    expect(error.message).toContain("category=invalid_response")
+    expect(error.message).toContain("stage=validation")
+    expect(error.message).not.toContain("private-")
+  })
+
+  it.each([
+    [new DOMException("private-token", "TimeoutError"), "timeout_or_cancelled", "20000 ms deadline"],
+    [new DOMException("private-token", "AbortError"), "timeout_or_cancelled", "cancelled"],
+    [new TypeError("private-token"), "response_read_error", "reading the response body failed"],
+  ])("distinguishes response body failures from invalid member data", async (failure, category, reason) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        status: 200,
+        ok: true,
+        headers: new Headers({ "x-request-id": "body-failure" }),
+        text: async () => {
+          throw failure
+        },
+      })),
+    )
+    const error = (await listTeamMembers("team-1").catch((cause: unknown) => cause)) as Error
+    expect(error.message).toContain(`category=${category}`)
+    expect(error.message).toContain(reason)
+    expect(error.message).toContain("stage=response_body")
+    expect(error.message).toContain("requestId=body-failure")
+    expect(error.message).not.toContain("private-token")
+  })
+
+  it("reports unavailable network evidence without guessing a root cause", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("private-token")
+      }),
+    )
+    const error = (await listTeamMembers("team-1").catch((cause: unknown) => cause)) as Error
+    expect(error.message).toContain("category=network_error")
+    expect(error.message).toContain("stage=request")
+    expect(error.message).toContain("status=unavailable")
+    expect(error.message).toContain("cannot distinguish DNS, TLS, proxy, CORS, or connection failures")
+    expect(error.message).not.toContain("private-token")
+  })
+})

--- a/src/lib/teams-client.test.ts
+++ b/src/lib/teams-client.test.ts
@@ -370,6 +370,7 @@ describe("member read diagnostics", () => {
     )
     const error = await listTeamMembers("team-1").catch((cause: unknown) => cause)
     expect(error).toMatchObject({ status: 503 })
+    expect((error as Error).message).toContain("category=http_error")
     expect((error as Error).message).toContain("requestId=member-request-123")
     expect((error as Error).message).toContain("GET https://")
     expect((error as Error).message).not.toContain("private-person")
@@ -379,6 +380,41 @@ describe("member read diagnostics", () => {
 
 describe("member failure explanations", () => {
   afterEach(() => vi.unstubAllGlobals())
+
+  it.each([null, "private-status", 0, {}, []])(
+    "rejects malformed disable values without exposing them",
+    async (disable) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json({ members: [{ user_id: "private-id", role: "member", disable }] })),
+      )
+      const error = (await listTeamMembers("team-1").catch((cause: unknown) => cause)) as Error
+      expect(error.message).toContain("members[0]: disable must be a boolean when provided")
+      expect(error.message).toContain("category=invalid_response")
+      expect(error.message).not.toContain("private-")
+    },
+  )
+
+  it.each([500, 403, 0])("retains HTTP %s when reading its response body fails", async (status) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        status,
+        ok: false,
+        headers: new Headers({ "x-request-id": "failed-body" }),
+        text: async () => {
+          throw new TypeError("private-error")
+        },
+      })),
+    )
+    const error = (await listTeamMembers("team-1").catch((cause: unknown) => cause)) as Error
+    expect(error).toMatchObject({ status })
+    expect(error.message).toContain(`status=${status}`)
+    expect(error.message).toContain("category=response_read_error")
+    expect(error.message).toContain("stage=response_body")
+    expect(error.message).toContain("requestId=failed-body")
+    expect(error.message).not.toContain("private-error")
+  })
 
   it.each([
     [{ members: null }, "Expected members array; received null"],

--- a/src/lib/teams-client.ts
+++ b/src/lib/teams-client.ts
@@ -147,15 +147,32 @@ function normalizeTeamMember(value: unknown): TeamMember | undefined {
   }
 }
 
+class TeamMembersValidationError extends Error {}
+
+function responseValueType(value: unknown): string {
+  if (value === undefined) return "missing"
+  if (value === null) return "null"
+  return Array.isArray(value) ? "array" : typeof value
+}
+
 function normalizeTeamMembers(value: unknown): TeamMember[] {
   if (!Array.isArray(value)) {
-    throw new Error("Team members response is invalid.")
+    throw new TeamMembersValidationError(
+      `Team members response is invalid. Expected members array; received ${responseValueType(value)}.`,
+    )
   }
-  const members = value.map(normalizeTeamMember)
-  if (members.some((member) => !member)) {
-    throw new Error("Team members response contains an invalid member.")
-  }
-  return members as TeamMember[]
+  return value.map((value, index) => {
+    const member = normalizeTeamMember(value)
+    if (member) return member
+    const reason = !isPlainObject(value)
+      ? `expected object; received ${responseValueType(value)}`
+      : !asString(value["user_id"])
+        ? `user_id must be a non-empty string; received ${responseValueType(value["user_id"])}`
+        : "role must be creator, admin, or member"
+    throw new TeamMembersValidationError(
+      `Team members response contains an invalid member. members[${index}]: ${reason}.`,
+    )
+  })
 }
 
 function normalizeUserSummaryMap(value: unknown): Record<string, TeamUserSummary> {
@@ -380,40 +397,58 @@ export async function listTeamMembers(teamId: string): Promise<TeamMember[]> {
   const startedAt = Date.now()
   let status: number | undefined
   let requestId: string | undefined
+  let stage: "request" | "response_body" | "validation" = "request"
   try {
     const result = await requestTeamControlJson(path, {
       onResponse: (response) => {
         status = response.status
+        stage = "response_body"
         const value = response.headers.get("x-request-id") ?? response.headers.get("request-id")
         if (value && /^[a-zA-Z0-9._:-]{1,128}$/.test(value)) requestId = value
       },
     })
-    return normalizeTeamMembers(isPlainObject(result) ? result["members"] : undefined)
+    stage = "validation"
+    if (!isPlainObject(result)) {
+      throw new TeamMembersValidationError(
+        `Team members response is invalid. Expected JSON object; received ${responseValueType(result)}.`,
+      )
+    }
+    return normalizeTeamMembers(result["members"])
   } catch (cause) {
-    const category =
-      status && status >= 200 && status < 300
+    const interrupted = cause instanceof Error && (cause.name === "TimeoutError" || cause.name === "AbortError")
+    const category = interrupted
+      ? "timeout_or_cancelled"
+      : cause instanceof TeamMembersValidationError
         ? "invalid_response"
-        : status
+        : status && (status < 200 || status >= 300)
           ? "http_error"
-          : cause instanceof Error && (cause.name === "TimeoutError" || cause.name === "AbortError")
-            ? "timeout_or_cancelled"
+          : status
+            ? "response_read_error"
             : "network_error"
-    // Never copy raw response bodies, API messages, cookies, or arbitrary error strings into diagnostics.
-    const validation =
-      category === "invalid_response" &&
-      cause instanceof Error &&
-      ["Team members response is invalid.", "Team members response contains an invalid member."].includes(cause.message)
+    // Only generated explanations are shared; raw bodies and exception messages may contain credentials or personal data.
+    const reason =
+      cause instanceof TeamMembersValidationError
         ? cause.message
-        : category
+        : interrupted
+          ? cause.name === "TimeoutError"
+            ? `Request exceeded the ${teamRequestTimeoutMs} ms deadline.`
+            : "Request was cancelled before completion."
+          : category === "http_error"
+            ? `Server returned HTTP ${status}. Use the request ID and timestamp to check server logs.`
+            : category === "response_read_error"
+              ? "Response headers arrived, but reading the response body failed."
+              : "No HTTP response was available. The browser cannot distinguish DNS, TLS, proxy, CORS, or connection failures here."
     const error = Object.assign(
       new Error(
         [
           "Team members read failed",
-          validation,
+          `reason=${reason}`,
+          `stage=${stage}`,
           `GET ${teamControlBaseUrl}${path}`,
           `time=${new Date(startedAt).toISOString()}`,
           `status=${status ?? "unavailable"}; category=${category}; elapsedMs=${Date.now() - startedAt}`,
           `requestId=${requestId ?? "unavailable"}`,
+          `platform=${globalThis.wanta?.platform ?? "unknown"}`,
           `version=${globalThis.wanta?.version ?? "unknown"}; commit=${globalThis.wanta?.appCommit ?? "unknown"}`,
         ].join("\n"),
       ),

--- a/src/lib/teams-client.ts
+++ b/src/lib/teams-client.ts
@@ -140,6 +140,9 @@ function normalizeTeamMember(value: unknown): TeamMember | undefined {
   if (!userId || (role !== "creator" && role !== "admin" && role !== "member")) {
     return undefined
   }
+  if (value["disable"] !== undefined && typeof value["disable"] !== "boolean") {
+    return undefined
+  }
   return {
     user_id: userId,
     role,
@@ -168,7 +171,9 @@ function normalizeTeamMembers(value: unknown): TeamMember[] {
       ? `expected object; received ${responseValueType(value)}`
       : !asString(value["user_id"])
         ? `user_id must be a non-empty string; received ${responseValueType(value["user_id"])}`
-        : "role must be creator, admin, or member"
+        : value["role"] !== "creator" && value["role"] !== "admin" && value["role"] !== "member"
+          ? "role must be creator, admin, or member"
+          : `disable must be a boolean when provided; received ${responseValueType(value["disable"])}`
     throw new TeamMembersValidationError(
       `Team members response contains an invalid member. members[${index}]: ${reason}.`,
     )
@@ -420,9 +425,9 @@ export async function listTeamMembers(teamId: string): Promise<TeamMember[]> {
       ? "timeout_or_cancelled"
       : cause instanceof TeamMembersValidationError
         ? "invalid_response"
-        : status && (status < 200 || status >= 300)
+        : cause instanceof TeamRequestError
           ? "http_error"
-          : status
+          : status !== undefined
             ? "response_read_error"
             : "network_error"
     // Only generated explanations are shared; raw bodies and exception messages may contain credentials or personal data.

--- a/src/routes/Skills/TeamMembersPanel.tsx
+++ b/src/routes/Skills/TeamMembersPanel.tsx
@@ -213,8 +213,8 @@ function MemberAccessWarning({
     <div className="mx-3 mt-3 flex items-start justify-between gap-3 rounded-md border border-[var(--oo-warning-border)] bg-[var(--oo-warning-surface)] px-3 py-2">
       <div className="oo-text-caption min-w-0">
         {t(hasMembers ? "teams.membersForbiddenPartial" : "teams.membersForbiddenEmpty")}
+        {error ? <MemberDiagnostics error={error} /> : null}
       </div>
-      {error ? <CopyMemberDiagnosticsButton error={error} /> : null}
       <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={onRetry}>
         <RefreshCwIcon className="size-3.5" />
         {t("teams.retry")}
@@ -228,7 +228,7 @@ function MemberLoadError({ error, onRetry }: { error: string; onRetry: () => voi
   return (
     <div className="flex min-h-32 flex-col items-center justify-center gap-3 px-4 py-8 text-center">
       <div className="oo-text-body text-muted-foreground">{t("teams.membersLoadFailedDescription")}</div>
-      <CopyMemberDiagnosticsButton error={error} />
+      <MemberDiagnostics error={error} />
       <Button type="button" variant="outline" size="sm" onClick={onRetry}>
         <RefreshCwIcon className="size-3.5" />
         {t("teams.retry")}
@@ -389,6 +389,19 @@ export function TeamMemberAdditionNotice({
         </div>
       </AlertDescription>
     </Alert>
+  )
+}
+
+function MemberDiagnostics({ error }: { error: string }) {
+  const { t } = useAppI18n()
+  return (
+    <div className="w-full max-w-2xl min-w-0 text-left">
+      <details className="rounded-md border border-border p-3 text-sm">
+        <summary className="cursor-pointer text-muted-foreground">{t("teams.memberDiagnosticsDetails")}</summary>
+        <pre className="mt-2 max-h-60 overflow-auto text-xs break-all whitespace-pre-wrap select-text">{error}</pre>
+      </details>
+      <CopyMemberDiagnosticsButton error={error} />
+    </div>
   )
 }
 

--- a/src/routes/Skills/team-management.lifecycle.test.tsx
+++ b/src/routes/Skills/team-management.lifecycle.test.tsx
@@ -330,10 +330,13 @@ test("member selection and DOM survive background refresh and a refresh failure"
   }
 })
 
-test("403 without loaded members shows diagnostics and retry instead of an empty roster", async () => {
+test.each([false, true])("member failure shows copyable diagnostics and retry (forbidden=%s)", async (forbidden) => {
   const host = document.createElement("div")
   const root = createRoot(host)
   const retry = vi.fn()
+  const copy = vi.fn(async () => undefined)
+  vi.stubGlobal("wanta", { writeClipboardText: copy })
+  const diagnostics = `status=${forbidden ? 403 : 503}; requestId=test`
   try {
     await act(async () =>
       root.render(
@@ -344,8 +347,8 @@ test("403 without loaded members shows diagnostics and retry instead of an empty
           canManage
           members={[]}
           membersComplete={false}
-          membersError="status=403; requestId=test"
-          membersForbidden
+          membersError={diagnostics}
+          membersForbidden={forbidden}
           membersLoading={false}
           team={{ id: "t", name: "Team", creator_user_id: "creator", avatar: "" }}
           onAddMember={vi.fn()}
@@ -357,7 +360,13 @@ test("403 without loaded members shows diagnostics and retry instead of an empty
         />,
       ),
     )
-    expect(host.textContent).toContain("teams.membersForbiddenEmpty")
+    expect(host.textContent).toContain(forbidden ? "teams.membersForbiddenEmpty" : "teams.membersLoadFailedDescription")
+    expect(host.querySelector("details pre")?.textContent).toBe(diagnostics)
+    const copyButton = [...host.querySelectorAll("button")].find(
+      (element) => element.textContent === "teams.copyMemberDiagnostics",
+    )!
+    await act(async () => copyButton.click())
+    expect(copy).toHaveBeenCalledWith(diagnostics)
     expect(host.textContent).toContain("teams.copyMemberDiagnostics")
     expect(host.textContent).not.toContain("teams.emptyMembersDescription")
     const button = [...host.querySelectorAll("button")].find((element) => element.textContent === "teams.retry")!


### PR DESCRIPTION
When a team member list fails to load, users can now expand the error details and copy the same diagnostic text to support. The details entry is localized across all eight supported languages and is available for both permission errors and other request failures.

Previously, diagnostics grouped successful HTTP responses with body-read failures under invalid responses and provided only a generic message for malformed members. The client now reports the request stage, platform, and a specific explanation, including the index and failing field of an invalid member. Timeouts, cancellation, body-read failures, HTTP errors, and network failures are distinguished. Network failures explicitly describe the limits of browser evidence rather than assigning an unverified root cause. Raw response bodies, member values, and arbitrary exception messages are excluded from the report. Invalid non-boolean disable values are rejected while omitted values remain supported by the optional-field contract. Response-body read failures retain their HTTP status and are classified separately even for non-2xx responses.

This improves evidence collection for the reported user-specific failure; it does not claim to fix the underlying service or network issue.

Validation:
- Full repository lint: corepack pnpm run lint
- Full repository formatting: corepack pnpm run format
- TypeScript: corepack pnpm run ts-check
- 78 tests passed across the teams client, team detail resource, team management lifecycle, and localization catalog suites, including clipboard behavior and safe failure explanations.
- git diff --check

